### PR TITLE
merge: fix/admin-dashboard-surgical into main

### DIFF
--- a/app/api/barber/webhook/route.ts
+++ b/app/api/barber/webhook/route.ts
@@ -211,6 +211,7 @@ async function _POST(request: NextRequest) {
             }
           }
 
+
           // ── Wire weekly billing via Stripe subscription ──────────────────
           // Only for card payments on a payment plan (BNPL providers manage
           // their own schedules; fully-paid students have no recurring balance).

--- a/app/apply/page.tsx
+++ b/app/apply/page.tsx
@@ -134,7 +134,9 @@ export default async function ApplyPage({
                 Student Programs
               </h2>
               <p className="text-slate-700 mb-3">
-                Start by checking eligibility for funded training and apprenticeships.
+                Apply for career training in healthcare, skilled trades, barbering, IT, and more.
+                Many programs are funded through WIOA, WRG, and Job Ready Indy grants. Some programs
+                have tuition with flexible payment options available.
               </p>
               <ul className="text-slate-600 text-sm space-y-1 mb-4 list-disc list-inside">
                 <li>Many programs are fully funded through WIOA, WRG, and Job Ready Indy</li>

--- a/app/programs/barber-apprenticeship/BarberApprenticeshipClient.tsx
+++ b/app/programs/barber-apprenticeship/BarberApprenticeshipClient.tsx
@@ -91,10 +91,10 @@ export default function BarberApprenticeshipClient({ program: p }: Props) {
               <h2 className="text-xl font-bold text-slate-900">Career Pathway</h2>
             </div>
             <p className="text-slate-700 leading-relaxed">
-              Start as a <strong>Barber Apprentice</strong> — a W-2 employee at your host shop — while you train under a licensed barber.
-              After completing 2,000 hours and passing the Indiana state exam, you become a <strong>Licensed Barber</strong>.
-              With experience and an established clientele, you can advance to <strong>Senior Barber</strong> or open your own shop.
-              Compensation is determined by each participating shop and must comply with applicable wage requirements. Elevate tracks training progress and hours.
+              Start as a <strong>Barber Apprentice</strong> — a paid W-2 employee at your host shop — while you train under a licensed barber.
+              After completing 2,000 hours and passing the Indiana state exam, you become a <strong>Licensed Barber</strong> ($30,000–$45,000).
+              With 3–5 years of experience and an established clientele, you advance to <strong>Senior Barber</strong> ($45,000–$65,000).
+              Many graduates go on to open their own shop as a <strong>Shop Owner / Master Barber</strong> ($65,000–$100,000+).
             </p>
           </div>
           <div className="relative h-72 rounded-xl overflow-hidden shadow-lg">

--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -96,6 +96,7 @@ export default function HeroVideo({
         {/* autoPlayOnMount + preloadFull — hero is above the fold, load immediately */}
         <CanonicalVideo
           src={videoSrc}
+          poster={posterImage}
           className="absolute inset-0 w-full h-full object-cover object-center"
           autoPlayOnMount
           preloadFull

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -60,8 +60,6 @@ export default tseslint.config(
       'react-hooks/gating': 'off',
       'react-hooks/unsupported-syntax': 'off',
       'no-unsafe-optional-chaining': 'warn',
-      // @next/eslint-plugin-next is not registered — suppress inline-disable warnings
-      '@next/next/no-img-element': 'off',
     },
   },
   {


### PR DESCRIPTION
Merges 41 commits from `fix/admin-dashboard-surgical` that were never merged.

**Includes:**
- Admin dashboard: replace fake KPIs, revenue, activity feed, dead code
- Course builder: incremental DB-backed generation with admin controls
- Barber: billing suspension, compliance copy, timeclock fixes
- JRI rename: replace all JRI abbreviations with Job Ready Indy across codebase
- Rise Foundation: restore Wix site clone, fix DB bug, remove hero overlays
- About/accreditation: add credentials, remove CAGE/UEI from public pages
- Remove Choice Medical CNA School from all public and admin pages
- Lint fixes, CI improvements

**Conflicts resolved (5 files):**
- `barber/webhook`: kept hardened appUpdateResult + runBarberPostPayment pipeline from main
- `apply/page`: took branch copy (more complete program description)
- `check-eligibility`: kept HEAD dynamic banner rendering
- `BarberApprenticeshipClient`: took branch salary ranges
- `rise-foundation`: kept HEAD dead-link fix