### PR TITLE
fix(generator): write step_type and passing_score for checkpoint lessons

### DIFF
--- a/lib/services/curriculum-generator.ts
+++ b/lib/services/curriculum-generator.ts
@@ -112,6 +112,19 @@ export interface LessonDef {
   credentialDomainKey?: string;
   /** training_courses.id — links this lesson to the LMS course page */
   courseId?: string;
+  /**
+   * Lesson type. Controls rendering and completion rules.
+   * Defaults to 'lesson' if omitted.
+   * Set to 'checkpoint' on module-boundary lessons that gate the next module.
+   */
+  stepType?: 'lesson' | 'quiz' | 'checkpoint' | 'lab' | 'assignment' | 'exam' | 'certification';
+  /**
+   * Minimum score (0–100) required to pass.
+   * Required for checkpoint/quiz/exam step types.
+   * Defaults to 0 for plain lessons (no pass threshold).
+   * curriculum_lessons.passing_score is NOT NULL — always written explicitly.
+   */
+  passingScore?: number;
   quizzes?: QuizDef[];
   recaps?: RecapDef[];
 }
@@ -354,6 +367,9 @@ export class CurriculumGenerator {
           diagram_file:         def.diagramFile ?? null,
           duration_minutes:     def.durationMinutes ?? null,
           credential_domain_id: credentialDomainId,
+          step_type:            def.stepType ?? 'lesson',
+          // NOT NULL column — 0 for plain lessons, explicit threshold for checkpoints/quizzes/exams
+          passing_score:        def.passingScore ?? (def.stepType && def.stepType !== 'lesson' ? 80 : 0),
           status:               'published',
           updated_at:           new Date().toISOString(),
         },

--- a/scripts/seed-hvac-curriculum.ts
+++ b/scripts/seed-hvac-curriculum.ts
@@ -246,9 +246,11 @@ async function main() {
     });
 
     for (const [lessonIndex, lesson] of mod.lessons.entries()) {
-      const lessonSlug = `${mod.id}-${lesson.id}`;
-      const rawQuizzes = QUIZ_QUESTIONS[lesson.id];
-      const quizzes    = rawQuizzes?.map((q, i) => ({ ...q, quizOrder: i }));
+      const lessonSlug   = `${mod.id}-${lesson.id}`;
+      const rawQuizzes   = QUIZ_QUESTIONS[lesson.id];
+      const quizzes      = rawQuizzes?.map((q, i) => ({ ...q, quizOrder: i }));
+      // Module-boundary quiz lessons gate the next module
+      const isCheckpoint = lesson.type === 'quiz';
 
       await gen.upsertLesson({
         lessonSlug,
@@ -260,6 +262,8 @@ async function main() {
         lessonOrder:         lessonIndex + 1,
         moduleOrder:         modIndex + 1,
         credentialDomainKey: domainKey,
+        stepType:            isCheckpoint ? 'checkpoint' : 'lesson',
+        passingScore:        isCheckpoint ? 80 : 0,
         quizzes,
       });
     }

--- a/scripts/seed-prs-curriculum.ts
+++ b/scripts/seed-prs-curriculum.ts
@@ -223,9 +223,11 @@ async function main() {
     });
 
     for (const [lessonIndex, lesson] of mod.lessons.entries()) {
-      const lessonSlug  = `${mod.id}-${lesson.id}`;
-      const rawQuizzes  = QUIZ_QUESTIONS[lesson.id];
-      const quizzes     = rawQuizzes?.map((q, i) => ({ ...q, quizOrder: i }));
+      const lessonSlug    = `${mod.id}-${lesson.id}`;
+      const rawQuizzes    = QUIZ_QUESTIONS[lesson.id];
+      const quizzes       = rawQuizzes?.map((q, i) => ({ ...q, quizOrder: i }));
+      // Module-boundary quiz lessons gate the next module
+      const isCheckpoint  = lesson.type === 'quiz';
 
       await gen.upsertLesson({
         lessonSlug,
@@ -237,6 +239,8 @@ async function main() {
         lessonOrder:         lessonIndex + 1,
         moduleOrder:         modIndex + 1,
         credentialDomainKey: domainKey,
+        stepType:            isCheckpoint ? 'checkpoint' : 'lesson',
+        passingScore:        isCheckpoint ? 80 : 0,
         quizzes,
       });
     }


### PR DESCRIPTION
## Problem

`curriculum_lessons.passing_score` is `NOT NULL` with no column default. The generator was omitting both `step_type` and `passing_score` from the upsert payload, so:

- Every lesson was written as `step_type = 'lesson'` (DB default) — no checkpoints ever seeded
- `passing_score` was set to `70` (DB default) for all lessons, including plain reading/video lessons
- The checkpoint gate system had no rows to enforce — the gate was effectively disabled for all generator-seeded courses

This was discovered during a live A–J generator acceptance test against the production DB.

## Changes

**`lib/services/curriculum-generator.ts`**
- `LessonDef` gains two optional fields: `stepType` and `passingScore`
- `upsertLesson` writes both explicitly in the upsert payload
- Defaults: `step_type = 'lesson'`, `passing_score = 0` for plain lessons; `passing_score = 80` for any non-lesson step type when `passingScore` is not supplied

**`scripts/seed-prs-curriculum.ts`** and **`scripts/seed-hvac-curriculum.ts`**
- Detect `lesson.type === 'quiz'` from the course data (module-boundary quiz lessons)
- Pass `stepType: 'checkpoint', passingScore: 80` for those lessons

## Backfill required

Existing `curriculum_lessons` rows for PRS and HVAC are **not** updated by this PR. Two options:

**Option A — re-run seed scripts with `--force`:**
```bash
npx ts-node scripts/seed-prs-curriculum.ts --force
npx ts-node scripts/seed-hvac-curriculum.ts --force
```

**Option B — targeted SQL UPDATE in Supabase Dashboard:**
```sql
-- Identify quiz lesson slugs first:
SELECT lesson_slug, step_type, passing_score
FROM curriculum_lessons
WHERE program_id IN (<prs_program_id>, <hvac_program_id>)
ORDER BY module_order, lesson_order;

-- Then update the checkpoint rows:
UPDATE curriculum_lessons
SET step_type = 'checkpoint', passing_score = 80
WHERE program_id IN (<prs_program_id>, <hvac_program_id>)
  AND lesson_slug IN (<quiz-lesson-slugs>);
```

Quiz lesson IDs are the last lesson in each module — verify against `lms-data/courses/program-peer-recovery.ts` and `lms-data/courses/program-hvac.ts`.

## Verification

Generator acceptance test (A–J) passed against live DB with zero defects after this fix. Gate enforcement confirmed: blocked before checkpoint pass, open after score ≥ passing_score.