### PR TITLE
feat(admin): program builder — single-page structured editor with publish enforcement

### DIFF
--- a/app/admin/course-builder/page.tsx
+++ b/app/admin/course-builder/page.tsx
@@ -1,46 +1,198 @@
 import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
-import { requireAdmin } from '@/lib/authGuards';
-import Link from 'next/link';
-import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import CourseBuilderClient from './CourseBuilderClient';
+import ProgramBuilderClient from '@/components/admin/course-builder/ProgramBuilderClient';
+import type {
+  ProgramBuilderState,
+  ProgramPhase,
+  ProgramModule,
+  ProgramLesson,
+} from '@/components/admin/course-builder/types';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
-  alternates: { canonical: 'https://www.elevateforhumanity.org/admin/course-builder' },
-  title: 'Course Builder | Elevate For Humanity',
-  description: 'Create and manage courses for your programs.',
+  title: 'Program Builder | Admin | Elevate For Humanity',
 };
 
-export default async function CourseBuilderPage() {
-  await requireAdmin(); // enforces admin/super_admin/staff, redirects on failure
+interface PageProps {
+  searchParams: Promise<{ program?: string }>;
+}
 
+export default async function CourseBuilderPage({ searchParams }: PageProps) {
+  const params = await searchParams;
+
+  // Auth
   const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user) redirect('/login?redirect=/admin/course-builder');
 
-  // Fetch courses from database
-  const { data: courses } = await supabase
-    .from('courses')
-    .select('*, programs(id, title)')
-    .order('created_at', { ascending: false });
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .single();
+  if (!['admin', 'super_admin', 'staff'].includes(profile?.role ?? '')) {
+    redirect('/unauthorized');
+  }
 
-  // Fetch programs for dropdown
-  const { data: programs } = await supabase
+  const db = createAdminClient();
+
+  // If no program specified, redirect to programs list so admin picks one
+  const programId = params.program ?? null;
+  if (!programId) redirect('/admin/programs?action=build');
+
+  const { data: program } = await db
     .from('programs')
-    .select('id, title')
-    .order('title');
+    .select('*')
+    .eq('id', programId)
+    .single();
+
+  if (!program) redirect('/admin/programs?error=not_found');
+
+  // Load related data in parallel
+  const [
+    { data: outcomesRaw },
+    { data: credentialsRaw },
+    { data: modulesRaw },
+    { data: ctasRaw },
+    { data: tracksRaw },
+    { data: mediaRaw },
+    { data: allCredentials },
+  ] = await Promise.all([
+    db.from('program_outcomes')
+      .select('id, outcome, outcome_order')
+      .eq('program_id', programId)
+      .order('outcome_order'),
+
+    db.from('program_credentials')
+      .select('id, credential_id, is_required, sort_order, credentials(id, name, abbreviation, issuing_authority)')
+      .eq('program_id', programId)
+      .order('sort_order'),
+
+    db.from('program_modules')
+      .select('id, title, sort_order, program_lessons(id, title, lesson_type, sort_order, duration_minutes)')
+      .eq('program_id', programId)
+      .order('sort_order'),
+
+    db.from('program_ctas')
+      .select('id, cta_type, label, href, style_variant, sort_order')
+      .eq('program_id', programId)
+      .order('sort_order'),
+
+    db.from('program_tracks')
+      .select('id, track_code, title, funding_type, cost_cents, available, sort_order')
+      .eq('program_id', programId)
+      .order('sort_order'),
+
+    db.from('program_media')
+      .select('id, media_type, url, alt_text')
+      .eq('program_id', programId),
+
+    db.from('credentials')
+      .select('id, name, abbreviation, issuing_authority')
+      .order('name'),
+  ]);
+
+  // Shape modules into a single phase (phase column not yet on program_modules)
+  const modules: ProgramModule[] = (modulesRaw ?? []).map((m: any) => ({
+    id: m.id,
+    title: m.title,
+    sort_order: m.sort_order,
+    lessons: (m.program_lessons ?? []).map((l: any): ProgramLesson => ({
+      id: l.id,
+      title: l.title,
+      lesson_type: l.lesson_type ?? 'lesson',
+      sort_order: l.sort_order,
+      duration_minutes: l.duration_minutes ?? null,
+      is_published: false,
+      has_video: false,
+      has_reading: false,
+    })),
+  }));
+
+  const phases: ProgramPhase[] = modules.length > 0
+    ? [{ id: 'default', title: 'Program Curriculum', sort_order: 0, modules }]
+    : [];
+
+  const initialState: ProgramBuilderState = {
+    id: program.id,
+    title: program.title ?? '',
+    subtitle: program.name ?? '',
+    slug: program.slug ?? '',
+    category: program.category ?? '',
+    description: program.description ?? program.full_description ?? '',
+    hero_image_url: program.hero_image_url ?? program.hero_image ?? program.image_url ?? null,
+
+    outcomes: (outcomesRaw ?? []).map((o: any) => ({
+      id: o.id,
+      text: o.outcome,
+      outcome_order: o.outcome_order,
+    })),
+
+    credentials: (credentialsRaw ?? []).map((c: any) => ({
+      id: c.id,
+      credential_id: c.credential_id,
+      credential_name: c.credentials?.name ?? '',
+      credential_abbreviation: c.credentials?.abbreviation ?? null,
+      is_required: c.is_required,
+      is_primary: c.sort_order === 0,
+      sort_order: c.sort_order,
+    })),
+
+    phases,
+
+    ctas: (ctasRaw ?? []).map((c: any) => ({
+      id: c.id,
+      cta_type: c.cta_type,
+      label: c.label,
+      href: c.href,
+      style_variant: c.style_variant,
+      sort_order: c.sort_order,
+    })),
+
+    tracks: (tracksRaw ?? []).map((t: any) => ({
+      id: t.id,
+      track_code: t.track_code,
+      title: t.title,
+      funding_type: t.funding_type,
+      cost_cents: t.cost_cents,
+      available: t.available,
+      sort_order: t.sort_order,
+    })),
+
+    media: (mediaRaw ?? []).map((m: any) => ({
+      id: m.id,
+      media_type: m.media_type,
+      url: m.url,
+      alt_text: m.alt_text,
+    })),
+
+    estimated_weeks: program.estimated_weeks ?? program.duration_weeks ?? null,
+    estimated_hours: program.estimated_hours ?? program.total_hours ?? program.training_hours ?? null,
+    delivery_method: (program.delivery_method ?? null) as ProgramBuilderState['delivery_method'],
+
+    wioa_approved: program.wioa_approved ?? false,
+    dol_registered: program.dol_registered ?? false,
+    etpl_listed: false,
+
+    status: program.published ? 'published' : 'draft',
+    published: program.published ?? false,
+  };
+
+  const availableCredentials = (allCredentials ?? []).map((c: any) => ({
+    id: c.id,
+    name: c.name,
+    abbreviation: c.abbreviation,
+    issuing_authority: c.issuing_authority,
+  }));
 
   return (
-    <div className="min-h-screen bg-gray-50">
-
-      {/* Hero Image */}
-      <div className="bg-slate-50 border-b">
-        <div className="max-w-7xl mx-auto px-4 py-3">
-          <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Course Builder' }]} />
-        </div>
-      </div>
-      <CourseBuilderClient initialCourses={courses || []} programs={programs || []} />
-    </div>
+    <ProgramBuilderClient
+      initialState={initialState}
+      availableCredentials={availableCredentials}
+    />
   );
 }

--- a/components/admin/course-builder/BuilderSection.tsx
+++ b/components/admin/course-builder/BuilderSection.tsx
@@ -1,0 +1,37 @@
+// Shared card shell used by every builder section
+import type { ReactNode } from 'react';
+
+interface Props {
+  title: string;
+  description: string;
+  required?: boolean;
+  warning?: string;
+  children: ReactNode;
+}
+
+export default function BuilderSection({ title, description, required, warning, children }: Props) {
+  return (
+    <div className="rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-5 py-4">
+        <div className="flex items-start justify-between gap-2">
+          <div>
+            <h2 className="text-base font-semibold text-slate-900">
+              {title}
+              {required && <span className="ml-1.5 text-xs font-normal text-red-500">required</span>}
+            </h2>
+            <p className="mt-0.5 text-sm text-slate-500">{description}</p>
+          </div>
+        </div>
+        {warning && (
+          <div className="mt-3 flex items-start gap-2 rounded-lg bg-amber-50 border border-amber-200 px-3 py-2 text-sm text-amber-700">
+            <svg className="mt-0.5 h-4 w-4 flex-shrink-0" fill="none" viewBox="0 0 24 24" stroke="currentColor">
+              <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M12 9v2m0 4h.01M10.29 3.86L1.82 18a2 2 0 001.71 3h16.94a2 2 0 001.71-3L13.71 3.86a2 2 0 00-3.42 0z" />
+            </svg>
+            {warning}
+          </div>
+        )}
+      </div>
+      <div className="px-5 py-5">{children}</div>
+    </div>
+  );
+}

--- a/components/admin/course-builder/BuilderSidebar.tsx
+++ b/components/admin/course-builder/BuilderSidebar.tsx
@@ -1,0 +1,205 @@
+'use client';
+
+'use client';
+
+import type { ElementType } from 'react';
+import Link from 'next/link';
+import {
+  CheckCircle, XCircle, AlertCircle, Plus, Eye,
+  BookOpen, Video, AlertTriangle, Layers,
+} from 'lucide-react';
+import type { ProgramBuilderState, ProgramDerivedState } from './types';
+
+interface Props {
+  state: ProgramBuilderState;
+  derived: ProgramDerivedState;
+  onAddLesson?: () => void;
+  onAddModule?: () => void;
+  onPreview?: () => void;
+}
+
+// Each checklist item maps to a required field
+const CHECKLIST_ITEMS: {
+  key: string;
+  label: string;
+  check: (s: ProgramBuilderState, d: ProgramDerivedState) => boolean;
+  href?: string;
+}[] = [
+  { key: 'title',       label: 'Program title',       check: (s) => !!s.title?.trim() },
+  { key: 'description', label: 'Description',          check: (s) => !!s.description?.trim() },
+  { key: 'hero',        label: 'Hero image',           check: (s) => !!s.hero_image_url },
+  { key: 'outcomes',    label: '3+ learning outcomes', check: (s) => s.outcomes.length >= 3 },
+  { key: 'curriculum',  label: '1+ phase, 3+ modules, 10+ lessons',
+    check: (_, d) => d.totalPhases >= 1 && d.totalModules >= 3 && d.totalLessons >= 10 },
+  { key: 'duration',    label: 'Duration set',         check: (s) => !!s.estimated_weeks },
+  { key: 'delivery',    label: 'Delivery mode',        check: (s) => !!s.delivery_method },
+  { key: 'cta',         label: 'Primary CTA',          check: (s) => s.ctas.length > 0 },
+];
+
+export default function BuilderSidebar({ state, derived, onAddLesson, onAddModule, onPreview }: Props) {
+  const completedCount = CHECKLIST_ITEMS.filter(item => item.check(state, derived)).length;
+  const totalCount = CHECKLIST_ITEMS.length;
+
+  return (
+    <div className="sticky top-20 space-y-4">
+
+      {/* ── Completion Checklist ── */}
+      <div className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <div className="flex items-center justify-between">
+            <h3 className="text-sm font-semibold text-slate-900">Publish Checklist</h3>
+            <span className={`text-xs font-semibold tabular-nums ${completedCount === totalCount ? 'text-emerald-600' : 'text-slate-500'}`}>
+              {completedCount}/{totalCount}
+            </span>
+          </div>
+          {/* Progress bar */}
+          <div className="mt-2 h-1.5 w-full rounded-full bg-slate-100 overflow-hidden">
+            <div
+              className={`h-full rounded-full transition-all duration-300 ${completedCount === totalCount ? 'bg-emerald-500' : 'bg-brand-blue-500'}`}
+              style={{ width: `${(completedCount / totalCount) * 100}%` }}
+            />
+          </div>
+        </div>
+        <ul className="divide-y divide-slate-50 px-5 py-2">
+          {CHECKLIST_ITEMS.map(item => {
+            const done = item.check(state, derived);
+            return (
+              <li key={item.key} className="flex items-center gap-2.5 py-2">
+                {done
+                  ? <CheckCircle className="h-4 w-4 flex-shrink-0 text-emerald-500" />
+                  : <XCircle className="h-4 w-4 flex-shrink-0 text-slate-300" />
+                }
+                <span className={`text-xs ${done ? 'text-slate-600' : 'text-slate-400'}`}>
+                  {item.label}
+                </span>
+              </li>
+            );
+          })}
+        </ul>
+      </div>
+
+      {/* ── Program Health ── */}
+      <div className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <h3 className="text-sm font-semibold text-slate-900">Program Health</h3>
+          <p className="mt-0.5 text-xs text-slate-500">Content coverage across all lessons</p>
+        </div>
+        <div className="px-5 py-4 space-y-3">
+          <HealthRow
+            icon={Layers}
+            label="Total lessons"
+            value={String(derived.totalLessons)}
+            status={derived.totalLessons >= 10 ? 'ok' : 'warn'}
+          />
+          <HealthRow
+            icon={AlertCircle}
+            label="Empty lessons"
+            value={String(derived.emptyLessons)}
+            status={derived.emptyLessons === 0 ? 'ok' : 'error'}
+            note={derived.emptyLessons > 0 ? 'No video or reading' : undefined}
+          />
+          <HealthRow
+            icon={Video}
+            label="Missing video"
+            value={String(derived.lessonsMissingVideo)}
+            status={derived.lessonsMissingVideo === 0 ? 'ok' : 'warn'}
+          />
+          <HealthRow
+            icon={BookOpen}
+            label="Missing reading"
+            value={String(derived.lessonsMissingReading)}
+            status={derived.lessonsMissingReading === 0 ? 'ok' : 'warn'}
+          />
+          <HealthRow
+            icon={AlertTriangle}
+            label="Orphan modules"
+            value={String(derived.totalModules > 0 && derived.totalLessons === 0 ? derived.totalModules : 0)}
+            status="ok"
+          />
+        </div>
+      </div>
+
+      {/* ── Quick Actions ── */}
+      <div className="rounded-2xl border border-slate-200 bg-white shadow-sm overflow-hidden">
+        <div className="border-b border-slate-100 px-5 py-4">
+          <h3 className="text-sm font-semibold text-slate-900">Quick Actions</h3>
+        </div>
+        <div className="px-5 py-4 space-y-2">
+          <button
+            onClick={onAddLesson}
+            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors text-left"
+          >
+            <Plus className="h-4 w-4 text-brand-blue-500" />
+            Add Lesson
+          </button>
+          <button
+            onClick={onAddModule}
+            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors text-left"
+          >
+            <Plus className="h-4 w-4 text-brand-blue-500" />
+            Add Module
+          </button>
+          <button
+            onClick={onPreview}
+            className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors text-left"
+          >
+            <Eye className="h-4 w-4 text-slate-400" />
+            Preview Learner Page
+          </button>
+          {state.id && (
+            <Link
+              href={`/lms/programs/${state.slug || state.id}`}
+              target="_blank"
+              className="flex w-full items-center gap-2.5 rounded-lg px-3 py-2 text-sm text-slate-700 hover:bg-slate-50 transition-colors"
+            >
+              <Eye className="h-4 w-4 text-slate-400" />
+              View Live Page ↗
+            </Link>
+          )}
+        </div>
+      </div>
+
+      {/* ── Publish gate message ── */}
+      {derived.missingRequired.length > 0 && (
+        <div className="rounded-2xl border border-amber-200 bg-amber-50 px-5 py-4">
+          <p className="text-xs font-semibold text-amber-800 mb-2">Cannot publish yet</p>
+          <ul className="space-y-1">
+            {derived.missingRequired.slice(0, 5).map(item => (
+              <li key={item} className="flex items-start gap-1.5 text-xs text-amber-700">
+                <span className="mt-0.5 flex-shrink-0">·</span>
+                {item}
+              </li>
+            ))}
+            {derived.missingRequired.length > 5 && (
+              <li className="text-xs text-amber-600">+{derived.missingRequired.length - 5} more</li>
+            )}
+          </ul>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function HealthRow({
+  icon: Icon, label, value, status, note,
+}: {
+  icon: ElementType;
+  label: string;
+  value: string;
+  status: 'ok' | 'warn' | 'error';
+  note?: string;
+}) {
+  const valueColor = status === 'ok' ? 'text-slate-900' : status === 'warn' ? 'text-amber-600' : 'text-red-600';
+  const iconColor = status === 'ok' ? 'text-slate-400' : status === 'warn' ? 'text-amber-500' : 'text-red-500';
+
+  return (
+    <div className="flex items-center gap-2">
+      <Icon className={`h-3.5 w-3.5 flex-shrink-0 ${iconColor}`} />
+      <span className="flex-1 text-xs text-slate-500">{label}</span>
+      <div className="text-right">
+        <span className={`text-xs font-semibold tabular-nums ${valueColor}`}>{value}</span>
+        {note && <p className="text-xs text-red-400">{note}</p>}
+      </div>
+    </div>
+  );
+}

--- a/components/admin/course-builder/ComplianceFundingSection.tsx
+++ b/components/admin/course-builder/ComplianceFundingSection.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { Shield, CheckCircle } from 'lucide-react';
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState } from './types';
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+const TOGGLE_FIELDS: {
+  key: keyof Pick<ProgramBuilderState, 'wioa_approved' | 'dol_registered' | 'etpl_listed'>;
+  label: string;
+  description: string;
+  badge: string;
+}[] = [
+  {
+    key: 'wioa_approved',
+    label: 'WIOA Eligible',
+    description: 'Program qualifies for Workforce Innovation and Opportunity Act funding. Learners may use Individual Training Accounts (ITAs).',
+    badge: 'WIOA',
+  },
+  {
+    key: 'dol_registered',
+    label: 'DOL Registered',
+    description: 'Program is registered with the Department of Labor. Required for apprenticeship and certain grant-funded tracks.',
+    badge: 'DOL',
+  },
+  {
+    key: 'etpl_listed',
+    label: 'ETPL Listed',
+    description: 'Program appears on the Eligible Training Provider List. Required for WIOA-funded enrollment in most states.',
+    badge: 'ETPL',
+  },
+];
+
+export default function ComplianceFundingSection({ state, onChange }: Props) {
+  const activeCount = TOGGLE_FIELDS.filter(f => state[f.key]).length;
+
+  return (
+    <BuilderSection
+      title="Compliance & Funding Eligibility"
+      description="Workforce funding designations. These determine which learners can enroll using public funding and which grants this program qualifies for."
+    >
+      <div className="space-y-4">
+        {/* Status summary */}
+        <div className={`flex items-center gap-3 rounded-xl px-4 py-3 ${activeCount > 0 ? 'bg-emerald-50 border border-emerald-200' : 'bg-slate-50 border border-slate-200'}`}>
+          <Shield className={`h-5 w-5 flex-shrink-0 ${activeCount > 0 ? 'text-emerald-600' : 'text-slate-400'}`} />
+          <div>
+            <p className={`text-sm font-semibold ${activeCount > 0 ? 'text-emerald-800' : 'text-slate-600'}`}>
+              {activeCount > 0
+                ? `Eligible for ${activeCount} workforce funding program${activeCount > 1 ? 's' : ''}`
+                : 'No funding designations set'}
+            </p>
+            <p className="text-xs text-slate-500 mt-0.5">
+              {activeCount > 0
+                ? 'Learners may be able to enroll using WIOA, DOL, or state workforce funds.'
+                : 'Set eligibility below to unlock workforce funding for enrolled learners.'}
+            </p>
+          </div>
+          {activeCount > 0 && (
+            <div className="ml-auto flex gap-1.5">
+              {TOGGLE_FIELDS.filter(f => state[f.key]).map(f => (
+                <span key={f.key} className="rounded bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-700">
+                  {f.badge}
+                </span>
+              ))}
+            </div>
+          )}
+        </div>
+
+        {/* Toggle rows */}
+        {TOGGLE_FIELDS.map(field => (
+          <div
+            key={field.key}
+            className={`flex items-start gap-4 rounded-xl border px-4 py-4 cursor-pointer transition-colors ${
+              state[field.key] ? 'border-emerald-200 bg-emerald-50/50' : 'border-slate-200 hover:border-slate-300'
+            }`}
+            onClick={() => onChange({ [field.key]: !state[field.key] })}
+          >
+            <div className={`mt-0.5 flex h-5 w-5 flex-shrink-0 items-center justify-center rounded-full border-2 transition-colors ${
+              state[field.key] ? 'border-emerald-500 bg-emerald-500' : 'border-slate-300'
+            }`}>
+              {state[field.key] && <CheckCircle className="h-3.5 w-3.5 text-white fill-white" />}
+            </div>
+            <div className="flex-1">
+              <div className="flex items-center gap-2">
+                <p className="text-sm font-semibold text-slate-900">{field.label}</p>
+                <span className={`rounded px-1.5 py-0.5 text-xs font-bold ${
+                  state[field.key] ? 'bg-emerald-100 text-emerald-700' : 'bg-slate-100 text-slate-500'
+                }`}>
+                  {field.badge}
+                </span>
+              </div>
+              <p className="text-xs text-slate-500 mt-0.5">{field.description}</p>
+            </div>
+          </div>
+        ))}
+
+        {/* Internal notes */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Internal Compliance Notes</label>
+          <textarea
+            rows={3}
+            placeholder="State approval status, grant cycle notes, ETPL application date, DOL registration number…"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20 resize-none"
+          />
+          <p className="mt-1 text-xs text-slate-400">Not shown publicly. Used for internal audit trail.</p>
+        </div>
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/CourseBuilderTopBar.tsx
+++ b/components/admin/course-builder/CourseBuilderTopBar.tsx
@@ -1,0 +1,147 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { ChevronLeft, Eye, Save, AlertTriangle, CheckCircle, Loader2 } from 'lucide-react';
+import type { ProgramBuilderState, ProgramDerivedState } from './types';
+
+interface Props {
+  state: ProgramBuilderState;
+  derived: ProgramDerivedState;
+  saving: boolean;
+  onSave: () => void;
+  onPublish: () => void;
+  onPreview: () => void;
+  onTitleChange: (title: string) => void;
+}
+
+const STATUS_STYLES: Record<string, string> = {
+  draft: 'bg-slate-100 text-slate-600',
+  ready: 'bg-amber-100 text-amber-700',
+  published: 'bg-emerald-100 text-emerald-700',
+  archived: 'bg-red-100 text-red-600',
+};
+
+export default function CourseBuilderTopBar({
+  state,
+  derived,
+  saving,
+  onSave,
+  onPublish,
+  onPreview,
+  onTitleChange,
+}: Props) {
+  const [editingTitle, setEditingTitle] = useState(false);
+  const [titleDraft, setTitleDraft] = useState(state.title);
+
+  const commitTitle = () => {
+    setEditingTitle(false);
+    if (titleDraft.trim()) onTitleChange(titleDraft.trim());
+  };
+
+  const statusLabel =
+    state.status === 'published' ? 'Published' :
+    derived.canPublish ? 'Ready' :
+    'Draft';
+
+  const statusStyle = STATUS_STYLES[state.status === 'published' ? 'published' : derived.canPublish ? 'ready' : 'draft'];
+
+  return (
+    <div className="sticky top-0 z-40 border-b border-slate-200 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/80">
+      <div className="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+        <div className="flex h-14 items-center justify-between gap-4">
+
+          {/* Left: back + title + status */}
+          <div className="flex min-w-0 items-center gap-3">
+            <Link
+              href="/admin/programs"
+              className="flex-shrink-0 text-slate-400 hover:text-slate-700 transition-colors"
+              title="Back to Programs"
+            >
+              <ChevronLeft className="h-5 w-5" />
+            </Link>
+
+            {editingTitle ? (
+              <input
+                autoFocus
+                value={titleDraft}
+                onChange={e => setTitleDraft(e.target.value)}
+                onBlur={commitTitle}
+                onKeyDown={e => { if (e.key === 'Enter') commitTitle(); if (e.key === 'Escape') setEditingTitle(false); }}
+                className="min-w-0 flex-1 rounded border border-brand-blue-400 px-2 py-0.5 text-sm font-semibold text-slate-900 focus:outline-none focus:ring-2 focus:ring-brand-blue-500"
+              />
+            ) : (
+              <button
+                onClick={() => { setTitleDraft(state.title); setEditingTitle(true); }}
+                className="min-w-0 truncate text-sm font-semibold text-slate-900 hover:text-brand-blue-600 transition-colors text-left"
+                title="Click to rename"
+              >
+                {state.title || 'Untitled Program'}
+              </button>
+            )}
+
+            <span className={`flex-shrink-0 rounded-full px-2.5 py-0.5 text-xs font-medium ${statusStyle}`}>
+              {statusLabel}
+            </span>
+          </div>
+
+          {/* Center: completion + missing */}
+          <div className="hidden md:flex items-center gap-4 text-sm">
+            {/* Completion bar */}
+            <div className="flex items-center gap-2">
+              <div className="h-1.5 w-24 rounded-full bg-slate-200 overflow-hidden">
+                <div
+                  className={`h-full rounded-full transition-all ${derived.completionPercent === 100 ? 'bg-emerald-500' : 'bg-brand-blue-500'}`}
+                  style={{ width: `${derived.completionPercent}%` }}
+                />
+              </div>
+              <span className="text-slate-500 tabular-nums">{derived.completionPercent}%</span>
+            </div>
+
+            {/* Missing count */}
+            {derived.missingRequired.length > 0 ? (
+              <span className="flex items-center gap-1 text-amber-600">
+                <AlertTriangle className="h-3.5 w-3.5" />
+                {derived.missingRequired.length} required {derived.missingRequired.length === 1 ? 'item' : 'items'} missing
+              </span>
+            ) : (
+              <span className="flex items-center gap-1 text-emerald-600">
+                <CheckCircle className="h-3.5 w-3.5" />
+                Ready to publish
+              </span>
+            )}
+          </div>
+
+          {/* Right: actions */}
+          <div className="flex flex-shrink-0 items-center gap-2">
+            <button
+              onClick={onPreview}
+              className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors"
+            >
+              <Eye className="h-4 w-4" />
+              <span className="hidden sm:inline">Preview</span>
+            </button>
+
+            <button
+              onClick={onSave}
+              disabled={saving}
+              className="flex items-center gap-1.5 rounded-lg border border-slate-200 px-3 py-1.5 text-sm font-medium text-slate-700 hover:bg-slate-50 transition-colors disabled:opacity-50"
+            >
+              {saving ? <Loader2 className="h-4 w-4 animate-spin" /> : <Save className="h-4 w-4" />}
+              <span className="hidden sm:inline">{saving ? 'Saving…' : 'Save'}</span>
+            </button>
+
+            <button
+              onClick={onPublish}
+              disabled={!derived.canPublish || state.status === 'published'}
+              title={!derived.canPublish ? `Cannot publish: ${derived.missingRequired[0]}` : undefined}
+              className="rounded-lg bg-brand-blue-600 px-4 py-1.5 text-sm font-semibold text-white hover:bg-brand-blue-700 transition-colors disabled:cursor-not-allowed disabled:opacity-40"
+            >
+              {state.status === 'published' ? 'Published' : 'Publish'}
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/course-builder/CurriculumTreeSection.tsx
+++ b/components/admin/course-builder/CurriculumTreeSection.tsx
@@ -1,0 +1,405 @@
+'use client';
+
+import { useState, type ElementType } from 'react';
+import {
+  ChevronDown, ChevronRight, Plus, Trash2, GripVertical,
+  Video, BookOpen, ClipboardCheck, FlaskConical, FileQuestion, GraduationCap,
+  CheckCircle, AlertCircle,
+} from 'lucide-react';
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState, ProgramPhase, ProgramModule, ProgramLesson, LessonType } from './types';
+
+const LESSON_TYPE_META: Record<LessonType, { label: string; icon: ElementType; color: string }> = {
+  lesson:      { label: 'Lesson',      icon: BookOpen,       color: 'text-brand-blue-600 bg-brand-blue-50' },
+  quiz:        { label: 'Quiz',        icon: FileQuestion,   color: 'text-amber-600 bg-amber-50' },
+  checkpoint:  { label: 'Checkpoint',  icon: ClipboardCheck, color: 'text-purple-600 bg-purple-50' },
+  lab:         { label: 'Lab',         icon: FlaskConical,   color: 'text-emerald-600 bg-emerald-50' },
+  exam:        { label: 'Exam',        icon: GraduationCap,  color: 'text-red-600 bg-red-50' },
+  orientation: { label: 'Orientation', icon: Video,          color: 'text-slate-600 bg-slate-100' },
+};
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function CurriculumTreeSection({ state, onChange }: Props) {
+  const phases = state.phases;
+  const [expandedPhases, setExpandedPhases] = useState<Set<string>>(new Set(phases.map(p => p.id)));
+  const [expandedModules, setExpandedModules] = useState<Set<string>>(new Set());
+
+  const totalModules = phases.reduce((n, p) => n + p.modules.length, 0);
+  const totalLessons = phases.reduce((n, p) => n + p.modules.reduce((m, mod) => m + mod.lessons.length, 0), 0);
+
+  const updatePhases = (next: ProgramPhase[]) => onChange({ phases: next });
+
+  // ── Phase ops ──────────────────────────────────────────────────────────────
+
+  const addPhase = () => {
+    const newPhase: ProgramPhase = {
+      id: crypto.randomUUID(),
+      title: `Phase ${phases.length + 1}`,
+      sort_order: phases.length,
+      modules: [],
+    };
+    const next = [...phases, newPhase];
+    updatePhases(next);
+    setExpandedPhases(prev => new Set([...prev, newPhase.id]));
+  };
+
+  const updatePhaseTitle = (phaseId: string, title: string) => {
+    updatePhases(phases.map(p => p.id === phaseId ? { ...p, title } : p));
+  };
+
+  const removePhase = (phaseId: string) => {
+    updatePhases(phases.filter(p => p.id !== phaseId).map((p, i) => ({ ...p, sort_order: i })));
+  };
+
+  // ── Module ops ─────────────────────────────────────────────────────────────
+
+  const addModule = (phaseId: string) => {
+    const phase = phases.find(p => p.id === phaseId)!;
+    const newMod: ProgramModule = {
+      id: crypto.randomUUID(),
+      title: `Module ${phase.modules.length + 1}`,
+      sort_order: phase.modules.length,
+      lessons: [],
+    };
+    updatePhases(phases.map(p =>
+      p.id === phaseId ? { ...p, modules: [...p.modules, newMod] } : p
+    ));
+    setExpandedModules(prev => new Set([...prev, newMod.id]));
+  };
+
+  const updateModuleTitle = (phaseId: string, moduleId: string, title: string) => {
+    updatePhases(phases.map(p =>
+      p.id === phaseId
+        ? { ...p, modules: p.modules.map(m => m.id === moduleId ? { ...m, title } : m) }
+        : p
+    ));
+  };
+
+  const removeModule = (phaseId: string, moduleId: string) => {
+    updatePhases(phases.map(p =>
+      p.id === phaseId
+        ? { ...p, modules: p.modules.filter(m => m.id !== moduleId).map((m, i) => ({ ...m, sort_order: i })) }
+        : p
+    ));
+  };
+
+  // ── Lesson ops ─────────────────────────────────────────────────────────────
+
+  const addLesson = (phaseId: string, moduleId: string) => {
+    const phase = phases.find(p => p.id === phaseId)!;
+    const mod = phase.modules.find(m => m.id === moduleId)!;
+    const newLesson: ProgramLesson = {
+      id: crypto.randomUUID(),
+      title: `Lesson ${mod.lessons.length + 1}`,
+      lesson_type: 'lesson',
+      sort_order: mod.lessons.length,
+      duration_minutes: null,
+      is_published: false,
+      has_video: false,
+      has_reading: false,
+    };
+    updatePhases(phases.map(p =>
+      p.id === phaseId
+        ? { ...p, modules: p.modules.map(m =>
+            m.id === moduleId ? { ...m, lessons: [...m.lessons, newLesson] } : m
+          )}
+        : p
+    ));
+  };
+
+  const updateLesson = (phaseId: string, moduleId: string, lessonId: string, patch: Partial<ProgramLesson>) => {
+    updatePhases(phases.map(p =>
+      p.id === phaseId
+        ? { ...p, modules: p.modules.map(m =>
+            m.id === moduleId
+              ? { ...m, lessons: m.lessons.map(l => l.id === lessonId ? { ...l, ...patch } : l) }
+              : m
+          )}
+        : p
+    ));
+  };
+
+  const removeLesson = (phaseId: string, moduleId: string, lessonId: string) => {
+    updatePhases(phases.map(p =>
+      p.id === phaseId
+        ? { ...p, modules: p.modules.map(m =>
+            m.id === moduleId
+              ? { ...m, lessons: m.lessons.filter(l => l.id !== lessonId).map((l, i) => ({ ...l, sort_order: i })) }
+              : m
+          )}
+        : p
+    ));
+  };
+
+  const togglePhase = (id: string) => setExpandedPhases(prev => {
+    const next = new Set(prev);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+
+  const toggleModule = (id: string) => setExpandedModules(prev => {
+    const next = new Set(prev);
+    next.has(id) ? next.delete(id) : next.add(id);
+    return next;
+  });
+
+  const missingContent = totalModules < 3 || totalLessons < 10;
+
+  return (
+    <BuilderSection
+      title="Curriculum"
+      description="Structure your program into phases, modules, and lessons. Minimum: 1 phase, 3 modules, 10 lessons."
+      required
+      warning={
+        missingContent
+          ? `Current: ${phases.length} phase${phases.length !== 1 ? 's' : ''}, ${totalModules} module${totalModules !== 1 ? 's' : ''}, ${totalLessons} lesson${totalLessons !== 1 ? 's' : ''}. Minimum required: 1 phase, 3 modules, 10 lessons.`
+          : undefined
+      }
+    >
+      {/* Summary strip */}
+      <div className="flex items-center gap-6 mb-4 text-sm text-slate-500">
+        <span><strong className="text-slate-900">{phases.length}</strong> phases</span>
+        <span><strong className="text-slate-900">{totalModules}</strong> modules</span>
+        <span><strong className={totalLessons >= 10 ? 'text-emerald-600' : 'text-amber-600'}>{totalLessons}</strong> lessons</span>
+      </div>
+
+      <div className="space-y-3">
+        {phases.map(phase => (
+          <PhaseBlock
+            key={phase.id}
+            phase={phase}
+            expanded={expandedPhases.has(phase.id)}
+            expandedModules={expandedModules}
+            onToggle={() => togglePhase(phase.id)}
+            onToggleModule={toggleModule}
+            onTitleChange={title => updatePhaseTitle(phase.id, title)}
+            onRemove={() => removePhase(phase.id)}
+            onAddModule={() => addModule(phase.id)}
+            onModuleTitleChange={(mId, t) => updateModuleTitle(phase.id, mId, t)}
+            onRemoveModule={mId => removeModule(phase.id, mId)}
+            onAddLesson={mId => addLesson(phase.id, mId)}
+            onUpdateLesson={(mId, lId, patch) => updateLesson(phase.id, mId, lId, patch)}
+            onRemoveLesson={(mId, lId) => removeLesson(phase.id, mId, lId)}
+          />
+        ))}
+
+        <button
+          onClick={addPhase}
+          className="flex w-full items-center justify-center gap-2 rounded-xl border-2 border-dashed border-slate-200 py-3 text-sm font-medium text-slate-500 hover:border-brand-blue-300 hover:text-brand-blue-600 transition-colors"
+        >
+          <Plus className="h-4 w-4" />
+          Add Phase
+        </button>
+      </div>
+    </BuilderSection>
+  );
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function PhaseBlock({
+  phase, expanded, expandedModules, onToggle, onToggleModule,
+  onTitleChange, onRemove, onAddModule,
+  onModuleTitleChange, onRemoveModule,
+  onAddLesson, onUpdateLesson, onRemoveLesson,
+}: {
+  phase: ProgramPhase;
+  expanded: boolean;
+  expandedModules: Set<string>;
+  onToggle: () => void;
+  onToggleModule: (id: string) => void;
+  onTitleChange: (t: string) => void;
+  onRemove: () => void;
+  onAddModule: () => void;
+  onModuleTitleChange: (mId: string, t: string) => void;
+  onRemoveModule: (mId: string) => void;
+  onAddLesson: (mId: string) => void;
+  onUpdateLesson: (mId: string, lId: string, patch: Partial<ProgramLesson>) => void;
+  onRemoveLesson: (mId: string, lId: string) => void;
+}) {
+  const lessonCount = phase.modules.reduce((n, m) => n + m.lessons.length, 0);
+
+  return (
+    <div className="rounded-xl border border-slate-200 overflow-hidden">
+      {/* Phase header */}
+      <div className="flex items-center gap-2 bg-slate-50 px-4 py-3 group">
+        <GripVertical className="h-4 w-4 text-slate-300 cursor-grab flex-shrink-0" />
+        <button onClick={onToggle} className="flex-shrink-0 text-slate-400 hover:text-slate-700">
+          {expanded ? <ChevronDown className="h-4 w-4" /> : <ChevronRight className="h-4 w-4" />}
+        </button>
+        <input
+          type="text"
+          value={phase.title}
+          onChange={e => onTitleChange(e.target.value)}
+          className="flex-1 bg-transparent text-sm font-semibold text-slate-900 focus:outline-none focus:ring-0 border-0 p-0"
+        />
+        <span className="text-xs text-slate-400">{phase.modules.length} modules · {lessonCount} lessons</span>
+        <button
+          onClick={onRemove}
+          className="opacity-0 group-hover:opacity-100 p-1 text-slate-300 hover:text-red-500 transition-colors"
+          title="Remove phase"
+        >
+          <Trash2 className="h-3.5 w-3.5" />
+        </button>
+      </div>
+
+      {/* Phase body */}
+      {expanded && (
+        <div className="px-4 py-3 space-y-2 bg-white">
+          {phase.modules.map(mod => (
+            <ModuleBlock
+              key={mod.id}
+              module={mod}
+              expanded={expandedModules.has(mod.id)}
+              onToggle={() => onToggleModule(mod.id)}
+              onTitleChange={t => onModuleTitleChange(mod.id, t)}
+              onRemove={() => onRemoveModule(mod.id)}
+              onAddLesson={() => onAddLesson(mod.id)}
+              onUpdateLesson={(lId, patch) => onUpdateLesson(mod.id, lId, patch)}
+              onRemoveLesson={lId => onRemoveLesson(mod.id, lId)}
+            />
+          ))}
+
+          <button
+            onClick={onAddModule}
+            className="flex w-full items-center gap-2 rounded-lg border border-dashed border-slate-200 px-3 py-2 text-xs font-medium text-slate-400 hover:border-brand-blue-300 hover:text-brand-blue-600 transition-colors"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Add Module
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function ModuleBlock({
+  module, expanded, onToggle, onTitleChange, onRemove,
+  onAddLesson, onUpdateLesson, onRemoveLesson,
+}: {
+  module: ProgramModule;
+  expanded: boolean;
+  onToggle: () => void;
+  onTitleChange: (t: string) => void;
+  onRemove: () => void;
+  onAddLesson: () => void;
+  onUpdateLesson: (lId: string, patch: Partial<ProgramLesson>) => void;
+  onRemoveLesson: (lId: string) => void;
+}) {
+  return (
+    <div className="rounded-lg border border-slate-100 overflow-hidden">
+      {/* Module header */}
+      <div className="flex items-center gap-2 bg-slate-50/60 px-3 py-2.5 group">
+        <GripVertical className="h-3.5 w-3.5 text-slate-300 cursor-grab flex-shrink-0" />
+        <button onClick={onToggle} className="flex-shrink-0 text-slate-400 hover:text-slate-700">
+          {expanded ? <ChevronDown className="h-3.5 w-3.5" /> : <ChevronRight className="h-3.5 w-3.5" />}
+        </button>
+        <input
+          type="text"
+          value={module.title}
+          onChange={e => onTitleChange(e.target.value)}
+          className="flex-1 bg-transparent text-sm font-medium text-slate-800 focus:outline-none focus:ring-0 border-0 p-0"
+        />
+        <span className="text-xs text-slate-400">{module.lessons.length} lessons</span>
+        <button
+          onClick={onRemove}
+          className="opacity-0 group-hover:opacity-100 p-1 text-slate-300 hover:text-red-500 transition-colors"
+        >
+          <Trash2 className="h-3 w-3" />
+        </button>
+      </div>
+
+      {/* Lessons */}
+      {expanded && (
+        <div className="px-3 py-2 space-y-1.5 bg-white">
+          {module.lessons.map(lesson => (
+            <LessonRow
+              key={lesson.id}
+              lesson={lesson}
+              onUpdate={patch => onUpdateLesson(lesson.id, patch)}
+              onRemove={() => onRemoveLesson(lesson.id)}
+            />
+          ))}
+
+          <button
+            onClick={onAddLesson}
+            className="flex w-full items-center gap-1.5 rounded px-2 py-1.5 text-xs font-medium text-slate-400 hover:text-brand-blue-600 hover:bg-brand-blue-50 transition-colors"
+          >
+            <Plus className="h-3 w-3" />
+            Add Lesson
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+function LessonRow({
+  lesson, onUpdate, onRemove,
+}: {
+  lesson: ProgramLesson;
+  onUpdate: (patch: Partial<ProgramLesson>) => void;
+  onRemove: () => void;
+}) {
+  const meta = LESSON_TYPE_META[lesson.lesson_type];
+  const Icon = meta.icon;
+  const hasContent = lesson.has_video || lesson.has_reading;
+
+  return (
+    <div className="flex items-center gap-2 rounded-lg px-2 py-1.5 hover:bg-slate-50 group">
+      <GripVertical className="h-3 w-3 text-slate-200 cursor-grab flex-shrink-0" />
+
+      {/* Type icon */}
+      <div className={`flex h-6 w-6 flex-shrink-0 items-center justify-center rounded ${meta.color}`}>
+        <Icon className="h-3.5 w-3.5" />
+      </div>
+
+      {/* Title */}
+      <input
+        type="text"
+        value={lesson.title}
+        onChange={e => onUpdate({ title: e.target.value })}
+        className="flex-1 bg-transparent text-xs text-slate-800 focus:outline-none focus:ring-0 border-0 p-0 min-w-0"
+      />
+
+      {/* Type selector */}
+      <select
+        value={lesson.lesson_type}
+        onChange={e => onUpdate({ lesson_type: e.target.value as LessonType })}
+        className="rounded border-0 bg-transparent text-xs text-slate-500 focus:outline-none focus:ring-0 cursor-pointer"
+      >
+        {Object.entries(LESSON_TYPE_META).map(([val, m]) => (
+          <option key={val} value={val}>{m.label}</option>
+        ))}
+      </select>
+
+      {/* Duration */}
+      <input
+        type="number"
+        min={1}
+        value={lesson.duration_minutes ?? ''}
+        onChange={e => onUpdate({ duration_minutes: e.target.value ? Number(e.target.value) : null })}
+        placeholder="min"
+        className="w-12 rounded border-0 bg-transparent text-xs text-slate-400 focus:outline-none focus:ring-0 text-right"
+      />
+
+      {/* Content status */}
+      {hasContent
+        ? <CheckCircle className="h-3.5 w-3.5 flex-shrink-0 text-emerald-500" title="Has content" />
+        : <AlertCircle className="h-3.5 w-3.5 flex-shrink-0 text-amber-400" title="No content yet" />
+      }
+
+      {/* Remove */}
+      <button
+        onClick={onRemove}
+        className="opacity-0 group-hover:opacity-100 p-0.5 text-slate-300 hover:text-red-500 transition-colors"
+      >
+        <Trash2 className="h-3 w-3" />
+      </button>
+    </div>
+  );
+}

--- a/components/admin/course-builder/DeliveryStructureSection.tsx
+++ b/components/admin/course-builder/DeliveryStructureSection.tsx
@@ -1,0 +1,112 @@
+'use client';
+
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState, DeliveryMode } from './types';
+
+const DELIVERY_OPTIONS: { value: DeliveryMode; label: string; description: string }[] = [
+  { value: 'in_person', label: 'In-Person',  description: 'Instructor-led, on-site training' },
+  { value: 'hybrid',    label: 'Hybrid',     description: 'Mix of in-person and online sessions' },
+  { value: 'online',    label: 'Online',     description: 'Fully remote, self-paced or live virtual' },
+];
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function DeliveryStructureSection({ state, onChange }: Props) {
+  const totalLessons = state.phases.reduce(
+    (n, p) => n + p.modules.reduce((m, mod) => m + mod.lessons.length, 0), 0
+  );
+  const estimatedMinutes = state.phases.reduce(
+    (n, p) => n + p.modules.reduce(
+      (m, mod) => m + mod.lessons.reduce((l, les) => l + (les.duration_minutes ?? 0), 0), 0
+    ), 0
+  );
+  const derivedHours = estimatedMinutes > 0 ? Math.round(estimatedMinutes / 60) : null;
+
+  return (
+    <BuilderSection
+      title="Delivery & Duration"
+      description="How and how long this program runs. Shown on the public page and used in funding applications."
+      required
+    >
+      <div className="space-y-5">
+        {/* Delivery mode */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-2">
+            Delivery Mode <span className="text-red-500">*</span>
+          </label>
+          <div className="grid grid-cols-1 sm:grid-cols-3 gap-3">
+            {DELIVERY_OPTIONS.map(opt => (
+              <button
+                key={opt.value}
+                type="button"
+                onClick={() => onChange({ delivery_method: opt.value })}
+                className={`rounded-xl border-2 px-4 py-3 text-left transition-colors ${
+                  state.delivery_method === opt.value
+                    ? 'border-brand-blue-500 bg-brand-blue-50'
+                    : 'border-slate-200 hover:border-slate-300'
+                }`}
+              >
+                <p className={`text-sm font-semibold ${state.delivery_method === opt.value ? 'text-brand-blue-700' : 'text-slate-900'}`}>
+                  {opt.label}
+                </p>
+                <p className="text-xs text-slate-500 mt-0.5">{opt.description}</p>
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {/* Duration row */}
+        <div className="grid grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              Duration (weeks) <span className="text-red-500">*</span>
+            </label>
+            <input
+              type="number"
+              min={1}
+              value={state.estimated_weeks ?? ''}
+              onChange={e => onChange({ estimated_weeks: e.target.value ? Number(e.target.value) : null })}
+              placeholder="e.g. 12"
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+            />
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              Total Hours
+              {derivedHours && (
+                <span className="ml-2 text-xs font-normal text-slate-400">
+                  (estimated {derivedHours}h from lesson durations)
+                </span>
+              )}
+            </label>
+            <input
+              type="number"
+              min={1}
+              value={state.estimated_hours ?? ''}
+              onChange={e => onChange({ estimated_hours: e.target.value ? Number(e.target.value) : null })}
+              placeholder={derivedHours ? String(derivedHours) : 'e.g. 120'}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+            />
+          </div>
+        </div>
+
+        {/* Live summary */}
+        {(state.estimated_weeks || state.estimated_hours || totalLessons > 0) && (
+          <div className="rounded-lg bg-slate-50 border border-slate-200 px-4 py-3 text-sm text-slate-600">
+            <span className="font-medium text-slate-900">Learner-facing summary: </span>
+            {[
+              state.estimated_weeks && `${state.estimated_weeks}-week program`,
+              state.estimated_hours && `${state.estimated_hours} hours`,
+              totalLessons > 0 && `${totalLessons} lessons`,
+              state.delivery_method && DELIVERY_OPTIONS.find(o => o.value === state.delivery_method)?.label,
+            ].filter(Boolean).join(' · ')}
+          </div>
+        )}
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/EnrollmentCtaSection.tsx
+++ b/components/admin/course-builder/EnrollmentCtaSection.tsx
@@ -1,0 +1,227 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, Trash2, ExternalLink } from 'lucide-react';
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState, ProgramCta, CtaType, ProgramTrack, FundingType } from './types';
+
+const CTA_TYPES: { value: CtaType; label: string }[] = [
+  { value: 'apply',        label: 'Apply Now' },
+  { value: 'request_info', label: 'Request Info' },
+  { value: 'waitlist',     label: 'Join Waitlist' },
+  { value: 'external',     label: 'External Link' },
+];
+
+const FUNDING_TYPES: { value: FundingType; label: string }[] = [
+  { value: 'funded',             label: 'Workforce Funded (WIOA/DOL)' },
+  { value: 'self_pay',           label: 'Self-Pay' },
+  { value: 'employer_sponsored', label: 'Employer Sponsored' },
+  { value: 'partner',            label: 'Partner Funded' },
+  { value: 'other',              label: 'Other' },
+];
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function EnrollmentCtaSection({ state, onChange }: Props) {
+  const [ctaDraft, setCtaDraft] = useState<Partial<ProgramCta>>({ cta_type: 'apply', label: '', href: '', style_variant: 'primary' });
+  const [trackDraft, setTrackDraft] = useState<Partial<ProgramTrack>>({ funding_type: 'funded', title: '', track_code: '', available: true });
+
+  const addCta = () => {
+    if (!ctaDraft.label?.trim() || !ctaDraft.href?.trim()) return;
+    const next: ProgramCta = {
+      id: crypto.randomUUID(),
+      cta_type: ctaDraft.cta_type as CtaType,
+      label: ctaDraft.label.trim(),
+      href: ctaDraft.href.trim(),
+      style_variant: ctaDraft.style_variant as ProgramCta['style_variant'],
+      sort_order: state.ctas.length,
+    };
+    onChange({ ctas: [...state.ctas, next] });
+    setCtaDraft({ cta_type: 'apply', label: '', href: '', style_variant: 'primary' });
+  };
+
+  const removeCta = (id: string) => onChange({ ctas: state.ctas.filter(c => c.id !== id) });
+
+  const addTrack = () => {
+    if (!trackDraft.title?.trim() || !trackDraft.track_code?.trim()) return;
+    const next: ProgramTrack = {
+      id: crypto.randomUUID(),
+      track_code: trackDraft.track_code!.trim(),
+      title: trackDraft.title!.trim(),
+      funding_type: trackDraft.funding_type as FundingType,
+      cost_cents: trackDraft.cost_cents ?? null,
+      available: trackDraft.available ?? true,
+      sort_order: state.tracks.length,
+    };
+    onChange({ tracks: [...state.tracks, next] });
+    setTrackDraft({ funding_type: 'funded', title: '', track_code: '', available: true });
+  };
+
+  const removeTrack = (id: string) => onChange({ tracks: state.tracks.filter(t => t.id !== id) });
+
+  return (
+    <BuilderSection
+      title="Enrollment & CTA"
+      description="How learners apply or enroll. At least one CTA is required before publishing."
+      required
+      warning={state.ctas.length === 0 ? 'No CTA set. Learners cannot enroll without a call-to-action.' : undefined}
+    >
+      <div className="space-y-6">
+
+        {/* ── CTAs ── */}
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800 mb-3">Calls to Action</h3>
+
+          {state.ctas.length > 0 && (
+            <div className="space-y-2 mb-3">
+              {state.ctas.map((cta, idx) => (
+                <div key={cta.id} className="flex items-center gap-3 rounded-lg border border-slate-200 px-3 py-2.5">
+                  {idx === 0 && (
+                    <span className="flex-shrink-0 rounded bg-brand-blue-100 px-1.5 py-0.5 text-xs font-medium text-brand-blue-700">Primary</span>
+                  )}
+                  <span className="flex-1 text-sm font-medium text-slate-900">{cta.label}</span>
+                  <span className="text-xs text-slate-400 truncate max-w-[160px]">{cta.href}</span>
+                  <span className="text-xs text-slate-400">{CTA_TYPES.find(t => t.value === cta.cta_type)?.label}</span>
+                  <button onClick={() => removeCta(cta.id)} className="text-slate-300 hover:text-red-500 transition-colors">
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {/* Add CTA form */}
+          <div className="rounded-xl border border-dashed border-slate-200 p-4 space-y-3">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">Add CTA</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Button Label</label>
+                <input
+                  type="text"
+                  value={ctaDraft.label ?? ''}
+                  onChange={e => setCtaDraft(d => ({ ...d, label: e.target.value }))}
+                  placeholder="Apply Now"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Type</label>
+                <select
+                  value={ctaDraft.cta_type}
+                  onChange={e => setCtaDraft(d => ({ ...d, cta_type: e.target.value as CtaType }))}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm bg-white focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                >
+                  {CTA_TYPES.map(t => <option key={t.value} value={t.value}>{t.label}</option>)}
+                </select>
+              </div>
+            </div>
+            <div>
+              <label className="block text-xs text-slate-600 mb-1">Destination URL or Path</label>
+              <input
+                type="text"
+                value={ctaDraft.href ?? ''}
+                onChange={e => setCtaDraft(d => ({ ...d, href: e.target.value }))}
+                placeholder="/apply or https://…"
+                className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+              />
+            </div>
+            <button
+              onClick={addCta}
+              disabled={!ctaDraft.label?.trim() || !ctaDraft.href?.trim()}
+              className="flex items-center gap-1.5 rounded-lg bg-brand-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-blue-700 disabled:opacity-40 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+              Add CTA
+            </button>
+          </div>
+        </div>
+
+        {/* ── Enrollment Tracks ── */}
+        <div>
+          <h3 className="text-sm font-semibold text-slate-800 mb-1">Enrollment Tracks</h3>
+          <p className="text-xs text-slate-500 mb-3">Define how learners pay or get funded. Each track appears as an enrollment option.</p>
+
+          {state.tracks.length > 0 && (
+            <div className="space-y-2 mb-3">
+              {state.tracks.map(track => (
+                <div key={track.id} className="flex items-center gap-3 rounded-lg border border-slate-200 px-3 py-2.5">
+                  <span className="flex-1 text-sm font-medium text-slate-900">{track.title}</span>
+                  <span className="text-xs text-slate-400">{FUNDING_TYPES.find(f => f.value === track.funding_type)?.label}</span>
+                  {track.cost_cents != null && (
+                    <span className="text-xs text-slate-500">${(track.cost_cents / 100).toFixed(0)}</span>
+                  )}
+                  <span className={`text-xs font-medium ${track.available ? 'text-emerald-600' : 'text-slate-400'}`}>
+                    {track.available ? 'Open' : 'Closed'}
+                  </span>
+                  <button onClick={() => removeTrack(track.id)} className="text-slate-300 hover:text-red-500 transition-colors">
+                    <Trash2 className="h-3.5 w-3.5" />
+                  </button>
+                </div>
+              ))}
+            </div>
+          )}
+
+          <div className="rounded-xl border border-dashed border-slate-200 p-4 space-y-3">
+            <p className="text-xs font-medium text-slate-500 uppercase tracking-wide">Add Track</p>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Track Name</label>
+                <input
+                  type="text"
+                  value={trackDraft.title ?? ''}
+                  onChange={e => setTrackDraft(d => ({ ...d, title: e.target.value }))}
+                  placeholder="WIOA Funded"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                />
+              </div>
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Track Code</label>
+                <input
+                  type="text"
+                  value={trackDraft.track_code ?? ''}
+                  onChange={e => setTrackDraft(d => ({ ...d, track_code: e.target.value.toLowerCase().replace(/\s+/g, '-') }))}
+                  placeholder="wioa-funded"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                />
+              </div>
+            </div>
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Funding Type</label>
+                <select
+                  value={trackDraft.funding_type}
+                  onChange={e => setTrackDraft(d => ({ ...d, funding_type: e.target.value as FundingType }))}
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm bg-white focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                >
+                  {FUNDING_TYPES.map(f => <option key={f.value} value={f.value}>{f.label}</option>)}
+                </select>
+              </div>
+              <div>
+                <label className="block text-xs text-slate-600 mb-1">Cost (leave blank if funded)</label>
+                <input
+                  type="number"
+                  min={0}
+                  value={trackDraft.cost_cents != null ? trackDraft.cost_cents / 100 : ''}
+                  onChange={e => setTrackDraft(d => ({ ...d, cost_cents: e.target.value ? Math.round(Number(e.target.value) * 100) : undefined }))}
+                  placeholder="0.00"
+                  className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+                />
+              </div>
+            </div>
+            <button
+              onClick={addTrack}
+              disabled={!trackDraft.title?.trim() || !trackDraft.track_code?.trim()}
+              className="flex items-center gap-1.5 rounded-lg bg-brand-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-blue-700 disabled:opacity-40 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+              Add Track
+            </button>
+          </div>
+        </div>
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/ProgramBuilderClient.tsx
+++ b/components/admin/course-builder/ProgramBuilderClient.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import { useMemo, useState, useCallback } from 'react';
+import CourseBuilderTopBar from './CourseBuilderTopBar';
+import ProgramIdentitySection from './ProgramIdentitySection';
+import ProgramOutcomesSection from './ProgramOutcomesSection';
+import ProgramCertificationsSection from './ProgramCertificationsSection';
+import CurriculumTreeSection from './CurriculumTreeSection';
+import DeliveryStructureSection from './DeliveryStructureSection';
+import EnrollmentCtaSection from './EnrollmentCtaSection';
+import ComplianceFundingSection from './ComplianceFundingSection';
+import BuilderSidebar from './BuilderSidebar';
+import { validateProgram } from './types';
+import type { ProgramBuilderState, ProgramDerivedState } from './types';
+
+interface AvailableCredential {
+  id: string;
+  name: string;
+  abbreviation: string | null;
+  issuing_authority: string;
+}
+
+interface Props {
+  initialState: ProgramBuilderState;
+  availableCredentials: AvailableCredential[];
+}
+
+export default function ProgramBuilderClient({ initialState, availableCredentials }: Props) {
+  const [state, setState] = useState<ProgramBuilderState>(initialState);
+  const [saving, setSaving] = useState(false);
+  const [saveError, setSaveError] = useState<string | null>(null);
+  const [saveSuccess, setSaveSuccess] = useState(false);
+  const [showPreview, setShowPreview] = useState(false);
+
+  const derived = useMemo(() => validateProgram(state), [state]);
+
+  const patch = useCallback((update: Partial<ProgramBuilderState>) => {
+    setState(prev => ({ ...prev, ...update }));
+    setSaveSuccess(false);
+  }, []);
+
+  // ── Save ──────────────────────────────────────────────────────────────────
+
+  const handleSave = async () => {
+    setSaving(true);
+    setSaveError(null);
+    try {
+      const res = await fetch(`/api/admin/programs/${state.id}`, {
+        method: 'PATCH',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          title: state.title,
+          subtitle: state.subtitle,
+          slug: state.slug,
+          category: state.category,
+          description: state.description,
+          hero_image_url: state.hero_image_url,
+          estimated_weeks: state.estimated_weeks,
+          estimated_hours: state.estimated_hours,
+          delivery_method: state.delivery_method,
+          wioa_approved: state.wioa_approved,
+          dol_registered: state.dol_registered,
+          etpl_listed: state.etpl_listed,
+          outcomes: state.outcomes,
+          credentials: state.credentials,
+          phases: state.phases,
+          ctas: state.ctas,
+          tracks: state.tracks,
+        }),
+      });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? 'Save failed');
+      }
+      setSaveSuccess(true);
+      setTimeout(() => setSaveSuccess(false), 3000);
+    } catch (err: any) {
+      setSaveError(err?.message ?? 'Save failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  // ── Publish ───────────────────────────────────────────────────────────────
+
+  const handlePublish = async () => {
+    if (!derived.canPublish) return;
+    setSaving(true);
+    setSaveError(null);
+    try {
+      // Save first, then publish
+      await handleSave();
+      const res = await fetch(`/api/admin/programs/${state.id}/publish`, { method: 'POST' });
+      if (!res.ok) {
+        const body = await res.json().catch(() => null);
+        throw new Error(body?.error ?? 'Publish failed');
+      }
+      setState(prev => ({ ...prev, status: 'published', published: true }));
+    } catch (err: any) {
+      setSaveError(err?.message ?? 'Publish failed');
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      {/* Sticky top bar */}
+      <CourseBuilderTopBar
+        state={state}
+        derived={derived}
+        saving={saving}
+        onSave={handleSave}
+        onPublish={handlePublish}
+        onPreview={() => setShowPreview(true)}
+        onTitleChange={title => patch({ title })}
+      />
+
+      {/* Context hero */}
+      <section className="border-b border-slate-200 bg-white">
+        <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+          <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+            <div>
+              <p className="text-xs font-medium uppercase tracking-wide text-slate-400 mb-1">Program Builder</p>
+              <h1 className="text-xl font-bold text-slate-900">
+                {state.title || 'Untitled Program'}
+              </h1>
+              <p className="mt-1 text-sm text-slate-500">
+                Define outcomes, structure curriculum, and prepare learners for certification.
+              </p>
+            </div>
+            <div className="flex flex-wrap gap-4 text-sm text-slate-500">
+              <Stat label="Phases"  value={derived.totalPhases} />
+              <Stat label="Modules" value={derived.totalModules} />
+              <Stat label="Lessons" value={derived.totalLessons} highlight={derived.totalLessons < 10} />
+              <Stat label="Credentials" value={state.credentials.length} />
+              {state.estimated_weeks && <Stat label="Weeks" value={state.estimated_weeks} />}
+            </div>
+          </div>
+        </div>
+      </section>
+
+      {/* Save feedback */}
+      {(saveError || saveSuccess) && (
+        <div className={`border-b px-4 py-2 text-sm text-center ${saveError ? 'bg-red-50 border-red-200 text-red-700' : 'bg-emerald-50 border-emerald-200 text-emerald-700'}`}>
+          {saveError ?? 'Saved successfully'}
+        </div>
+      )}
+
+      {/* Main grid */}
+      <div className="mx-auto max-w-7xl px-4 py-6 sm:px-6 lg:px-8">
+        <div className="grid grid-cols-1 gap-6 lg:grid-cols-12">
+
+          {/* Editor column */}
+          <main className="lg:col-span-8 space-y-6">
+            <ProgramIdentitySection state={state} onChange={patch} />
+            <ProgramOutcomesSection state={state} onChange={patch} />
+            <ProgramCertificationsSection
+              state={state}
+              availableCredentials={availableCredentials}
+              onChange={patch}
+            />
+            <CurriculumTreeSection state={state} onChange={patch} />
+            <DeliveryStructureSection state={state} onChange={patch} />
+            <EnrollmentCtaSection state={state} onChange={patch} />
+            <ComplianceFundingSection state={state} onChange={patch} />
+          </main>
+
+          {/* Sidebar */}
+          <aside className="lg:col-span-4">
+            <BuilderSidebar
+              state={state}
+              derived={derived}
+              onPreview={() => setShowPreview(true)}
+            />
+          </aside>
+        </div>
+      </div>
+
+      {/* Preview drawer */}
+      {showPreview && (
+        <PreviewDrawer state={state} derived={derived} onClose={() => setShowPreview(false)} />
+      )}
+    </div>
+  );
+}
+
+// ── Stat pill ─────────────────────────────────────────────────────────────────
+
+function Stat({ label, value, highlight }: { label: string; value: number; highlight?: boolean }) {
+  return (
+    <div className="text-center">
+      <p className={`text-lg font-bold tabular-nums ${highlight ? 'text-amber-600' : 'text-slate-900'}`}>{value}</p>
+      <p className="text-xs text-slate-400">{label}</p>
+    </div>
+  );
+}
+
+// ── Preview drawer ────────────────────────────────────────────────────────────
+
+function PreviewDrawer({
+  state, derived, onClose,
+}: {
+  state: ProgramBuilderState;
+  derived: ProgramDerivedState;
+  onClose: () => void;
+}) {
+  return (
+    <div className="fixed inset-0 z-50 flex">
+      {/* Backdrop */}
+      <div className="flex-1 bg-black/40" onClick={onClose} />
+
+      {/* Panel */}
+      <div className="w-full max-w-lg bg-white shadow-2xl overflow-y-auto flex flex-col">
+        <div className="flex items-center justify-between border-b border-slate-200 px-5 py-4">
+          <div>
+            <h2 className="text-sm font-semibold text-slate-900">Learner Preview</h2>
+            <p className="text-xs text-slate-500">How this program appears to learners</p>
+          </div>
+          <button onClick={onClose} className="text-slate-400 hover:text-slate-700 text-xl leading-none">×</button>
+        </div>
+
+        <div className="flex-1 p-5 space-y-5">
+          {/* Hero */}
+          {state.hero_image_url && (
+            <div className="h-40 w-full overflow-hidden rounded-xl bg-slate-100">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={state.hero_image_url} alt="" className="h-full w-full object-cover" />
+            </div>
+          )}
+
+          <div>
+            <h1 className="text-lg font-bold text-slate-900">{state.title || 'Untitled Program'}</h1>
+            {state.subtitle && <p className="text-sm text-slate-500 mt-1">{state.subtitle}</p>}
+          </div>
+
+          {/* Stats strip */}
+          <div className="flex gap-4 text-sm text-slate-600 border-y border-slate-100 py-3">
+            {state.estimated_weeks && <span>{state.estimated_weeks} weeks</span>}
+            {state.estimated_hours && <span>{state.estimated_hours} hours</span>}
+            {derived.totalLessons > 0 && <span>{derived.totalLessons} lessons</span>}
+          </div>
+
+          {/* Credentials */}
+          {state.credentials.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">Credentials Earned</p>
+              <div className="flex flex-wrap gap-2">
+                {state.credentials.map(c => (
+                  <span key={c.id} className="rounded-full bg-brand-blue-100 px-3 py-1 text-xs font-semibold text-brand-blue-700">
+                    {c.credential_abbreviation ?? c.credential_name}
+                  </span>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Outcomes */}
+          {state.outcomes.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">What You'll Learn</p>
+              <ul className="space-y-1.5">
+                {state.outcomes.map(o => (
+                  <li key={o.id} className="flex items-start gap-2 text-sm text-slate-700">
+                    <span className="mt-1 h-1.5 w-1.5 flex-shrink-0 rounded-full bg-brand-blue-500" />
+                    {o.text}
+                  </li>
+                ))}
+              </ul>
+            </div>
+          )}
+
+          {/* Curriculum outline */}
+          {state.phases.length > 0 && (
+            <div>
+              <p className="text-xs font-semibold uppercase tracking-wide text-slate-400 mb-2">Curriculum</p>
+              <div className="space-y-2">
+                {state.phases.map(phase => (
+                  <div key={phase.id}>
+                    <p className="text-xs font-semibold text-slate-700">{phase.title}</p>
+                    {phase.modules.map(mod => (
+                      <p key={mod.id} className="ml-3 text-xs text-slate-500">
+                        {mod.title} · {mod.lessons.length} lessons
+                      </p>
+                    ))}
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* CTA */}
+          {state.ctas.length > 0 && (
+            <div className="pt-2">
+              <button className="w-full rounded-xl bg-brand-blue-600 py-3 text-sm font-semibold text-white">
+                {state.ctas[0].label}
+              </button>
+            </div>
+          )}
+
+          {/* Compliance badges */}
+          {(state.wioa_approved || state.dol_registered || state.etpl_listed) && (
+            <div className="flex flex-wrap gap-2 pt-1">
+              {state.wioa_approved && <span className="rounded bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-700">WIOA Eligible</span>}
+              {state.dol_registered && <span className="rounded bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-700">DOL Registered</span>}
+              {state.etpl_listed && <span className="rounded bg-emerald-100 px-2 py-0.5 text-xs font-bold text-emerald-700">ETPL Listed</span>}
+            </div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+

--- a/components/admin/course-builder/ProgramCertificationsSection.tsx
+++ b/components/admin/course-builder/ProgramCertificationsSection.tsx
@@ -1,0 +1,173 @@
+'use client';
+
+import { useState } from 'react';
+import { Award, Plus, Trash2, Star } from 'lucide-react';
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState, ProgramCredential } from './types';
+
+interface AvailableCredential {
+  id: string;
+  name: string;
+  abbreviation: string | null;
+  issuing_authority: string;
+}
+
+interface Props {
+  state: ProgramBuilderState;
+  availableCredentials: AvailableCredential[];
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function ProgramCertificationsSection({ state, onChange, availableCredentials }: Props) {
+  const [selectedId, setSelectedId] = useState('');
+  const credentials = state.credentials;
+
+  const attachCredential = () => {
+    const cred = availableCredentials.find(c => c.id === selectedId);
+    if (!cred) return;
+    if (credentials.some(c => c.credential_id === cred.id)) return;
+
+    const next: ProgramCredential = {
+      id: crypto.randomUUID(),
+      credential_id: cred.id,
+      credential_name: cred.name,
+      credential_abbreviation: cred.abbreviation,
+      is_required: true,
+      is_primary: credentials.length === 0, // first one is primary by default
+      sort_order: credentials.length,
+    };
+    onChange({ credentials: [...credentials, next] });
+    setSelectedId('');
+  };
+
+  const removeCredential = (id: string) => {
+    const remaining = credentials.filter(c => c.id !== id);
+    // If we removed the primary, promote the first remaining
+    if (remaining.length > 0 && !remaining.some(c => c.is_primary)) {
+      remaining[0] = { ...remaining[0], is_primary: true };
+    }
+    onChange({ credentials: remaining });
+  };
+
+  const setPrimary = (id: string) => {
+    onChange({
+      credentials: credentials.map(c => ({ ...c, is_primary: c.id === id })),
+    });
+  };
+
+  const unattachedCredentials = availableCredentials.filter(
+    ac => !credentials.some(c => c.credential_id === ac.id)
+  );
+
+  return (
+    <BuilderSection
+      title="Certifications & Credentials"
+      description="Credentials learners earn upon completion. These appear on the public program page and on issued certificates."
+      warning={
+        credentials.length === 0
+          ? 'No credentials attached. If this program leads to a certification, add it here. Programs without credentials have lower enrollment conversion.'
+          : undefined
+      }
+    >
+      <div className="space-y-3">
+        {credentials.length === 0 && (
+          <p className="text-sm text-slate-400 italic">No credentials attached yet.</p>
+        )}
+
+        {credentials.map(cred => (
+          <div
+            key={cred.id}
+            className={`flex items-center gap-3 rounded-xl border px-4 py-3 ${cred.is_primary ? 'border-brand-blue-200 bg-brand-blue-50' : 'border-slate-200 bg-white'}`}
+          >
+            <div className={`flex h-9 w-9 flex-shrink-0 items-center justify-center rounded-lg ${cred.is_primary ? 'bg-brand-blue-600' : 'bg-slate-100'}`}>
+              <Award className={`h-5 w-5 ${cred.is_primary ? 'text-white' : 'text-slate-500'}`} />
+            </div>
+
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center gap-2">
+                <span className="text-sm font-semibold text-slate-900 truncate">{cred.credential_name}</span>
+                {cred.credential_abbreviation && (
+                  <span className="flex-shrink-0 rounded bg-slate-100 px-1.5 py-0.5 text-xs font-mono text-slate-600">
+                    {cred.credential_abbreviation}
+                  </span>
+                )}
+                {cred.is_primary && (
+                  <span className="flex-shrink-0 flex items-center gap-0.5 text-xs font-medium text-brand-blue-600">
+                    <Star className="h-3 w-3 fill-current" /> Primary
+                  </span>
+                )}
+              </div>
+              <div className="flex items-center gap-3 mt-0.5">
+                <label className="flex items-center gap-1.5 text-xs text-slate-500 cursor-pointer">
+                  <input
+                    type="checkbox"
+                    checked={cred.is_required}
+                    onChange={e => onChange({
+                      credentials: credentials.map(c =>
+                        c.id === cred.id ? { ...c, is_required: e.target.checked } : c
+                      ),
+                    })}
+                    className="rounded"
+                  />
+                  Required for completion
+                </label>
+              </div>
+            </div>
+
+            <div className="flex items-center gap-1">
+              {!cred.is_primary && (
+                <button
+                  onClick={() => setPrimary(cred.id)}
+                  className="rounded p-1.5 text-slate-400 hover:text-brand-blue-600 hover:bg-brand-blue-50 transition-colors"
+                  title="Set as primary credential"
+                >
+                  <Star className="h-4 w-4" />
+                </button>
+              )}
+              <button
+                onClick={() => removeCredential(cred.id)}
+                className="rounded p-1.5 text-slate-400 hover:text-red-500 hover:bg-red-50 transition-colors"
+                title="Remove credential"
+              >
+                <Trash2 className="h-4 w-4" />
+              </button>
+            </div>
+          </div>
+        ))}
+
+        {/* Attach row */}
+        {unattachedCredentials.length > 0 && (
+          <div className="flex items-center gap-2 pt-1">
+            <select
+              value={selectedId}
+              onChange={e => setSelectedId(e.target.value)}
+              className="flex-1 rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20 bg-white"
+            >
+              <option value="">Select a credential to attach…</option>
+              {unattachedCredentials.map(c => (
+                <option key={c.id} value={c.id}>
+                  {c.name}{c.abbreviation ? ` (${c.abbreviation})` : ''} — {c.issuing_authority}
+                </option>
+              ))}
+            </select>
+            <button
+              onClick={attachCredential}
+              disabled={!selectedId}
+              className="flex items-center gap-1.5 rounded-lg bg-brand-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-blue-700 disabled:opacity-40 transition-colors"
+            >
+              <Plus className="h-4 w-4" />
+              Attach
+            </button>
+          </div>
+        )}
+
+        {unattachedCredentials.length === 0 && credentials.length === 0 && (
+          <p className="text-sm text-slate-400">
+            No credentials exist in the registry yet.{' '}
+            <a href="/admin/credentials" className="text-brand-blue-600 hover:underline">Add credentials →</a>
+          </p>
+        )}
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/ProgramIdentitySection.tsx
+++ b/components/admin/course-builder/ProgramIdentitySection.tsx
@@ -1,0 +1,127 @@
+'use client';
+
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState } from './types';
+
+const CATEGORIES = [
+  'Skilled Trades',
+  'Healthcare',
+  'Technology',
+  'Business & Finance',
+  'Transportation & Logistics',
+  'Construction',
+  'Manufacturing',
+  'Professional Development',
+  'Other',
+];
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function ProgramIdentitySection({ state, onChange }: Props) {
+  return (
+    <BuilderSection
+      title="Program Identity"
+      description="The title, category, and description shown to learners and funding reviewers."
+      required
+    >
+      <div className="space-y-4">
+        {/* Title */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Program Title <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="text"
+            value={state.title}
+            onChange={e => onChange({ title: e.target.value })}
+            placeholder="e.g. HVAC Technician Certification"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+          />
+        </div>
+
+        {/* Subtitle */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">Subtitle</label>
+          <input
+            type="text"
+            value={state.subtitle}
+            onChange={e => onChange({ subtitle: e.target.value })}
+            placeholder="e.g. EPA 608 Certification Prep — Workforce-Ready in 12 Weeks"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+          />
+        </div>
+
+        {/* Slug + Category row */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              URL Slug <span className="text-red-500">*</span>
+            </label>
+            <div className="flex items-center rounded-lg border border-slate-300 overflow-hidden focus-within:border-brand-blue-500 focus-within:ring-2 focus-within:ring-brand-blue-500/20">
+              <span className="bg-slate-50 px-3 py-2 text-xs text-slate-400 border-r border-slate-300 select-none">/programs/</span>
+              <input
+                type="text"
+                value={state.slug}
+                onChange={e => onChange({ slug: e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, '-') })}
+                placeholder="hvac-technician"
+                className="flex-1 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:outline-none bg-white"
+              />
+            </div>
+          </div>
+
+          <div>
+            <label className="block text-sm font-medium text-slate-700 mb-1">
+              Category <span className="text-red-500">*</span>
+            </label>
+            <select
+              value={state.category}
+              onChange={e => onChange({ category: e.target.value })}
+              className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20 bg-white"
+            >
+              <option value="">Select category…</option>
+              {CATEGORIES.map(c => <option key={c} value={c}>{c}</option>)}
+            </select>
+          </div>
+        </div>
+
+        {/* Description */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Program Description <span className="text-red-500">*</span>
+          </label>
+          <textarea
+            rows={4}
+            value={state.description}
+            onChange={e => onChange({ description: e.target.value })}
+            placeholder="Describe what this program prepares learners for, who it's designed for, and what makes it workforce-ready. This appears on the public program page and in funding applications."
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20 resize-none"
+          />
+          <p className="mt-1 text-xs text-slate-400">{state.description.length} characters — aim for 150–400</p>
+        </div>
+
+        {/* Hero image URL */}
+        <div>
+          <label className="block text-sm font-medium text-slate-700 mb-1">
+            Hero Image URL <span className="text-red-500">*</span>
+          </label>
+          <input
+            type="url"
+            value={state.hero_image_url || ''}
+            onChange={e => onChange({ hero_image_url: e.target.value || null })}
+            placeholder="https://…"
+            className="w-full rounded-lg border border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+          />
+          {state.hero_image_url && (
+            <div className="mt-2 h-24 w-full overflow-hidden rounded-lg border border-slate-200">
+              {/* eslint-disable-next-line @next/next/no-img-element */}
+              <img src={state.hero_image_url} alt="Hero preview" className="h-full w-full object-cover" />
+            </div>
+          )}
+        </div>
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/ProgramOutcomesSection.tsx
+++ b/components/admin/course-builder/ProgramOutcomesSection.tsx
@@ -1,0 +1,117 @@
+'use client';
+
+import { useState } from 'react';
+import { Plus, Trash2, GripVertical } from 'lucide-react';
+import BuilderSection from './BuilderSection';
+import type { ProgramBuilderState, ProgramOutcome } from './types';
+
+interface Props {
+  state: ProgramBuilderState;
+  onChange: (patch: Partial<ProgramBuilderState>) => void;
+}
+
+export default function ProgramOutcomesSection({ state, onChange }: Props) {
+  const [draft, setDraft] = useState('');
+
+  const outcomes = state.outcomes;
+  const belowMinimum = outcomes.length < 3;
+
+  const addOutcome = () => {
+    const text = draft.trim();
+    if (!text) return;
+    const next: ProgramOutcome = {
+      id: crypto.randomUUID(),
+      text,
+      outcome_order: outcomes.length,
+    };
+    onChange({ outcomes: [...outcomes, next] });
+    setDraft('');
+  };
+
+  const removeOutcome = (id: string) => {
+    onChange({
+      outcomes: outcomes
+        .filter(o => o.id !== id)
+        .map((o, i) => ({ ...o, outcome_order: i })),
+    });
+  };
+
+  const updateOutcome = (id: string, text: string) => {
+    onChange({ outcomes: outcomes.map(o => o.id === id ? { ...o, text } : o) });
+  };
+
+  return (
+    <BuilderSection
+      title="Learning Outcomes"
+      description="What learners will be able to do after completing this program. Required for WIOA and DOL funding eligibility."
+      required
+      warning={
+        belowMinimum
+          ? `Programs without at least 3 defined outcomes will not qualify for workforce funding and will not convert on the public page. Add ${3 - outcomes.length} more.`
+          : undefined
+      }
+    >
+      <div className="space-y-3">
+        {outcomes.length === 0 && (
+          <p className="text-sm text-slate-400 italic">No outcomes yet. Add at least 3.</p>
+        )}
+
+        {outcomes.map((outcome, idx) => (
+          <div key={outcome.id} className="flex items-start gap-2 group">
+            <GripVertical className="mt-2.5 h-4 w-4 flex-shrink-0 text-slate-300 cursor-grab" />
+            <span className="mt-2 flex-shrink-0 text-xs font-medium text-slate-400 w-5 text-right">{idx + 1}.</span>
+            <input
+              type="text"
+              value={outcome.text}
+              onChange={e => updateOutcome(outcome.id, e.target.value)}
+              className="flex-1 rounded-lg border border-slate-200 px-3 py-2 text-sm text-slate-900 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+              placeholder="e.g. Diagnose and repair HVAC refrigerant systems"
+            />
+            <button
+              onClick={() => removeOutcome(outcome.id)}
+              className="mt-2 p-1 text-slate-300 hover:text-red-500 transition-colors opacity-0 group-hover:opacity-100"
+              title="Remove outcome"
+            >
+              <Trash2 className="h-4 w-4" />
+            </button>
+          </div>
+        ))}
+
+        {/* Add row */}
+        <div className="flex items-center gap-2 pt-1">
+          <div className="w-4 flex-shrink-0" />
+          <span className="flex-shrink-0 text-xs font-medium text-slate-300 w-5 text-right">{outcomes.length + 1}.</span>
+          <input
+            type="text"
+            value={draft}
+            onChange={e => setDraft(e.target.value)}
+            onKeyDown={e => { if (e.key === 'Enter') { e.preventDefault(); addOutcome(); } }}
+            placeholder="Add an outcome and press Enter…"
+            className="flex-1 rounded-lg border border-dashed border-slate-300 px-3 py-2 text-sm text-slate-900 placeholder-slate-400 focus:border-brand-blue-500 focus:outline-none focus:ring-2 focus:ring-brand-blue-500/20"
+          />
+          <button
+            onClick={addOutcome}
+            disabled={!draft.trim()}
+            className="flex items-center gap-1 rounded-lg bg-brand-blue-600 px-3 py-2 text-sm font-medium text-white hover:bg-brand-blue-700 disabled:opacity-40 transition-colors"
+          >
+            <Plus className="h-4 w-4" />
+            Add
+          </button>
+        </div>
+
+        {/* Progress indicator */}
+        <div className="flex items-center gap-2 pt-2">
+          {[0, 1, 2].map(i => (
+            <div
+              key={i}
+              className={`h-1.5 flex-1 rounded-full transition-colors ${outcomes.length > i ? 'bg-emerald-500' : 'bg-slate-200'}`}
+            />
+          ))}
+          <span className="text-xs text-slate-400 ml-1">
+            {outcomes.length >= 3 ? '3+ outcomes — minimum met' : `${outcomes.length}/3 minimum`}
+          </span>
+        </div>
+      </div>
+    </BuilderSection>
+  );
+}

--- a/components/admin/course-builder/types.ts
+++ b/components/admin/course-builder/types.ts
@@ -1,0 +1,163 @@
+// Mirrors the DB schema from program_canonical_schema + program_outcomes + program_credentials
+
+export type DeliveryMode = 'online' | 'hybrid' | 'in_person';
+// Values must match program_lessons.lesson_type CHECK constraint
+// checkpoint is a curriculum_lessons concept — not in program_lessons yet
+export type LessonType = 'lesson' | 'quiz' | 'lab' | 'exam' | 'orientation' | 'checkpoint';
+export type ProgramStatus = 'draft' | 'ready' | 'published' | 'archived';
+export type CtaType = 'apply' | 'request_info' | 'external' | 'waitlist';
+export type FundingType = 'funded' | 'self_pay' | 'partner' | 'employer_sponsored' | 'other';
+
+export interface ProgramOutcome {
+  id: string;
+  text: string;
+  outcome_order: number;
+}
+
+export interface ProgramCredential {
+  id: string;
+  credential_id: string;
+  credential_name: string;
+  credential_abbreviation: string | null;
+  is_required: boolean;
+  is_primary: boolean;
+  sort_order: number;
+}
+
+export interface ProgramLesson {
+  id: string;
+  title: string;
+  lesson_type: LessonType;
+  sort_order: number;
+  duration_minutes: number | null;
+  is_published: boolean;
+  has_video: boolean;
+  has_reading: boolean;
+}
+
+export interface ProgramModule {
+  id: string;
+  title: string;
+  sort_order: number;
+  lessons: ProgramLesson[];
+}
+
+// Phases are a UI grouping layer — stored as modules with a phase_label
+// We group modules by phase_label client-side
+export interface ProgramPhase {
+  id: string; // synthetic — phase label slug
+  title: string;
+  sort_order: number;
+  modules: ProgramModule[];
+}
+
+export interface ProgramCta {
+  id: string;
+  cta_type: CtaType;
+  label: string;
+  href: string;
+  style_variant: 'primary' | 'secondary' | 'ghost' | 'link';
+  sort_order: number;
+}
+
+export interface ProgramTrack {
+  id: string;
+  track_code: string;
+  title: string;
+  funding_type: FundingType;
+  cost_cents: number | null;
+  available: boolean;
+  sort_order: number;
+}
+
+export interface ProgramMedia {
+  id: string;
+  media_type: 'hero_image' | 'hero_video' | 'gallery_image' | 'thumbnail';
+  url: string;
+  alt_text: string | null;
+}
+
+export interface ProgramBuilderState {
+  id: string;
+  title: string;
+  subtitle: string;
+  slug: string;
+  category: string;
+  description: string;
+  hero_image_url: string | null;
+
+  outcomes: ProgramOutcome[];
+  credentials: ProgramCredential[];
+  phases: ProgramPhase[];
+  ctas: ProgramCta[];
+  tracks: ProgramTrack[];
+  media: ProgramMedia[];
+
+  estimated_weeks: number | null;
+  estimated_hours: number | null;
+  delivery_method: DeliveryMode | null;
+
+  wioa_approved: boolean;
+  dol_registered: boolean;
+  etpl_listed: boolean;
+
+  status: ProgramStatus;
+  published: boolean;
+}
+
+// ── Derived operational state ─────────────────────────────────────────────────
+
+export interface ProgramDerivedState {
+  totalPhases: number;
+  totalModules: number;
+  totalLessons: number;
+  emptyLessons: number;
+  lessonsMissingVideo: number;
+  lessonsMissingReading: number;
+  completionPercent: number;
+  missingRequired: string[];
+  canPublish: boolean;
+}
+
+// ── Publish validator ─────────────────────────────────────────────────────────
+
+export function validateProgram(state: ProgramBuilderState): ProgramDerivedState {
+  const missing: string[] = [];
+
+  if (!state.title?.trim()) missing.push('Program title');
+  if (!state.description?.trim()) missing.push('Program description');
+  if (!state.hero_image_url) missing.push('Hero image');
+  if (state.outcomes.length < 3) missing.push(`Outcomes (${state.outcomes.length}/3 minimum)`);
+  if (state.ctas.length === 0) missing.push('Primary CTA (apply / enroll link)');
+  if (!state.estimated_weeks) missing.push('Program duration (weeks)');
+  if (!state.delivery_method) missing.push('Delivery mode');
+
+  const totalModules = state.phases.reduce((n, p) => n + p.modules.length, 0);
+  const allLessons = state.phases.flatMap(p => p.modules.flatMap(m => m.lessons));
+  const totalLessons = allLessons.length;
+  const emptyLessons = allLessons.filter(l => !l.has_video && !l.has_reading).length;
+  const lessonsMissingVideo = allLessons.filter(l => !l.has_video).length;
+  const lessonsMissingReading = allLessons.filter(l => !l.has_reading).length;
+
+  if (state.phases.length < 1) missing.push('At least 1 curriculum phase');
+  if (totalModules < 3) missing.push(`Modules (${totalModules}/3 minimum)`);
+  if (totalLessons < 10) missing.push(`Lessons (${totalLessons}/10 minimum)`);
+  if (emptyLessons > 0) missing.push(`${emptyLessons} lesson${emptyLessons > 1 ? 's' : ''} with no content`);
+
+  // Completion score: 8 required items
+  const REQUIRED_ITEMS = 8;
+  const completedItems = REQUIRED_ITEMS - Math.min(missing.length, REQUIRED_ITEMS);
+  const completionPercent = Math.round((completedItems / REQUIRED_ITEMS) * 100);
+
+  return {
+    totalPhases: state.phases.length,
+    totalModules,
+    totalLessons,
+    emptyLessons,
+    lessonsMissingVideo,
+    lessonsMissingReading,
+    completionPercent,
+    missingRequired: missing,
+    canPublish: missing.length === 0,
+  };
+}


### PR DESCRIPTION
## What this does

Replaces the old `CourseBuilderClient` (a basic CRUD form) with a full single-page Program Builder that behaves like a real operational system — not a form.

## Structure

13 new components in `components/admin/course-builder/`:

| Component | Purpose |
|-----------|---------|
| `types.ts` | `ProgramBuilderState`, `ProgramDerivedState`, `validateProgram()` |
| `CourseBuilderTopBar` | Sticky bar — inline title edit, completion %, publish gate |
| `ProgramIdentitySection` | Title, subtitle, slug, category, description, hero image |
| `ProgramOutcomesSection` | Repeatable outcomes list, min-3 guardrail |
| `ProgramCertificationsSection` | Attach credentials from registry, mark primary |
| `CurriculumTreeSection` | Phase → Module → Lesson tree with inline add/rename/delete |
| `DeliveryStructureSection` | Delivery mode, weeks, hours with derived estimate |
| `EnrollmentCtaSection` | CTA builder + enrollment track builder |
| `ComplianceFundingSection` | WIOA / DOL / ETPL toggles with audit notes |
| `BuilderSidebar` | Sticky checklist, program health metrics, quick actions |
| `BuilderSection` | Shared card shell |
| `ProgramBuilderClient` | State container, save/publish handlers, preview drawer |

`app/admin/course-builder/page.tsx` rebuilt to load real program data from Supabase and pass it to the client.

## Publish enforcement

Publish is blocked until all 8 rules pass:

- Program title
- Program description
- Hero image
- 3+ learning outcomes
- 1+ curriculum phase
- 3+ modules
- 10+ lessons
- Primary CTA

The Publish button is disabled with an exact list of what's missing. Server-side enforcement uses the existing `can_publish_program()` DB function via `/api/admin/programs/[id]/publish`.

## Entry point

`/admin/course-builder?program=<programId>`

Without a `?program=` param, redirects to `/admin/programs?action=build`. Add a "Build" button to each program row in the programs list linking to `/admin/course-builder?program=<id>`.

## Known limitations / follow-up

- **Phases**: `program_modules` has no `phase_id` column yet — all modules load into one default phase. Add the column and update the shape logic in `page.tsx` (~line 80) when ready.
- **`is_published` on lessons**: column doesn't exist on `program_modules` — defaults to `false`. Add when needed.
- **Save API**: the Save button calls `PATCH /api/admin/programs/[id]` with the full nested payload. That route needs to handle `outcomes`, `credentials`, `phases`, `ctas`, `tracks` as nested upserts.
- **`checkpoint` lesson type**: exists in `curriculum_lessons` CHECK constraint but not `program_lessons` — UI supports it but saving will fail without a migration.