### PR TITLE
fix: add inbound links to orphaned public pages

### DIFF
--- a/app/about/page.tsx
+++ b/app/about/page.tsx
@@ -93,6 +93,11 @@ export default function AboutPage() {
             facing barriers to employment with high-quality, funded career training, individualized
             employment support, and direct employer placement.
           </p>
+          <div className="mt-6">
+            <Link href="/about/mission" className="inline-flex items-center text-white/80 hover:text-white text-sm font-semibold underline underline-offset-4">
+              Full mission statement &amp; values <ArrowRight className="ml-1 w-4 h-4" />
+            </Link>
+          </div>
         </div>
       </section>
 
@@ -505,10 +510,10 @@ export default function AboutPage() {
       <section className="py-12 bg-white">
         <div className="max-w-4xl mx-auto px-4">
           <h2 className="text-2xl font-bold text-slate-900 text-center mb-6">For Organizations &amp; Partners</h2>
-          <div className="grid sm:grid-cols-2 gap-6">
+          <div className="grid sm:grid-cols-3 gap-6">
             <Link href="/pathways/partners" className="bg-slate-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-md transition">
               <div className="relative h-40 overflow-hidden">
-                <Image src="/images/pages/about-partner-cta.jpg" alt="Partner with Elevate" fill sizes="50vw" quality={90} className="object-cover" />
+                <Image src="/images/pages/about-partner-cta.jpg" alt="Partner with Elevate" fill sizes="(max-width: 640px) 100vw, 33vw" quality={90} className="object-cover" />
               </div>
               <div className="p-5">
                 <h3 className="font-bold text-slate-900 mb-2">Partner With Us</h3>
@@ -518,9 +523,21 @@ export default function AboutPage() {
                 </span>
               </div>
             </Link>
+            <Link href="/about/partners" className="bg-slate-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-md transition">
+              <div className="relative h-40 overflow-hidden">
+                <Image src="/images/pages/about-employer-partners.jpg" alt="Employer and community partners" fill sizes="(max-width: 640px) 100vw, 33vw" quality={90} className="object-cover" />
+              </div>
+              <div className="p-5">
+                <h3 className="font-bold text-slate-900 mb-2">Our Partners</h3>
+                <p className="text-sm text-gray-600 mb-2">Employers, workforce boards, and community organizations we work with across Central Indiana.</p>
+                <span className="text-brand-red-600 text-sm font-semibold inline-flex items-center">
+                  View Partners <ArrowRight className="ml-1 w-4 h-4" />
+                </span>
+              </div>
+            </Link>
             <Link href="/pathways" className="bg-slate-50 rounded-xl overflow-hidden border border-gray-200 hover:shadow-md transition">
               <div className="relative h-40 overflow-hidden">
-                <Image src="/images/pages/about-career-pathways.jpg" alt="Career pathways" fill sizes="50vw" quality={90} className="object-cover" />
+                <Image src="/images/pages/about-career-pathways.jpg" alt="Career pathways" fill sizes="(max-width: 640px) 100vw, 33vw" quality={90} className="object-cover" />
               </div>
               <div className="p-5">
                 <h3 className="font-bold text-slate-900 mb-2">Career Pathways Framework</h3>

--- a/app/how-it-works/page.tsx
+++ b/app/how-it-works/page.tsx
@@ -123,6 +123,9 @@ export default function HowItWorksPage() {
             <Link href="/apply" className="border-2 border-white text-white font-bold px-6 py-3 rounded-lg text-base hover:bg-white/10 transition-colors text-center">
               Apply for Training
             </Link>
+            <Link href="/booking/enrollment" className="border-2 border-white/60 text-white/90 font-bold px-6 py-3 rounded-lg text-base hover:bg-white/10 transition-colors text-center">
+              Book Enrollment Session
+            </Link>
           </div>
         </div>
       </section>

--- a/app/license/page.tsx
+++ b/app/license/page.tsx
@@ -123,6 +123,26 @@ export default async function LicensePage() {
         </div>
       </section>
 
+      {/* Quick nav */}
+      <section className="py-3 bg-slate-800 border-b border-slate-700">
+        <div className="max-w-5xl mx-auto px-4">
+          <div className="flex flex-wrap gap-3 justify-center">
+            <Link href="/license/features" className="px-4 py-1.5 bg-slate-700 text-slate-200 rounded-full text-sm font-medium hover:bg-slate-600 transition-colors">
+              Full Feature List
+            </Link>
+            <Link href="/license/integrations" className="px-4 py-1.5 bg-slate-700 text-slate-200 rounded-full text-sm font-medium hover:bg-slate-600 transition-colors">
+              Integrations
+            </Link>
+            <Link href="/license/pricing" className="px-4 py-1.5 bg-slate-700 text-slate-200 rounded-full text-sm font-medium hover:bg-slate-600 transition-colors">
+              Pricing
+            </Link>
+            <Link href="/license/onboarding" className="px-4 py-1.5 bg-brand-orange-600 text-white rounded-full text-sm font-medium hover:bg-brand-orange-700 transition-colors">
+              Start Onboarding
+            </Link>
+          </div>
+        </div>
+      </section>
+
       {/* Features */}
       <section className="py-16 bg-white">
         <div className="max-w-7xl mx-auto px-4">

--- a/app/programs/page.tsx
+++ b/app/programs/page.tsx
@@ -109,6 +109,12 @@ export default function ProgramCatalogPage() {
               Apply Now
             </Link>
             <Link
+              href="/for/students"
+              className="bg-slate-700 text-white px-8 py-3 rounded-lg font-semibold text-sm hover:bg-slate-600 transition-colors"
+            >
+              Student Overview
+            </Link>
+            <Link
               href="/contact"
               className="border border-slate-500 text-white px-8 py-3 rounded-lg font-semibold text-sm hover:border-white transition-colors"
             >

--- a/app/tax/page.tsx
+++ b/app/tax/page.tsx
@@ -58,17 +58,17 @@ export default function TaxServicesPage() {
       <section className="py-4 bg-gray-100 border-b">
         <div className="max-w-6xl mx-auto px-4">
           <div className="flex flex-wrap gap-3 justify-center">
-            <Link href="/tax" className="px-4 py-2 bg-brand-green-100 text-brand-green-800 rounded-full text-sm font-medium hover:bg-brand-green-200 transition-colors">
+            <Link href="/tax/free" className="px-4 py-2 bg-brand-green-100 text-brand-green-800 rounded-full text-sm font-medium hover:bg-brand-green-200 transition-colors">
               VITA Free Tax Prep
             </Link>
-            <Link href="/supersonic-fast-cash" className="px-4 py-2 bg-brand-red-100 text-brand-red-800 rounded-full text-sm font-medium hover:bg-brand-red-200 transition-colors">
+            <Link href="/tax/professional" className="px-4 py-2 bg-brand-red-100 text-brand-red-800 rounded-full text-sm font-medium hover:bg-brand-red-200 transition-colors">
+              Professional Services
+            </Link>
+            <Link href="/tax/supersonicfastcash/services" className="px-4 py-2 bg-brand-red-100 text-brand-red-800 rounded-full text-sm font-medium hover:bg-brand-red-200 transition-colors">
               Supersonic Fast Cash
             </Link>
-            <Link href="/tax" className="px-4 py-2 bg-brand-blue-100 text-brand-blue-800 rounded-full text-sm font-medium hover:bg-brand-blue-200 transition-colors">
-              Locations
-            </Link>
-            <Link href="/tax" className="px-4 py-2 bg-brand-blue-100 text-brand-blue-800 rounded-full text-sm font-medium hover:bg-brand-blue-200 transition-colors">
-              What to Bring
+            <Link href="/tax/book-appointment" className="px-4 py-2 bg-brand-blue-100 text-brand-blue-800 rounded-full text-sm font-medium hover:bg-brand-blue-200 transition-colors">
+              Book Appointment
             </Link>
             <Link href="/tax/volunteer" className="px-4 py-2 bg-brand-orange-100 text-brand-orange-800 rounded-full text-sm font-medium hover:bg-brand-orange-200 transition-colors">
               Volunteer
@@ -141,7 +141,7 @@ export default function TaxServicesPage() {
                 </ul>
 
                 <Link
-                  href="/tax"
+                  href="/tax/free"
                   className="block w-full text-center px-6 py-4 bg-brand-green-600 hover:bg-brand-green-700 text-white rounded-xl font-bold transition-colors"
                 >
                   Get Free Tax Help
@@ -201,7 +201,7 @@ export default function TaxServicesPage() {
                 </ul>
 
                 <Link
-                  href="/supersonic-fast-cash"
+                  href="/tax/professional"
                   className="block w-full text-center px-6 py-4 bg-brand-red-600 hover:bg-brand-red-700 text-white rounded-xl font-bold transition-colors"
                 >
                   Get Started Now

--- a/app/training/certifications/page.tsx
+++ b/app/training/certifications/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import { Clock, DollarSign, MapPin } from 'lucide-react';
+import { ArrowRight, Clock, DollarSign, MapPin } from 'lucide-react';
 
 export const metadata: Metadata = {
   title: 'Certification Training Programs | Elevate for Humanity',
@@ -78,6 +78,20 @@ export default function CertificationsPage() {
               </Link>
             ))}
           </div>
+        </div>
+      </section>
+
+      {/* Short-format options */}
+      <section className="py-10 bg-slate-50 border-t border-slate-200">
+        <div className="max-w-4xl mx-auto px-4 text-center">
+          <h2 className="text-xl font-bold text-slate-900 mb-2">Need Something Shorter?</h2>
+          <p className="text-sm text-slate-600 mb-4">
+            Micro-classes are 4–8 hour focused sessions covering CPR, OSHA 10, food handler safety, and more.
+            Available as standalone or add-ons to any program.
+          </p>
+          <Link href="/microclasses" className="inline-flex items-center text-brand-red-600 font-semibold text-sm hover:text-brand-red-700">
+            Browse Micro-Classes <ArrowRight className="ml-1 w-4 h-4" />
+          </Link>
         </div>
       </section>
 

--- a/components/site/ServerFooter.tsx
+++ b/components/site/ServerFooter.tsx
@@ -19,6 +19,7 @@ const footerLinks = {
     { name: 'Apprenticeships', href: '/programs/barber-apprenticeship' },
     { name: 'Certifications', href: '/training/certifications' },
     { name: 'Career Services', href: '/career-counseling' },
+    { name: 'Platform Features', href: '/features' },
   ],
   funding: [
     { name: 'How Enrollment Works', href: '/how-it-works' },
@@ -30,6 +31,7 @@ const footerLinks = {
   ],
   partners: [
     { name: 'Employer Partners', href: '/employer' },
+    { name: 'Government & Agencies', href: '/government' },
     { name: 'Workforce Boards', href: '/workforce-board' },
     { name: 'Partner Directory', href: '/directory' },
     { name: 'Become a Partner', href: '/partnerships' },
@@ -39,6 +41,7 @@ const footerLinks = {
     { name: 'Student Portal', href: '/login' },
     { name: 'Employer Portal', href: '/employer' },
     { name: 'Partner Portal', href: '/partner-portal' },
+    { name: 'Mobile App', href: '/mobile-app' },
     { name: 'Support', href: '/support' },
     { name: 'FAQ', href: '/faq' },
   ],


### PR DESCRIPTION
## What

Audited all public routes for zero inbound links. 15 real, complete pages had no way to be discovered through normal navigation. This PR adds entry points for all of them across 7 files.

## Changes

**`app/about/page.tsx`**
- Added "Full mission statement & values" link to `/about/mission` inside the mission banner
- Expanded "For Organizations & Partners" from 2 to 3 cards, adding `/about/partners`

**`app/tax/page.tsx`**
- Fixed quick-links nav — all 3 links previously pointed to `/tax` (self-referential)
- Now: VITA Free → `/tax/free`, Professional → `/tax/professional`, Supersonic Fast Cash → `/tax/supersonicfastcash/services`, Book Appointment → `/tax/book-appointment`
- Updated both service card CTAs to point to the correct sub-pages

**`app/license/page.tsx`**
- Added secondary nav strip below hero: `/license/features`, `/license/integrations`, `/license/pricing`, `/license/onboarding`

**`components/site/ServerFooter.tsx`**
- Training column: added "Platform Features" → `/features`
- Partners column: added "Government & Agencies" → `/government`
- Portals column: added "Mobile App" → `/mobile-app`

**`app/training/certifications/page.tsx`**
- Added "Need Something Shorter?" section before CTA → `/microclasses`

**`app/programs/page.tsx`**
- Added "Student Overview" button → `/for/students` in the advisor CTA

**`app/how-it-works/page.tsx`**
- Added "Book Enrollment Session" button → `/booking/enrollment`

## Not included

Pages intentionally left without public links (internal tools / auth redirects):
`/pwa`, `/creator/analytics`, `/file-manager`, `/card`, `/connect`, `/calculator/revenue-share`, `/portal/staff/dashboard`, `/learner`