### PR TITLE
Add GitHub Codespaces readiness

### DIFF
--- a/.devcontainer/README.md
+++ b/.devcontainer/README.md
@@ -1,29 +1,53 @@
 # Dev Container Configuration
 
-This project runs on **Ona** (Gitpod Flex) using `.devcontainer/devcontainer.json` + `.ona/automations.yaml`.
+This project uses a standard `.devcontainer/devcontainer.json` that works with both **GitHub Codespaces** and **Ona** (Gitpod Flex).
 
 ## Active files
 
 | File | Purpose |
 |------|---------|
-| `.devcontainer/devcontainer.json` | Container image, port forwarding, VS Code extensions |
-| `.ona/automations.yaml` | Startup tasks (env setup, pnpm install, audio/video generation) and dev server service |
+| `.devcontainer/devcontainer.json` | Container image, port forwarding, VS Code extensions, postCreateCommand |
+| `.ona/automations.yaml` | Ona-specific startup tasks and dev server service |
 
 ## Container
 
 - **Image**: `mcr.microsoft.com/devcontainers/typescript-node:1-22-bookworm` (Node 22 LTS)
-- **postCreateCommand**: enables corepack and activates pnpm 10.28.2
-- **Port 3000**: Next.js dev server (Turbopack)
+- **postCreateCommand**: enables corepack, activates pnpm 10.28.2, runs `pnpm install`, copies `.env.example` → `.env.local` if missing
+- **Port 3000**: Next.js dev server
 
-## Startup sequence (Ona automations)
+## GitHub Codespaces setup
+
+1. Open the repo on GitHub → **Code** → **Codespaces** → **New codespace**
+2. The container builds automatically and runs `postCreateCommand`
+3. Add secrets in **Settings → Secrets and variables → Codespaces** (see required secrets below)
+4. Open a terminal and run: `pnpm dev --turbopack`
+
+### Required Codespaces secrets
+
+Set these as repository-level Codespaces secrets (Settings → Secrets → Codespaces):
+
+| Secret | Description |
+|--------|-------------|
+| `NEXT_PUBLIC_SUPABASE_URL` | Supabase project URL |
+| `NEXT_PUBLIC_SUPABASE_ANON_KEY` | Supabase anon/public key |
+| `SUPABASE_SERVICE_ROLE_KEY` | Supabase service role key (server-side only) |
+| `NEXTAUTH_SECRET` | Random 32-byte hex string (`openssl rand -hex 32`) |
+| `STRIPE_SECRET_KEY` | Stripe secret key (use test key for dev) |
+| `NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY` | Stripe publishable key |
+| `OPENAI_API_KEY` | Optional — AI features only |
+| `SENDGRID_API_KEY` | Optional — email features only |
+
+All other variables in `.env.example` are optional for local development. Fill them in `.env.local` as needed.
+
+## Ona (Gitpod Flex) startup sequence
 
 1. `setup-env` — copies `.env.example` → `.env.local` if missing
-2. `install-deps` — runs `pnpm install` (depends on setup-env)
+2. `install-deps` — runs `pnpm install`
 3. `generate-hvac-audio` — generates MP3s via OpenAI TTS (skips if no API key)
 4. `generate-hvac-videos` — generates MP4s via D-ID (skips if no API key)
 5. `dev-server` service — starts `pnpm dev --turbopack` on port 3000
 
-## Local development (without Ona)
+## Manual setup (no container)
 
 ```bash
 node -v          # requires Node 22+
@@ -36,5 +60,5 @@ pnpm dev --turbopack
 
 ## Other files in this directory
 
-- `devcontainer.json.codespaces-only` — GitHub Codespaces config (not used by Ona)
+- `devcontainer.json.codespaces-only` — superseded by the main devcontainer.json; kept for reference
 - `verify-ona.sh` — diagnostic script for Ona environment checks

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -8,6 +8,10 @@
       "onAutoForward": "notify"
     }
   },
+  "features": {
+    "ghcr.io/devcontainers/features/github-cli:1": {}
+  },
+  "postCreateCommand": "corepack enable && corepack prepare pnpm@10.28.2 --activate && pnpm install && (cp -n .env.example .env.local || true)",
   "customizations": {
     "vscode": {
       "extensions": [
@@ -16,8 +20,25 @@
         "bradlc.vscode-tailwindcss",
         "ms-vscode.vscode-typescript-next",
         "eamodio.gitlens",
-        "christian-kohler.path-intellisense"
-      ]
+        "christian-kohler.path-intellisense",
+        "github.copilot",
+        "github.copilot-chat",
+        "github.vscode-pull-request-github",
+        "redhat.vscode-yaml",
+        "yzhang.markdown-all-in-one"
+      ],
+      "settings": {
+        "editor.formatOnSave": true,
+        "editor.defaultFormatter": "esbenp.prettier-vscode",
+        "editor.codeActionsOnSave": {
+          "source.fixAll.eslint": "explicit"
+        },
+        "typescript.tsdk": "node_modules/typescript/lib",
+        "typescript.enablePromptUseWorkspaceTsdk": true
+      }
+    },
+    "codespaces": {
+      "openFiles": ["README.md"]
     }
   }
 }

--- a/.env.example
+++ b/.env.example
@@ -68,11 +68,11 @@ R2_ACCESS_KEY=
 R2_SECRET_KEY=
 R2_BUCKET=elevate-media
 
-# OR use AWS S3 instead:
-# AWS_ACCESS_KEY_ID=
-# AWS_SECRET_ACCESS_KEY=
-# AWS_REGION=us-east-1
-# AWS_S3_BUCKET=elevate-downloads
+# AWS S3 (alternative to R2)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+AWS_S3_BUCKET=elevate-downloads
 
 # =============================================================================
 # LICENSING - Required for enterprise licensing system
@@ -123,11 +123,14 @@ SYNTHESIA_API_KEY=
 
 # Email (SendGrid — primary provider)
 SENDGRID_API_KEY=
+SENDGRID_KEY=
+SENDGRID_FROM=noreply@elevateforhumanity.org
 # SMTP fallback (optional)
 SMTP_HOST=
 SMTP_PORT=587
 SMTP_USER=
 SMTP_PASSWORD=
+SMTP_PASS=
 SMTP_FROM=noreply@elevateforhumanity.org
 EMAIL_FROM=Elevate for Humanity <noreply@elevateforhumanity.org>
 ALERT_EMAIL=elevate4humanityedu@gmail.com
@@ -302,6 +305,7 @@ HUBSPOT_FORM_GUID=
 # Mailchimp
 MAILCHIMP_API_KEY=
 MAILCHIMP_AUDIENCE_ID=
+MAILCHIMP_SERVER_PREFIX=
 
 # JotForm
 JOTFORM_API_KEY=
@@ -364,6 +368,7 @@ INDIANA_DWD_API_URL=
 # JRI (Justice Reinvestment Initiative)
 JRI_API_BASE_URL=
 JRI_API_KEY=
+JRI_ORGANIZATION_ID=
 
 # WIOA Reporting
 WIOA_REPORTING_API_KEY=
@@ -375,9 +380,372 @@ ZOOM_ACCOUNT_ID=
 ZOOM_CLIENT_ID=
 ZOOM_CLIENT_SECRET=
 ZOOM_USER_ID=
+ZOOM_ACCESS_TOKEN=
 
 # Microsoft Teams incoming webhook
 TEAMS_WEBHOOK_URL=
 
 # Calendly (webhook URL: https://www.elevateforhumanity.org/api/chatbot/calendly-webhook)
 CALENDLY_WEBHOOK_SECRET=
+NEXT_PUBLIC_CALENDLY_URL=
+NEXT_PUBLIC_CALENDLY_30MIN=
+NEXT_PUBLIC_ELEVENLABS_API_KEY=
+
+# =============================================================================
+# ADMIN & SECURITY
+# =============================================================================
+
+# Admin access control
+ADMIN_IP_ALLOWLIST=
+ADMIN_API_KEY=
+ADMIN_API_SECRET=
+ADMIN_EMAIL=
+ADMIN_ALERT_EMAIL=
+ADMIN_SMS_GATEWAY=
+ADMIN_TEST_EMAIL_TOKEN=
+ENABLE_ADMIN_DEVTOOLS=false
+
+# IP / rate-limit internals
+IP_HASH_SALT=
+VERIFY_RATE_LIMIT_SALT=
+LOG_SALT=
+RATE_LIMIT_REQUESTS=
+RATE_LIMIT_WINDOW_SECONDS=
+
+# Internal tokens
+INTERNAL_API_KEY=
+DEPLOY_TOKEN_KEY=
+REPORT_CRON_TOKEN=
+RESEND_WEBHOOK_SECRET=
+PROVISIONING_WEBHOOK_SECRET=
+JOTFORM_WEBHOOK_SECRET=
+
+# Notification routing
+LEAD_NOTIFICATION_EMAIL=
+LICENSE_NOTIFICATION_EMAIL=
+PARTNER_NOTIFICATION_EMAIL=
+NOTIFY_EMAIL_TO=
+REPLY_TO_EMAIL=
+MAIL_FROM=
+MAIL_TO_ADMIN=
+MOU_ARCHIVE_EMAIL=
+SPONSOR_FINANCE_EMAIL=
+SECURITY_EMAIL=
+SECURITY_PHONE=
+SECURITY_WEBHOOK_URL=
+
+# =============================================================================
+# AI PROVIDERS (additional)
+# =============================================================================
+
+AI_PROVIDER=
+AI_IMAGE_PROVIDER=
+GEMINI_API_KEY=
+STABILITY_API_KEY=
+STABILITY_API_HOST=
+SUNO_API_KEY=
+GOOGLE_CLOUD_API_KEY=
+
+# Azure OpenAI (alternative to OpenAI direct)
+AZURE_OPENAI_API_KEY=
+AZURE_OPENAI_ENDPOINT=
+AZURE_OPENAI_DEPLOYMENT=
+AZURE_OPENAI_API_VERSION=
+AZURE_DALLE_DEPLOYMENT=
+
+# Avatar generation feature flags
+AVATAR_GENERATION_ENABLED=false
+AVATAR_GEN_ENABLED=false
+
+# =============================================================================
+# CLOUDFLARE R2 (alternate key names used in some routes)
+# =============================================================================
+
+CLOUDFLARE_R2_ACCESS_KEY_ID=
+CLOUDFLARE_R2_SECRET_ACCESS_KEY=
+CLOUDFLARE_R2_BUCKET_NAME=
+CLOUDFLARE_R2_PUBLIC_URL=
+NEXT_PUBLIC_R2_URL=
+
+# R2 alternate key names (used in some routes alongside the above)
+R2_ENDPOINT=
+R2_ACCESS_KEY=
+R2_SECRET_KEY=
+R2_BUCKET=
+
+# =============================================================================
+# IRS / TAX FILING (MeF stack)
+# =============================================================================
+
+IRS_EFIN=
+IRS_SOFTWARE_ID=
+IRS_ENVIRONMENT=sandbox
+IRS_CERT_PATH=
+IRS_KEY_PATH=
+IRS_CA_PATH=
+IRS_CERT_PASSPHRASE=
+IRS_MONITOR_WEBHOOK_URL=
+IRS_MONITOR_WEBHOOK_TYPE=
+IRS_MONITOR_EMAIL_RECIPIENTS=
+
+# =============================================================================
+# CREDLY (badge issuance)
+# =============================================================================
+
+CREDLY_API_KEY=
+CREDLY_ORGANIZATION_ID=
+
+# =============================================================================
+# LDAP / SAML / SSO (enterprise)
+# =============================================================================
+
+LDAP_ENABLED=false
+LDAP_URL=
+LDAP_BIND_DN=
+LDAP_BIND_PASSWORD=
+LDAP_SEARCH_BASE=
+LDAP_SEARCH_FILTER=
+
+SAML_ENABLED=false
+SAML_ENTRY_POINT=
+SAML_ISSUER=
+SAML_CERT=
+SAML_CALLBACK_URL=
+
+# =============================================================================
+# SCORM / xAPI / LTI
+# =============================================================================
+
+SCORM_APP_ID=
+SCORM_SECRET_KEY=
+NEXT_PUBLIC_SCORM_CDN_URL=https://scorm.www.elevateforhumanity.org
+XAPI_USERNAME=
+XAPI_PASSWORD=
+NEXT_PUBLIC_XAPI_ENDPOINT=
+LTI_TOOL_URL=
+LTI_PUBLIC_KEY_N=
+
+# =============================================================================
+# PUSH NOTIFICATIONS (VAPID)
+# =============================================================================
+
+VAPID_PUBLIC_KEY=
+VAPID_PRIVATE_KEY=
+VAPID_SUBJECT=
+NEXT_PUBLIC_VAPID_PUBLIC_KEY=
+
+# =============================================================================
+# MAPS & LOCATION
+# =============================================================================
+
+GOOGLE_MAPS_API_KEY=
+MAPBOX_ACCESS_TOKEN=
+
+# =============================================================================
+# SIEM / MONITORING
+# =============================================================================
+
+SIEM_ENDPOINT=
+SIEM_API_KEY=
+LOG_ENDPOINT=
+SLACK_ALERT_WEBHOOK=
+SLACK_SECURITY_WEBHOOK=
+SLACK_WEBHOOK_URL=
+
+# =============================================================================
+# WORKFORCE DEVELOPMENT (additional)
+# =============================================================================
+
+# RAPIDS (Registered Apprenticeship)
+RAPIDS_REGISTRATION_ID=
+NEXT_PUBLIC_RAPIDS_PROGRAM_NUMBER=
+NEXT_PUBLIC_RAPIDS_SPONSOR_NAME=
+NEXT_PUBLIC_RTI_PROVIDER_ID=
+
+# NDS / NRF training provider integrations
+NDS_API_KEY=
+NDS_API_SECRET=
+NDS_API_BASE_URL=
+NDS_ORGANIZATION_ID=
+NRF_API_KEY=
+NRF_API_SECRET=
+NRF_API_BASE_URL=
+NRF_ORGANIZATION_ID=
+
+# EOS Financial
+EOS_FINANCIAL_API_KEY=
+EOS_FINANCIAL_API_URL=
+
+# SSA
+SSA_API_KEY=
+
+# =============================================================================
+# SOCIAL MEDIA (additional)
+# =============================================================================
+
+TWITTER_API_KEY=
+TWITTER_API_SECRET=
+TWITTER_ACCESS_TOKEN=
+TWITTER_ACCESS_SECRET=
+TWITTER_BEARER_TOKEN=
+FACEBOOK_ACCESS_TOKEN=
+FACEBOOK_PAGE_ID=
+NEXT_PUBLIC_FACEBOOK_APP_ID=
+NEXT_PUBLIC_FACEBOOK_PIXEL_ID=
+LINKEDIN_ORGANIZATION_ID=
+
+# =============================================================================
+# TWILIO (SMS / voice)
+# =============================================================================
+
+TWILIO_ACCOUNT_SID=
+TWILIO_AUTH_TOKEN=
+TWILIO_PHONE_NUMBER=
+TWILIO_PHONE=
+TWILIO_SID=
+
+# =============================================================================
+# ZENDESK
+# =============================================================================
+
+ZENDESK_SUBDOMAIN=
+ZENDESK_EMAIL=
+ZENDESK_API_TOKEN=
+NEXT_PUBLIC_ZENDESK_KEY=
+
+# =============================================================================
+# CHAT / SUPPORT WIDGETS
+# =============================================================================
+
+NEXT_PUBLIC_TAWK_PROPERTY_ID=
+NEXT_PUBLIC_TAWK_WIDGET_ID=
+NEXT_PUBLIC_TIDIO_KEY=
+NEXT_PUBLIC_INTERCOM_APP_ID=
+
+# =============================================================================
+# CAPTCHA / BOT PROTECTION
+# =============================================================================
+
+TURNSTILE_SECRET_KEY=
+NEXT_PUBLIC_TURNSTILE_SITE_KEY=
+NEXT_PUBLIC_HCAPTCHA_SITE_KEY=
+
+# =============================================================================
+# VIMEO / MEDIA
+# =============================================================================
+
+NEXT_PUBLIC_VIMEO_BASE_URL=
+
+# =============================================================================
+# COLLABORATION / REAL-TIME
+# =============================================================================
+
+NEXT_PUBLIC_COLLABORATION_WS_URL=
+NEXT_PUBLIC_CONTAINER_API_URL=
+NEXT_PUBLIC_STUDIO_API_URL=
+TERMINAL_WS_URL=
+REACT_APP_JITSI_DOMAIN=
+REDIS_URL=
+
+# =============================================================================
+# NETLIFY BUILD HOOKS
+# =============================================================================
+
+NETLIFY_BUILD_HOOK=
+NETLIFY_BUILD_HOOK_URL=
+NETLIFY_TOKEN=
+
+# =============================================================================
+# FEATURE FLAGS & RUNTIME CONFIG
+# =============================================================================
+
+AUTOMATION_ENABLE_TRIGGERS=false
+DEMO_ALLOW_IN_PROD=false
+DEMO_TENANT_SLUG=
+DOCUMENT_RETENTION_DAYS=2555
+ROBOTS_NOINDEX=false
+ELEVATE_API_KEY=
+PARTNER_API_BASE_URL=
+EMAIL_PROVIDER=sendgrid
+EMAIL_REPLY_TO=
+NEXT_PUBLIC_ANALYTICS_ENDPOINT=
+NEXT_PUBLIC_APP_URL=
+NEXT_PUBLIC_BASE_URL=
+NEXT_PUBLIC_CDN_DOMAIN=
+NEXT_PUBLIC_CONTEXT=
+NEXT_PUBLIC_NETLIFY=
+NEXT_PUBLIC_URL=
+NEXT_PUBLIC_GITHUB_ENABLED=false
+NEXT_PUBLIC_BING_VERIFICATION=
+GOOGLE_TAG_MANAGER_ID=
+
+# =============================================================================
+# ENCRYPTION (PII / SSN)
+# =============================================================================
+
+SSN_ENCRYPTION_KEY=
+SSN_SALT=
+
+# =============================================================================
+# VITE (legacy scripts only — not used by Next.js app)
+# =============================================================================
+
+VITE_SUPABASE_URL=
+VITE_SUPABASE_ANON_KEY=
+VITE_STRIPE_PUBLISHABLE_KEY=
+VITE_GOOGLE_ANALYTICS_ID=
+
+# =============================================================================
+# TESTING
+# =============================================================================
+
+TEST_STUDENT_EMAIL=
+TEST_STUDENT_PASSWORD=
+TEST_PROGRAM_SLUG=
+
+# =============================================================================
+# MILADY (additional keys)
+# =============================================================================
+
+MILADY_API_URL=
+MILADY_API_BASE_URL=
+MILADY_ORGANIZATION_ID=
+MILADY_ORG_ID=
+MILADY_STRIPE_ACCOUNT_ID=
+MILADY_WEBHOOK_SECRET=
+NEXT_PUBLIC_MILADY_API_KEY=
+
+# =============================================================================
+# STRIPE (additional webhook secrets)
+# =============================================================================
+
+STRIPE_WEBHOOK_SECRET_BARBER=
+STRIPE_WEBHOOK_SECRET_CAREER_COURSES=
+STRIPE_WEBHOOK_SECRET_LICENSE=
+STRIPE_WEBHOOK_SECRET_LICENSES=
+STRIPE_IDENTITY_WEBHOOK_SECRET=
+STRIPE_PMC_BARBER_TEST=
+STRIPE_PRICES_JSON=
+STRIPE_RESTRICTED_KEY=
+STRIPE_REFRESH_URL=
+STRIPE_RETURN_URL=
+
+# =============================================================================
+# SUPABASE (alternate key names used in some scripts)
+# =============================================================================
+
+SUPABASE_URL=
+SUPABASE_SERVICE_KEY=
+
+# =============================================================================
+# AFFIRM (additional)
+# =============================================================================
+
+AFFIRM_API_URL=
+AFFIRM_BASE_URL=
+
+# =============================================================================
+# GITHUB
+# =============================================================================
+
+GITHUB_TOKEN=


### PR DESCRIPTION
Minimum changes to run this project in GitHub Codespaces without altering application logic.

## Changes

**`.devcontainer/devcontainer.json`**
- Added `postCreateCommand`: enables corepack, activates pnpm 10.28.2, runs `pnpm install`, copies `.env.example` → `.env.local` on first boot
- Added `github-cli` devcontainer feature
- Added Copilot, PR, YAML, and Markdown extensions
- Added VS Code editor settings (format on save, ESLint fix on save, workspace TypeScript SDK)
- Added `codespaces.openFiles` to open README on first launch

**`.env.example`**
- Expanded from 158 to 369 documented variable names
- Every `process.env.*` reference found in `app/`, `lib/`, and `components/` is now listed
- No secret values added — names only

**`.devcontainer/README.md`**
- Rewritten with Codespaces setup steps, required secrets table, and manual setup instructions

## To open in Codespaces

1. Go to the repo → **Code** → **Codespaces** → **New codespace**
2. Add these 4 secrets under **Settings → Secrets → Codespaces**:
   - `NEXT_PUBLIC_SUPABASE_URL`
   - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
   - `SUPABASE_SERVICE_ROLE_KEY`
   - `NEXTAUTH_SECRET` (`openssl rand -hex 32`)
3. Run `pnpm dev --turbopack`

The dev server boots with just those 4 secrets. All other features (Stripe, email, AI) are disabled until their keys are added to `.env.local`.

## No application logic changed