### PR TITLE
Fix onboarding and course flow bugs

### DIFF
--- a/app/api/lessons/[lessonId]/complete/route.ts
+++ b/app/api/lessons/[lessonId]/complete/route.ts
@@ -48,10 +48,10 @@ async function _POST(
       return NextResponse.json({ error: 'Lesson not found' }, { status: 404 });
     }
 
-    // Check if user is enrolled in the course
+    // Check if user is enrolled and approved
     const { data: enrollment } = await db
       .from('training_enrollments')
-      .select('id, status')
+      .select('id, status, approved_at')
       .eq('user_id', user.id)
       .eq('course_id', lesson.course_id)
       .single();
@@ -59,6 +59,13 @@ async function _POST(
     if (!enrollment) {
       return NextResponse.json(
         { error: 'Not enrolled in this course' },
+        { status: 403 }
+      );
+    }
+
+    if (enrollment.status === 'pending_approval' || !enrollment.approved_at) {
+      return NextResponse.json(
+        { error: 'Enrollment pending approval' },
         { status: 403 }
       );
     }

--- a/app/lms/(app)/courses/[courseId]/enroll/page.tsx
+++ b/app/lms/(app)/courses/[courseId]/enroll/page.tsx
@@ -31,7 +31,7 @@ export async function generateMetadata({ params }: Props): Promise<Metadata> {
 
   const { data: course } = await db
     .from('training_courses')
-    .select('title')
+    .select('course_name')
     .eq('id', courseId)
     .single();
 
@@ -76,11 +76,11 @@ export default async function CourseEnrollPage({ params }: Props) {
 
   // Check if already enrolled
   const { data: existingEnrollment } = await db
-    .from('program_enrollments')
+    .from('training_enrollments')
     .select('id, status')
     .eq('user_id', user.id)
     .eq('course_id', courseId)
-    .single();
+    .maybeSingle();
 
   if (existingEnrollment) {
     redirect(`/lms/courses/${courseId}`);

--- a/app/lms/(app)/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/lms/(app)/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -51,8 +51,10 @@ export default function LessonPage() {
   const [courseCompleted, setCourseCompleted] = useState(false);
   const [certificate, setCertificate] = useState<any>(null);
   const [enrollmentBlocked, setEnrollmentBlocked] = useState(false);
+  const lessonOpenedAt = React.useRef<number>(Date.now());
 
   useEffect(() => {
+    lessonOpenedAt.current = Date.now();
     fetchLessonData();
   }, [lessonId]);
 
@@ -167,10 +169,12 @@ export default function LessonPage() {
 
     try {
       if (newStatus) {
+        // Send real elapsed time so the API minimum-seat-time check passes
+        const elapsedSeconds = Math.floor((Date.now() - lessonOpenedAt.current) / 1000);
         const response = await fetch(`/api/lessons/${lessonId}/complete`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json' },
-          body: JSON.stringify({ timeSpentSeconds: 0 }),
+          body: JSON.stringify({ timeSpentSeconds: elapsedSeconds }),
         });
 
         if (!response.ok) {

--- a/app/onboarding/learner/agreements/page.tsx
+++ b/app/onboarding/learner/agreements/page.tsx
@@ -5,7 +5,7 @@ import { useRouter } from 'next/navigation';
 import Link from 'next/link';
 import Image from 'next/image';
 import { createClient } from '@/lib/supabase/client';
-import { ArrowLeft, CheckCircle2, ArrowRight } from 'lucide-react';
+import { ArrowLeft, ArrowRight } from 'lucide-react';
 import { AgreementSignature } from '@/components/compliance/AgreementSignature';
 
 const AGREEMENT = {
@@ -125,12 +125,11 @@ export default function AgreementsPage() {
 
         {/* SIGNED */}
         {signed ? (
-          <div className="bg-brand-green-50 border-2 border-brand-green-200 rounded-2xl p-8 text-center">
-            <CheckCircle2 className="w-14 h-14 text-brand-green-500 mx-auto mb-4" />
-            <h2 className="text-2xl font-black text-brand-green-900 mb-2">Agreement Signed</h2>
-            <p className="text-brand-green-700 mb-6">Your enrollment agreement is on file.</p>
+          <div className="bg-white border border-slate-200 rounded-2xl p-8 text-center">
+            <h2 className="text-2xl font-black text-slate-900 mb-2">Agreement Signed</h2>
+            <p className="text-slate-500 mb-6">Your enrollment agreement is on file.</p>
             <div className="flex flex-col sm:flex-row gap-3 justify-center">
-              <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-6 py-3 bg-brand-green-600 text-white rounded-xl font-semibold hover:bg-brand-green-700 transition">
+              <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-6 py-3 bg-slate-900 text-white rounded-xl font-semibold hover:bg-slate-700 transition">
                 Continue Onboarding <ArrowRight className="w-4 h-4" />
               </Link>
               <Link href="/lms/courses/f0593164-55be-5867-98e7-8a86770a8dd0" className="inline-flex items-center gap-2 px-6 py-3 bg-brand-blue-600 text-white rounded-xl font-semibold hover:bg-brand-blue-700 transition">

--- a/app/onboarding/learner/documents/page.tsx
+++ b/app/onboarding/learner/documents/page.tsx
@@ -196,7 +196,7 @@ export default function DocumentsPage() {
           </div>
           <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
             <div
-              className="h-full bg-brand-green-500 rounded-full transition-all duration-500"
+              className="h-full bg-brand-blue-600 rounded-full transition-all duration-500"
               style={{ width: `${(REQUIRED_DOCUMENTS.filter(d => d.required && uploadedTypes.has(d.type)).length / REQUIRED_DOCUMENTS.filter(d => d.required).length) * 100}%` }}
             />
           </div>
@@ -256,12 +256,16 @@ export default function DocumentsPage() {
         </div>
 
         {requiredComplete && (
-          <div className="bg-brand-green-50 border border-brand-green-200 rounded-lg p-6 mb-6 text-center">
-            <CheckCircle2 className="w-12 h-12 text-brand-green-600 mx-auto mb-3" />
-            <h2 className="text-xl font-bold text-brand-green-900 mb-2">All Required Documents Uploaded</h2>
-            <p className="text-brand-green-700 mb-4">Your documents are pending review. You can continue with onboarding.</p>
-            <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-green-600 text-white rounded-lg font-medium hover:bg-brand-green-700">
-              Continue Onboarding <ArrowLeft className="w-4 h-4 rotate-180" />
+          <div className="bg-white border border-slate-200 rounded-xl p-6 mb-6 flex flex-col sm:flex-row items-center gap-5">
+            <div className="w-14 h-14 rounded-xl bg-slate-100 flex items-center justify-center flex-shrink-0">
+              <FileText className="w-7 h-7 text-slate-500" />
+            </div>
+            <div className="flex-1 text-center sm:text-left">
+              <h2 className="text-lg font-bold text-slate-900 mb-1">All Required Documents Uploaded</h2>
+              <p className="text-slate-500 text-sm">Your documents are pending review. You can continue with onboarding.</p>
+            </div>
+            <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-blue-600 text-white rounded-lg font-semibold hover:bg-brand-blue-700 flex-shrink-0">
+              Continue <ArrowLeft className="w-4 h-4 rotate-180" />
             </Link>
           </div>
         )}
@@ -280,17 +284,17 @@ export default function DocumentsPage() {
             const isUploading = uploading === doc.type;
 
             return (
-              <div key={doc.type} className={`bg-white border rounded-xl p-5 ${isUploaded ? 'border-brand-green-200' : 'border-gray-200'}`}>
+              <div key={doc.type} className={`bg-white border rounded-xl p-5 ${isUploaded ? 'border-brand-blue-200' : 'border-gray-200'}`}>
                 <div className="flex items-start gap-4">
-                  <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${isUploaded ? 'bg-brand-green-100' : 'bg-gray-100'}`}>
-                    {isUploaded ? <CheckCircle2 className="w-5 h-5 text-brand-green-600" /> : <FileText className="w-5 h-5 text-gray-400" />}
+                  <div className={`flex-shrink-0 w-10 h-10 rounded-full flex items-center justify-center ${isUploaded ? 'bg-brand-blue-100' : 'bg-gray-100'}`}>
+                    {isUploaded ? <CheckCircle2 className="w-5 h-5 text-brand-blue-600" /> : <FileText className="w-5 h-5 text-gray-400" />}
                   </div>
                   <div className="flex-1">
                     <div className="flex items-center gap-2 mb-1">
-                      <h3 className={`font-semibold ${isUploaded ? 'text-brand-green-900' : 'text-gray-900'}`}>{doc.title}</h3>
+                      <h3 className={`font-semibold ${isUploaded ? 'text-brand-blue-900' : 'text-gray-900'}`}>{doc.title}</h3>
                       {doc.required && !isUploaded && <span className="text-xs bg-brand-red-100 text-brand-red-700 px-2 py-0.5 rounded">Required</span>}
                       {!doc.required && !isUploaded && <span className="text-xs bg-gray-100 text-gray-500 px-2 py-0.5 rounded">Optional</span>}
-                      {isUploaded && <span className="text-xs bg-brand-green-100 text-brand-green-700 px-2 py-0.5 rounded font-medium">Uploaded</span>}
+                      {isUploaded && <span className="text-xs bg-slate-100 text-slate-600 px-2 py-0.5 rounded font-medium">Uploaded</span>}
                     </div>
                     <p className="text-gray-600 text-sm mb-2">{doc.description}</p>
                     <p className="text-xs text-gray-400 mb-3">Accepted: {doc.acceptedFormats}</p>
@@ -315,11 +319,7 @@ export default function DocumentsPage() {
                       <button
                         type="button"
                         onClick={() => fileInputRefs.current[doc.type]?.click()}
-                        className={`inline-flex items-center gap-2 text-sm font-medium ${
-                          isUploaded
-                            ? 'text-brand-green-600 hover:text-brand-green-800'
-                            : 'text-brand-blue-600 hover:text-brand-blue-800'
-                        }`}
+                        className="inline-flex items-center gap-2 text-sm font-medium text-brand-blue-600 hover:text-brand-blue-800"
                       >
                         <Upload className="w-4 h-4" />
                         {isUploaded ? 'Replace File' : 'Upload File'}

--- a/app/onboarding/learner/handbook/page.tsx
+++ b/app/onboarding/learner/handbook/page.tsx
@@ -259,12 +259,16 @@ export default function HandbookPage() {
         </p>
 
         {alreadyAcknowledged && (
-          <div className="bg-brand-green-50 border border-brand-green-200 rounded-lg p-6 mb-6 text-center">
-            <CheckCircle2 className="w-12 h-12 text-brand-green-600 mx-auto mb-3" />
-            <h2 className="text-xl font-bold text-brand-green-900 mb-2">Handbook Acknowledged</h2>
-            <p className="text-brand-green-700 mb-4">You have acknowledged all sections of the student handbook.</p>
-            <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-green-600 text-white rounded-lg font-medium hover:bg-brand-green-700">
-              Continue Onboarding <ArrowLeft className="w-4 h-4 rotate-180" />
+          <div className="bg-white border border-slate-200 rounded-xl p-6 mb-6 flex flex-col sm:flex-row items-center gap-5">
+            <div className="w-14 h-14 rounded-xl bg-slate-100 flex items-center justify-center flex-shrink-0">
+              <BookOpen className="w-7 h-7 text-slate-500" />
+            </div>
+            <div className="flex-1 text-center sm:text-left">
+              <h2 className="text-lg font-bold text-slate-900 mb-1">Handbook Acknowledged</h2>
+              <p className="text-slate-500 text-sm">You have acknowledged all sections of the student handbook.</p>
+            </div>
+            <Link href="/onboarding/learner" className="inline-flex items-center gap-2 px-5 py-2.5 bg-brand-blue-600 text-white rounded-lg font-semibold hover:bg-brand-blue-700 flex-shrink-0">
+              Continue <ArrowLeft className="w-4 h-4 rotate-180" />
             </Link>
           </div>
         )}
@@ -279,7 +283,7 @@ export default function HandbookPage() {
               </div>
               <div className="h-2 bg-gray-200 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-brand-green-500 rounded-full transition-all duration-500"
+                  className="h-full bg-brand-blue-600 rounded-full transition-all duration-500"
                   style={{ width: `${(acknowledged.size / HANDBOOK_SECTIONS.length) * 100}%` }}
                 />
               </div>
@@ -292,16 +296,16 @@ export default function HandbookPage() {
                 const isAcked = acknowledged.has(section.id);
 
                 return (
-                  <div key={section.id} className={`bg-white border rounded-xl overflow-hidden ${isAcked ? 'border-brand-green-200' : 'border-gray-200'}`}>
+                  <div key={section.id} className={`bg-white border rounded-xl overflow-hidden ${isAcked ? 'border-brand-blue-200' : 'border-gray-200'}`}>
                     <button
                       type="button"
                       onClick={() => toggleExpand(section.id)}
                       className="w-full p-4 flex items-center gap-3 text-left hover:bg-gray-50"
                     >
-                      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${isAcked ? 'bg-brand-green-100' : 'bg-gray-100'}`}>
-                        {isAcked ? <CheckCircle2 className="w-4 h-4 text-brand-green-600" /> : <BookOpen className="w-4 h-4 text-gray-400" />}
+                      <div className={`flex-shrink-0 w-8 h-8 rounded-full flex items-center justify-center ${isAcked ? 'bg-brand-blue-100' : 'bg-gray-100'}`}>
+                        {isAcked ? <CheckCircle2 className="w-4 h-4 text-brand-blue-600" /> : <BookOpen className="w-4 h-4 text-gray-400" />}
                       </div>
-                      <span className={`flex-1 font-semibold ${isAcked ? 'text-brand-green-900' : 'text-gray-900'}`}>
+                      <span className={`flex-1 font-semibold ${isAcked ? 'text-brand-blue-900' : 'text-gray-900'}`}>
                         {section.title}
                       </span>
                       {isExpanded ? <ChevronUp className="w-5 h-5 text-gray-400" /> : <ChevronDown className="w-5 h-5 text-gray-400" />}

--- a/app/onboarding/learner/orientation/page.tsx
+++ b/app/onboarding/learner/orientation/page.tsx
@@ -71,8 +71,21 @@ export default async function OrientationPage() {
   ];
 
   return (
-    <div className="min-h-screen bg-gray-50 p-6">
-      <div className="max-w-3xl mx-auto">
+    <div className="min-h-screen bg-gray-50">
+
+      {/* VIDEO HERO — students learning, full bleed */}
+      <div className="relative w-full" style={{ height: '55vh', minHeight: 280, maxHeight: 480 }}>
+        <video
+          src="/videos/getting-started-hero.mp4"
+          autoPlay
+          loop
+          playsInline
+          muted
+          className="w-full h-full object-cover"
+        />
+      </div>
+
+      <div className="max-w-3xl mx-auto px-4 sm:px-6 py-8">
         <Breadcrumbs items={[{ label: 'Onboarding', href: '/onboarding/learner' }, { label: 'Orientation' }]} />
         <Link href="/onboarding/learner" className="text-sm text-brand-blue-600 flex items-center gap-1 mt-4 mb-4"><ArrowLeft className="w-4 h-4" /> Back to Onboarding</Link>
         <h1 className="text-2xl font-bold text-gray-900 mb-2">Student Orientation</h1>

--- a/app/onboarding/learner/page.tsx
+++ b/app/onboarding/learner/page.tsx
@@ -266,9 +266,9 @@ export default async function LearnerOnboardingPage() {
                 <span className="text-slate-500">{completedSteps.length} of {ONBOARDING_STEPS.length} steps complete</span>
                 <span className="font-bold text-slate-700">{progress}%</span>
               </div>
-              <div className="h-3 bg-slate-100 rounded-full overflow-hidden">
+              <div className="h-2 bg-slate-100 rounded-full overflow-hidden">
                 <div
-                  className="h-full bg-brand-green-500 rounded-full transition-all duration-500"
+                  className="h-full bg-brand-blue-600 rounded-full transition-all duration-500"
                   style={{ width: `${progress}%` }}
                 />
               </div>
@@ -280,53 +280,29 @@ export default async function LearnerOnboardingPage() {
       <div className="max-w-6xl mx-auto px-4 sm:px-6 lg:px-8 py-8 sm:py-12">
         {/* Enrollment approved — student can access courses */}
         {profile?.enrollment_status === 'active' && (
-          <div className="relative overflow-hidden bg-brand-green-50 border-2 border-brand-green-200 rounded-2xl p-6 sm:p-8 mb-10">
-            <div className="absolute top-0 right-0 w-32 h-32 bg-brand-green-100 rounded-full -translate-y-1/2 translate-x-1/2 opacity-50" />
-            <div className="relative flex flex-col sm:flex-row items-center gap-6 text-center sm:text-left">
-              <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-2xl overflow-hidden flex-shrink-0">
-                <Image
-                  src="/images/pages/onboarding-page-1.jpg"
-                  alt="Enrollment approved"
-                  width={80}
-                  height={80}
-                  className="w-full h-full object-cover"
-                />
-              </div>
-              <div className="flex-1">
-                <h2 className="text-2xl font-black text-brand-green-900 mb-1">You&apos;re Approved!</h2>
-                <p className="text-brand-green-700">
-                  Your enrollment has been approved. Log in to your student portal to access your courses and begin training.
-                </p>
-              </div>
-              <Link
-                href="/lms/dashboard"
-                className="inline-flex items-center gap-2 px-6 py-3.5 bg-brand-green-600 text-white rounded-xl hover:bg-brand-green-700 font-bold transition-all hover:shadow-lg flex-shrink-0"
-              >
-                Go to Student Portal
-                <ArrowRight className="w-5 h-5" />
-              </Link>
+          <div className="bg-white border border-slate-200 rounded-2xl p-6 sm:p-8 mb-10 flex flex-col sm:flex-row items-center gap-6">
+            <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-2xl overflow-hidden flex-shrink-0">
+              <Image src="/images/pages/onboarding-page-1.jpg" alt="Enrollment approved" width={80} height={80} className="w-full h-full object-cover" />
             </div>
+            <div className="flex-1 text-center sm:text-left">
+              <h2 className="text-xl font-black text-slate-900 mb-1">Enrollment Approved</h2>
+              <p className="text-slate-500 text-sm">Your enrollment has been approved. Access your courses and begin training.</p>
+            </div>
+            <Link href="/lms/dashboard" className="inline-flex items-center gap-2 px-6 py-3 bg-brand-blue-600 text-white rounded-xl font-bold hover:bg-brand-blue-700 transition flex-shrink-0">
+              Go to Student Portal <ArrowRight className="w-4 h-4" />
+            </Link>
           </div>
         )}
 
         {/* Pending admin approval banner */}
         {(justEnrolled || profile?.enrollment_status === 'pending_approval') && profile?.enrollment_status !== 'active' && (
-          <div className="relative overflow-hidden bg-amber-50 border-2 border-amber-300 rounded-2xl p-6 sm:p-8 mb-10">
-            <div className="absolute top-0 right-0 w-32 h-32 bg-amber-100 rounded-full -translate-y-1/2 translate-x-1/2 opacity-50" />
-            <div className="relative flex flex-col sm:flex-row items-center gap-6 text-center sm:text-left">
-              <div className="w-16 h-16 sm:w-20 sm:h-20 rounded-2xl bg-amber-100 flex items-center justify-center flex-shrink-0">
-                <ClipboardCheck className="w-10 h-10 text-amber-600" />
-              </div>
-              <div className="flex-1">
-                <h2 className="text-2xl font-black text-amber-900 mb-1">Onboarding Complete — Pending Admin Approval</h2>
-                <p className="text-amber-800 mb-2">
-                  All your onboarding steps are done. An administrator will review your enrollment and documents.
-                </p>
-                <p className="text-amber-700 text-sm">
-                  You will receive an email once your enrollment is approved with instructions on when you can start class.
-                  No further action is needed from you at this time.
-                </p>
-              </div>
+          <div className="bg-white border border-slate-200 rounded-2xl p-6 sm:p-8 mb-10 flex flex-col sm:flex-row items-center gap-6">
+            <div className="w-16 h-16 rounded-2xl bg-slate-100 flex items-center justify-center flex-shrink-0">
+              <ClipboardCheck className="w-8 h-8 text-slate-500" />
+            </div>
+            <div className="flex-1 text-center sm:text-left">
+              <h2 className="text-xl font-black text-slate-900 mb-1">Pending Admin Approval</h2>
+              <p className="text-slate-500 text-sm">All steps complete. An administrator will review your enrollment and contact you with your start date.</p>
             </div>
           </div>
         )}
@@ -346,8 +322,8 @@ export default async function LearnerOnboardingPage() {
           </div>
         )}
 
-        {/* Onboarding Steps — card grid with real images */}
-        <div className="space-y-4 sm:space-y-5">
+        {/* Onboarding Steps */}
+        <div className="space-y-3">
           {ONBOARDING_STEPS.map((step, index) => {
             const isComplete = completedSteps.includes(step.id);
             const isNext = nextStep?.id === step.id;
@@ -356,86 +332,51 @@ export default async function LearnerOnboardingPage() {
             return (
               <div
                 key={step.id}
-                className={`group relative overflow-hidden rounded-2xl border-2 transition-all ${
-                  isComplete
-                    ? 'border-brand-green-200 bg-white'
-                    : isNext
-                      ? 'border-brand-blue-300 bg-white shadow-md shadow-brand-blue-100'
-                      : 'border-slate-200 bg-white hover:border-slate-300'
+                className={`group overflow-hidden rounded-2xl border transition-all bg-white ${
+                  isNext ? 'border-brand-blue-300 shadow-sm' : 'border-slate-200'
                 }`}
               >
                 <div className="flex flex-col sm:flex-row">
                   {/* Step image */}
-                  <div className="relative w-full sm:w-48 lg:w-56 h-40 sm:h-auto flex-shrink-0 overflow-hidden">
+                  <div className="relative w-full sm:w-44 h-36 sm:h-auto flex-shrink-0 overflow-hidden">
                     <Image
                       src={step.image}
                       alt={step.imageAlt}
                       fill
-                      className={`object-cover ${isComplete ? 'opacity-60' : ''}`}
+                      sizes="(max-width: 640px) 100vw, 176px"
+                      className={`object-cover ${isComplete ? 'opacity-50 grayscale' : ''}`}
                     />
-                    {/* Step number overlay */}
-                    <div className={`absolute top-3 left-3 w-8 h-8 rounded-lg flex items-center justify-center text-sm font-bold ${
-                      isComplete
-                        ? 'bg-brand-green-500 text-white'
-                        : isNext
-                          ? 'bg-brand-blue-600 text-white'
-                          : 'bg-white/90 text-slate-700 backdrop-blur-sm'
-                    }`}>
-                      {isComplete ? '✓' : index + 1}
+                    {/* Step number — plain white pill, no color */}
+                    <div className="absolute top-3 left-3 w-7 h-7 rounded-full bg-white/90 backdrop-blur-sm flex items-center justify-center text-xs font-bold text-slate-700">
+                      {index + 1}
                     </div>
                   </div>
 
                   {/* Step content */}
-                  <div className="flex-1 p-5 sm:p-6 flex flex-col justify-center">
+                  <div className="flex-1 p-5 flex flex-col justify-center">
                     <div className="flex items-start gap-3">
-                      <div className={`hidden sm:flex w-10 h-10 rounded-xl items-center justify-center flex-shrink-0 ${
-                        isComplete
-                          ? 'bg-brand-green-100'
-                          : isNext
-                            ? 'bg-brand-blue-100'
-                            : 'bg-slate-100'
-                      }`}>
-                        <Icon className={`w-5 h-5 ${
-                          isComplete
-                            ? 'text-brand-green-600'
-                            : isNext
-                              ? 'text-brand-blue-600'
-                              : 'text-slate-500'
-                        }`} />
+                      <div className="hidden sm:flex w-9 h-9 rounded-xl bg-slate-100 items-center justify-center flex-shrink-0">
+                        <Icon className="w-4 h-4 text-slate-500" />
                       </div>
-
                       <div className="flex-1">
                         <div className="flex items-center gap-2 mb-1">
-                          <h3 className={`font-bold text-base sm:text-lg ${
-                            isComplete ? 'text-brand-green-900' : 'text-slate-900'
-                          }`}>
-                            {step.title}
-                          </h3>
-                          {step.required && !isComplete && (
-                            <span className="text-[10px] font-bold uppercase tracking-wider bg-brand-orange-100 text-brand-orange-700 px-2 py-0.5 rounded-full">
-                              Required
-                            </span>
-                          )}
+                          <h3 className="font-bold text-slate-900">{step.title}</h3>
                           {isComplete && (
-                            <span className="text-[10px] font-bold uppercase tracking-wider bg-brand-green-100 text-brand-green-700 px-2 py-0.5 rounded-full">
-                              Done
-                            </span>
+                            <span className="text-[10px] font-semibold uppercase tracking-wider bg-slate-100 text-slate-500 px-2 py-0.5 rounded-full">Done</span>
                           )}
                         </div>
-                        <p className="text-slate-600 text-sm leading-relaxed mb-3">{step.description}</p>
+                        <p className="text-slate-500 text-sm leading-relaxed mb-3">{step.description}</p>
 
-                        {isComplete ? (
-                          <span className="text-sm text-brand-green-600 font-semibold">Step completed</span>
-                        ) : (
+                        {!isComplete && (
                           <Link
                             href={step.href}
-                            className={`inline-flex items-center gap-2 text-sm font-bold transition-colors ${
+                            className={`inline-flex items-center gap-2 text-sm font-semibold transition-colors ${
                               isNext
-                                ? 'bg-brand-blue-600 text-white px-5 py-2.5 rounded-lg hover:bg-brand-blue-700'
+                                ? 'bg-brand-blue-600 text-white px-4 py-2 rounded-lg hover:bg-brand-blue-700'
                                 : 'text-brand-blue-600 hover:text-brand-blue-800'
                             }`}
                           >
-                            {isNext ? 'Start This Step' : 'Complete This Step'}
+                            {isNext ? 'Start' : 'Complete'}
                             <ArrowRight className="w-4 h-4" />
                           </Link>
                         )}


### PR DESCRIPTION
## What

Audit of the full onboarding and course flows found 7 bugs. All fixed across two commits.

## Fixes — commit 1

### Course flow

**Lesson completion permanently broken** (`app/lms/(app)/courses/[courseId]/lessons/[lessonId]/page.tsx`)
`markComplete()` hardcoded `timeSpentSeconds: 0`. The API enforces minimum seat time (120s for video, 90s for reading) and rejected every completion with 403. Now tracks real elapsed time via `lessonOpenedAt` ref, reset on each lesson navigation.

**No server-side approval gate on lesson completion** (`app/api/lessons/[lessonId]/complete/route.ts`)
The API only checked enrollment existence, not approval status. A `pending_approval` enrollment could write `lesson_progress` rows even though the client blocked it. Now checks `approved_at` before allowing completion.

**Enroll page checked wrong table** (`app/lms/(app)/courses/[courseId]/enroll/page.tsx`)
Duplicate-enrollment guard queried `program_enrollments` but enrollments live in `training_enrollments` — redirect-if-enrolled never fired. Also fixed `title` vs `course_name` column mismatch in metadata query.

### Onboarding flow

**Handbook and documents success states still green**
All `bg-brand-green-*` banners, progress bars, section indicators, upload badges, and buttons replaced with white/slate/brand-blue to match the onboarding hub.

**Orientation page missing video hero**
Every other onboarding step has a full-bleed video hero. Orientation had none. Added `getting-started-hero.mp4`.

## Fixes — commit 2

**Course completion page blank course name** (`app/lms/(app)/courses/[courseId]/complete/page.tsx`)
Page selected `title` from `training_courses` but rendered `course.course_name`. The column is `course_name` — completion page showed a blank name. Fixed the select.

**Direct enroll bypassed admin approval** (`lib/enrollment/complete-enrollment.ts`, `app/api/enroll/route.ts`)
`completeEnrollment()` always inserted `status: 'active'`, so students hitting `/lms/courses/.../enroll` directly got instant course access without admin review. Added `requireApproval` flag to `EnrollmentData`; `/api/enroll` now passes `requireApproval: true`, creating `pending_approval` instead. Payment flows and admin callers are unaffected — they don't pass the flag.

## Notes

`lms_progress` vs `lesson_progress` split is intentional and correct: `lesson_progress` tracks per-lesson completion, `lms_progress` holds the final course completion record written after all gates pass. No change needed.