### PR TITLE
fix: declare posterImage prop in HeroVideo

### DIFF
--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -29,6 +29,8 @@ export interface HeroVideoProps {
   videoSrcDesktop: string;
   /** Mobile video source — falls back to desktop if omitted */
   videoSrcMobile?: string;
+  /** Poster image shown while video loads — optional */
+  posterImage?: string;
   /** 2–4 word micro-label rendered in bottom-left corner of video */
   microLabel?: string;
   /** Show small brand bug in top-left corner */
@@ -58,6 +60,7 @@ export interface HeroVideoProps {
 export default function HeroVideo({
   videoSrcDesktop,
   videoSrcMobile,
+  posterImage,
   microLabel,
   showBrandBug = false,
   belowHeroHeadline,


### PR DESCRIPTION
poster={posterImage} was used in the render but posterImage was never in the props interface or destructuring after the merge. Caused ReferenceError prerender crash on /employers and /platform.