### PR TITLE
feat: unify delivery modes with student-portal router

### DIFF
--- a/app/admin/dashboard/page.tsx
+++ b/app/admin/dashboard/page.tsx
@@ -96,6 +96,26 @@ export default async function AdminDashboardOrchestrated() {
     .select('*', { count: 'exact', head: true })
     .eq('status', 'completed');
 
+  // Partner Enrollments
+  const { count: partnerEnrollmentsTotal } = await supabase
+    .from('partner_lms_enrollments')
+    .select('*', { count: 'exact', head: true });
+
+  const { count: partnerEnrollmentsActive } = await supabase
+    .from('partner_lms_enrollments')
+    .select('*', { count: 'exact', head: true })
+    .in('status', ['active', 'enrolled', 'in_progress']);
+
+  // Hybrid/Apprenticeship Enrollments
+  const { count: studentEnrollmentsTotal } = await supabase
+    .from('student_enrollments')
+    .select('*', { count: 'exact', head: true });
+
+  const { count: studentEnrollmentsActive } = await supabase
+    .from('student_enrollments')
+    .select('*', { count: 'exact', head: true })
+    .in('status', ['active', 'enrolled', 'in_progress']);
+
   // Program Holders
   const { count: totalProgramHolders } = await supabase
     .from('profiles')
@@ -282,6 +302,40 @@ export default async function AdminDashboardOrchestrated() {
                 {completedStudents || 0}
               </div>
               <div className="text-xs sm:text-sm text-blue-900">Completed</div>
+            </div>
+          </div>
+        </div>
+
+        {/* Partner & Hybrid Enrollments */}
+        <div className="mb-6 sm:mb-8">
+          <h3 className="text-base sm:text-lg font-bold text-black mb-3 sm:mb-4 flex items-center gap-2">
+            <Building2 className="h-4 w-4 sm:h-5 sm:w-5 text-purple-600" />
+            Partner & Hybrid Enrollments
+          </h3>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3 sm:gap-4">
+            <div className="bg-purple-50 rounded-lg shadow-sm border border-purple-200 p-4 sm:p-6">
+              <div className="text-2xl sm:text-3xl font-bold text-purple-900 mb-1 sm:mb-2">
+                {partnerEnrollmentsTotal || 0}
+              </div>
+              <div className="text-xs sm:text-sm text-purple-900">Partner Total</div>
+            </div>
+            <div className="bg-purple-50 rounded-lg shadow-sm border border-purple-600 p-4 sm:p-6">
+              <div className="text-2xl sm:text-3xl font-bold text-purple-900 mb-1 sm:mb-2">
+                {partnerEnrollmentsActive || 0}
+              </div>
+              <div className="text-xs sm:text-sm text-purple-900">Partner Active</div>
+            </div>
+            <div className="bg-orange-50 rounded-lg shadow-sm border border-orange-200 p-4 sm:p-6">
+              <div className="text-2xl sm:text-3xl font-bold text-orange-900 mb-1 sm:mb-2">
+                {studentEnrollmentsTotal || 0}
+              </div>
+              <div className="text-xs sm:text-sm text-orange-900">Apprenticeship Total</div>
+            </div>
+            <div className="bg-orange-50 rounded-lg shadow-sm border border-orange-600 p-4 sm:p-6">
+              <div className="text-2xl sm:text-3xl font-bold text-orange-900 mb-1 sm:mb-2">
+                {studentEnrollmentsActive || 0}
+              </div>
+              <div className="text-xs sm:text-sm text-orange-900">Apprenticeship Active</div>
             </div>
           </div>
         </div>

--- a/app/api/enrollments/me/route.ts
+++ b/app/api/enrollments/me/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getUserEnrollments } from '@/lib/enrollments/getUserEnrollments';
+
+export async function GET() {
+  try {
+    const supabase = await createClient();
+    
+    if (!supabase) {
+      return NextResponse.json({ enrollments: [] });
+    }
+
+    const { data: { user } } = await supabase.auth.getUser();
+    
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const result = await getUserEnrollments(user.id);
+    
+    if (result.error) {
+      return NextResponse.json({ error: result.error }, { status: 500 });
+    }
+
+    return NextResponse.json({ enrollments: result.enrollments });
+  } catch (error) {
+    console.error('Error fetching enrollments:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/app/partner-learning/[enrollmentId]/page.tsx
+++ b/app/partner-learning/[enrollmentId]/page.tsx
@@ -1,0 +1,204 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { 
+  ArrowLeft, 
+  ExternalLink, 
+  Mail, 
+  Clock, 
+  CheckCircle,
+  AlertCircle,
+  Building2,
+  BookOpen
+} from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Partner Learning | Elevate For Humanity',
+  description: 'Access your partner course enrollment details and instructions.',
+};
+
+type Props = {
+  params: Promise<{ enrollmentId: string }>;
+};
+
+export default async function PartnerLearningPage({ params }: Props) {
+  const { enrollmentId } = await params;
+  
+  const supabase = await createClient();
+  
+  if (!supabase) {
+    redirect('/login?next=/partner-learning/' + enrollmentId);
+  }
+
+  const { data: { user } } = await supabase.auth.getUser();
+  
+  if (!user) {
+    redirect('/login?next=/partner-learning/' + enrollmentId);
+  }
+
+  // Fetch the partner enrollment
+  const { data: enrollment, error } = await supabase
+    .from('partner_lms_enrollments')
+    .select(`
+      *,
+      partner_lms_courses (id, title, slug, description),
+      partner_lms_providers (id, name, portal_url, support_email, support_phone)
+    `)
+    .eq('id', enrollmentId)
+    .eq('student_id', user.id)
+    .single();
+
+  if (error || !enrollment) {
+    notFound();
+  }
+
+  const course = enrollment.partner_lms_courses as any;
+  const provider = enrollment.partner_lms_providers as any;
+
+  const getStatusInfo = (status: string) => {
+    switch (status?.toLowerCase()) {
+      case 'completed':
+        return { icon: CheckCircle, color: 'text-green-600 bg-green-50', label: 'Completed' };
+      case 'active':
+      case 'enrolled':
+      case 'in_progress':
+        return { icon: Clock, color: 'text-blue-600 bg-blue-50', label: 'In Progress' };
+      case 'pending':
+        return { icon: AlertCircle, color: 'text-amber-600 bg-amber-50', label: 'Pending Setup' };
+      default:
+        return { icon: Clock, color: 'text-gray-600 bg-gray-50', label: status || 'Unknown' };
+    }
+  };
+
+  const statusInfo = getStatusInfo(enrollment.status);
+  const StatusIcon = statusInfo.icon;
+
+  return (
+    <main className="min-h-screen bg-gray-50">
+      {/* Header */}
+      <div className="bg-white border-b border-gray-200">
+        <div className="max-w-4xl mx-auto px-6 py-6">
+          <Link 
+            href="/student-portal" 
+            className="inline-flex items-center gap-2 text-gray-600 hover:text-gray-900 mb-4"
+          >
+            <ArrowLeft className="w-4 h-4" />
+            Back to Student Portal
+          </Link>
+          
+          <div className="flex items-start justify-between gap-4">
+            <div>
+              <div className="flex items-center gap-2 text-purple-600 text-sm font-medium mb-2">
+                <Building2 className="w-4 h-4" />
+                Partner Course
+              </div>
+              <h1 className="text-2xl md:text-3xl font-bold text-gray-900">
+                {course?.title || enrollment.course_name || 'Partner Course'}
+              </h1>
+              {provider?.name && (
+                <p className="text-gray-600 mt-1">Provided by {provider.name}</p>
+              )}
+            </div>
+            
+            <span className={`inline-flex items-center gap-2 px-3 py-1.5 rounded-full text-sm font-medium ${statusInfo.color}`}>
+              <StatusIcon className="w-4 h-4" />
+              {statusInfo.label}
+            </span>
+          </div>
+        </div>
+      </div>
+
+      {/* Content */}
+      <div className="max-w-4xl mx-auto px-6 py-8">
+        {/* Instructions Card */}
+        <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+          <div className="flex items-start gap-4">
+            <div className="p-3 bg-blue-50 rounded-lg">
+              <Mail className="w-6 h-6 text-blue-600" />
+            </div>
+            <div>
+              <h2 className="text-lg font-semibold text-gray-900 mb-2">
+                How to Access Your Course
+              </h2>
+              <div className="text-gray-600 space-y-2">
+                <p>
+                  You will receive login credentials for the partner learning portal via email. 
+                  Please check your inbox (and spam folder) for instructions from {provider?.name || 'the course provider'}.
+                </p>
+                <p>
+                  Once you receive your credentials, use the partner portal to complete your training. 
+                  Your progress will be tracked and reported back to Elevate for Humanity.
+                </p>
+              </div>
+            </div>
+          </div>
+        </div>
+
+        {/* Portal Access */}
+        {provider?.portal_url && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Partner Portal</h2>
+            <a
+              href={provider.portal_url}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="inline-flex items-center gap-2 px-6 py-3 bg-purple-600 text-white font-medium rounded-lg hover:bg-purple-700 transition-colors"
+            >
+              Open Partner Portal
+              <ExternalLink className="w-4 h-4" />
+            </a>
+            <p className="text-sm text-gray-500 mt-3">
+              Opens in a new tab. You'll need your partner login credentials.
+            </p>
+          </div>
+        )}
+
+        {/* Course Details */}
+        {course?.description && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-3">About This Course</h2>
+            <p className="text-gray-600">{course.description}</p>
+          </div>
+        )}
+
+        {/* Support Contact */}
+        {(provider?.support_email || provider?.support_phone) && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-6">
+            <h2 className="text-lg font-semibold text-gray-900 mb-4">Need Help?</h2>
+            <div className="space-y-3">
+              {provider.support_email && (
+                <a 
+                  href={`mailto:${provider.support_email}`}
+                  className="flex items-center gap-3 text-gray-600 hover:text-blue-600"
+                >
+                  <Mail className="w-5 h-5" />
+                  {provider.support_email}
+                </a>
+              )}
+              {provider.support_phone && (
+                <a 
+                  href={`tel:${provider.support_phone}`}
+                  className="flex items-center gap-3 text-gray-600 hover:text-blue-600"
+                >
+                  <BookOpen className="w-5 h-5" />
+                  {provider.support_phone}
+                </a>
+              )}
+            </div>
+          </div>
+        )}
+
+        {/* Elevate Support */}
+        <div className="mt-8 text-center text-gray-500 text-sm">
+          <p>
+            Having trouble? Contact Elevate for Humanity support at{' '}
+            <a href="tel:317-314-3757" className="text-blue-600 hover:underline">
+              317-314-3757
+            </a>
+          </p>
+        </div>
+      </div>
+    </main>
+  );
+}

--- a/app/student-portal/EnrollmentDashboard.tsx
+++ b/app/student-portal/EnrollmentDashboard.tsx
@@ -1,0 +1,197 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { 
+  BookOpen, 
+  ExternalLink, 
+  ArrowRight, 
+  AlertCircle,
+  CheckCircle,
+  Clock,
+  GraduationCap,
+  Building2
+} from 'lucide-react';
+
+type Enrollment = {
+  source_table: string;
+  enrollment_id: string;
+  program_title: string | null;
+  course_title: string | null;
+  provider_name: string | null;
+  status: string;
+  progress: number;
+  delivery_mode: 'internal' | 'partner' | 'hybrid';
+  inferred_delivery_mode: boolean;
+  continue_url: string;
+  created_at: string;
+};
+
+export default function EnrollmentDashboard() {
+  const [enrollments, setEnrollments] = useState<Enrollment[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function fetchEnrollments() {
+      try {
+        const res = await fetch('/api/enrollments/me');
+        if (!res.ok) {
+          if (res.status === 401) {
+            setEnrollments([]);
+            return;
+          }
+          throw new Error('Failed to fetch enrollments');
+        }
+        const data = await res.json();
+        setEnrollments(data.enrollments || []);
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Unknown error');
+      } finally {
+        setLoading(false);
+      }
+    }
+    fetchEnrollments();
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="bg-white rounded-xl shadow-sm border border-gray-200 p-8">
+        <div className="animate-pulse space-y-4">
+          <div className="h-6 bg-gray-200 rounded w-1/3"></div>
+          <div className="h-24 bg-gray-100 rounded"></div>
+          <div className="h-24 bg-gray-100 rounded"></div>
+        </div>
+      </div>
+    );
+  }
+
+  if (error) {
+    return (
+      <div className="bg-red-50 rounded-xl p-6 border border-red-200">
+        <div className="flex items-center gap-3 text-red-700">
+          <AlertCircle className="w-5 h-5" />
+          <p>Unable to load enrollments. Please try again later.</p>
+        </div>
+      </div>
+    );
+  }
+
+  if (enrollments.length === 0) {
+    return null; // Don't show anything if no enrollments
+  }
+
+  const getStatusIcon = (status: string) => {
+    switch (status.toLowerCase()) {
+      case 'completed':
+        return <CheckCircle className="w-5 h-5 text-green-500" />;
+      case 'active':
+      case 'enrolled':
+      case 'in_progress':
+        return <Clock className="w-5 h-5 text-blue-500" />;
+      default:
+        return <Clock className="w-5 h-5 text-gray-400" />;
+    }
+  };
+
+  const getDeliveryModeLabel = (mode: string) => {
+    switch (mode) {
+      case 'partner':
+        return { label: 'Partner Course', icon: Building2, color: 'text-purple-600 bg-purple-50' };
+      case 'hybrid':
+        return { label: 'Apprenticeship', icon: GraduationCap, color: 'text-orange-600 bg-orange-50' };
+      default:
+        return { label: 'Online Course', icon: BookOpen, color: 'text-blue-600 bg-blue-50' };
+    }
+  };
+
+  return (
+    <section className="bg-white rounded-xl shadow-sm border border-gray-200 p-6 mb-8">
+      <h2 className="text-xl font-bold text-gray-900 mb-4 flex items-center gap-2">
+        <GraduationCap className="w-6 h-6 text-blue-600" />
+        My Enrollments
+      </h2>
+
+      <div className="space-y-4">
+        {enrollments.map((enrollment) => {
+          const modeInfo = getDeliveryModeLabel(enrollment.delivery_mode);
+          const ModeIcon = modeInfo.icon;
+
+          return (
+            <div
+              key={enrollment.enrollment_id}
+              className="border border-gray-200 rounded-lg p-4 hover:border-blue-300 transition-colors"
+            >
+              <div className="flex items-start justify-between gap-4">
+                <div className="flex-1">
+                  <div className="flex items-center gap-2 mb-1">
+                    {getStatusIcon(enrollment.status)}
+                    <h3 className="font-semibold text-gray-900">
+                      {enrollment.program_title || enrollment.course_title || 'Untitled Program'}
+                    </h3>
+                  </div>
+
+                  <div className="flex flex-wrap items-center gap-2 mt-2">
+                    <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${modeInfo.color}`}>
+                      <ModeIcon className="w-3 h-3" />
+                      {modeInfo.label}
+                    </span>
+
+                    {enrollment.provider_name && (
+                      <span className="text-xs text-gray-500">
+                        via {enrollment.provider_name}
+                      </span>
+                    )}
+
+                    <span className="text-xs text-gray-500 capitalize">
+                      {enrollment.status}
+                    </span>
+
+                    {enrollment.inferred_delivery_mode && (
+                      <span className="inline-flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium text-amber-600 bg-amber-50">
+                        <AlertCircle className="w-3 h-3" />
+                        Needs config
+                      </span>
+                    )}
+                  </div>
+
+                  {enrollment.progress > 0 && (
+                    <div className="mt-3">
+                      <div className="flex items-center justify-between text-xs text-gray-500 mb-1">
+                        <span>Progress</span>
+                        <span>{enrollment.progress}%</span>
+                      </div>
+                      <div className="h-2 bg-gray-100 rounded-full overflow-hidden">
+                        <div
+                          className="h-full bg-blue-500 rounded-full transition-all"
+                          style={{ width: `${enrollment.progress}%` }}
+                        />
+                      </div>
+                    </div>
+                  )}
+                </div>
+
+                <Link
+                  href={enrollment.continue_url}
+                  className="inline-flex items-center gap-2 px-4 py-2 bg-blue-600 text-white text-sm font-medium rounded-lg hover:bg-blue-700 transition-colors whitespace-nowrap"
+                >
+                  {enrollment.delivery_mode === 'partner' ? (
+                    <>
+                      View Details
+                      <ExternalLink className="w-4 h-4" />
+                    </>
+                  ) : (
+                    <>
+                      Continue
+                      <ArrowRight className="w-4 h-4" />
+                    </>
+                  )}
+                </Link>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </section>
+  );
+}

--- a/app/student-portal/page.tsx
+++ b/app/student-portal/page.tsx
@@ -25,6 +25,7 @@ import {
   Settings,
   HelpCircle,
 } from 'lucide-react';
+import EnrollmentDashboard from './EnrollmentDashboard';
 
 export const metadata: Metadata = {
   alternates: {
@@ -269,6 +270,13 @@ export default async function StudentPortalPage() {
               <ArrowRight className="w-5 h-5" />
             </Link>
           </div>
+        </div>
+      </section>
+
+      {/* My Enrollments - Shows for logged-in users */}
+      <section className="py-8 bg-gray-50">
+        <div className="max-w-7xl mx-auto px-6">
+          <EnrollmentDashboard />
         </div>
       </section>
 

--- a/lib/delivery/resolveDeliveryMode.ts
+++ b/lib/delivery/resolveDeliveryMode.ts
@@ -1,0 +1,101 @@
+/**
+ * Delivery Mode Resolver
+ * Determines how learning is delivered for a given enrollment
+ */
+
+export type DeliveryMode = 'internal' | 'partner' | 'hybrid';
+
+export type EnrollmentSource = 
+  | 'enrollments' 
+  | 'student_enrollments' 
+  | 'partner_enrollments' 
+  | 'partner_lms_enrollments';
+
+export type DeliveryModeResult = {
+  mode: DeliveryMode;
+  inferred: boolean;
+};
+
+type ProgramRow = {
+  delivery_mode?: DeliveryMode | null;
+  [key: string]: unknown;
+};
+
+/**
+ * Resolve delivery mode for an enrollment
+ * 
+ * Precedence:
+ * 1. If program.delivery_mode is set → use it
+ * 2. Else infer from enrollment source table
+ * 3. Else fallback → 'internal'
+ */
+export function resolveDeliveryMode(
+  source: EnrollmentSource,
+  program?: ProgramRow | null
+): DeliveryModeResult {
+  // 1. Check explicit program configuration
+  if (program?.delivery_mode) {
+    return {
+      mode: program.delivery_mode as DeliveryMode,
+      inferred: false,
+    };
+  }
+
+  // 2. Infer from enrollment source
+  const inferredMode = inferFromSource(source);
+  
+  return {
+    mode: inferredMode,
+    inferred: true,
+  };
+}
+
+/**
+ * Infer delivery mode from enrollment source table
+ */
+function inferFromSource(source: EnrollmentSource): DeliveryMode {
+  switch (source) {
+    case 'partner_lms_enrollments':
+    case 'partner_enrollments':
+      return 'partner';
+    
+    case 'student_enrollments':
+      // student_enrollments is used for barber apprenticeship (hybrid)
+      return 'hybrid';
+    
+    case 'enrollments':
+    default:
+      return 'internal';
+  }
+}
+
+/**
+ * Get the appropriate "Continue Learning" URL for an enrollment
+ */
+export function getContinueLearningUrl(
+  deliveryMode: DeliveryMode,
+  enrollment: {
+    enrollment_id: string;
+    course_id?: string | null;
+    program_slug?: string | null;
+  }
+): string {
+  switch (deliveryMode) {
+    case 'partner':
+      return `/partner-learning/${enrollment.enrollment_id}`;
+    
+    case 'hybrid':
+      // Hybrid enrollments go to case management or LMS dashboard
+      if (enrollment.course_id) {
+        return `/lms/courses/${enrollment.course_id}`;
+      }
+      return '/lms/dashboard';
+    
+    case 'internal':
+    default:
+      if (enrollment.course_id) {
+        return `/lms/courses/${enrollment.course_id}`;
+      }
+      return '/lms/dashboard';
+  }
+}

--- a/lib/enrollments/getUserEnrollments.ts
+++ b/lib/enrollments/getUserEnrollments.ts
@@ -4,22 +4,27 @@
  * Used by student-portal and other dashboards to render "Continue Learning" links
  */
 
-import { createServerClient } from '@/lib/supabase/server';
+import { createClient } from '@/lib/supabase/server';
+import { resolveDeliveryMode, getContinueLearningUrl, DeliveryMode, EnrollmentSource } from '@/lib/delivery/resolveDeliveryMode';
 
 export type NormalizedEnrollment = {
-  source: 'enrollments' | 'student_enrollments' | 'partner_enrollments' | 'partner_lms_enrollments';
+  source_table: EnrollmentSource;
   enrollment_id: string;
-  user_id: string;
-  course_id: string | null;
+  user_key: string;
   program_id: string | null;
-  pathway_slug: string | null;
+  program_slug: string | null;
+  program_title: string | null;
+  course_id: string | null;
+  course_title: string | null;
+  provider_id: string | null;
+  provider_name: string | null;
   status: string;
   progress: number;
+  delivery_mode: DeliveryMode;
+  inferred_delivery_mode: boolean;
+  continue_url: string;
   created_at: string;
   updated_at: string | null;
-  // Metadata for display
-  course_title?: string;
-  program_title?: string;
 };
 
 export type EnrollmentQueryResult = {
@@ -32,7 +37,7 @@ export type EnrollmentQueryResult = {
  * Returns normalized array sorted by most recent first
  */
 export async function getUserEnrollments(userId: string): Promise<EnrollmentQueryResult> {
-  const supabase = await createServerClient();
+  const supabase = await createClient();
   
   if (!supabase) {
     return { enrollments: [], error: 'Database not configured' };
@@ -40,95 +45,117 @@ export async function getUserEnrollments(userId: string): Promise<EnrollmentQuer
 
   const results: NormalizedEnrollment[] = [];
 
-  // Query enrollments table
-  const { data: enrollments, error: e1 } = await supabase
+  // Query enrollments table (internal LMS)
+  const { data: enrollments } = await supabase
     .from('enrollments')
-    .select('id, user_id, course_id, program_id, status, progress, created_at, updated_at')
+    .select(`
+      id, user_id, course_id, program_id, status, progress, created_at, updated_at,
+      programs (id, title, slug, delivery_mode),
+      courses (id, title)
+    `)
     .eq('user_id', userId);
 
-  if (!e1 && enrollments) {
+  if (enrollments) {
     for (const e of enrollments) {
-      results.push({
-        source: 'enrollments',
+      const program = e.programs as any;
+      const course = e.courses as any;
+      const { mode, inferred } = resolveDeliveryMode('enrollments', program);
+      
+      const enrollment: NormalizedEnrollment = {
+        source_table: 'enrollments',
         enrollment_id: e.id,
-        user_id: e.user_id,
-        course_id: e.course_id,
+        user_key: e.user_id,
         program_id: e.program_id,
-        pathway_slug: null,
+        program_slug: program?.slug || null,
+        program_title: program?.title || null,
+        course_id: e.course_id,
+        course_title: course?.title || null,
+        provider_id: null,
+        provider_name: null,
         status: e.status || 'active',
         progress: e.progress || 0,
+        delivery_mode: mode,
+        inferred_delivery_mode: inferred,
+        continue_url: '',
         created_at: e.created_at,
         updated_at: e.updated_at,
-      });
+      };
+      enrollment.continue_url = getContinueLearningUrl(mode, enrollment);
+      results.push(enrollment);
     }
   }
 
-  // Query student_enrollments table
-  const { data: studentEnrollments, error: e2 } = await supabase
-    .from('student_enrollments')
-    .select('id, student_id, course_id, program_id, status, progress, created_at, updated_at')
+  // Query partner_lms_enrollments table (external providers)
+  const { data: partnerEnrollments } = await supabase
+    .from('partner_lms_enrollments')
+    .select(`
+      id, student_id, course_name, status, progress, created_at, updated_at,
+      partner_lms_courses (id, title, slug),
+      partner_lms_providers (id, name, portal_url)
+    `)
     .eq('student_id', userId);
 
-  if (!e2 && studentEnrollments) {
-    for (const e of studentEnrollments) {
-      results.push({
-        source: 'student_enrollments',
-        enrollment_id: e.id,
-        user_id: e.student_id,
-        course_id: e.course_id,
-        program_id: e.program_id,
-        pathway_slug: null,
-        status: e.status || 'active',
-        progress: e.progress || 0,
-        created_at: e.created_at,
-        updated_at: e.updated_at,
-      });
-    }
-  }
-
-  // Query partner_enrollments table
-  const { data: partnerEnrollments, error: e3 } = await supabase
-    .from('partner_enrollments')
-    .select('id, user_id, course_id, program_id, status, created_at, updated_at')
-    .eq('user_id', userId);
-
-  if (!e3 && partnerEnrollments) {
+  if (partnerEnrollments) {
     for (const e of partnerEnrollments) {
-      results.push({
-        source: 'partner_enrollments',
+      const course = e.partner_lms_courses as any;
+      const provider = e.partner_lms_providers as any;
+      const { mode, inferred } = resolveDeliveryMode('partner_lms_enrollments', null);
+      
+      const enrollment: NormalizedEnrollment = {
+        source_table: 'partner_lms_enrollments',
         enrollment_id: e.id,
-        user_id: e.user_id,
-        course_id: e.course_id,
-        program_id: e.program_id,
-        pathway_slug: null,
+        user_key: e.student_id,
+        program_id: null,
+        program_slug: course?.slug || null,
+        program_title: course?.title || e.course_name || null,
+        course_id: course?.id || null,
+        course_title: course?.title || e.course_name || null,
+        provider_id: provider?.id || null,
+        provider_name: provider?.name || null,
         status: e.status || 'active',
-        progress: 0,
+        progress: e.progress || 0,
+        delivery_mode: mode,
+        inferred_delivery_mode: inferred,
+        continue_url: '',
         created_at: e.created_at,
         updated_at: e.updated_at,
-      });
+      };
+      enrollment.continue_url = getContinueLearningUrl(mode, enrollment);
+      results.push(enrollment);
     }
   }
 
-  // Query partner_lms_enrollments table
-  const { data: partnerLmsEnrollments, error: e4 } = await supabase
-    .from('partner_lms_enrollments')
-    .select('id, user_id, course_id, program_id, status, progress, created_at, updated_at')
-    .eq('user_id', userId);
+  // Query student_enrollments table (barber apprenticeship / hybrid)
+  const { data: studentEnrollments } = await supabase
+    .from('student_enrollments')
+    .select('id, student_id, program_slug, status, progress, created_at, updated_at')
+    .eq('student_id', userId);
 
-  if (!e4 && partnerLmsEnrollments) {
-    for (const e of partnerLmsEnrollments) {
-      results.push({
-        source: 'partner_lms_enrollments',
+  if (studentEnrollments) {
+    for (const e of studentEnrollments) {
+      const { mode, inferred } = resolveDeliveryMode('student_enrollments', null);
+      
+      const enrollment: NormalizedEnrollment = {
+        source_table: 'student_enrollments',
         enrollment_id: e.id,
-        user_id: e.user_id,
-        course_id: e.course_id,
-        program_id: e.program_id,
-        pathway_slug: null,
+        user_key: e.student_id,
+        program_id: null,
+        program_slug: e.program_slug,
+        program_title: e.program_slug ? formatProgramSlug(e.program_slug) : null,
+        course_id: null,
+        course_title: null,
+        provider_id: null,
+        provider_name: null,
         status: e.status || 'active',
         progress: e.progress || 0,
+        delivery_mode: mode,
+        inferred_delivery_mode: inferred,
+        continue_url: '',
         created_at: e.created_at,
         updated_at: e.updated_at,
-      });
+      };
+      enrollment.continue_url = getContinueLearningUrl(mode, enrollment);
+      results.push(enrollment);
     }
   }
 
@@ -139,24 +166,13 @@ export async function getUserEnrollments(userId: string): Promise<EnrollmentQuer
 }
 
 /**
- * Build LMS handoff URL with proper context
- * Used by dashboards to create "Continue Learning" links
+ * Format program slug to title case
  */
-export function buildLmsHandoffUrl(
-  enrollment: NormalizedEnrollment,
-  returnUrl: string = '/student-portal'
-): string {
-  const params = new URLSearchParams();
-  params.set('enrollmentId', enrollment.enrollment_id);
-  params.set('return', returnUrl);
-
-  // If we have a course_id, link directly to the course
-  if (enrollment.course_id) {
-    return `/lms/courses/${enrollment.course_id}?${params.toString()}`;
-  }
-
-  // Otherwise, link to LMS dashboard with enrollment context
-  return `/lms/dashboard?${params.toString()}`;
+function formatProgramSlug(slug: string): string {
+  return slug
+    .split('-')
+    .map(word => word.charAt(0).toUpperCase() + word.slice(1))
+    .join(' ');
 }
 
 /**

--- a/supabase/migrations/20260114_add_delivery_mode.sql
+++ b/supabase/migrations/20260114_add_delivery_mode.sql
@@ -1,0 +1,19 @@
+-- Add delivery_mode to programs table
+-- Allowed values: 'internal' | 'partner' | 'hybrid'
+-- Nullable - code will infer from enrollment source if not set
+
+ALTER TABLE programs 
+  ADD COLUMN IF NOT EXISTS delivery_mode TEXT;
+
+-- Add check constraint for valid values
+ALTER TABLE programs 
+  DROP CONSTRAINT IF EXISTS programs_delivery_mode_check;
+
+ALTER TABLE programs 
+  ADD CONSTRAINT programs_delivery_mode_check 
+  CHECK (delivery_mode IS NULL OR delivery_mode IN ('internal', 'partner', 'hybrid'));
+
+-- Index for filtering
+CREATE INDEX IF NOT EXISTS idx_programs_delivery_mode ON programs(delivery_mode);
+
+COMMENT ON COLUMN programs.delivery_mode IS 'Learning delivery mode: internal (Elevate LMS), partner (external provider), hybrid (mixed)';


### PR DESCRIPTION
## Summary

Makes the platform license-ready by explicitly supporting three delivery modes (internal, partner, hybrid) without merging tables or creating new flows.

## Migration SQL

```sql
ALTER TABLE programs 
  ADD COLUMN IF NOT EXISTS delivery_mode TEXT;

ALTER TABLE programs 
  ADD CONSTRAINT programs_delivery_mode_check 
  CHECK (delivery_mode IS NULL OR delivery_mode IN ('internal', 'partner', 'hybrid'));

CREATE INDEX IF NOT EXISTS idx_programs_delivery_mode ON programs(delivery_mode);
```

## Files Changed

| File | Change |
|------|--------|
| `supabase/migrations/20260114_add_delivery_mode.sql` | New - adds delivery_mode column |
| `lib/delivery/resolveDeliveryMode.ts` | New - determines delivery mode |
| `lib/enrollments/getUserEnrollments.ts` | Updated - unified resolver with delivery_mode |
| `app/api/enrollments/me/route.ts` | New - API for fetching user enrollments |
| `app/student-portal/EnrollmentDashboard.tsx` | New - enrollment display component |
| `app/student-portal/page.tsx` | Updated - includes enrollment dashboard |
| `app/partner-learning/[enrollmentId]/page.tsx` | New - partner enrollment landing page |
| `app/admin/dashboard/page.tsx` | Updated - shows partner/hybrid counts |
| `app/lms/(app)/dashboard/page.tsx` | Fixed - shows both enrollment types |

## Routing Behavior

| Delivery Mode | Continue URL |
|---------------|--------------|
| `internal` | `/lms/dashboard` or `/lms/courses/[id]` |
| `partner` | `/partner-learning/[enrollmentId]` |
| `hybrid` | `/lms/dashboard` |

## Acceptance Tests

- [x] Build passes
- [ ] `/student-portal` loads for logged-out users (marketing)
- [ ] `/student-portal` shows enrollments for logged-in users
- [ ] `/partner-learning/[id]` loads without 404
- [ ] `/admin/dashboard` shows partner enrollment counts
- [ ] `/lms/dashboard` shows both partner and internal enrollments