### PR TITLE
Fix broken redirects, missing CTA pages, dead form actions, and wrong DB queries

### DIFF
--- a/app/admin/funding/allocations/page.tsx
+++ b/app/admin/funding/allocations/page.tsx
@@ -9,5 +9,5 @@ export default async function FundingAllocationsPage() {
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login');
   
-  redirect('/admin/financial-aid');
+  redirect('/admin/funding');
 }

--- a/app/admin/mou/page.tsx
+++ b/app/admin/mou/page.tsx
@@ -18,7 +18,7 @@ export default async function MOUPage() {
   const { data: profile } = await supabase.from('profiles').select('*').eq('id', user.id).single();
   if (profile?.role !== 'admin' && profile?.role !== 'super_admin') redirect('/unauthorized');
 
-  const { data: mous, count } = await supabase.from('mous').select('*', { count: 'exact' }).order('created_at', { ascending: false }).limit(20);
+  const { data: mous, count } = await supabase.from('partner_mous').select('*, partners:partner_id(name)', { count: 'exact' }).order('created_at', { ascending: false }).limit(20);
 
   return (
     <div className="min-h-screen bg-gray-50">
@@ -39,7 +39,7 @@ export default async function MOUPage() {
           <div className="divide-y">
             {mous && mous.length > 0 ? mous.map((mou: any) => (
               <div key={mou.id} className="p-4 flex items-center justify-between hover:bg-gray-50">
-                <div><p className="font-medium">{mou.partner_name || 'Partner'}</p><p className="text-sm text-gray-500">{mou.type} • Expires: {mou.expiry_date ? new Date(mou.expiry_date).toLocaleDateString() : 'N/A'}</p></div>
+                <div><p className="font-medium">{mou.partners?.name || 'Partner'}</p><p className="text-sm text-gray-500">{mou.mou_version || 'Standard'} • Expires: {mou.expiry_date ? new Date(mou.expiry_date).toLocaleDateString() : 'N/A'}</p></div>
                 <span className={`px-2 py-1 rounded-full text-xs ${mou.status === 'active' ? 'bg-brand-green-100 text-brand-green-800' : 'bg-yellow-100 text-yellow-800'}`}>{mou.status || 'pending'}</span>
               </div>
             )) : <div className="p-8 text-center text-gray-500">No MOUs found</div>}

--- a/app/api/account/notifications/route.ts
+++ b/app/api/account/notifications/route.ts
@@ -1,0 +1,34 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const supabase = await createClient();
+    const { data: { user } } = await supabase.auth.getUser();
+
+    if (!user) {
+      return NextResponse.redirect(new URL('/login', request.url));
+    }
+
+    const formData = await request.formData();
+    const preferences: Record<string, boolean> = {};
+
+    for (const [key, value] of formData.entries()) {
+      if (key.startsWith('notify_')) {
+        preferences[key] = value === 'on' || value === 'true';
+      }
+    }
+
+    await supabase
+      .from('notification_preferences')
+      .upsert({
+        user_id: user.id,
+        preferences,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'user_id' });
+
+    return NextResponse.redirect(new URL('/account/settings/notifications?success=saved', request.url));
+  } catch {
+    return NextResponse.redirect(new URL('/account/settings/notifications?error=server-error', request.url));
+  }
+}

--- a/app/api/community/inquiry/route.ts
+++ b/app/api/community/inquiry/route.ts
@@ -1,0 +1,27 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const name = formData.get('name') as string;
+    const email = formData.get('email') as string;
+    const message = formData.get('message') as string;
+
+    if (!name || !email) {
+      return NextResponse.redirect(new URL('/community?error=missing-fields', request.url));
+    }
+
+    const supabase = await createClient();
+    await supabase.from('inquiries').insert({
+      name,
+      email,
+      message: message || '',
+      source: 'community-page',
+    });
+
+    return NextResponse.redirect(new URL('/community?success=sent', request.url));
+  } catch {
+    return NextResponse.redirect(new URL('/community?error=server-error', request.url));
+  }
+}

--- a/app/api/community/join/route.ts
+++ b/app/api/community/join/route.ts
@@ -1,0 +1,26 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+
+export async function POST(request: NextRequest) {
+  try {
+    const formData = await request.formData();
+    const name = formData.get('name') as string;
+    const email = formData.get('email') as string;
+    const status = formData.get('status') as string;
+
+    if (!name || !email) {
+      return NextResponse.redirect(new URL('/community?error=missing-fields', request.url));
+    }
+
+    const supabase = await createClient();
+    await supabase.from('community_members').insert({
+      full_name: name,
+      email,
+      status: status || 'prospective',
+    });
+
+    return NextResponse.redirect(new URL('/community?success=joined', request.url));
+  } catch {
+    return NextResponse.redirect(new URL('/community?error=server-error', request.url));
+  }
+}

--- a/app/apply/full/page.tsx
+++ b/app/apply/full/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function ApplyFullRedirect() {
+  redirect('/apply/student');
+}

--- a/app/cm/page.tsx
+++ b/app/cm/page.tsx
@@ -11,5 +11,5 @@ export const metadata: Metadata = {
 };
 
 export default function CmPage() {
-  redirect('/admin/case-management');
+  redirect('/admin/reports/caseload');
 }

--- a/app/create-course/page.tsx
+++ b/app/create-course/page.tsx
@@ -11,5 +11,5 @@ export const metadata: Metadata = {
 };
 
 export default function CreateCoursePage() {
-  redirect('/instructor/courses/create');
+  redirect('/instructor/courses');
 }

--- a/app/enroll/barber-apprenticeship/page.tsx
+++ b/app/enroll/barber-apprenticeship/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function BarberEnrollRedirect() {
+  redirect('/programs/barber-apprenticeship/apply');
+}

--- a/app/enroll/page.tsx
+++ b/app/enroll/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function EnrollRedirect() {
+  redirect('/apply/student');
+}

--- a/app/error/page.tsx
+++ b/app/error/page.tsx
@@ -1,0 +1,52 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import { AlertTriangle } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: 'Error | Elevate for Humanity',
+  description: 'Something went wrong.',
+};
+
+const ERROR_MESSAGES: Record<string, string> = {
+  'service-unavailable': 'This service is temporarily unavailable. Please try again later.',
+  'unauthorized': 'You do not have permission to access this page.',
+  'not-found': 'The page you are looking for does not exist.',
+};
+
+export default async function ErrorPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ message?: string }>;
+}) {
+  const params = await searchParams;
+  const messageKey = params.message || '';
+  const displayMessage = ERROR_MESSAGES[messageKey] || 'An unexpected error occurred. Please try again.';
+
+  return (
+    <div className="min-h-screen bg-gray-50 flex items-center justify-center px-4">
+      <div className="max-w-md w-full text-center">
+        <div className="bg-white rounded-2xl shadow-sm border p-8">
+          <div className="w-16 h-16 bg-brand-red-100 rounded-full flex items-center justify-center mx-auto mb-6">
+            <AlertTriangle className="w-8 h-8 text-brand-red-600" />
+          </div>
+          <h1 className="text-2xl font-bold text-gray-900 mb-3">Something went wrong</h1>
+          <p className="text-gray-600 mb-8">{displayMessage}</p>
+          <div className="flex flex-col sm:flex-row gap-3 justify-center">
+            <Link
+              href="/"
+              className="px-6 py-3 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700 font-medium"
+            >
+              Go Home
+            </Link>
+            <Link
+              href="/support"
+              className="px-6 py-3 border border-gray-300 text-gray-700 rounded-lg hover:bg-gray-50 font-medium"
+            >
+              Contact Support
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/license/onboarding/page.tsx
+++ b/app/license/onboarding/page.tsx
@@ -46,7 +46,7 @@ export default async function LicenseeOnboardingPage() {
   // If onboarding is complete, redirect to dashboard
   const org = license?.organizations as any;
   if (org?.onboarding_completed) {
-    redirect('/license/dashboard');
+    redirect('/license');
   }
 
   const steps = [

--- a/app/mentorship/apply/page.tsx
+++ b/app/mentorship/apply/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function MentorshipApplyRedirect() {
+  redirect('/apply/student?program=mentorship');
+}

--- a/app/partner/page.tsx
+++ b/app/partner/page.tsx
@@ -14,5 +14,5 @@ export const metadata: Metadata = {
   },
 };
 export default function PartnerPage() {
-  redirect('/partner/dashboard');
+  redirect('/partner/onboarding');
 }

--- a/app/platform/student-portal/handbook/page.tsx
+++ b/app/platform/student-portal/handbook/page.tsx
@@ -1,5 +1,5 @@
 import { redirect } from 'next/navigation';
 
 export default function StudentHandbookRedirect() {
-  redirect('/student/handbook');
+  redirect('/student-handbook');
 }

--- a/app/portal/partner/enroll/host-shop/page.tsx
+++ b/app/portal/partner/enroll/host-shop/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function HostShopEnrollRedirect() {
+  redirect('/partner/apply');
+}

--- a/app/program-holder/apply/page.tsx
+++ b/app/program-holder/apply/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function ProgramHolderApplyRedirect() {
+  redirect('/apply/program-holder');
+}

--- a/app/program-holder/reports/page.tsx
+++ b/app/program-holder/reports/page.tsx
@@ -61,7 +61,7 @@ export default async function ReportsPage() {
     .single();
 
   if (!programHolder) {
-    redirect('/program-holder/apply');
+    redirect('/program-holder/onboarding');
   }
 
   // Fetch compliance reports (using apprentice_weekly_reports as template)

--- a/app/store/licenses/checkout/managed/page.tsx
+++ b/app/store/licenses/checkout/managed/page.tsx
@@ -1,2 +1,2 @@
 import { redirect } from 'next/navigation';
-export default function ManagedCheckoutRedirect() { redirect('/store/licensing/checkout/managed-platform'); }
+export default function ManagedCheckoutRedirect() { redirect('/store/licensing/managed'); }

--- a/app/student-handbook/page.tsx
+++ b/app/student-handbook/page.tsx
@@ -24,9 +24,11 @@ export default async function StudentHandbookPage() {
   const { data: handbook } = await supabase
     .from('documents')
     .select('*')
-    .eq('type', 'student-handbook')
-    .eq('is_active', true)
-    .single();
+    .eq('status', 'approved')
+    .contains('metadata', { handbook_type: 'student-handbook' })
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
 
   const { data: acknowledgment } = user ? await supabase
     .from('handbook_acknowledgments')


### PR DESCRIPTION
## Motivation

End-to-end audit found 8 redirects pointing to nonexistent pages, 6 CTA buttons linking to missing destinations, 3 form actions submitting to missing API routes, and 2 database queries using wrong table/column names. All of these cause 404s or runtime errors for users.

## Changes

### Redirect fixes (8 files)
| Old target | New target | Source file |
|---|---|---|
| `/admin/case-management` | `/admin/reports/caseload` | `app/cm/page.tsx` |
| `/admin/financial-aid` | `/admin/funding` | `app/admin/funding/allocations/page.tsx` |
| `/instructor/courses/create` | `/instructor/courses` | `app/create-course/page.tsx` |
| `/license/dashboard` | `/license` | `app/license/onboarding/page.tsx` |
| `/partner/dashboard` | `/partner/onboarding` | `app/partner/page.tsx` |
| `/program-holder/apply` | `/program-holder/onboarding` | `app/program-holder/reports/page.tsx` |
| `/student/handbook` | `/student-handbook` | `app/platform/student-portal/handbook/page.tsx` |
| `/store/licensing/checkout/managed-platform` | `/store/licensing/managed` | `app/store/licenses/checkout/managed/page.tsx` |

### New pages (10 files)
- `/error` — error page for 12 files that redirect to `/error?message=...`
- `/apply/full` → redirects to `/apply/student`
- `/enroll` → redirects to `/apply/student`
- `/enroll/barber-apprenticeship` → redirects to `/programs/barber-apprenticeship/apply`
- `/mentorship/apply` → redirects to `/apply/student?program=mentorship`
- `/program-holder/apply` → redirects to `/apply/program-holder`
- `/portal/partner/enroll/host-shop` → redirects to `/partner/apply`

### API route handlers (3 files)
- `POST /api/community/join` — community join form
- `POST /api/community/inquiry` — community inquiry form
- `POST /api/account/notifications` — notification preferences

### Database query fixes (2 files)
- `/admin/mou` — changed `from('mous')` to `from('partner_mous')` with correct join/columns
- `/student-handbook` — changed `.eq('type', ...)` to `.eq('status', 'approved').contains('metadata', ...)`

## Build
947 pages, zero errors.