### PR TITLE
fix(admin): replace fake data with live DB-backed pages and real health checks

### DIFF
--- a/app/admin/compliance/financial-assurance/page.tsx
+++ b/app/admin/compliance/financial-assurance/page.tsx
@@ -1,390 +1,115 @@
-import { Metadata } from 'next';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
-import { 
-  Shield, AlertTriangle, Clock, FileText, 
-  Calendar, DollarSign, Building2, Plus, Download, Bell
-} from 'lucide-react';
-
-export const metadata: Metadata = {
-  title: 'Financial Assurance | Admin | Elevate',
-  description: 'Track bonds, letters of credit, and financial assurance requirements.',
-};
 
 export const dynamic = 'force-dynamic';
 
-interface FinancialAssurance {
-  id: string;
-  type: 'surety_bond' | 'letter_of_credit' | 'escrow' | 'insurance';
-  provider: string;
-  amount: number;
-  issue_date: string;
-  expiration_date: string;
-  status: 'active' | 'expiring_soon' | 'expired' | 'pending';
-  document_url?: string;
-  notes?: string;
-}
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Financial Assurance | Admin | Elevate For Humanity',
+};
 
-// Default data for demo
-const defaultAssurances: FinancialAssurance[] = [
-  {
-    id: '1',
-    type: 'surety_bond',
-    provider: 'Indiana Surety Company',
-    amount: 50000,
-    issue_date: '2025-01-15',
-    expiration_date: '2026-01-15',
-    status: 'active',
-    notes: 'Required for ETPL listing',
-  },
-  {
-    id: '2',
-    type: 'letter_of_credit',
-    provider: 'First National Bank',
-    amount: 25000,
-    issue_date: '2025-06-01',
-    expiration_date: '2026-02-28',
-    status: 'expiring_soon',
-    notes: 'Backup financial assurance',
-  },
-  {
-    id: '3',
-    type: 'insurance',
-    provider: 'State Farm Business Insurance',
-    amount: 1000000,
-    issue_date: '2025-03-01',
-    expiration_date: '2026-03-01',
-    status: 'active',
-    notes: 'General liability coverage',
-  },
-];
-
-function getStatusColor(status: string) {
-  switch (status) {
-    case 'active': return 'bg-brand-green-100 text-brand-green-700';
-    case 'expiring_soon': return 'bg-yellow-100 text-yellow-700';
-    case 'expired': return 'bg-brand-red-100 text-brand-red-700';
-    case 'pending': return 'bg-brand-blue-100 text-brand-blue-700';
-    default: return 'bg-gray-100 text-gray-700';
-  }
-}
-
-function getTypeLabel(type: string) {
-  switch (type) {
-    case 'surety_bond': return 'Surety Bond';
-    case 'letter_of_credit': return 'Letter of Credit';
-    case 'escrow': return 'Escrow Account';
-    case 'insurance': return 'Insurance Policy';
-    default: return type;
-  }
-}
-
-function getDaysUntilExpiration(date: string) {
-  const expDate = new Date(date);
-  const today = new Date();
-  const diffTime = expDate.getTime() - today.getTime();
-  return Math.ceil(diffTime / (1000 * 60 * 60 * 24));
-}
+const STATUS_BADGE: Record<string, string> = {
+  active:    'bg-green-100 text-green-800',
+  expired:   'bg-red-100 text-red-800',
+  pending:   'bg-yellow-100 text-yellow-800',
+  cancelled: 'bg-gray-100 text-gray-600',
+};
 
 export default async function FinancialAssurancePage() {
-  const supabase = await createClient();
-  
-  let assurances = defaultAssurances;
-  
-  if (supabase) {
-    const { data } = await supabase
-      .from('financial_assurances')
+  await requireAdmin();
+  const db = createAdminClient();
+
+  const [{ data: records }, { data: summary }] = await Promise.all([
+    db.from('financial_assurance_records')
       .select('*')
-      .order('expiration_date', { ascending: true });
-    
-    if (data && data.length > 0) {
-      assurances = data;
-    }
-  }
+      .order('expiration_date', { ascending: true, nullsFirst: false }),
+    db.from('v_admin_financial_assurance_summary')
+      .select('*')
+      .single(),
+  ]);
 
-  // Calculate stats
-  const totalCoverage = assurances.reduce((sum, a) => sum + a.amount, 0);
-  const activeCount = assurances.filter(a => a.status === 'active').length;
-  const expiringCount = assurances.filter(a => a.status === 'expiring_soon').length;
-  const expiredCount = assurances.filter(a => a.status === 'expired').length;
-
-  // Find next expiration
-  const nextExpiring = assurances
-    .filter(a => a.status !== 'expired')
-    .sort((a, b) => new Date(a.expiration_date).getTime() - new Date(b.expiration_date).getTime())[0];
+  const s = summary as any;
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Compliance', href: '/admin/compliance' }, { label: 'Financial Assurance' }]} />
 
-      {/* Hero Image */}
-            <div className="max-w-7xl mx-auto px-4 py-4">
-        <Breadcrumbs items={[{ label: "Admin", href: "/admin" }, { label: "Financial Assurance" }]} />
-      </div>
-<div className="max-w-7xl mx-auto px-4 py-8">
-        {/* Header */}
-        <div className="flex items-center justify-between mb-8">
+        <div className="flex items-center justify-between mt-4 mb-6">
           <div>
-            <div className="flex items-center gap-2 text-sm text-gray-500 mb-2">
-              <Link href="/admin" className="hover:text-gray-700">Admin</Link>
-              <span>/</span>
-              <Link href="/admin/compliance" className="hover:text-gray-700">Compliance</Link>
-              <span>/</span>
-              <span className="text-gray-900">Financial Assurance</span>
-            </div>
             <h1 className="text-3xl font-bold text-gray-900">Financial Assurance</h1>
-            <p className="text-gray-600 mt-1">Track bonds, letters of credit, and insurance requirements</p>
+            <p className="text-gray-500 text-sm mt-1">Live records — bonds, insurance, letters of credit</p>
           </div>
-          <div className="flex items-center gap-3">
-            <button className="flex items-center gap-2 px-4 py-2 text-gray-700 bg-white border rounded-lg hover:bg-gray-50">
-              <Download className="w-4 h-4" />
-              Export
-            </button>
-            <button className="flex items-center gap-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700">
-              <Plus className="w-4 h-4" />
-              Add New
-            </button>
-          </div>
+          <Link href="/admin/compliance/financial-assurance/new"
+            className="bg-brand-orange-600 hover:bg-brand-orange-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors">
+            + Add Record
+          </Link>
         </div>
 
-        {/* Alert Banner */}
-        {expiringCount > 0 && (
-          <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4 mb-6 flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
-            <div>
-              <h3 className="font-medium text-yellow-800">Attention Required</h3>
-              <p className="text-sm text-yellow-700">
-                {expiringCount} financial assurance{expiringCount > 1 ? 's' : ''} expiring within 60 days. 
-                Review and renew to maintain compliance.
-              </p>
+        {/* KPI strip */}
+        <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+          {[
+            { label: 'Total Records',       value: s?.total_records ?? 0 },
+            { label: 'Active',              value: s?.active_records ?? 0 },
+            { label: 'Expired',             value: s?.expired_records ?? 0 },
+            { label: 'Expiring in 30 Days', value: s?.expiring_soon_records ?? 0 },
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-white rounded-lg border p-4 shadow-sm">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">{kpi.label}</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">{kpi.value}</p>
             </div>
-          </div>
-        )}
-
-        {/* Stats Cards */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-4 mb-8">
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-brand-blue-100 rounded-lg flex items-center justify-center">
-                <DollarSign className="w-6 h-6 text-brand-blue-600" />
-              </div>
-              <div>
-                <p className="text-sm text-gray-500">Total Coverage</p>
-                <p className="text-2xl font-bold text-gray-900">
-                  ${totalCoverage.toLocaleString()}
-                </p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-brand-green-100 rounded-lg flex items-center justify-center">
-                <span className="text-slate-400 flex-shrink-0">•</span>
-              </div>
-              <div>
-                <p className="text-sm text-gray-500">Active</p>
-                <p className="text-2xl font-bold text-gray-900">{activeCount}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-yellow-100 rounded-lg flex items-center justify-center">
-                <Clock className="w-6 h-6 text-yellow-600" />
-              </div>
-              <div>
-                <p className="text-sm text-gray-500">Expiring Soon</p>
-                <p className="text-2xl font-bold text-gray-900">{expiringCount}</p>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-brand-blue-100 rounded-lg flex items-center justify-center">
-                <Calendar className="w-6 h-6 text-brand-blue-600" />
-              </div>
-              <div>
-                <p className="text-sm text-gray-500">Next Renewal</p>
-                <p className="text-lg font-bold text-gray-900">
-                  {nextExpiring ? new Date(nextExpiring.expiration_date).toLocaleDateString() : 'N/A'}
-                </p>
-              </div>
-            </div>
-          </div>
+          ))}
         </div>
 
-        {/* Assurances Table */}
-        <div className="bg-white rounded-xl shadow-sm border overflow-hidden">
-          <div className="px-6 py-4 border-b flex items-center justify-between">
-            <h2 className="text-lg font-semibold text-gray-900">Financial Assurances</h2>
-            <div className="flex items-center gap-2">
-              <button className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">
-                All
-              </button>
-              <button className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">
-                Active
-              </button>
-              <button className="px-3 py-1.5 text-sm text-gray-600 hover:bg-gray-100 rounded-lg">
-                Expiring
-              </button>
-            </div>
+        {/* Table */}
+        <div className="bg-white rounded-lg border shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50 flex items-center justify-between">
+            <h2 className="font-semibold text-slate-800">Records</h2>
+            {s?.active_coverage_total > 0 && (
+              <span className="text-sm text-slate-600">
+                Active coverage: <strong>${Number(s.active_coverage_total).toLocaleString()}</strong>
+              </span>
+            )}
           </div>
-
           <div className="overflow-x-auto">
-            <table className="w-full">
-              <thead className="bg-gray-50">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 border-b">
                 <tr>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Type</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Provider</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Amount</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Issue Date</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Expiration</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Status</th>
-                  <th className="px-6 py-3 text-left text-xs font-medium text-gray-500 uppercase tracking-wider">Actions</th>
+                  {['Provider', 'Type', 'Reference #', 'Coverage', 'Effective', 'Expiration', 'Status'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left font-medium text-slate-600">{h}</th>
+                  ))}
                 </tr>
               </thead>
-              <tbody className="divide-y divide-gray-200">
-                {assurances.map((assurance) => {
-                  const daysUntil = getDaysUntilExpiration(assurance.expiration_date);
-                  
-                  return (
-                    <tr key={assurance.id} className="hover:bg-gray-50">
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center gap-3">
-                          <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
-                            {assurance.type === 'surety_bond' && <Shield className="w-5 h-5 text-gray-600" />}
-                            {assurance.type === 'letter_of_credit' && <FileText className="w-5 h-5 text-gray-600" />}
-                            {assurance.type === 'escrow' && <DollarSign className="w-5 h-5 text-gray-600" />}
-                            {assurance.type === 'insurance' && <Building2 className="w-5 h-5 text-gray-600" />}
-                          </div>
-                          <span className="font-medium text-gray-900">{getTypeLabel(assurance.type)}</span>
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                        {assurance.provider}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap font-medium text-gray-900">
-                        ${assurance.amount.toLocaleString()}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap text-gray-600">
-                        {new Date(assurance.issue_date).toLocaleDateString()}
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div>
-                          <span className="text-gray-900">{new Date(assurance.expiration_date).toLocaleDateString()}</span>
-                          {daysUntil > 0 && daysUntil <= 60 && (
-                            <span className="block text-xs text-yellow-600">{daysUntil} days remaining</span>
-                          )}
-                          {daysUntil <= 0 && (
-                            <span className="block text-xs text-brand-red-600">Expired</span>
-                          )}
-                        </div>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <span className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${getStatusColor(assurance.status)}`}>
-                          {assurance.status.replace('_', ' ').replace(/\b\w/g, l => l.toUpperCase())}
-                        </span>
-                      </td>
-                      <td className="px-6 py-4 whitespace-nowrap">
-                        <div className="flex items-center gap-2">
-                          <button className="text-brand-blue-600 hover:text-brand-blue-700 text-sm font-medium">
-                            View
-                          </button>
-                          <button className="text-gray-600 hover:text-gray-700 text-sm font-medium">
-                            Edit
-                          </button>
-                          {assurance.status === 'expiring_soon' && (
-                            <button className="text-brand-orange-600 hover:text-brand-orange-700 text-sm font-medium">
-                              Renew
-                            </button>
-                          )}
-                        </div>
-                      </td>
-                    </tr>
-                  );
-                })}
+              <tbody className="divide-y">
+                {(records ?? []).map((r: any) => (
+                  <tr key={r.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">{r.provider_name}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.record_type.replace(/_/g, ' ')}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.policy_or_reference_number ?? '—'}</td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {r.coverage_amount != null ? `$${Number(r.coverage_amount).toLocaleString()}` : '—'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.effective_date ?? '—'}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.expiration_date ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE[r.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {r.status}
+                      </span>
+                    </td>
+                  </tr>
+                ))}
+                {(records ?? []).length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-slate-500">
+                      No financial assurance records. Add your first record to get started.
+                    </td>
+                  </tr>
+                )}
               </tbody>
             </table>
-          </div>
-        </div>
-
-        {/* Compliance Requirements */}
-        <div className="mt-8 grid md:grid-cols-2 gap-6">
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">State Requirements</h3>
-            <div className="space-y-3">
-              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                <div className="flex items-center gap-3">
-                  <span className="text-slate-400 flex-shrink-0">•</span>
-                  <span className="text-gray-700">Indiana ETPL Surety Bond</span>
-                </div>
-                <span className="text-sm text-brand-green-600 font-medium">Compliant</span>
-              </div>
-              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                <div className="flex items-center gap-3">
-                  <span className="text-slate-400 flex-shrink-0">•</span>
-                  <span className="text-gray-700">General Liability Insurance</span>
-                </div>
-                <span className="text-sm text-brand-green-600 font-medium">Compliant</span>
-              </div>
-              <div className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                <div className="flex items-center gap-3">
-                  <span className="text-slate-400 flex-shrink-0">•</span>
-                  <span className="text-gray-700">Workers Compensation</span>
-                </div>
-                <span className="text-sm text-brand-green-600 font-medium">Compliant</span>
-              </div>
-            </div>
-          </div>
-
-          <div className="bg-white rounded-xl shadow-sm border p-6">
-            <h3 className="text-lg font-semibold text-gray-900 mb-4">Upcoming Renewals</h3>
-            <div className="space-y-3">
-              {assurances
-                .filter(a => a.status !== 'expired')
-                .sort((a, b) => new Date(a.expiration_date).getTime() - new Date(b.expiration_date).getTime())
-                .slice(0, 3)
-                .map((assurance) => {
-                  const daysUntil = getDaysUntilExpiration(assurance.expiration_date);
-                  return (
-                    <div key={assurance.id} className="flex items-center justify-between p-3 bg-gray-50 rounded-lg">
-                      <div>
-                        <span className="font-medium text-gray-900">{getTypeLabel(assurance.type)}</span>
-                        <span className="block text-sm text-gray-500">{assurance.provider}</span>
-                      </div>
-                      <div className="text-right">
-                        <span className={`text-sm font-medium ${daysUntil <= 30 ? 'text-brand-red-600' : daysUntil <= 60 ? 'text-yellow-600' : 'text-gray-600'}`}>
-                          {daysUntil} days
-                        </span>
-                        <span className="block text-xs text-gray-500">
-                          {new Date(assurance.expiration_date).toLocaleDateString()}
-                        </span>
-                      </div>
-                    </div>
-                  );
-                })}
-            </div>
-          </div>
-        </div>
-
-        {/* Notification Settings */}
-        <div className="mt-8 bg-brand-blue-50 rounded-xl p-6">
-          <div className="flex items-start gap-4">
-            <div className="w-12 h-12 bg-brand-blue-100 rounded-lg flex items-center justify-center flex-shrink-0">
-              <Bell className="w-6 h-6 text-brand-blue-600" />
-            </div>
-            <div className="flex-1">
-              <h3 className="font-semibold text-gray-900">Renewal Reminders</h3>
-              <p className="text-sm text-gray-600 mt-1">
-                Get notified 90, 60, and 30 days before your financial assurances expire.
-              </p>
-              <button className="mt-3 text-sm text-brand-blue-600 hover:text-brand-blue-700 font-medium">
-                Configure Notifications →
-              </button>
-            </div>
           </div>
         </div>
       </div>

--- a/app/admin/docs/mou/page.tsx
+++ b/app/admin/docs/mou/page.tsx
@@ -1,52 +1,116 @@
-import { Metadata } from 'next';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  alternates: { canonical: 'https://www.elevateforhumanity.org/admin/docs/mou' },
-  title: 'MOU Documentation | Elevate For Humanity',
-  description: 'MOU templates and documentation.',
+  robots: { index: false, follow: false },
+  title: 'MOU Documents | Admin | Elevate For Humanity',
 };
 
-export default async function MOUDocsPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
-  const { data: profile } = await supabase.from('profiles').select('*').eq('id', user.id).single();
-  if (profile?.role !== 'admin' && profile?.role !== 'super_admin') redirect('/unauthorized');
+const STATUS_BADGE: Record<string, string> = {
+  draft:    'bg-gray-100 text-gray-600',
+  sent:     'bg-blue-100 text-blue-800',
+  signed:   'bg-green-100 text-green-800',
+  expired:  'bg-red-100 text-red-800',
+  archived: 'bg-slate-100 text-slate-600',
+};
 
-  const templates = [
-    { name: 'Standard Partnership MOU', type: 'Partnership', lastUpdated: '2024-01-15' },
-    { name: 'Training Provider Agreement', type: 'Training', lastUpdated: '2024-01-10' },
-    { name: 'Employer Hiring Commitment', type: 'Employment', lastUpdated: '2024-01-05' },
-  ];
+export default async function MouDocumentsPage() {
+  await requireAdmin();
+  const db = createAdminClient();
+
+  const { data: documents } = await db
+    .from('mou_documents')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  const rows = documents ?? [];
+  const signed  = rows.filter((r: any) => r.document_status === 'signed').length;
+  const expiring = rows.filter((r: any) => {
+    if (!r.expiration_date) return false;
+    const exp = new Date(r.expiration_date);
+    const soon = new Date();
+    soon.setDate(soon.getDate() + 30);
+    return exp >= new Date() && exp <= soon;
+  }).length;
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Docs', href: '/admin/docs' }, { label: 'MOUs' }]} />
 
-      {/* Hero Image */}
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <nav className="text-sm mb-4"><ol className="flex items-center space-x-2 text-gray-500"><li><Link href="/admin" className="hover:text-primary">Admin</Link></li><li>/</li><li><Link href="/admin/docs" className="hover:text-primary">Docs</Link></li><li>/</li><li className="text-gray-900 font-medium">MOU</li></ol></nav>
-          <div className="flex justify-between items-center">
-            <div><h1 className="text-3xl font-bold text-gray-900">MOU Documentation</h1><p className="text-gray-600 mt-2">Templates and agreements</p></div>
-            <button className="bg-brand-blue-600 text-white px-4 py-2 rounded-lg hover:bg-brand-blue-700">Upload Template</button>
+        <div className="flex items-center justify-between mt-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">MOU Documents</h1>
+            <p className="text-gray-500 text-sm mt-1">Live MOU records from the database</p>
           </div>
+          <Link href="/admin/docs/mou/new"
+            className="bg-brand-orange-600 hover:bg-brand-orange-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors">
+            + New MOU
+          </Link>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border">
-          <div className="divide-y">
-            {templates.map((t, i) => (
-              <div key={i} className="p-4 flex items-center justify-between hover:bg-gray-50">
-                <div className="flex items-center gap-4">
-                  <div className="w-10 h-10 bg-brand-blue-100 rounded flex items-center justify-center"><svg className="w-5 h-5 text-brand-blue-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12h6m-6 4h6m2 5H7a2 2 0 01-2-2V5a2 2 0 012-2h5.586a1 1 0 01.707.293l5.414 5.414a1 1 0 01.293.707V19a2 2 0 01-2 2z" /></svg></div>
-                  <div><p className="font-medium">{t.name}</p><p className="text-sm text-gray-500">{t.type} • Updated {t.lastUpdated}</p></div>
-                </div>
-                <button className="text-brand-blue-600 hover:text-brand-blue-800 text-sm">Download</button>
-              </div>
-            ))}
+
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          {[
+            { label: 'Total MOUs',         value: rows.length },
+            { label: 'Signed',             value: signed },
+            { label: 'Expiring in 30 Days', value: expiring },
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-white rounded-lg border p-4 shadow-sm">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">{kpi.label}</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">{kpi.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="bg-white rounded-lg border shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50">
+            <h2 className="font-semibold text-slate-800">Documents</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 border-b">
+                <tr>
+                  {['Title', 'Organization', 'Status', 'Effective', 'Expiration', 'File'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left font-medium text-slate-600">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((r: any) => (
+                  <tr key={r.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">{r.title}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.organization_name ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE[r.document_status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {r.document_status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.effective_date ?? '—'}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.expiration_date ?? '—'}</td>
+                    <td className="px-4 py-3">
+                      {r.file_url ? (
+                        <a href={r.file_url} target="_blank" rel="noreferrer"
+                          className="text-brand-blue-600 hover:underline text-xs font-medium">
+                          Open
+                        </a>
+                      ) : '—'}
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                      No MOU documents yet. Add your first document to get started.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/app/admin/email-marketing/automation/page.tsx
+++ b/app/admin/email-marketing/automation/page.tsx
@@ -1,451 +1,113 @@
-"use client";
-import React from 'react';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-
-import { useEffect, useState } from 'react';
-import Image from 'next/image';
 import Link from 'next/link';
-import { useRouter } from 'next/navigation';
 
-
-import {
-
-
-  Plus,
-  Play,
-  Pause,
-  Trash2,
-  Edit,
-  Users,
-  Mail,
-  Clock,
-  Zap,
-} from 'lucide-react';
 export const dynamic = 'force-dynamic';
 
-interface Workflow {
-  id: string;
-  name: string;
-  trigger: string;
-  status: 'active' | 'paused' | 'draft';
-  emails: number;
-  recipients: number;
-  lastRun: string | null;
-}
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Email Automations | Admin | Elevate For Humanity',
+};
 
-export default function AutomationPage() {
-  const router = useRouter();
+const STATUS_BADGE: Record<string, string> = {
+  success: 'bg-green-100 text-green-800',
+  failed:  'bg-red-100 text-red-800',
+  partial: 'bg-yellow-100 text-yellow-800',
+};
 
-  useEffect(() => {
-    // Check admin auth
-    fetch('/api/auth/check-admin')
-      .then((res) => res.json())
-      .then((data) => {
-        if (!data.isAdmin) {
-          router.push('/login?redirect=/admin');
-        }
-      })
-      .catch(() => router.push('/login'));
-  }, [router]);
+export default async function EmailAutomationPage() {
+  await requireAdmin();
+  const db = createAdminClient();
 
-  const [workflows, setWorkflows] = useState<Workflow[]>([
-    {
-      id: '1',
-      name: 'Welcome Series',
-      trigger: 'New Student Enrollment',
-      status: 'active',
-      emails: 3,
-      recipients: 142,
-      lastRun: '2025-12-07T10:30:00Z',
-    },
-    {
-      id: '2',
-      name: 'Application Follow-Up',
-      trigger: 'Abandoned Application',
-      status: 'active',
-      emails: 2,
-      recipients: 67,
-      lastRun: '2025-12-06T15:45:00Z',
-    },
-    {
-      id: '3',
-      name: 'Course Completion',
-      trigger: 'Program Completed',
-      status: 'paused',
-      emails: 4,
-      recipients: 0,
-      lastRun: null,
-    },
-  ]);
+  const { data: automations } = await db
+    .from('email_automations')
+    .select('*')
+    .order('updated_at', { ascending: false });
 
-  const toggleStatus = (id: string) => {
-    setWorkflows(
-      workflows.map((w) =>
-        w.id === id
-          ? { ...w, status: w.status === 'active' ? 'paused' : 'active' }
-          : w
-      )
-    );
-  };
-
-  const deleteWorkflow = (id: string) => {
-    if (confirm('Delete this workflow?')) {
-      setWorkflows(workflows.filter((w) => w.id !== id));
-    }
-  };
+  const rows = automations ?? [];
+  const active = rows.filter((r: any) => r.is_active).length;
+  const totalRecipients = rows.reduce((sum: number, r: any) => sum + (r.total_recipients ?? 0), 0);
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Email Marketing', href: '/admin/email-marketing' }, { label: 'Automations' }]} />
 
-      {/* Hero Image */}
-            <div className="max-w-7xl mx-auto px-4 py-4">
-        <Breadcrumbs items={[{ label: "Admin", href: "/admin" }, { label: "Automation" }]} />
-      </div>
-{/* Hero Section */}
-      <section className="relative h-48 md:h-64 overflow-hidden">
-        <Image
-          src="/images/pages/admin-email-automation-d1.jpg"
-          alt="Automation"
-          fill
-          className="object-cover"
-          quality={100}
-          priority
-          sizes="100vw"
-        />
-
-      </section>
-
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-black">
-                Marketing Automation
-              </h1>
-              <p className="text-black mt-1">
-                Create automated email workflows and drip campaigns
-              </p>
-            </div>
-
-            <button
-              onClick={() =>
-                router.push('/admin/email-marketing/automation/new')
-              }
-              className="flex items-center space-x-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700"
-            >
-              <Plus className="w-4 h-4" />
-              <span>Create Workflow</span>
-            </button>
+        <div className="flex items-center justify-between mt-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Email Automations</h1>
+            <p className="text-gray-500 text-sm mt-1">Live workflow records from the database</p>
           </div>
-        </div>
-      </div>
-
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Zap className="w-8 h-8 text-brand-blue-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {workflows.length}
-            </div>
-            <div className="text-sm text-black">Total Workflows</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Play className="w-8 h-8 text-brand-green-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {workflows.filter((w) => w.status === 'active').length}
-            </div>
-            <div className="text-sm text-black">Active Workflows</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Mail className="w-8 h-8 text-brand-blue-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {workflows.reduce((sum, w) => sum + w.emails, 0)}
-            </div>
-            <div className="text-sm text-black">Total Emails</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Users className="w-8 h-8 text-brand-orange-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {workflows.reduce((sum, w) => sum + w.recipients, 0)}
-            </div>
-            <div className="text-sm text-black">Active Recipients</div>
-          </div>
+          <Link href="/admin/email-marketing/automation/new"
+            className="bg-brand-orange-600 hover:bg-brand-orange-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors">
+            + New Automation
+          </Link>
         </div>
 
-        {/* Workflow Templates */}
-        <div className="mb-8">
-          <h2 className="text-xl font-semibold text-black mb-4">
-            Quick Start Templates
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-3 gap-6">
-            <WorkflowTemplate
-              title="Welcome Series"
-              description="Onboard new students with 3-email sequence"
-              icon={Mail}
-              color="blue"
-              onClick={() =>
-                router.push(
-                  '/admin/email-marketing/automation/new?template=welcome'
-                )
-              }
-            />
-            <WorkflowTemplate
-              title="Abandoned Application"
-              description="Re-engage applicants who didn't complete"
-              icon={Clock}
-              color="orange"
-              onClick={() =>
-                router.push(
-                  '/admin/email-marketing/automation/new?template=abandoned'
-                )
-              }
-            />
-            <WorkflowTemplate
-              title="Course Reminders"
-              description="Send reminders before class starts"
-              icon={Zap}
-              color="blue"
-              onClick={() =>
-                router.push(
-                  '/admin/email-marketing/automation/new?template=reminder'
-                )
-              }
-            />
-          </div>
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          {[
+            { label: 'Total Automations', value: rows.length },
+            { label: 'Active',            value: active },
+            { label: 'Total Recipients',  value: totalRecipients.toLocaleString() },
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-white rounded-lg border p-4 shadow-sm">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">{kpi.label}</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">{kpi.value}</p>
+            </div>
+          ))}
         </div>
 
-        {/* Workflows List */}
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200">
-            <h2 className="text-xl font-semibold text-black">
-              Your Workflows
-            </h2>
+        <div className="bg-white rounded-lg border shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50">
+            <h2 className="font-semibold text-slate-800">Workflows</h2>
           </div>
-
-          {workflows.length === 0 ? (
-            <div className="p-12 text-center">
-              <Zap className="w-12 h-12 text-black mx-auto mb-4" />
-              <h3 className="text-lg font-medium text-black mb-2">
-                No workflows yet
-              </h3>
-              <p className="text-black mb-6">
-                Create your first automated workflow to save time
-              </p>
-              <button
-                onClick={() =>
-                  router.push('/admin/email-marketing/automation/new')
-                }
-                className="inline-flex items-center space-x-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700"
-              >
-                <Plus className="w-4 h-4" />
-                <span>Create Workflow</span>
-              </button>
-            </div>
-          ) : (
-            <div className="divide-y divide-gray-200">
-              {workflows.map((workflow) => (
-                <div
-                  key={workflow.id}
-                  className="p-6 hover:bg-gray-50 transition-colors"
-                >
-                  <div className="flex items-center justify-between">
-                    <div className="flex-1">
-                      <div className="flex items-center space-x-3 mb-2">
-                        <h3 className="text-lg font-semibold text-black">
-                          {workflow.name}
-                        </h3>
-                        <span
-                          className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                            workflow.status === 'active'
-                              ? 'bg-brand-green-100 text-brand-green-800'
-                              : workflow.status === 'paused'
-                                ? 'bg-yellow-100 text-yellow-800'
-                                : 'bg-gray-100 text-black'
-                          }`}
-                        >
-                          {workflow.status === 'active'
-                            ? '● Active'
-                            : workflow.status === 'paused'
-                              ? '⏸ Paused'
-                              : '○ Draft'}
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 border-b">
+                <tr>
+                  {['Name', 'Trigger', 'Audience', 'Active', 'Last Run', 'Recipients', 'Last Status'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left font-medium text-slate-600">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((r: any) => (
+                  <tr key={r.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">{r.name}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.trigger_type.replace(/_/g, ' ')}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.audience_type}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${r.is_active ? 'bg-green-100 text-green-800' : 'bg-gray-100 text-gray-600'}`}>
+                        {r.is_active ? 'Active' : 'Inactive'}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {r.last_run_at ? new Date(r.last_run_at).toLocaleString() : 'Never'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.last_recipient_count}</td>
+                    <td className="px-4 py-3">
+                      {r.last_run_status ? (
+                        <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE[r.last_run_status] ?? 'bg-gray-100 text-gray-600'}`}>
+                          {r.last_run_status}
                         </span>
-                      </div>
-
-                      <div className="flex items-center space-x-6 text-sm text-black">
-                        <div className="flex items-center space-x-2">
-                          <Zap className="w-4 h-4" />
-                          <span>Trigger: {workflow.trigger}</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Mail className="w-4 h-4" />
-                          <span>{workflow.emails} emails</span>
-                        </div>
-                        <div className="flex items-center space-x-2">
-                          <Users className="w-4 h-4" />
-                          <span>{workflow.recipients} recipients</span>
-                        </div>
-                        {workflow.lastRun && (
-                          <div className="flex items-center space-x-2">
-                            <Clock className="w-4 h-4" />
-                            <span>
-                              Last run:{' '}
-                              {new Date(workflow.lastRun).toLocaleDateString()}
-                            </span>
-                          </div>
-                        )}
-                      </div>
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      <button
-                        onClick={() => toggleStatus(workflow.id)}
-                        className={`p-2 rounded-lg transition-colors ${
-                          workflow.status === 'active'
-                            ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200'
-                            : 'bg-brand-green-100 text-brand-green-700 hover:bg-brand-green-200'
-                        }`}
-                        title={
-                          workflow.status === 'active' ? 'Pause' : 'Activate'
-                        }
-                      >
-                        {workflow.status === 'active' ? (
-                          <Pause className="w-4 h-4" />
-                        ) : (
-                          <Play className="w-4 h-4" />
-                        )}
-                      </button>
-
-                      <button
-                        onClick={() =>
-                          router.push(
-                            `/admin/email-marketing/automation/${workflow.id}/edit`
-                          )
-                        }
-                        className="p-2 bg-brand-blue-100 text-brand-blue-700 rounded-lg hover:bg-brand-blue-200 transition-colors"
-                        title="Edit"
-                      >
-                        <Edit className="w-4 h-4" />
-                      </button>
-
-                      <button
-                        onClick={() => deleteWorkflow(workflow.id)}
-                        className="p-2 bg-brand-red-100 text-brand-red-700 rounded-lg hover:bg-brand-red-200 transition-colors"
-                        title="Delete"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-          )}
-        </div>
-
-        {/* Storytelling Section */}
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="max-w-7xl mx-auto">
-              <div className="grid md:grid-cols-2 gap-12 items-center">
-                <div>
-                  <h2 className="text-2xl md:text-3xl font-bold mb-6 text-black">
-                    Your Journey Starts Here
-                  </h2>
-                  <p className="text-lg text-black mb-6 leading-relaxed">
-                    Every great career begins with a single step. Whether you're
-                    looking to change careers, upgrade your skills, or enter the
-                    workforce for the first time, we're here to help you
-                    succeed. Our programs are Funded, government-funded, and
-                    designed to get you hired fast.
-                  </p>
-                  <ul className="space-y-4">
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Funded training - no tuition, no hidden costs
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Industry-recognized certifications that employers value
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Job placement assistance and career support
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Flexible scheduling for working adults
-                      </span>
-                    </li>
-                  </ul>
-                </div>
-                <div className="relative h-[60vh] min-h-[400px] max-h-[720px] rounded-2xl overflow-hidden shadow-2xl">
-                  <Image
-                    src="/images/pages/admin-email-automation-d2.jpg"
-                    alt="Students learning"
-                    fill
-                    className="object-cover"
-                    quality={100}
-                    sizes="(max-width: 768px) 100vw, 50vw"
-                  />
-                </div>
-              </div>
-            </div>
+                      ) : '—'}
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-slate-500">
+                      No automations yet. Create your first workflow to get started.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
-        </section>
+        </div>
       </div>
     </div>
-  );
-}
-
-interface WorkflowTemplateProps {
-  title: string;
-  description: string;
-  icon: React.ComponentType<{ className?: string }>;
-  color: 'blue' | 'orange' | 'blue';
-  onClick: () => void;
-}
-
-function WorkflowTemplate({
-  title,
-  description,
-  icon: Icon,
-  color,
-  onClick,
-}: WorkflowTemplateProps) {
-  const colorClasses = {
-    blue: 'bg-brand-blue-50 text-brand-blue-600 hover:bg-gray-100',
-    orange: 'bg-brand-orange-50 text-brand-orange-600 hover:bg-brand-orange-100',
-    blue: 'bg-brand-blue-50 text-brand-blue-600 hover:bg-brand-blue-100',
-  };
-
-  return (
-    <button
-      onClick={onClick}
-      className={`p-6 rounded-lg border-2 border-gray-200 hover:border-gray-300 transition-all text-left ${colorClasses[color]}`}
-    >
-      <Icon className="w-8 h-8 mb-3" />
-      <h3 className="font-semibold text-black mb-2">{title}</h3>
-      <p className="text-sm text-black">{description}</p>
-    </button>
   );
 }

--- a/app/admin/site-health/page.tsx
+++ b/app/admin/site-health/page.tsx
@@ -1,56 +1,74 @@
-import { Metadata } from 'next';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
-import Link from 'next/link';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { getSiteHealthSnapshot } from '@/lib/admin/get-site-health';
+import type { HealthStatus } from '@/lib/admin/get-site-health';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  alternates: { canonical: 'https://www.elevateforhumanity.org/admin/site-health' },
+  robots: { index: false, follow: false },
   title: 'Site Health | Elevate For Humanity',
-  description: 'Monitor website health and performance metrics.',
 };
 
-export default async function SiteHealthPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
-  const { data: profile } = await supabase.from('profiles').select('*').eq('id', user.id).single();
-  if (profile?.role !== 'admin' && profile?.role !== 'super_admin') redirect('/unauthorized');
+function statusBadge(status: HealthStatus) {
+  if (status === 'healthy')  return 'bg-green-100 text-green-800';
+  if (status === 'degraded') return 'bg-yellow-100 text-yellow-800';
+  return 'bg-red-100 text-red-800';
+}
 
-  const healthChecks = [
-    { name: 'Database', status: 'healthy', latency: '12ms' },
-    { name: 'Authentication', status: 'healthy', latency: '45ms' },
-    { name: 'Storage', status: 'healthy', latency: '23ms' },
-    { name: 'Email Service', status: 'healthy', latency: '156ms' },
-  ];
+function statusDot(status: HealthStatus) {
+  if (status === 'healthy')  return 'bg-green-500';
+  if (status === 'degraded') return 'bg-yellow-500';
+  return 'bg-red-500';
+}
+
+function overallBanner(status: HealthStatus) {
+  if (status === 'healthy')
+    return { bg: 'bg-green-50 border-green-200', text: 'text-green-800', label: 'All Systems Operational' };
+  if (status === 'degraded')
+    return { bg: 'bg-yellow-50 border-yellow-200', text: 'text-yellow-800', label: 'Partial Degradation' };
+  return { bg: 'bg-red-50 border-red-200', text: 'text-red-800', label: 'Service Disruption' };
+}
+
+export default async function SiteHealthPage() {
+  await requireAdmin();
+  const health = await getSiteHealthSnapshot();
+  const banner = overallBanner(health.overallStatus);
 
   return (
     <div className="min-h-screen bg-gray-50">
-
-      {/* Hero Image */}
       <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <nav className="text-sm mb-4"><ol className="flex items-center space-x-2 text-gray-500"><li><Link href="/admin" className="hover:text-primary">Admin</Link></li><li>/</li><li className="text-gray-900 font-medium">Site Health</li></ol></nav>
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Site Health' }]} />
+        <div className="mt-4 mb-6">
           <h1 className="text-3xl font-bold text-gray-900">Site Health</h1>
-          <p className="text-gray-600 mt-2">Monitor system status and performance</p>
+          <p className="text-gray-500 text-sm mt-1">
+            Live checks — last run {new Date(health.checkedAt).toLocaleString()}
+          </p>
         </div>
-        <div className="bg-brand-green-50 border border-brand-green-200 rounded-lg p-4 mb-6 flex items-center gap-3">
-          <svg className="w-6 h-6 text-brand-green-600" fill="none" stroke="currentColor" viewBox="0 0 24 24"><path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z" /></svg>
-          <div><p className="font-medium text-brand-green-800">All Systems Operational</p><p className="text-sm text-brand-green-700">Last checked: just now</p></div>
+        <div className={`border rounded-lg p-4 mb-6 flex items-center gap-3 ${banner.bg}`}>
+          <span className={`w-3 h-3 rounded-full flex-shrink-0 ${statusDot(health.overallStatus)}`} />
+          <p className={`font-semibold ${banner.text}`}>{banner.label}</p>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border">
-          <div className="p-4 border-b"><h2 className="font-semibold">Service Status</h2></div>
+        <div className="bg-white rounded-lg shadow-sm border overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50">
+            <h2 className="font-semibold text-slate-800">Service Status</h2>
+          </div>
           <div className="divide-y">
-            {healthChecks.map((check) => (
-              <div key={check.name} className="p-4 flex items-center justify-between">
-                <div className="flex items-center gap-3">
-                  <span className="w-3 h-3 bg-brand-green-500 rounded-full"></span>
-                  <span className="font-medium">{check.name}</span>
+            {health.services.map((svc) => (
+              <div key={svc.name} className="px-4 py-4 flex items-center justify-between gap-4">
+                <div className="flex items-center gap-3 min-w-0">
+                  <span className={`w-2.5 h-2.5 rounded-full flex-shrink-0 ${statusDot(svc.status)}`} />
+                  <span className="font-medium text-slate-900">{svc.name}</span>
                 </div>
-                <div className="flex items-center gap-4">
-                  <span className="text-sm text-gray-500">{check.latency}</span>
-                  <span className="px-2 py-1 bg-brand-green-100 text-brand-green-800 rounded text-xs">{check.status}</span>
+                <div className="flex items-center gap-4 flex-shrink-0">
+                  <span className="text-sm text-slate-500 hidden sm:block">{svc.detail}</span>
+                  {svc.latencyMs !== null && (
+                    <span className="text-sm text-slate-400">{svc.latencyMs} ms</span>
+                  )}
+                  <span className={`px-2 py-0.5 rounded text-xs font-medium ${statusBadge(svc.status)}`}>
+                    {svc.status}
+                  </span>
                 </div>
               </div>
             ))}

--- a/app/admin/social-media/page.tsx
+++ b/app/admin/social-media/page.tsx
@@ -1,533 +1,110 @@
-'use client';
-
-import React from 'react';
-import { useEffect, useState } from 'react';
-import Image from 'next/image';
-import Link from 'next/link';
-import { useRouter } from 'next/navigation';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import SocialMediaAutomation from '@/lib/new-ecosystem-services/SocialMediaAutomation';
+import Link from 'next/link';
 
-import {
-  Plus,
-  Calendar,
-  TrendingUp,
-  Users,
-  Share2,
-  Facebook,
-  Linkedin,
-  Instagram,
-  Clock,
-  Play,
-  Pause,
-  Edit,
-  Trash2,
-  BarChart3,
-} from 'lucide-react';
+export const dynamic = 'force-dynamic';
 
-interface Campaign {
-  id: string;
-  name: string;
-  status: 'active' | 'paused' | 'draft';
-  frequency: '3x-daily' | 'daily' | 'weekly';
-  platforms: string[];
-  postsScheduled: number;
-  lastPost: string | null;
-  nextPost: string | null;
-}
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+  title: 'Social Media | Admin | Elevate For Humanity',
+};
 
-export default function SocialMediaPage() {
-  const router = useRouter();
+const STATUS_BADGE: Record<string, string> = {
+  active:    'bg-green-100 text-green-800',
+  paused:    'bg-yellow-100 text-yellow-800',
+  draft:     'bg-gray-100 text-gray-600',
+  scheduled: 'bg-blue-100 text-blue-800',
+  completed: 'bg-purple-100 text-purple-800',
+  failed:    'bg-red-100 text-red-800',
+};
 
-  useEffect(() => {
-    // Check admin auth
-    fetch('/api/auth/check-admin')
-      .then((res) => res.json())
-      .then((data) => {
-        if (!data.isAdmin) {
-          router.push('/login?redirect=/admin');
-        }
-      })
-      .catch(() => router.push('/login'));
-  }, [router]);
+export default async function SocialMediaPage() {
+  await requireAdmin();
+  const db = createAdminClient();
 
-  const [campaigns, setCampaigns] = useState<Campaign[]>([
-    {
-      id: '1',
-      name: 'Barber Program Promotion',
-      status: 'active',
-      frequency: '3x-daily',
-      platforms: ['facebook', 'instagram', 'linkedin'],
-      postsScheduled: 90,
-      lastPost: '2025-12-07T10:00:00Z',
-      nextPost: '2025-12-07T14:00:00Z',
-    },
-    {
-      id: '2',
-      name: 'Student Success Stories',
-      status: 'active',
-      frequency: '3x-daily',
-      platforms: ['facebook', 'instagram', 'linkedin'],
-      postsScheduled: 60,
-      lastPost: '2025-12-07T09:30:00Z',
-      nextPost: '2025-12-07T13:30:00Z',
-    },
-    {
-      id: '3',
-      name: 'WIOA Eligibility Info',
-      status: 'paused',
-      frequency: 'daily',
-      platforms: ['facebook', 'linkedin'],
-      postsScheduled: 30,
-      lastPost: '2025-12-06T12:00:00Z',
-      nextPost: null,
-    },
-  ]);
+  const { data: campaigns } = await db
+    .from('social_campaigns')
+    .select('*')
+    .order('updated_at', { ascending: false });
 
-  const toggleStatus = (id: string) => {
-    setCampaigns(
-      campaigns.map((c) =>
-        c.id === id
-          ? { ...c, status: c.status === 'active' ? 'paused' : 'active' }
-          : c
-      )
-    );
-  };
+  const rows = campaigns ?? [];
+  const active = rows.filter((r: any) => r.status === 'active').length;
+  const totalPublished = rows.reduce((sum: number, r: any) => sum + (r.published_posts ?? 0), 0);
 
   return (
     <div className="min-h-screen bg-gray-50">
-      {/* Hero Section */}
-      <section className="relative h-48 md:h-64 overflow-hidden">
-        <Image
-          src="/images/pages/admin-social-hero.jpg"
-          alt="Social Media"
-          fill
-          className="object-cover"
-          quality={100}
-          priority
-          sizes="100vw"
-        />
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Social Media' }]} />
 
-      </section>
+        <div className="flex items-center justify-between mt-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Social Media Campaigns</h1>
+            <p className="text-gray-500 text-sm mt-1">Live campaign records from the database</p>
+          </div>
+          <Link href="/admin/social-media/campaigns/new"
+            className="bg-brand-orange-600 hover:bg-brand-orange-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors">
+            + New Campaign
+          </Link>
+        </div>
 
-      {/* Header */}
-      <div className="bg-white border-b border-gray-200">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-6">
-          <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Social Media' }]} />
-          <div className="flex items-center justify-between">
-            <div>
-              <h1 className="text-3xl font-bold text-black">
-                Social Media Automation
-              </h1>
-              <p className="text-black mt-1" />
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          {[
+            { label: 'Total Campaigns',  value: rows.length },
+            { label: 'Active',           value: active },
+            { label: 'Posts Published',  value: totalPublished.toLocaleString() },
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-white rounded-lg border p-4 shadow-sm">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">{kpi.label}</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">{kpi.value}</p>
             </div>
+          ))}
+        </div>
 
-            <button
-              onClick={() => router.push('/admin/social-media/campaigns/new')}
-              className="flex items-center space-x-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700"
-            >
-              <Plus className="w-4 h-4" />
-              <span>Create Campaign</span>
-            </button>
+        <div className="bg-white rounded-lg border shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50">
+            <h2 className="font-semibold text-slate-800">Campaigns</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 border-b">
+                <tr>
+                  {['Campaign', 'Platform', 'Status', 'Scheduled', 'Published', 'Failed', 'Last Published'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left font-medium text-slate-600">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((r: any) => (
+                  <tr key={r.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">{r.name}</td>
+                    <td className="px-4 py-3 text-slate-600 capitalize">{r.platform}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE[r.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {r.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.scheduled_posts}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.published_posts}</td>
+                    <td className="px-4 py-3 text-slate-600">{r.failed_posts}</td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {r.last_published_at ? new Date(r.last_published_at).toLocaleString() : 'Never'}
+                    </td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={7} className="px-4 py-8 text-center text-slate-500">
+                      No campaigns yet. Create your first campaign to get started.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>
-
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        {/* Stats */}
-        <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Share2 className="w-8 h-8 text-brand-blue-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {campaigns.filter((c) => c.status === 'active').length}
-            </div>
-            <div className="text-sm text-black">Active Campaigns</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Calendar className="w-8 h-8 text-brand-green-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">
-              {campaigns.reduce((sum, c) => sum + c.postsScheduled, 0)}
-            </div>
-            <div className="text-sm text-black">Posts Scheduled</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <Clock className="w-8 h-8 text-brand-blue-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">3x Daily</div>
-            <div className="text-sm text-black">Post Frequency</div>
-          </div>
-
-          <div className="bg-white rounded-lg shadow p-6">
-            <div className="flex items-center justify-between mb-2">
-              <TrendingUp className="w-8 h-8 text-brand-orange-600" />
-            </div>
-            <div className="text-2xl font-bold text-black">4</div>
-            <div className="text-sm text-black">Connected Platforms</div>
-          </div>
-        </div>
-
-        {/* Connected Platforms */}
-        <div className="bg-white rounded-lg shadow p-6 mb-8">
-          <h2 className="text-xl font-semibold text-black mb-4">
-            Connected Platforms
-          </h2>
-          <div className="grid grid-cols-1 md:grid-cols-4 gap-4">
-            <PlatformCard
-              name="Facebook"
-              icon={Facebook}
-              color="blue"
-              connected={false}
-              followers="Not connected"
-            />
-            <PlatformCard
-              name="Twitter"
-              icon={Share2}
-              color="sky"
-              connected={false}
-              followers="Not connected"
-            />
-            <PlatformCard
-              name="LinkedIn"
-              icon={Linkedin}
-              color="blue"
-              connected={false}
-              followers="Not connected"
-            />
-            <PlatformCard
-              name="Instagram"
-              icon={Instagram}
-              color="pink"
-              connected={false}
-              followers="Not connected"
-            />
-          </div>
-        </div>
-
-        {/* Posting Schedule */}
-        <div className="bg-white rounded-lg shadow p-6 mb-8">
-          <h2 className="text-xl font-semibold text-black mb-4">
-            Daily Posting Schedule (3x Daily)
-          </h2>
-          <div className="space-y-4">
-            <ScheduleSlot
-              time="9:00 AM EST"
-              status="completed"
-              campaign="Barber Program Promotion"
-            />
-            <ScheduleSlot
-              time="1:00 PM EST"
-              status="upcoming"
-              campaign="Student Success Stories"
-            />
-            <ScheduleSlot
-              time="5:00 PM EST"
-              status="scheduled"
-              campaign="WIOA Eligibility Info"
-            />
-          </div>
-        </div>
-
-        {/* Campaigns List */}
-        <div className="bg-white rounded-lg shadow overflow-hidden">
-          <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between">
-            <h2 className="text-xl font-semibold text-black">
-              Your Campaigns
-            </h2>
-            <button
-              onClick={() => router.push('/admin/social-media/analytics')}
-              className="flex items-center space-x-2 text-brand-blue-600 hover:text-brand-blue-700"
-            >
-              <BarChart3 className="w-4 h-4" />
-              <span>View Analytics</span>
-            </button>
-          </div>
-
-          <div className="divide-y divide-gray-200">
-            {campaigns.map((campaign) => (
-              <div
-                key={campaign.id}
-                className="p-6 hover:bg-gray-50 transition-colors"
-              >
-                <div className="flex items-center justify-between">
-                  <div className="flex-1">
-                    <div className="flex items-center space-x-3 mb-2">
-                      <h3 className="text-lg font-semibold text-black">
-                        {campaign.name}
-                      </h3>
-                      <span
-                        className={`inline-flex items-center px-2.5 py-0.5 rounded-full text-xs font-medium ${
-                          campaign.status === 'active'
-                            ? 'bg-brand-green-100 text-brand-green-800'
-                            : campaign.status === 'paused'
-                              ? 'bg-yellow-100 text-yellow-800'
-                              : 'bg-gray-100 text-black'
-                        }`}
-                      >
-                        {campaign.status === 'active'
-                          ? '● Active'
-                          : campaign.status === 'paused'
-                            ? '⏸ Paused'
-                            : '○ Draft'}
-                      </span>
-                    </div>
-
-                    <div className="flex items-center space-x-6 text-sm text-black mb-3">
-                      <div className="flex items-center space-x-2">
-                        <Clock className="w-4 h-4" />
-                        <span>
-                          {campaign.frequency === '3x-daily'
-                            ? '3x Daily'
-                            : campaign.frequency}
-                        </span>
-                      </div>
-                      <div className="flex items-center space-x-2">
-                        <Calendar className="w-4 h-4" />
-                        <span>{campaign.postsScheduled} posts scheduled</span>
-                      </div>
-                      {campaign.nextPost && (
-                        <div className="flex items-center space-x-2">
-                          <Clock className="w-4 h-4" />
-                          <span>
-                            Next:{' '}
-                            {new Date(campaign.nextPost).toLocaleTimeString()}
-                          </span>
-                        </div>
-                      )}
-                    </div>
-
-                    <div className="flex items-center space-x-2">
-                      {campaign.platforms.map((platform) => (
-                        <span
-                          key={platform}
-                          className="inline-flex items-center px-2 py-2 rounded-md text-xs font-medium bg-brand-blue-100 text-brand-blue-800"
-                        >
-                          {platform === 'facebook' && (
-                            <Facebook className="w-3 h-3 mr-1" />
-                          )}
-                          {platform === 'linkedin' && (
-                            <Linkedin className="w-3 h-3 mr-1" />
-                          )}
-                          {platform === 'instagram' && (
-                            <Instagram className="w-3 h-3 mr-1" />
-                          )}
-                          {platform.charAt(0).toUpperCase() + platform.slice(1)}
-                        </span>
-                      ))}
-                    </div>
-                  </div>
-
-                  <div className="flex items-center space-x-2">
-                    <button
-                      onClick={() => toggleStatus(campaign.id)}
-                      className={`p-2 rounded-lg transition-colors ${
-                        campaign.status === 'active'
-                          ? 'bg-yellow-100 text-yellow-700 hover:bg-yellow-200'
-                          : 'bg-brand-green-100 text-brand-green-700 hover:bg-brand-green-200'
-                      }`}
-                      title={
-                        campaign.status === 'active' ? 'Pause' : 'Activate'
-                      }
-                    >
-                      {campaign.status === 'active' ? (
-                        <Pause className="w-4 h-4" />
-                      ) : (
-                        <Play className="w-4 h-4" />
-                      )}
-                    </button>
-
-                    <button
-                      onClick={() =>
-                        router.push(
-                          `/admin/social-media/campaigns/${campaign.id}/edit`
-                        )
-                      }
-                      className="p-2 bg-brand-blue-100 text-brand-blue-700 rounded-lg hover:bg-brand-blue-200 transition-colors"
-                      title="Edit"
-                    >
-                      <Edit className="w-4 h-4" />
-                    </button>
-
-                    <button
-                      onClick={() => {
-                        if (confirm('Delete this campaign?')) {
-                          setCampaigns(
-                            campaigns.filter((c) => c.id !== campaign.id)
-                          );
-                        }
-                      }}
-                      className="p-2 bg-brand-red-100 text-brand-red-700 rounded-lg hover:bg-brand-red-200 transition-colors"
-                      title="Delete"
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-
-        {/* Storytelling Section */}
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="max-w-7xl mx-auto">
-              <div className="grid md:grid-cols-2 gap-12 items-center">
-                <div>
-                  <h2 className="text-2xl md:text-3xl font-bold mb-6 text-black">
-                    Your Journey Starts Here
-                  </h2>
-                  <p className="text-lg text-black mb-6 leading-relaxed">
-                    Every great career begins with a single step. Whether you're
-                    looking to change careers, upgrade your skills, or enter the
-                    workforce for the first time, we're here to help you
-                    succeed. Our programs are Funded, government-funded, and
-                    designed to get you hired fast.
-                  </p>
-                  <ul className="space-y-4">
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Funded training - no tuition, no hidden costs
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Industry-recognized certifications that employers value
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Job placement assistance and career support
-                      </span>
-                    </li>
-                    <li className="flex items-start">
-                      <span className="text-slate-400 flex-shrink-0">•</span>
-                      <span className="text-black">
-                        Flexible scheduling for working adults
-                      </span>
-                    </li>
-                  </ul>
-                </div>
-                <div className="relative h-[60vh] min-h-[400px] max-h-[720px] rounded-2xl overflow-hidden shadow-2xl">
-                  <Image
-                    src="/images/pages/social.jpg"
-                    alt="Students learning"
-                    fill
-                    className="object-cover"
-                    quality={100}
-                    sizes="(max-width: 768px) 100vw, 50vw"
-                  />
-                </div>
-              </div>
-            </div>
-          </div>
-        </section>
-
-        {/* CTA Section */}
-        <section className="py-16">
-          <div className="container mx-auto px-4">
-            <div className="max-w-4xl mx-auto text-center">
-              <h2 className="text-2xl md:text-3xl font-bold mb-6">
-              Social Media Management
-                          </h2>
-              <p className="text-base md:text-lg mb-8 text-brand-blue-100">
-              Schedule posts, track engagement, and manage brand presence.
-                          </p>
-              <div className="flex flex-col sm:flex-row gap-4 justify-center">
-                <Link
-                  href="/admin/social-media/campaigns/new"
-                  className="bg-white text-brand-blue-700 px-8 py-4 rounded-lg font-bold hover:bg-gray-50 text-lg shadow-2xl transition-all"
-                >
-                Create Campaign
-                </Link>
-                <Link
-                  href="/admin/dashboard"
-                  className="bg-brand-blue-800 text-white px-8 py-4 rounded-lg font-bold hover:bg-brand-blue-600 border-2 border-white text-lg shadow-2xl transition-all"
-                >
-                View Dashboard
-                </Link>
-              </div>
-            </div>
-          </div>
-        </section>
-      </div>
-    </div>
-  );
-}
-
-interface PlatformCardProps {
-  name: string;
-  icon: React.ComponentType<{ className?: string }>;
-  color: string;
-  connected: boolean;
-  followers: string;
-}
-
-function PlatformCard({
-  name,
-  icon: Icon,
-  color,
-  connected,
-  followers,
-}: PlatformCardProps) {
-  return (
-    <div className="border-2 border-gray-200 rounded-lg p-4">
-      <div className="flex items-center justify-between mb-3">
-        <Icon className={`w-8 h-8 text-${color}-600`} />
-        {connected && (
-          <span className="inline-flex items-center px-2 py-2 rounded-full text-xs font-medium bg-brand-green-100 text-brand-green-800">
-            ● Connected
-          </span>
-        )}
-      </div>
-      <h3 className="font-semibold text-black mb-1">{name}</h3>
-      <p className="text-sm text-black">{connected ? `${followers} followers` : followers}</p>
-    </div>
-  );
-}
-
-interface ScheduleSlotProps {
-  time: string;
-  status: 'completed' | 'upcoming' | 'scheduled';
-  campaign: string;
-}
-
-function ScheduleSlot({ time, status, campaign }: ScheduleSlotProps) {
-  const statusColors = {
-    completed: 'bg-brand-green-100 text-brand-green-800',
-    upcoming: 'bg-brand-blue-100 text-brand-blue-800',
-    scheduled: 'bg-gray-100 text-black',
-  };
-
-  return (
-    <div className="flex items-center justify-between p-4 border border-gray-200 rounded-lg">
-
-      {/* Hero Image */}
-      <div className="flex items-center space-x-4">
-        <Clock className="w-5 h-5 text-black" />
-        <div>
-          <div className="font-medium text-black">{time}</div>
-          <div className="text-sm text-black">{campaign}</div>
-        </div>
-      </div>
-      <span
-        className={`inline-flex items-center px-3 py-2 rounded-full text-xs font-medium ${statusColors[status]}`}
-      >
-        {status === 'completed'
-          ? '• Posted'
-          : status === 'upcoming'
-            ? '→ Next'
-            : '○ Scheduled'}
-      </span>
     </div>
   );
 }

--- a/app/admin/workflows/page.tsx
+++ b/app/admin/workflows/page.tsx
@@ -1,53 +1,104 @@
-import { Metadata } from 'next';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
+import type { Metadata } from 'next';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
 
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
-  alternates: { canonical: 'https://www.elevateforhumanity.org/admin/workflows' },
-  title: 'Workflow Automation | Elevate For Humanity',
-  description: 'Configure automated workflows and processes.',
+  robots: { index: false, follow: false },
+  title: 'Workflows | Admin | Elevate For Humanity',
+};
+
+const STATUS_BADGE: Record<string, string> = {
+  active:   'bg-green-100 text-green-800',
+  inactive: 'bg-gray-100 text-gray-600',
+  paused:   'bg-yellow-100 text-yellow-800',
+  error:    'bg-red-100 text-red-800',
 };
 
 export default async function WorkflowsPage() {
-  const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
-  const { data: profile } = await supabase.from('profiles').select('*').eq('id', user.id).single();
-  if (profile?.role !== 'admin' && profile?.role !== 'super_admin') redirect('/unauthorized');
+  await requireAdmin();
+  const db = createAdminClient();
 
-  const workflows = [
-    { name: 'New Enrollment', status: 'active', triggers: 'On enrollment', actions: 'Send welcome email, assign mentor' },
-    { name: 'Course Completion', status: 'active', triggers: 'On completion', actions: 'Issue certificate, notify admin' },
-    { name: 'Inactive User', status: 'active', triggers: '7 days inactive', actions: 'Send reminder email' },
-  ];
+  const { data: workflows } = await db
+    .from('workflows')
+    .select('*')
+    .order('updated_at', { ascending: false });
+
+  const rows = workflows ?? [];
+  const active = rows.filter((r: any) => r.status === 'active').length;
+  const totalRuns = rows.reduce((sum: number, r: any) => sum + (r.run_count ?? 0), 0);
 
   return (
     <div className="min-h-screen bg-gray-50">
+      <div className="max-w-6xl mx-auto px-4 py-8">
+        <Breadcrumbs items={[{ label: 'Admin', href: '/admin' }, { label: 'Workflows' }]} />
 
-      {/* Hero Image */}
-      <div className="max-w-7xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <nav className="text-sm mb-4"><ol className="flex items-center space-x-2 text-gray-500"><li><Link href="/admin" className="hover:text-primary">Admin</Link></li><li>/</li><li className="text-gray-900 font-medium">Workflows</li></ol></nav>
-          <div className="flex justify-between items-center">
-            <div><h1 className="text-3xl font-bold text-gray-900">Workflow Automation</h1><p className="text-gray-600 mt-2">Configure automated processes</p></div>
-            <button className="bg-brand-blue-600 text-white px-4 py-2 rounded-lg hover:bg-brand-blue-700">Create Workflow</button>
+        <div className="flex items-center justify-between mt-4 mb-6">
+          <div>
+            <h1 className="text-3xl font-bold text-gray-900">Workflows</h1>
+            <p className="text-gray-500 text-sm mt-1">Live workflow state from the database</p>
           </div>
+          <Link href="/admin/workflows/new"
+            className="bg-brand-orange-600 hover:bg-brand-orange-700 text-white text-sm font-semibold px-4 py-2 rounded-lg transition-colors">
+            + New Workflow
+          </Link>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border">
-          <div className="divide-y">
-            {workflows.map((wf, i) => (
-              <div key={i} className="p-4 hover:bg-gray-50">
-                <div className="flex items-center justify-between mb-2">
-                  <h3 className="font-medium">{wf.name}</h3>
-                  <span className="px-2 py-1 bg-brand-green-100 text-brand-green-800 rounded-full text-xs">{wf.status}</span>
-                </div>
-                <p className="text-sm text-gray-500"><strong>Trigger:</strong> {wf.triggers}</p>
-                <p className="text-sm text-gray-500"><strong>Actions:</strong> {wf.actions}</p>
-              </div>
-            ))}
+
+        <div className="grid grid-cols-2 md:grid-cols-3 gap-4 mb-6">
+          {[
+            { label: 'Total Workflows', value: rows.length },
+            { label: 'Active',          value: active },
+            { label: 'Total Runs',      value: totalRuns.toLocaleString() },
+          ].map((kpi) => (
+            <div key={kpi.label} className="bg-white rounded-lg border p-4 shadow-sm">
+              <p className="text-xs text-gray-500 uppercase tracking-wide">{kpi.label}</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">{kpi.value}</p>
+            </div>
+          ))}
+        </div>
+
+        <div className="bg-white rounded-lg border shadow-sm overflow-hidden">
+          <div className="px-4 py-3 border-b bg-slate-50">
+            <h2 className="font-semibold text-slate-800">All Workflows</h2>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="min-w-full text-sm">
+              <thead className="bg-slate-50 border-b">
+                <tr>
+                  {['Name', 'Category', 'Status', 'Runs', 'Last Run', 'Last Result'].map((h) => (
+                    <th key={h} className="px-4 py-3 text-left font-medium text-slate-600">{h}</th>
+                  ))}
+                </tr>
+              </thead>
+              <tbody className="divide-y">
+                {rows.map((r: any) => (
+                  <tr key={r.id} className="hover:bg-slate-50">
+                    <td className="px-4 py-3 font-medium text-slate-900">{r.name}</td>
+                    <td className="px-4 py-3 text-slate-600 capitalize">{r.category}</td>
+                    <td className="px-4 py-3">
+                      <span className={`px-2 py-0.5 rounded text-xs font-medium ${STATUS_BADGE[r.status] ?? 'bg-gray-100 text-gray-600'}`}>
+                        {r.status}
+                      </span>
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.run_count}</td>
+                    <td className="px-4 py-3 text-slate-600">
+                      {r.last_run_at ? new Date(r.last_run_at).toLocaleString() : 'Never'}
+                    </td>
+                    <td className="px-4 py-3 text-slate-600">{r.last_run_status ?? '—'}</td>
+                  </tr>
+                ))}
+                {rows.length === 0 && (
+                  <tr>
+                    <td colSpan={6} className="px-4 py-8 text-center text-slate-500">
+                      No workflows yet. Create your first workflow to get started.
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
           </div>
         </div>
       </div>

--- a/app/api/admin/email-automations/route.ts
+++ b/app/api/admin/email-automations/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeDbError } from '@/lib/api/safe-error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const { data, error } = await db.from('email_automations').select('*').order('updated_at', { ascending: false });
+  if (error) return safeDbError(error, 'Failed to fetch automations');
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const body = await request.json().catch(() => null);
+  if (!body?.name || !body?.trigger_type) {
+    return NextResponse.json({ error: 'name and trigger_type are required' }, { status: 400 });
+  }
+  const { data, error } = await db
+    .from('email_automations')
+    .insert({
+      name: body.name,
+      slug: body.slug ?? null,
+      trigger_type: body.trigger_type,
+      audience_type: body.audience_type ?? 'mixed',
+      is_active: Boolean(body.is_active),
+      provider: body.provider ?? 'sendgrid',
+      metadata: body.metadata ?? {},
+    })
+    .select()
+    .single();
+  if (error) return safeDbError(error, 'Failed to create automation');
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/admin/financial-assurance/route.ts
+++ b/app/api/admin/financial-assurance/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeInternalError, safeDbError } from '@/lib/api/safe-error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const { data, error } = await db
+    .from('financial_assurance_records')
+    .select('*')
+    .order('expiration_date', { ascending: true, nullsFirst: false });
+  if (error) return safeDbError(error, 'Failed to fetch records');
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const body = await request.json().catch(() => null);
+  if (!body?.record_type || !body?.provider_name) {
+    return NextResponse.json({ error: 'record_type and provider_name are required' }, { status: 400 });
+  }
+  const { data, error } = await db
+    .from('financial_assurance_records')
+    .insert({
+      record_type: body.record_type,
+      provider_name: body.provider_name,
+      policy_or_reference_number: body.policy_or_reference_number ?? null,
+      coverage_amount: body.coverage_amount ?? null,
+      effective_date: body.effective_date ?? null,
+      expiration_date: body.expiration_date ?? null,
+      status: body.status ?? 'active',
+      state: body.state ?? null,
+      notes: body.notes ?? null,
+      document_url: body.document_url ?? null,
+    })
+    .select()
+    .single();
+  if (error) return safeDbError(error, 'Failed to create record');
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/admin/mou-documents/route.ts
+++ b/app/api/admin/mou-documents/route.ts
@@ -1,0 +1,45 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeDbError } from '@/lib/api/safe-error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const { data, error } = await db.from('mou_documents').select('*').order('updated_at', { ascending: false });
+  if (error) return safeDbError(error, 'Failed to fetch MOU documents');
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const body = await request.json().catch(() => null);
+  if (!body?.title) {
+    return NextResponse.json({ error: 'title is required' }, { status: 400 });
+  }
+  const { data, error } = await db
+    .from('mou_documents')
+    .insert({
+      title: body.title,
+      organization_name: body.organization_name ?? null,
+      document_status: body.document_status ?? 'draft',
+      effective_date: body.effective_date ?? null,
+      expiration_date: body.expiration_date ?? null,
+      file_url: body.file_url ?? null,
+      external_document_id: body.external_document_id ?? null,
+      notes: body.notes ?? null,
+    })
+    .select()
+    .single();
+  if (error) return safeDbError(error, 'Failed to create MOU document');
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/admin/social-campaigns/route.ts
+++ b/app/api/admin/social-campaigns/route.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeDbError } from '@/lib/api/safe-error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const { data, error } = await db.from('social_campaigns').select('*').order('updated_at', { ascending: false });
+  if (error) return safeDbError(error, 'Failed to fetch campaigns');
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const body = await request.json().catch(() => null);
+  if (!body?.name || !body?.platform) {
+    return NextResponse.json({ error: 'name and platform are required' }, { status: 400 });
+  }
+  const { data, error } = await db
+    .from('social_campaigns')
+    .insert({
+      name: body.name,
+      platform: body.platform,
+      status: body.status ?? 'draft',
+      scheduled_posts: body.scheduled_posts ?? 0,
+      start_date: body.start_date ?? null,
+      end_date: body.end_date ?? null,
+      metadata: body.metadata ?? {},
+    })
+    .select()
+    .single();
+  if (error) return safeDbError(error, 'Failed to create campaign');
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/admin/workflows/route.ts
+++ b/app/api/admin/workflows/route.ts
@@ -1,0 +1,42 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { requireAdmin } from '@/lib/authGuards';
+import { createAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeDbError } from '@/lib/api/safe-error';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+export async function GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const { data, error } = await db.from('workflows').select('*').order('updated_at', { ascending: false });
+  if (error) return safeDbError(error, 'Failed to fetch workflows');
+  return NextResponse.json({ data });
+}
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+  await requireAdmin();
+  const db = createAdminClient();
+  const body = await request.json().catch(() => null);
+  if (!body?.name) {
+    return NextResponse.json({ error: 'name is required' }, { status: 400 });
+  }
+  const { data, error } = await db
+    .from('workflows')
+    .insert({
+      name: body.name,
+      workflow_key: body.workflow_key ?? null,
+      category: body.category ?? 'operations',
+      status: body.status ?? 'inactive',
+      metadata: body.metadata ?? {},
+    })
+    .select()
+    .single();
+  if (error) return safeDbError(error, 'Failed to create workflow');
+  return NextResponse.json({ data }, { status: 201 });
+}

--- a/app/api/webhooks/resend-inbound/route.ts
+++ b/app/api/webhooks/resend-inbound/route.ts
@@ -1,140 +1,16 @@
+/**
+ * Resend inbound webhook — DEPRECATED.
+ * Inbound email is now handled by SendGrid Inbound Parse.
+ * See: /api/webhooks/sendgrid-inbound
+ */
+import { NextResponse } from 'next/server';
 
-import { NextRequest, NextResponse } from 'next/server';
-import { sendEmail } from '@/lib/email/sendgrid';
-import { logger } from '@/lib/logger';
-import { withApiAudit } from '@/lib/audit/withApiAudit';
-import { claimWebhookEvent, finalizeWebhookEvent } from '@/lib/webhooks/event-tracker';
-import { fetchReceivedEmail, resolveForwardTarget } from '@/lib/email/resend-inbound';
 export const runtime = 'nodejs';
-export const maxDuration = 30;
-
 export const dynamic = 'force-dynamic';
 
-/**
- * Resend inbound webhook — receives email.received events and forwards
- * emails sent to @elevateforhumanity.org addresses to Gmail.
- *
- * Register this URL in Resend Dashboard → Webhooks:
- *   https://www.elevateforhumanity.org/api/webhooks/resend-inbound
- *   Event: email.received
- */
-async function _POST(request: NextRequest) {
-  try {
-    // Resend delivers webhooks via Svix — verify HMAC-SHA256 signature.
-    // Set RESEND_WEBHOOK_SECRET from Resend Dashboard → Webhooks → Signing Secret.
-    const webhookSecret = process.env.RESEND_WEBHOOK_SECRET;
-    if (!webhookSecret) {
-      logger.error('[Resend Inbound] RESEND_WEBHOOK_SECRET not configured — rejecting request');
-      return NextResponse.json({ error: 'Webhook not configured' }, { status: 503 });
-    }
-
-    const svixId = request.headers.get('svix-id');
-    const svixTimestamp = request.headers.get('svix-timestamp');
-    const svixSignature = request.headers.get('svix-signature');
-
-    if (!svixId || !svixTimestamp || !svixSignature) {
-      logger.warn('[Resend Inbound] Missing Svix signature headers');
-      return NextResponse.json({ error: 'Missing signature' }, { status: 401 });
-    }
-
-    // Reject stale webhooks (>5 min)
-    if (Math.abs(Date.now() / 1000 - Number(svixTimestamp)) > 300) {
-      logger.warn('[Resend Inbound] Stale timestamp rejected');
-      return NextResponse.json({ error: 'Request too old' }, { status: 401 });
-    }
-
-    const rawBody = await request.text();
-    const { createHmac, timingSafeEqual } = await import('crypto');
-    // Svix signs: "<svix-id>.<svix-timestamp>.<body>"
-    const toSign = `${svixId}.${svixTimestamp}.${rawBody}`;
-    // Secret is base64-encoded after the "whsec_" prefix
-    const secretBytes = Buffer.from(webhookSecret.replace(/^whsec_/, ''), 'base64');
-    const expected = createHmac('sha256', secretBytes).update(toSign).digest('base64');
-    // svix-signature may contain multiple space-separated "v1,<sig>" values
-    const signatures = svixSignature.split(' ').map(s => s.replace(/^v1,/, ''));
-    const valid = signatures.some(sig => {
-      try {
-        return timingSafeEqual(Buffer.from(sig, 'base64'), Buffer.from(expected, 'base64'));
-      } catch { return false; }
-    });
-    if (!valid) {
-      logger.error('[Resend Inbound] Signature mismatch — rejecting');
-      return NextResponse.json({ error: 'Invalid signature' }, { status: 401 });
-    }
-
-    const event = JSON.parse(rawBody);
-
-    // svix-id is the stable delivery ID — Svix retries reuse the same svix-id,
-    // making it the correct dedup key for this provider.
-    const eventId = svixId;
-
-    if (event.type !== 'email.received') {
-      // Track non-email events as skipped so the monitor sees all delivery attempts
-      await claimWebhookEvent('resend', eventId, event.type || 'unknown', { skipped: true })
-        .catch(() => {});
-      await finalizeWebhookEvent('resend', eventId, 'skipped', `unhandled type: ${event.type}`)
-        .catch(() => {});
-      return NextResponse.json({ ok: true, skipped: true });
-    }
-
-    const emailId = event.data?.email_id;
-    const toAddresses: string[] = event.data?.to || [];
-    const from = event.data?.from || '';
-    const subject = event.data?.subject || '(no subject)';
-
-    if (!emailId) {
-      logger.warn('[Resend Inbound] No email_id in event');
-      return NextResponse.json({ ok: false, error: 'missing email_id' }, { status: 400 });
-    }
-
-    const { shouldProcess, confident } = await claimWebhookEvent(
-      'resend',
-      eventId,
-      event.type,
-      { email_id: emailId, from, subject, to: toAddresses },
-    );
-
-    if (!shouldProcess) {
-      return NextResponse.json({ ok: true, idempotent: true });
-    }
-
-    if (!confident) {
-      logger.error('[Resend Inbound] Cannot verify idempotency — rejecting for retry', { eventId });
-      return NextResponse.json({ error: 'Temporary processing error' }, { status: 503 });
-    }
-
-    const forwardTo = resolveForwardTarget(toAddresses);
-
-    logger.info('[Resend Inbound] Forwarding email', { emailId, from, to: toAddresses, subject, forwardTo });
-
-    // Fetch full email content from Resend, then forward via SendGrid.
-    const received = await fetchReceivedEmail(emailId);
-
-    const html = received?.html ?? `<p><strong>From:</strong> ${from}</p><p><em>(Email body unavailable — RESEND_API_KEY not configured)</em></p>`;
-    const text = received?.text ?? `From: ${from}\n\n(Email body unavailable — RESEND_API_KEY not configured)`;
-    const replyTo = received?.reply_to?.[0] ?? from;
-
-    const result = await sendEmail({
-      to: forwardTo,
-      from: 'Elevate Forwarding <noreply@elevateforhumanity.org>',
-      replyTo,
-      subject: `Fwd: ${subject}`,
-      html,
-      text,
-    });
-
-    if (!result.success) {
-      logger.error('[Resend Inbound] Forward failed:', result.error);
-      await finalizeWebhookEvent('resend', eventId, 'errored', String(result.error));
-      return NextResponse.json({ ok: false, error: 'Forward failed' }, { status: 500 });
-    }
-
-    await finalizeWebhookEvent('resend', eventId, 'processed');
-    logger.info('[Resend Inbound] Forwarded successfully', { emailId, forwardTo });
-    return NextResponse.json({ ok: true });
-  } catch (err) {
-    logger.error('[Resend Inbound] Webhook error:', err);
-    return NextResponse.json({ ok: false, error: 'Internal error' }, { status: 500 });
-  }
+export async function POST() {
+  return NextResponse.json(
+    { error: 'Deprecated. Inbound email now uses SendGrid Inbound Parse at /api/webhooks/sendgrid-inbound' },
+    { status: 410 },
+  );
 }
-export const POST = withApiAudit('/api/webhooks/resend-inbound', _POST, { actor_type: 'webhook', skip_body: true });

--- a/app/api/webhooks/sendgrid-inbound/route.ts
+++ b/app/api/webhooks/sendgrid-inbound/route.ts
@@ -1,0 +1,85 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { sendEmail } from '@/lib/email/sendgrid';
+import { logger } from '@/lib/logger';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { claimWebhookEvent, finalizeWebhookEvent } from '@/lib/webhooks/event-tracker';
+import { parseInboundEmail, resolveForwardTarget } from '@/lib/email/sendgrid-inbound';
+
+export const runtime = 'nodejs';
+export const maxDuration = 30;
+export const dynamic = 'force-dynamic';
+
+/**
+ * SendGrid Inbound Parse webhook — receives emails sent to @elevateforhumanity.org
+ * and forwards them to Gmail.
+ *
+ * Setup required:
+ * 1. SendGrid Dashboard → Settings → Inbound Parse → Add Host & URL
+ *    - Receiving Domain: elevateforhumanity.org
+ *    - Destination URL:  https://www.elevateforhumanity.org/api/webhooks/sendgrid-inbound
+ *    - Check "POST the raw, full MIME message" OFF (use default form-encoded)
+ *    - Check "Send Raw" OFF
+ *
+ * 2. DNS — add MX record at your domain registrar:
+ *    Type: MX  |  Host: @  |  Value: mx.sendgrid.net  |  Priority: 10
+ *    (Remove or lower-priority any existing MX records for the root domain)
+ */
+async function _POST(request: NextRequest) {
+  try {
+    const parsed = await parseInboundEmail(request);
+
+    if (!parsed) {
+      return NextResponse.json({ error: 'Failed to parse inbound email' }, { status: 400 });
+    }
+
+    const { from, to, subject, html, text, replyTo, eventId } = parsed;
+
+    logger.info('[SendGrid Inbound] Received email', { from, to, subject, eventId });
+
+    // Dedup — same email delivered twice by SendGrid retries
+    const { shouldProcess, confident } = await claimWebhookEvent(
+      'sendgrid-inbound' as any,
+      eventId,
+      'email.received',
+      { from, to, subject },
+    );
+
+    if (!shouldProcess) {
+      return NextResponse.json({ ok: true, idempotent: true });
+    }
+
+    if (!confident) {
+      logger.error('[SendGrid Inbound] Cannot verify idempotency — rejecting for retry', { eventId });
+      return NextResponse.json({ error: 'Temporary processing error' }, { status: 503 });
+    }
+
+    const forwardTo = resolveForwardTarget(to);
+
+    logger.info('[SendGrid Inbound] Forwarding', { from, to, forwardTo, subject });
+
+    const result = await sendEmail({
+      to:      forwardTo,
+      from:    'Elevate Forwarding <noreply@elevateforhumanity.org>',
+      replyTo: replyTo || from,
+      subject: `Fwd: ${subject}`,
+      html:    html || `<p><strong>From:</strong> ${from}</p><p>${text || '(no body)'}</p>`,
+      text:    text || `From: ${from}\n\n(no body)`,
+    });
+
+    if (!result.success) {
+      logger.error('[SendGrid Inbound] Forward failed:', result.error);
+      await finalizeWebhookEvent('sendgrid-inbound' as any, eventId, 'errored', String(result.error));
+      return NextResponse.json({ ok: false, error: 'Forward failed' }, { status: 500 });
+    }
+
+    await finalizeWebhookEvent('sendgrid-inbound' as any, eventId, 'processed');
+    logger.info('[SendGrid Inbound] Forwarded successfully', { forwardTo, subject });
+    return NextResponse.json({ ok: true });
+
+  } catch (err) {
+    logger.error('[SendGrid Inbound] Webhook error:', err);
+    return NextResponse.json({ ok: false, error: 'Internal error' }, { status: 500 });
+  }
+}
+
+export const POST = withApiAudit('/api/webhooks/sendgrid-inbound', _POST, { actor_type: 'webhook', skip_body: true });

--- a/lib/admin/get-site-health.ts
+++ b/lib/admin/get-site-health.ts
@@ -1,0 +1,204 @@
+import { createAdminClient } from '@/lib/supabase/admin';
+
+export type HealthStatus = 'healthy' | 'degraded' | 'down';
+
+export type HealthCheckResult = {
+  name: string;
+  status: HealthStatus;
+  latencyMs: number | null;
+  detail: string;
+};
+
+export type SiteHealthSnapshot = {
+  overallStatus: HealthStatus;
+  checkedAt: string;
+  services: HealthCheckResult[];
+};
+
+function worstStatus(statuses: HealthStatus[]): HealthStatus {
+  if (statuses.includes('down')) return 'down';
+  if (statuses.includes('degraded')) return 'degraded';
+  return 'healthy';
+}
+
+async function timeCheck<T>(
+  fn: () => Promise<T>,
+): Promise<{ latencyMs: number; result?: T; error?: unknown }> {
+  const start = Date.now();
+  try {
+    const result = await fn();
+    return { latencyMs: Date.now() - start, result };
+  } catch (error) {
+    return { latencyMs: Date.now() - start, error };
+  }
+}
+
+export async function getSiteHealthSnapshot(): Promise<SiteHealthSnapshot> {
+  const db = createAdminClient();
+
+  const checks: Promise<HealthCheckResult>[] = [
+    // Real DB ping
+    (async () => {
+      const { latencyMs, error } = await timeCheck(async () => {
+        const { error } = await db
+          .from('profiles')
+          .select('id', { count: 'exact', head: true });
+        if (error) throw error;
+      });
+      if (error) {
+        return {
+          name: 'Supabase Database',
+          status: 'down' as HealthStatus,
+          latencyMs,
+          detail: error instanceof Error ? error.message : 'Query failed',
+        };
+      }
+      return {
+        name: 'Supabase Database',
+        status: (latencyMs > 1500 ? 'degraded' : 'healthy') as HealthStatus,
+        latencyMs,
+        detail: latencyMs > 1500 ? 'Slow response' : 'OK',
+      };
+    })(),
+
+    // Supabase env config
+    (async () => {
+      const ok =
+        Boolean(process.env.NEXT_PUBLIC_SUPABASE_URL) &&
+        Boolean(process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY) &&
+        Boolean(process.env.SUPABASE_SERVICE_ROLE_KEY);
+      return {
+        name: 'Supabase Config',
+        status: (ok ? 'healthy' : 'down') as HealthStatus,
+        latencyMs: null,
+        detail: ok ? 'All Supabase env vars present' : 'Missing Supabase environment variables',
+      };
+    })(),
+
+    // SendGrid
+    (async () => {
+      const configured = Boolean(process.env.SENDGRID_API_KEY);
+      if (!configured) {
+        return {
+          name: 'SendGrid',
+          status: 'down' as HealthStatus,
+          latencyMs: null,
+          detail: 'SENDGRID_API_KEY not set',
+        };
+      }
+      // Live ping to SendGrid
+      const { latencyMs, error } = await timeCheck(async () => {
+        const res = await fetch('https://api.sendgrid.com/v3/user/account', {
+          headers: { Authorization: `Bearer ${process.env.SENDGRID_API_KEY}` },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+      if (error) {
+        return {
+          name: 'SendGrid',
+          status: 'degraded' as HealthStatus,
+          latencyMs,
+          detail: error instanceof Error ? error.message : 'API check failed',
+        };
+      }
+      return {
+        name: 'SendGrid',
+        status: 'healthy' as HealthStatus,
+        latencyMs,
+        detail: 'API key valid, account reachable',
+      };
+    })(),
+
+    // Stripe
+    (async () => {
+      const configured = Boolean(process.env.STRIPE_SECRET_KEY);
+      if (!configured) {
+        return {
+          name: 'Stripe',
+          status: 'down' as HealthStatus,
+          latencyMs: null,
+          detail: 'STRIPE_SECRET_KEY not set',
+        };
+      }
+      const { latencyMs, error } = await timeCheck(async () => {
+        const res = await fetch('https://api.stripe.com/v1/balance', {
+          headers: {
+            Authorization: `Bearer ${process.env.STRIPE_SECRET_KEY}`,
+          },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+      if (error) {
+        return {
+          name: 'Stripe',
+          status: 'degraded' as HealthStatus,
+          latencyMs,
+          detail: error instanceof Error ? error.message : 'API check failed',
+        };
+      }
+      return {
+        name: 'Stripe',
+        status: 'healthy' as HealthStatus,
+        latencyMs,
+        detail: 'API key valid',
+      };
+    })(),
+
+    // Redis / Upstash
+    (async () => {
+      const configured =
+        Boolean(process.env.UPSTASH_REDIS_REST_URL) &&
+        Boolean(process.env.UPSTASH_REDIS_REST_TOKEN);
+      if (!configured) {
+        return {
+          name: 'Redis / Queue',
+          status: 'degraded' as HealthStatus,
+          latencyMs: null,
+          detail: 'UPSTASH_REDIS_REST_URL or TOKEN not set',
+        };
+      }
+      const { latencyMs, error } = await timeCheck(async () => {
+        const res = await fetch(`${process.env.UPSTASH_REDIS_REST_URL}/ping`, {
+          headers: {
+            Authorization: `Bearer ${process.env.UPSTASH_REDIS_REST_TOKEN}`,
+          },
+        });
+        if (!res.ok) throw new Error(`HTTP ${res.status}`);
+      });
+      if (error) {
+        return {
+          name: 'Redis / Queue',
+          status: 'degraded' as HealthStatus,
+          latencyMs,
+          detail: error instanceof Error ? error.message : 'Ping failed',
+        };
+      }
+      return {
+        name: 'Redis / Queue',
+        status: 'healthy' as HealthStatus,
+        latencyMs,
+        detail: 'Ping OK',
+      };
+    })(),
+
+    // Resend (inbound key check only)
+    (async () => {
+      const configured = Boolean(process.env.RESEND_API_KEY);
+      return {
+        name: 'Resend (inbound)',
+        status: (configured ? 'healthy' : 'degraded') as HealthStatus,
+        latencyMs: null,
+        detail: configured ? 'RESEND_API_KEY present' : 'RESEND_API_KEY not set — inbound email disabled',
+      };
+    })(),
+  ];
+
+  const services = await Promise.all(checks);
+  const overallStatus = worstStatus(services.map((s) => s.status));
+
+  return {
+    overallStatus,
+    checkedAt: new Date().toISOString(),
+    services,
+  };
+}

--- a/lib/email/sendgrid-inbound.ts
+++ b/lib/email/sendgrid-inbound.ts
@@ -1,0 +1,64 @@
+import { logger } from '@/lib/logger';
+
+// Forward map: local-part of recipient address → destination Gmail
+export const FORWARD_MAP: Record<string, string> = {
+  info:       'elevate4humanityedu@gmail.com',
+  support:    'elevate4humanityedu@gmail.com',
+  admissions: 'elevate4humanityedu@gmail.com',
+  enrollment: 'elevate4humanityedu@gmail.com',
+  contact:    'elevate4humanityedu@gmail.com',
+};
+export const DEFAULT_FORWARD = 'elevate4humanityedu@gmail.com';
+
+/**
+ * SendGrid Inbound Parse delivers a multipart/form-data POST.
+ * This parses the relevant fields from the FormData.
+ */
+export interface ParsedInboundEmail {
+  from:    string;
+  to:      string;
+  subject: string;
+  html:    string;
+  text:    string;
+  replyTo: string;
+  eventId: string; // SHA-256 of from+to+subject+timestamp for dedup
+}
+
+export async function parseInboundEmail(request: Request): Promise<ParsedInboundEmail | null> {
+  try {
+    const formData = await request.formData();
+
+    const from    = String(formData.get('from')    ?? '');
+    const to      = String(formData.get('to')      ?? '');
+    const subject = String(formData.get('subject') ?? '(no subject)');
+    const html    = String(formData.get('html')    ?? '');
+    const text    = String(formData.get('text')    ?? '');
+    const replyTo = String(formData.get('reply-to') ?? from);
+    const timestamp = String(formData.get('timestamp') ?? Date.now());
+
+    // Stable dedup key — SendGrid doesn't provide a unique event ID in Inbound Parse
+    const { createHash } = await import('crypto');
+    const eventId = createHash('sha256')
+      .update(`${from}|${to}|${subject}|${timestamp}`)
+      .digest('hex')
+      .slice(0, 32);
+
+    return { from, to, subject, html, text, replyTo, eventId };
+  } catch (err) {
+    logger.error('[SendGrid Inbound] Failed to parse form data:', err);
+    return null;
+  }
+}
+
+/**
+ * Resolve the forwarding destination from the To address.
+ * Matches on the local-part prefix against FORWARD_MAP; falls back to DEFAULT_FORWARD.
+ */
+export function resolveForwardTarget(toAddress: string): string {
+  // toAddress may be "Name <email>" or just "email"
+  const emailMatch = toAddress.match(/<(.+?)>/) ?? toAddress.match(/(\S+@\S+)/);
+  const email = emailMatch?.[1] ?? toAddress;
+  const prefix = email.split('@')[0]?.toLowerCase();
+  if (prefix && FORWARD_MAP[prefix]) return FORWARD_MAP[prefix];
+  return DEFAULT_FORWARD;
+}

--- a/supabase/migrations/20260402000011_admin_real_data.sql
+++ b/supabase/migrations/20260402000011_admin_real_data.sql
@@ -1,0 +1,222 @@
+-- Admin real data tables: replaces all hardcoded fake data in admin pages.
+-- Covers: financial assurance, email automations, social campaigns, workflows, MOU documents.
+
+-- 1) Financial assurance records
+create table if not exists public.financial_assurance_records (
+  id                        uuid primary key default gen_random_uuid(),
+  record_type               text not null check (record_type in ('surety_bond','letter_of_credit','insurance','other')),
+  provider_name             text not null,
+  policy_or_reference_number text,
+  coverage_amount           numeric(12,2),
+  effective_date            date,
+  expiration_date           date,
+  status                    text not null default 'active' check (status in ('active','expired','pending','cancelled')),
+  state                     text,
+  notes                     text,
+  document_url              text,
+  created_at                timestamptz not null default now(),
+  updated_at                timestamptz not null default now()
+);
+
+create index if not exists financial_assurance_records_status_idx
+  on public.financial_assurance_records(status);
+create index if not exists financial_assurance_records_expiration_idx
+  on public.financial_assurance_records(expiration_date);
+
+-- 2) Email automations
+create table if not exists public.email_automations (
+  id                    uuid primary key default gen_random_uuid(),
+  name                  text not null,
+  slug                  text unique,
+  trigger_type          text not null check (trigger_type in (
+                          'application_submitted','application_approved',
+                          'payment_failed','payment_received','manual','other')),
+  audience_type         text not null default 'mixed' check (audience_type in ('students','applicants','partners','mixed')),
+  is_active             boolean not null default false,
+  last_run_at           timestamptz,
+  last_run_status       text check (last_run_status in ('success','failed','partial')),
+  last_recipient_count  integer not null default 0,
+  total_runs            integer not null default 0,
+  total_recipients      integer not null default 0,
+  provider              text default 'sendgrid',
+  metadata              jsonb not null default '{}'::jsonb,
+  created_at            timestamptz not null default now(),
+  updated_at            timestamptz not null default now()
+);
+
+-- 3) Social campaigns
+create table if not exists public.social_campaigns (
+  id                uuid primary key default gen_random_uuid(),
+  name              text not null,
+  platform          text not null check (platform in ('facebook','instagram','linkedin','youtube','x','tiktok','multi')),
+  status            text not null default 'draft' check (status in ('draft','scheduled','active','paused','completed','failed')),
+  scheduled_posts   integer not null default 0,
+  published_posts   integer not null default 0,
+  failed_posts      integer not null default 0,
+  last_published_at timestamptz,
+  start_date        timestamptz,
+  end_date          timestamptz,
+  metadata          jsonb not null default '{}'::jsonb,
+  created_at        timestamptz not null default now(),
+  updated_at        timestamptz not null default now()
+);
+
+-- 4) Workflows
+create table if not exists public.workflows (
+  id               uuid primary key default gen_random_uuid(),
+  name             text not null,
+  workflow_key     text unique,
+  category         text not null default 'operations',
+  status           text not null default 'inactive' check (status in ('active','inactive','paused','error')),
+  last_run_at      timestamptz,
+  last_run_status  text check (last_run_status in ('success','failed','partial')),
+  run_count        integer not null default 0,
+  metadata         jsonb not null default '{}'::jsonb,
+  created_at       timestamptz not null default now(),
+  updated_at       timestamptz not null default now()
+);
+
+-- 5) MOU documents
+create table if not exists public.mou_documents (
+  id                    uuid primary key default gen_random_uuid(),
+  title                 text not null,
+  organization_name     text,
+  document_status       text not null default 'draft' check (document_status in ('draft','sent','signed','expired','archived')),
+  effective_date        date,
+  expiration_date       date,
+  file_url              text,
+  external_document_id  text,
+  notes                 text,
+  created_at            timestamptz not null default now(),
+  updated_at            timestamptz not null default now()
+);
+
+-- updated_at trigger (idempotent)
+create or replace function public.set_updated_at()
+returns trigger language plpgsql as $$
+begin
+  new.updated_at = now();
+  return new;
+end;
+$$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_financial_assurance_records_updated_at') then
+    create trigger trg_financial_assurance_records_updated_at
+    before update on public.financial_assurance_records
+    for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_email_automations_updated_at') then
+    create trigger trg_email_automations_updated_at
+    before update on public.email_automations
+    for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_social_campaigns_updated_at') then
+    create trigger trg_social_campaigns_updated_at
+    before update on public.social_campaigns
+    for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_workflows_updated_at') then
+    create trigger trg_workflows_updated_at
+    before update on public.workflows
+    for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+do $$ begin
+  if not exists (select 1 from pg_trigger where tgname = 'trg_mou_documents_updated_at') then
+    create trigger trg_mou_documents_updated_at
+    before update on public.mou_documents
+    for each row execute function public.set_updated_at();
+  end if;
+end $$;
+
+-- RLS
+alter table public.financial_assurance_records enable row level security;
+alter table public.email_automations           enable row level security;
+alter table public.social_campaigns            enable row level security;
+alter table public.workflows                   enable row level security;
+alter table public.mou_documents               enable row level security;
+
+-- Policies — uses profiles.role (matches existing project pattern)
+drop policy if exists "admins_manage_financial_assurance" on public.financial_assurance_records;
+create policy "admins_manage_financial_assurance"
+  on public.financial_assurance_records for all
+  using (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ))
+  with check (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ));
+
+drop policy if exists "admins_manage_email_automations" on public.email_automations;
+create policy "admins_manage_email_automations"
+  on public.email_automations for all
+  using (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ))
+  with check (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ));
+
+drop policy if exists "admins_manage_social_campaigns" on public.social_campaigns;
+create policy "admins_manage_social_campaigns"
+  on public.social_campaigns for all
+  using (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ))
+  with check (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ));
+
+drop policy if exists "admins_manage_workflows" on public.workflows;
+create policy "admins_manage_workflows"
+  on public.workflows for all
+  using (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ))
+  with check (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ));
+
+drop policy if exists "admins_manage_mou_documents" on public.mou_documents;
+create policy "admins_manage_mou_documents"
+  on public.mou_documents for all
+  using (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ))
+  with check (exists (
+    select 1 from public.profiles
+    where id = auth.uid() and role in ('admin','super_admin','staff')
+  ));
+
+-- Summary view for financial assurance dashboard
+create or replace view public.v_admin_financial_assurance_summary as
+select
+  count(*)::int                                                                          as total_records,
+  count(*) filter (where status = 'active')::int                                        as active_records,
+  count(*) filter (where expiration_date is not null
+                     and expiration_date < current_date)::int                           as expired_records,
+  count(*) filter (where expiration_date is not null
+                     and expiration_date >= current_date
+                     and expiration_date <= current_date + interval '30 days')::int     as expiring_soon_records,
+  coalesce(sum(coverage_amount) filter (where status = 'active'), 0)::numeric(12,2)    as active_coverage_total
+from public.financial_assurance_records;


### PR DESCRIPTION
## What this does

Removes all hardcoded fake data from admin pages and replaces with live Supabase queries. Also migrates inbound email from Resend (broken) to SendGrid Inbound Parse.

## Pages replaced

| Page | Was | Now |
|------|-----|-----|
| `/admin/site-health` | Hardcoded `12ms` latency, always green | Live pings to Supabase DB, SendGrid, Stripe, Redis |
| `/admin/compliance/financial-assurance` | 3 fake Indiana Surety / State Farm records | DB-backed, KPI strip, coverage total |
| `/admin/email-marketing/automation` | Fake workflows with Dec 2025 timestamps | DB-backed, honest empty state |
| `/admin/social-media` | Fake campaigns with fake post counts | DB-backed, honest empty state |
| `/admin/workflows` | Hardcoded list | DB-backed, honest empty state |
| `/admin/docs/mou` | 3 fake 2024 templates | DB-backed, expiring-soon count |

## New files

- `supabase/migrations/20260402000011_admin_real_data.sql` — creates 5 tables with RLS, triggers, and financial assurance summary view
- `lib/admin/get-site-health.ts` — live service health checker
- `app/api/admin/{financial-assurance,email-automations,social-campaigns,workflows,mou-documents}/route.ts` — GET + POST APIs for all 5 tables
- `app/api/webhooks/sendgrid-inbound/route.ts` — SendGrid Inbound Parse handler (replaces broken Resend inbound)
- `lib/email/sendgrid-inbound.ts` — parse + forward logic for SendGrid inbound

## ⚠️ Required before deploy

Apply migration in Supabase Dashboard → SQL Editor:
`supabase/migrations/20260402000011_admin_real_data.sql`

Pages will error on load until the migration runs. After it runs, all pages show honest empty states until real records are added.

## DNS still needed (inbound email)

Add MX record at domain registrar:
- Type: `MX` | Host: `@` | Value: `mx.sendgrid.net` | Priority: `10`