### PR TITLE
Phase B: Auth guards on top-risk admin and payment routes

### DIFF
--- a/app/api/admin/promo-codes/route.ts
+++ b/app/api/admin/promo-codes/route.ts
@@ -1,11 +1,15 @@
 import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { apiRequireAdmin } from '@/lib/authGuards';
 
 export const dynamic = 'force-dynamic';
 
 // GET - Fetch all promo codes
 export async function GET() {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     const supabase = createAdminClient();
 
     const { data: promoCodes, error } = await supabase
@@ -26,6 +30,9 @@ export async function GET() {
 // POST - Create new promo code
 export async function POST(req: Request) {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     const body = await req.json();
     const supabase = createAdminClient();
 
@@ -61,6 +68,9 @@ export async function POST(req: Request) {
 // PUT - Update promo code
 export async function PUT(req: Request) {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     const body = await req.json();
     const supabase = createAdminClient();
 
@@ -98,6 +108,9 @@ export async function PUT(req: Request) {
 // DELETE - Delete promo code
 export async function DELETE(req: Request) {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     const { searchParams } = new URL(req.url);
     const id = searchParams.get('id');
 

--- a/app/api/payments/split/route.ts
+++ b/app/api/payments/split/route.ts
@@ -6,6 +6,7 @@ export const maxDuration = 60;
 import { parseBody, getErrorMessage } from '@/lib/api-helpers';
 import { createClient } from '@/lib/supabase/server';
 import { logger } from '@/lib/logger';
+import { apiAuthGuard } from '@/lib/authGuards';
 
 // Program-specific vendor costs
 const VENDOR_COSTS = {
@@ -21,6 +22,11 @@ const VENDOR_COSTS = {
 };
 
 export async function POST(request: NextRequest) {
+  const authResult = await apiAuthGuard({ requireAuth: true });
+  if (!authResult.authorized) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
   const supabase = await createClient();
 
   try {

--- a/app/api/store/create-payment-intent/route.ts
+++ b/app/api/store/create-payment-intent/route.ts
@@ -5,9 +5,15 @@ export const maxDuration = 60;
 import { parseBody, getErrorMessage } from '@/lib/api-helpers';
 import { stripe } from '@/lib/stripe/client';
 import { toError, toErrorMessage } from '@/lib/safe';
+import { apiAuthGuard } from '@/lib/authGuards';
 
 export async function POST(request: NextRequest) {
   try {
+    const authResult = await apiAuthGuard({ requireAuth: true });
+    if (!authResult.authorized) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     if (!stripe) {
       return NextResponse.json(
         { error: 'Payment processing is not configured' },

--- a/app/api/store/create-product/route.ts
+++ b/app/api/store/create-product/route.ts
@@ -9,9 +9,13 @@ import { logger } from '@/lib/logger';
 import { toErrorMessage } from '@/lib/safe';
 import { requireActiveLicense, LicenseError, licenseErrorResponse } from '@/lib/license/requireActiveLicense';
 import { TenantContextError } from '@/lib/tenant';
+import { apiRequireAdmin } from '@/lib/authGuards';
 
 export async function POST(req: NextRequest) {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     // STEP 5B: Require active license for paid features
     await requireActiveLicense();
     

--- a/app/api/store/licenses/create-payment-intent/route.ts
+++ b/app/api/store/licenses/create-payment-intent/route.ts
@@ -7,6 +7,7 @@ import { parseBody, getErrorMessage } from '@/lib/api-helpers';
 import { stripe } from '@/lib/stripe/client';
 import { createClient } from '@/lib/supabase/server';
 import { getProductBySlug } from '@/app/data/store-products';
+import { apiAuthGuard } from '@/lib/authGuards';
 
 
 interface CustomerInfo {
@@ -23,6 +24,11 @@ interface RequestBody {
 
 export async function POST(request: NextRequest) {
   try {
+    const authResult = await apiAuthGuard({ requireAuth: true });
+    if (!authResult.authorized) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
     const body = await parseBody<RequestBody>(request);
     const { productId, customerInfo } = body;
 

--- a/app/api/stripe/connect/create/route.ts
+++ b/app/api/stripe/connect/create/route.ts
@@ -5,9 +5,13 @@ export const maxDuration = 60;
 
 import { NextResponse } from 'next/server';
 import { createAdminClient } from '@/lib/supabase/admin';
+import { apiRequireAdmin } from '@/lib/authGuards';
 
 export async function POST(req: Request) {
   try {
+    const adminCheck = await apiRequireAdmin();
+    if (adminCheck instanceof NextResponse) return adminCheck;
+
     const body = await req.json();
     const { employer_id } = body;
 

--- a/tests/unit/top-risk-auth-guards.test.ts
+++ b/tests/unit/top-risk-auth-guards.test.ts
@@ -1,0 +1,57 @@
+/**
+ * Verify that the top-risk API routes from the security audit
+ * have auth guards in their source code.
+ *
+ * This is a static analysis test — it reads the source files and
+ * confirms the auth import and guard call are present. It does NOT
+ * make HTTP requests (that requires a running server + Supabase).
+ */
+import { describe, it, expect } from 'vitest';
+import fs from 'fs';
+import path from 'path';
+
+function readRoute(routePath: string): string {
+  const fullPath = path.resolve(routePath);
+  return fs.readFileSync(fullPath, 'utf8');
+}
+
+describe('Top-risk routes have auth guards', () => {
+  it('/api/admin/promo-codes requires apiRequireAdmin', () => {
+    const src = readRoute('app/api/admin/promo-codes/route.ts');
+    expect(src).toContain("import { apiRequireAdmin } from '@/lib/authGuards'");
+    expect(src).toContain('await apiRequireAdmin()');
+    // All 4 handlers should be guarded
+    const guardCount = (src.match(/await apiRequireAdmin\(\)/g) || []).length;
+    expect(guardCount).toBeGreaterThanOrEqual(4);
+  });
+
+  it('/api/payments/split requires apiAuthGuard', () => {
+    const src = readRoute('app/api/payments/split/route.ts');
+    expect(src).toContain("import { apiAuthGuard } from '@/lib/authGuards'");
+    expect(src).toContain('await apiAuthGuard(');
+  });
+
+  it('/api/store/create-payment-intent requires apiAuthGuard', () => {
+    const src = readRoute('app/api/store/create-payment-intent/route.ts');
+    expect(src).toContain("import { apiAuthGuard } from '@/lib/authGuards'");
+    expect(src).toContain('await apiAuthGuard(');
+  });
+
+  it('/api/stripe/connect/create requires apiRequireAdmin', () => {
+    const src = readRoute('app/api/stripe/connect/create/route.ts');
+    expect(src).toContain("import { apiRequireAdmin } from '@/lib/authGuards'");
+    expect(src).toContain('await apiRequireAdmin()');
+  });
+
+  it('/api/store/licenses/create-payment-intent requires apiAuthGuard', () => {
+    const src = readRoute('app/api/store/licenses/create-payment-intent/route.ts');
+    expect(src).toContain("import { apiAuthGuard } from '@/lib/authGuards'");
+    expect(src).toContain('await apiAuthGuard(');
+  });
+
+  it('/api/store/create-product requires apiRequireAdmin', () => {
+    const src = readRoute('app/api/store/create-product/route.ts');
+    expect(src).toContain("import { apiRequireAdmin } from '@/lib/authGuards'");
+    expect(src).toContain('await apiRequireAdmin()');
+  });
+});


### PR DESCRIPTION
## Phase B — Auth hardening on the 6 highest-risk unauthenticated routes

**7 files changed.** Merge after Phase A.

---

### Routes fixed

| Route | Method | Guard | Risk |
|-------|--------|-------|------|
| `/api/admin/promo-codes` | GET/POST/PUT/DELETE | `apiRequireAdmin()` | Full CRUD on promo codes using service role key |
| `/api/stripe/connect/create` | POST | `apiRequireAdmin()` | Creates Stripe Connect accounts |
| `/api/store/create-product` | POST | `apiRequireAdmin()` | Creates Stripe products |
| `/api/payments/split` | POST | `apiAuthGuard()` | Triggers vendor payment splits |
| `/api/store/create-payment-intent` | POST | `apiAuthGuard()` | Creates Stripe payment intents (card testing vector) |
| `/api/store/licenses/create-payment-intent` | POST | `apiAuthGuard()` | Creates license payment intents |

### Verification

Each route was verified to have zero auth on `main`:
```bash
grep -c "auth\|getUser\|getSession" app/api/admin/promo-codes/route.ts        # 0
grep -c "auth\|getUser\|getSession" app/api/payments/split/route.ts            # 0
grep -c "auth\|getUser\|getSession" app/api/store/create-payment-intent/route.ts # 0
grep -c "auth\|getUser\|getSession" app/api/stripe/connect/create/route.ts     # 0
```

### Tests

Static analysis test (`tests/unit/top-risk-auth-guards.test.ts`) verifies each file contains the auth import and guard call. 532 tests pass, zero regressions.

### What this PR does NOT touch

- No changes to auth modules themselves
- No CSP/config changes
- No broad route sweep