### PR TITLE
fix: bugs found in recent commits

### DIFF
--- a/app/api/lms/enrollment-status/route.ts
+++ b/app/api/lms/enrollment-status/route.ts
@@ -16,10 +16,6 @@ export async function GET(req: NextRequest) {
   }
 
   const supabase = await createClient();
-  if (!supabase) {
-    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-  }
-
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) {
     return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });

--- a/app/api/onboarding/complete/route.ts
+++ b/app/api/onboarding/complete/route.ts
@@ -107,6 +107,11 @@ async function _POST(request: NextRequest) {
         .maybeSingle(),
     ]);
 
+    if (profileResult.error) {
+      logger.error('[onboarding/complete] Failed to fetch profile', { userId, error: profileResult.error.message });
+      return NextResponse.json({ error: 'Failed to load user profile' }, { status: 500 });
+    }
+
     const profile = profileResult.data;
     const application = appResult.data;
     const enrollment = enrollmentResult.data;
@@ -127,7 +132,7 @@ async function _POST(request: NextRequest) {
     }).eq('id', userId);
 
     // Run approval pipeline if application not yet approved
-    let programId = enrollment?.program_id || application?.program_id || null;
+    const programId = enrollment?.program_id || application?.program_id || null;
     if (application?.id && application.status !== 'approved') {
       const approvalResult = await approveApplication(db, {
         applicationId: application.id,

--- a/app/api/program-holder/setup/route.ts
+++ b/app/api/program-holder/setup/route.ts
@@ -47,9 +47,17 @@ async function _POST(req: NextRequest) {
     );
   }
 
+  // Reject banking submissions in production until column-level encryption is
+  // implemented. Storing account/routing numbers in plaintext JSONB is unsafe.
+  if (accountNumber && process.env.NODE_ENV === 'production') {
+    return NextResponse.json(
+      { error: 'Banking information cannot be submitted yet. Please contact support.' },
+      { status: 422 }
+    );
+  }
+
   // Upsert into program_holders using user_id as the conflict key.
-  // Program details and banking info go into metadata since the table
-  // has no dedicated columns for them yet.
+  // Program details go into metadata; banking is omitted until encryption is ready.
   const { data: holder, error: upsertError } = await supabase
     .from('program_holders')
     .upsert(
@@ -69,14 +77,16 @@ async function _POST(req: NextRequest) {
           assessment_type: assessmentType || null,
           custom_instructions: customInstructions || null,
           syllabus_url: syllabusUrl || null,
-          // Banking — plaintext for now; encrypt before production
+          // Banking stored only in non-production environments pending encryption.
+          // In production the block above returns 422 before reaching here.
           banking: accountNumber
             ? {
                 account_holder_name: accountHolderName || null,
                 bank_name: bankName || null,
                 account_type: accountType || 'checking',
-                routing_number: routingNumber || null,
-                account_number: accountNumber || null,
+                // Mask all but last 4 digits so the stored value is non-sensitive
+                routing_number: routingNumber ? `****${String(routingNumber).slice(-4)}` : null,
+                account_number: accountNumber ? `****${String(accountNumber).slice(-4)}` : null,
                 bank_document_url: bankDocumentUrl || null,
               }
             : null,

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -53,6 +53,9 @@ export async function GET(request: NextRequest) {
                 userId: user.id,
                 error: fetchError.message,
               });
+              // unlinked is null when fetchError is set — skip linking rather than
+              // proceeding with a non-null assertion that would throw.
+              return;
             }
 
             const pendingCount = unlinked?.length ?? 0;
@@ -122,6 +125,8 @@ export async function GET(request: NextRequest) {
       } else if (type === 'recovery') {
         // Use the next param set by sendRecoveryEmail's redirectTo option.
         // Fall back to /auth/reset-password if next wasn't passed or was stripped.
+        // `next` is already validated by validateRedirect() above — it only accepts
+        // same-origin paths (must start with /, no protocol-relative or external URLs).
         redirectTo = next !== '/' ? next : '/auth/reset-password';
       } else if (type === 'invite') {
         redirectTo = '/lms/dashboard?invited=true';

--- a/app/courses/[courseId]/lessons/[lessonId]/page.tsx
+++ b/app/courses/[courseId]/lessons/[lessonId]/page.tsx
@@ -676,7 +676,7 @@ export default function LessonPage() {
                       />
                     </div>
                     {lessonCaptions && (
-                      <VideoCaptions segments={lessonCaptions} />
+                      <VideoCaptions segments={lessonCaptions} videoSelector="[data-lesson-video]" />
                     )}
                   </>
                 );

--- a/components/lms/DragDropLab.tsx
+++ b/components/lms/DragDropLab.tsx
@@ -50,6 +50,14 @@ export default function DragDropLab({ config, onComplete }: Props) {
   const [score, setScore] = useState<number | null>(null);
   const containerRef = useRef<HTMLDivElement>(null);
 
+  // Reset all interaction state when the lab config changes (e.g. navigating between lessons)
+  useEffect(() => {
+    setPlacements({});
+    setRevealed(false);
+    setScore(null);
+    setDragItem(null);
+  }, [config.id]);
+
   // Which draggables are already placed
   const placedItemIds = new Set(Object.values(placements).filter(Boolean));
 

--- a/components/lms/LessonPlayer.tsx
+++ b/components/lms/LessonPlayer.tsx
@@ -395,6 +395,7 @@ export default function LessonPlayer({
         <div className="relative aspect-video">
           <video
             ref={videoRef}
+            data-lesson-video
             preload="metadata"
             playsInline
             crossOrigin="anonymous"

--- a/components/lms/QuizPlayer.tsx
+++ b/components/lms/QuizPlayer.tsx
@@ -116,8 +116,10 @@ export default function QuizPlayer({
 
   const handleNext = useCallback(() => {
     if (isLastQuestion) {
-      // Finish quiz
-      const finalCorrect = correctCount;
+      // Derive score from answeredQuestions rather than correctCount to avoid
+      // reading a stale closure value when the last answer was correct (setState
+      // is async so correctCount hasn't incremented yet at this point).
+      const finalCorrect = answeredQuestions.filter((q) => q.correct).length;
       const finalScore = Math.round((finalCorrect / questions.length) * 100);
       setFinished(true);
       onComplete(finalScore);
@@ -126,7 +128,7 @@ export default function QuizPlayer({
       setSelectedAnswer(null);
       setIsRevealed(false);
     }
-  }, [isLastQuestion, correctCount, questions.length, onComplete]);
+  }, [isLastQuestion, answeredQuestions, questions.length, onComplete]);
 
   const handleRetake = useCallback(() => {
     setCurrentIndex(0);

--- a/components/lms/VideoCaptions.tsx
+++ b/components/lms/VideoCaptions.tsx
@@ -10,6 +10,11 @@ export interface CaptionSegment {
 
 interface Props {
   segments: CaptionSegment[];
+  /**
+   * CSS selector used to locate the video element. Defaults to 'video' which
+   * finds the first video in the document. On pages with multiple video elements
+   * pass a scoped selector (e.g. '[data-lesson-video]') to target the correct one.
+   */
   videoSelector?: string;
 }
 


### PR DESCRIPTION
Automated scan of recent commits found potential bugs. Each fix is minimal and targeted. See the diff for details on what was found and fixed.

## Fixes

**QuizPlayer — stale closure, last-question score off by one** (`components/lms/QuizPlayer.tsx`)
`handleNext` closed over `correctCount` at render time. When the final answer was correct, `setCorrectCount` was enqueued but not yet committed, so `finalScore` was computed one answer short. Score is now derived from `answeredQuestions` which is updated synchronously in the same event handler.

**enrollment-status — dead null-check** (`app/api/lms/enrollment-status/route.ts`)
`createClient()` never returns null (it returns a mock client on misconfiguration). The `if (!supabase)` guard was always false and removed.

**program-holder/setup — plaintext banking credentials** (`app/api/program-holder/setup/route.ts`)
Account number and routing number were written verbatim to a `metadata` JSONB column. Production now returns 422 for any submission that includes banking fields. Non-production masks to last-4 digits before storage.

**DragDropLab — state not reset on config change** (`components/lms/DragDropLab.tsx`)
`placements`, `revealed`, `score`, and `dragItem` were never reset when the `config` prop changed. Navigating between lessons left the previous lab's answers pre-filled. Added `useEffect` keyed on `config.id`.

**VideoCaptions — wrong video element on multi-video pages** (`components/lms/LessonPlayer.tsx`, `components/lms/VideoCaptions.tsx`, lesson page)
`document.querySelector('video')` found the first `<video>` in the document. Lesson pages render multiple video elements, so captions attached to the wrong one. Added `data-lesson-video` attribute to `LessonPlayer`'s `<video>` and updated the call site to pass `videoSelector="[data-lesson-video]"`.

**auth/confirm — non-null assertion on potentially-null array** (`app/auth/confirm/route.ts`)
In the enrollment-linking block, `unlinked!` was used after a `fetchError` log that did not return early. If the DB query failed, `unlinked` was null but `pendingCount` was 0, so the block was never entered — making it safe in practice but fragile. Added an early `return` after the error log to make the invariant explicit. Also added a comment documenting that `validateRedirect` enforces same-origin paths only.

**onboarding/complete — Promise.all errors silently swallowed** (`app/api/onboarding/complete/route.ts`)
`profileResult.error` was never checked after `Promise.all`. A DB failure on the profile fetch silently continued with `profile = null`, skipping the approval pipeline and sending confirmation emails with `'Student'` as the name. Now returns 500 if the profile fetch fails. Also fixed a pre-existing `let` → `const` lint error on `programId`.

## Test results

603 passing / 5 failing. All 5 failures are pre-existing and unrelated to these changes:
- `safe-utils.test.ts` (2): `toErrorMessage` intentionally returns a generic string outside `development` mode; tests expect the raw message.
- `site-header.test.tsx` (3): tests look for `components/layout/SiteHeader.tsx` which does not exist (file is at `components/site/Header.tsx`).