### PR TITLE
fix(hero): remove voiceover autoplay on all program pages

### DIFF
--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -86,26 +86,14 @@ export default function HeroVideo({
   const [mounted, setMounted] = useState(false);
   useEffect(() => { setMounted(true); }, []);
 
-  // Attempt to autoplay voiceover immediately on mount.
-  // Browsers may block autoplay with audio — if blocked, stay muted so the
-  // user can manually unmute via the on-screen button.
-  // Respects prefers-reduced-motion.
+  // Voiceover is user-initiated only — no autoplay.
+  // Audio plays only when the user clicks the unmute button.
+  // Preload metadata so playback starts quickly when requested.
   useEffect(() => {
     if (!mounted) return;
     const audio = audioRef.current;
     if (!audio) return;
-
-    const prefersReduced = window.matchMedia('(prefers-reduced-motion: reduce)').matches;
-    if (prefersReduced) return;
-
     audio.load();
-    audio.currentTime = 0;
-    audio.play()
-      .then(() => setMuted(false))
-      .catch(() => {
-        // Browser blocked autoplay — stay muted; user can click unmute button
-        setMuted(true);
-      });
   }, [mounted]);
 
   // Voiceover audio toggle — only controls the separate audio track, not the video


### PR DESCRIPTION
The voiceover audio was autoplaying on mount on every page using `HeroVideo` — all program, healthcare, trades, technology, and barber pages. Removed the autoplay `useEffect`. Audio now only plays when the user clicks the sound toggle button. `preload=metadata` is kept so it starts immediately when requested.