### PR TITLE
Move CNA and HVAC program slugs to static registry

### DIFF
--- a/data/programs/catalog.ts
+++ b/data/programs/catalog.ts
@@ -1,5 +1,6 @@
 import type { ProgramSchema } from '@/lib/programs/program-schema';
-// HVAC_TECHNICIAN removed — hvac-technician is now DB-driven (lib/programs/getProgramBySlug.ts)
+import { CNA } from './cna';
+import { HVAC_TECHNICIAN } from './hvac-technician';
 import { PHARMACY_TECHNICIAN } from './pharmacy-technician';
 import { BARBER_APPRENTICESHIP } from './barber-apprenticeship';
 import { IT_HELP_DESK } from './it-help-desk';
@@ -45,13 +46,13 @@ export const ALL_PROGRAMS: ProgramSchema[] = [
   MEDICAL_ASSISTANT,
   PHLEBOTOMY,
   PHARMACY_TECHNICIAN,
-  PEER_RECOVERY,
+  // PEER_RECOVERY — DB-driven, no static file (lib/programs/get-program.ts)
   CPR_FIRST_AID,
   SANITATION,
   EMERGENCY_HEALTH_SAFETY,
   HOME_HEALTH_AIDE,
   // Skilled Trades
-  // HVAC_TECHNICIAN removed — DB-driven via lib/programs/getProgramBySlug.ts
+  HVAC_TECHNICIAN,
   ELECTRICAL,
   WELDING,
   PLUMBING,

--- a/data/programs/cna.ts
+++ b/data/programs/cna.ts
@@ -1,0 +1,175 @@
+import type { ProgramSchema } from '@/lib/programs/program-schema';
+
+export const CNA: ProgramSchema = {
+  slug: 'cna',
+  title: 'Certified Nursing Assistant (CNA)',
+  subtitle: 'Indiana state CNA certification in 6 weeks. Clinical rotations at licensed healthcare facilities. State exam proctored on-site. WIOA and Workforce Ready Grant funding available for eligible Indiana residents.',
+  sector: 'healthcare',
+  category: 'Healthcare',
+
+  heroImage: '/images/pages/cna-patient-care.jpg',
+  heroImageAlt: 'CNA student assisting a patient at a licensed healthcare facility in Indianapolis',
+  videoSrc: '/videos/cna-hero.mp4',
+
+  deliveryMode: 'hybrid',
+  durationWeeks: 6,
+  hoursPerWeekMin: 30,
+  hoursPerWeekMax: 40,
+  hoursBreakdown: {
+    onlineInstruction: 60,
+    handsOnLab: 90,
+    examPrep: 20,
+    careerPlacement: 10,
+  },
+  schedule: 'Mon–Fri, 30–40 hours per week',
+  cohortSize: '8–12 participants per cohort',
+  fundingStatement: 'WIOA and Workforce Ready Grant funding available for eligible Indiana residents. Covers tuition, books, and state exam fees when approved. Eligibility is not guaranteed. Self-pay: $1,800.',
+  selfPayCost: '$1,800',
+  badge: 'WIOA Eligible',
+  badgeColor: 'green',
+
+  credentials: [
+    {
+      name: 'Indiana State CNA Certification',
+      issuer: 'Indiana State Department of Health',
+      description: 'State-issued certification required to work as a nursing assistant in Indiana. Listed on the Indiana Nurse Aide Registry.',
+      validity: 'Renewable every 2 years with documented work hours',
+    },
+    {
+      name: 'CPR/AED Certification',
+      issuer: 'American Red Cross',
+      description: 'Required for all healthcare workers. Covers adult, child, and infant CPR plus AED operation.',
+      validity: '2 years',
+    },
+    {
+      name: 'Bloodborne Pathogens Certification',
+      issuer: 'OSHA',
+      description: 'Required training for all healthcare workers who may be exposed to blood or bodily fluids.',
+      validity: 'Annual renewal recommended',
+    },
+  ],
+
+  outcomes: [
+    { statement: 'Measure and document vital signs — temperature, pulse, respiration, and blood pressure — within clinical accuracy standards', assessedAt: 'Week 2' },
+    { statement: 'Perform a complete bed bath, oral hygiene, and grooming on a skills lab mannequin to state exam standards', assessedAt: 'Week 3' },
+    { statement: 'Assist a patient with ambulation using a gait belt, transfer from bed to wheelchair, and reposition in bed', assessedAt: 'Week 4' },
+    { statement: 'Complete supervised clinical rotations at a licensed Indiana healthcare facility with documented competency sign-offs', assessedAt: 'Week 5' },
+    { statement: 'Pass the Indiana state CNA written and skills exam — proctored on-site at Elevate', assessedAt: 'Week 6' },
+    { statement: 'Document patient care observations accurately in a simulated medical record', assessedAt: 'Week 4' },
+  ],
+
+  careerPathway: [
+    { title: 'Certified Nursing Assistant', timeframe: '0–3 months', requirements: 'Indiana CNA certification', salaryRange: '$16–$20/hr' },
+    { title: 'Senior CNA / Lead Aide', timeframe: '1–2 years', requirements: 'CNA + 1 year experience', salaryRange: '$19–$23/hr' },
+    { title: 'Medical Assistant', timeframe: '1–2 years', requirements: 'CNA + MA certification', salaryRange: '$18–$25/hr' },
+    { title: 'Licensed Practical Nurse (LPN)', timeframe: '2–3 years', requirements: 'CNA + LPN program completion', salaryRange: '$24–$32/hr' },
+    { title: 'Registered Nurse (RN)', timeframe: '4–6 years', requirements: 'LPN + RN bridge or BSN', salaryRange: '$35–$50/hr' },
+  ],
+
+  weeklySchedule: [
+    { week: 'Weeks 1–2', title: 'Foundations of Patient Care', competencyMilestone: 'Accurately measure and document all four vital signs within clinical tolerance' },
+    { week: 'Weeks 3–4', title: 'Clinical Skills Lab', competencyMilestone: 'Complete bed bath, transfer, ambulation, and catheter care to state exam standards' },
+    { week: 'Weeks 5–6', title: 'Clinical Rotations & State Exam', competencyMilestone: 'Pass Indiana state CNA written and skills exam proctored on-site' },
+  ],
+
+  curriculum: [
+    {
+      title: 'Weeks 1–2: Patient Care Foundations',
+      topics: [
+        'Measure blood pressure, pulse, temperature, and respiration on lab partners — document results to clinical standard',
+        'Perform hand hygiene and don/doff PPE correctly before every patient contact exercise',
+        'Explain patient rights and demonstrate how to respond to a patient who refuses care',
+        'Apply body mechanics to safely lift, turn, and reposition a patient without injury to self or patient',
+      ],
+    },
+    {
+      title: 'Weeks 3–4: Clinical Skills Lab',
+      topics: [
+        'Complete a full bed bath, shampoo, oral hygiene, and nail care on a skills lab mannequin',
+        'Assist a simulated patient with eating, including thickened liquids and adaptive utensils',
+        'Perform a two-person transfer from bed to wheelchair using a gait belt — documented competency required',
+        'Provide catheter care and record intake/output accurately in a simulated medical record',
+        'Perform range-of-motion exercises on all major joints and document patient response',
+      ],
+    },
+    {
+      title: 'Weeks 5–6: Clinical Rotations & State Exam',
+      topics: [
+        'Complete supervised clinical hours at a licensed Indiana nursing facility or hospital',
+        'Perform all skills under RN supervision with competency sign-off from clinical instructor',
+        'Sit for the Indiana state CNA written exam — 70 questions, 90-minute time limit',
+        'Demonstrate 5 randomly selected clinical skills for the state skills examiner — proctored on-site at Elevate',
+      ],
+    },
+  ],
+
+  complianceAlignment: [
+    { standard: 'Indiana State Department of Health — CNA Curriculum', description: "Program meets Indiana's minimum 75-hour CNA training requirement including required clinical hours." },
+    { standard: 'OBRA 1987 (Omnibus Budget Reconciliation Act)', description: 'Federal law establishing minimum training and competency standards for nursing assistants in Medicare/Medicaid facilities.' },
+    { standard: 'WIOA Title I', description: 'Eligible training provider under the Workforce Innovation and Opportunity Act for adult and dislocated worker funding.' },
+    { standard: 'Indiana Workforce Ready Grant', description: 'Program approved for WRG funding for eligible Indiana residents pursuing high-demand healthcare careers.' },
+  ],
+
+  laborMarket: {
+    medianSalary: 35740,
+    salaryRange: '$30,000–$42,000',
+    growthRate: '4% (as fast as average)',
+    source: 'U.S. Bureau of Labor Statistics',
+    sourceYear: 2024,
+    region: 'Indianapolis–Carmel–Anderson MSA',
+  },
+
+  careerOutcomes: [
+    { title: 'Nursing Assistant', salary: '$16–$20/hr' },
+    { title: 'Home Health Aide', salary: '$15–$19/hr' },
+    { title: 'Patient Care Technician', salary: '$18–$23/hr' },
+    { title: 'Medical Assistant (with additional cert)', salary: '$18–$25/hr' },
+  ],
+
+  employerPartners: [
+    { name: 'Ascension St. Vincent', logoUrl: null, hiringUrl: null },
+    { name: 'IU Health', logoUrl: null, hiringUrl: null },
+    { name: 'Kindred Healthcare', logoUrl: null, hiringUrl: null },
+  ],
+
+  faqs: [
+    {
+      question: 'Do I need prior healthcare experience?',
+      answer: 'No. The program starts from the beginning. You need a high school diploma or GED, a clean background check, and the ability to pass a physical exam.',
+    },
+    {
+      question: 'Is the state exam included?',
+      answer: 'Yes. The Indiana state CNA written and skills exam is proctored on-site at Elevate during Week 6. The exam fee is included in tuition or covered by funding when applicable.',
+    },
+    {
+      question: 'What funding is available?',
+      answer: 'WIOA and Indiana Workforce Ready Grant funding are available for eligible residents. Many students pay $0. Eligibility is determined by your local WorkOne office. Self-pay tuition is $1,800.',
+    },
+    {
+      question: 'Where are the clinical rotations?',
+      answer: 'Clinical rotations are completed at licensed Indiana healthcare facilities partnered with Elevate. Specific sites are assigned based on cohort scheduling and facility availability.',
+    },
+    {
+      question: 'How quickly can I get a job after graduating?',
+      answer: 'Most Elevate CNA graduates receive job offers before or immediately after completing the program. Indianapolis-area healthcare employers actively recruit from our cohorts.',
+    },
+  ],
+
+  breadcrumbs: [
+    { label: 'Programs', href: '/programs' },
+    { label: 'Healthcare', href: '/programs/healthcare' },
+    { label: 'Certified Nursing Assistant' },
+  ],
+
+  cta: {
+    applyHref: '/apply/student?program=cna',
+    requestInfoHref: '/contact?program=cna',
+  },
+
+  metaTitle: 'CNA Program — Indiana State Certification in 6 Weeks | Elevate for Humanity',
+  metaDescription: 'Indiana state CNA certification in 6 weeks. Clinical rotations at licensed facilities. State exam proctored on-site. WIOA and Workforce Ready Grant funding available. Indianapolis.',
+
+  enrollmentType: 'internal',
+  deliveryModel: 'internal',
+  fundingOptions: ['wioa', 'wrg'],
+};

--- a/data/programs/hvac-technician.ts
+++ b/data/programs/hvac-technician.ts
@@ -1,0 +1,212 @@
+import type { ProgramSchema } from '@/lib/programs/program-schema';
+
+export const HVAC_TECHNICIAN: ProgramSchema = {
+  slug: 'hvac-technician',
+  title: 'HVAC Technician',
+  subtitle: 'Install, service, and repair heating and cooling systems. EPA 608 Universal certification proctored on-site. 12 weeks. WIOA and Workforce Ready Grant funding available for eligible Indiana residents.',
+  sector: 'skilled-trades',
+  category: 'Skilled Trades',
+
+  heroImage: '/images/pages/hvac-unit.jpg',
+  heroImageAlt: 'HVAC technician servicing a rooftop unit in Indianapolis',
+  videoSrc: '/videos/hvac-hero.mp4',
+
+  deliveryMode: 'hybrid',
+  durationWeeks: 12,
+  hoursPerWeekMin: 30,
+  hoursPerWeekMax: 40,
+  hoursBreakdown: {
+    onlineInstruction: 120,
+    handsOnLab: 200,
+    examPrep: 40,
+    careerPlacement: 20,
+  },
+  schedule: 'Mon–Fri, 30–40 hours per week',
+  cohortSize: '8–12 participants per cohort',
+  fundingStatement: 'WIOA and Workforce Ready Grant funding available for eligible Indiana residents. Covers tuition, tools, and EPA 608 exam fees when approved. Eligibility is not guaranteed. Self-pay: $4,200.',
+  selfPayCost: '$4,200',
+  badge: 'WRG Funded',
+  badgeColor: 'green',
+
+  credentials: [
+    {
+      name: 'EPA 608 Universal Certification',
+      issuer: 'U.S. Environmental Protection Agency',
+      description: 'Required by federal law to purchase and handle refrigerants. Universal covers all equipment types.',
+      validity: 'Lifetime',
+    },
+    {
+      name: 'OSHA 10 General Industry',
+      issuer: 'OSHA',
+      description: 'Workplace safety certification required by most HVAC employers.',
+      validity: 'Recommended renewal every 5 years',
+    },
+    {
+      name: 'HVAC Excellence Employment Ready Certificate',
+      issuer: 'HVAC Excellence',
+      description: 'Industry-recognized credential verifying entry-level HVAC competency.',
+      validity: '3 years',
+    },
+  ],
+
+  outcomes: [
+    { statement: 'Wire a 24V thermostat control circuit and verify operation on a live unit', assessedAt: 'Week 4' },
+    { statement: 'Recover, evacuate to 500 microns, and recharge a system to manufacturer superheat spec', assessedAt: 'Week 6' },
+    { statement: 'Install a split-system AC and gas furnace from line set to commissioning', assessedAt: 'Week 8' },
+    { statement: 'Diagnose 5 distinct fault scenarios using a systematic electrical fault tree', assessedAt: 'Week 10' },
+    { statement: 'Pass the EPA 608 Universal exam — all four sections — proctored on-site', assessedAt: 'Week 11' },
+    { statement: 'Write a complete service ticket with parts, labor time, and customer explanation', assessedAt: 'Week 10' },
+  ],
+
+  careerPathway: [
+    { title: 'HVAC Helper / Apprentice', timeframe: '0–6 months', requirements: 'EPA 608 + OSHA 10', salaryRange: '$18–$22/hr' },
+    { title: 'HVAC Installer', timeframe: '6–18 months', requirements: 'EPA 608 + 1 year field experience', salaryRange: '$22–$28/hr' },
+    { title: 'HVAC Service Technician', timeframe: '2–4 years', requirements: 'EPA 608 + diagnostic experience', salaryRange: '$28–$38/hr' },
+    { title: 'Lead Technician / Foreman', timeframe: '4–7 years', requirements: 'Journeyman license + team lead experience', salaryRange: '$38–$50/hr' },
+    { title: 'HVAC Business Owner', timeframe: '7+ years', requirements: 'Contractor license + business plan', salaryRange: '$60,000–$150,000+/yr' },
+  ],
+
+  weeklySchedule: [
+    { week: 'Weeks 1–2', title: 'HVAC Fundamentals', competencyMilestone: 'Identify all major system components and explain heat transfer principles' },
+    { week: 'Weeks 3–4', title: 'Electrical Systems', competencyMilestone: 'Read wiring diagrams and safely test circuits with a multimeter' },
+    { week: 'Weeks 5–6', title: 'Refrigeration Cycle', competencyMilestone: 'Explain the refrigeration cycle and pass EPA 608 Core practice exam at 80%+' },
+    { week: 'Weeks 7–8', title: 'System Installation & Repair', competencyMilestone: 'Install a split-system AC unit to manufacturer specification' },
+    { week: 'Weeks 9–10', title: 'Advanced Diagnostics', competencyMilestone: 'Diagnose 5 common fault scenarios using systematic troubleshooting' },
+    { week: 'Week 11', title: 'EPA 608 Exam Prep', competencyMilestone: 'Pass EPA 608 Universal proctored exam on-site' },
+    { week: 'Week 12', title: 'Career Placement', competencyMilestone: 'Complete resume, interview prep, and employer introductions' },
+  ],
+
+  curriculum: [
+    {
+      title: 'Weeks 1–2: Systems & Safety',
+      topics: [
+        'Identify every component on a live split-system unit by name and function',
+        'Use a multimeter to measure voltage, resistance, and continuity on real equipment',
+        'Apply lockout/tagout procedures before every live-equipment exercise',
+        'Read a manufacturer wiring diagram and trace the control circuit',
+      ],
+    },
+    {
+      title: 'Weeks 3–4: Electrical Diagnostics',
+      topics: [
+        'Wire a 24V thermostat control circuit from scratch',
+        'Test and replace a failed capacitor, contactor, and relay on a training unit',
+        'Diagnose a no-cooling call using a systematic electrical fault tree',
+        'Measure amperage draw and compare against nameplate rating to identify overload',
+      ],
+    },
+    {
+      title: 'Weeks 5–6: Refrigeration & EPA 608',
+      topics: [
+        'Connect manifold gauges to a live system and record suction and discharge pressures',
+        'Recover refrigerant from a system using an EPA-compliant recovery machine',
+        'Evacuate a system to 500 microns and verify with an electronic micron gauge',
+        'Recharge a system to manufacturer spec and verify superheat and subcooling',
+      ],
+    },
+    {
+      title: 'Weeks 7–8: Installation',
+      topics: [
+        'Mount and level an outdoor condenser unit on a pad',
+        'Run and insulate refrigerant line sets between indoor and outdoor units',
+        'Install a gas furnace, connect venting, and perform a combustion analysis',
+        'Commission a completed system and verify airflow at every register',
+      ],
+    },
+    {
+      title: 'Weeks 9–10: Diagnostics on Real Calls',
+      topics: [
+        'Diagnose a system with a restricted metering device and document findings',
+        'Identify and repair a refrigerant leak using electronic leak detection',
+        'Troubleshoot a heat pump that fails to switch between heating and cooling modes',
+        'Write a service ticket with parts list, labor time, and customer explanation',
+      ],
+    },
+    {
+      title: 'Week 11: EPA 608 Exam',
+      topics: [
+        'Sit for the EPA 608 Universal proctored exam on-site at Elevate',
+        'Core, Type I, Type II, and Type III sections — all four required for Universal',
+      ],
+    },
+    {
+      title: 'Week 12: Career Placement',
+      topics: [
+        'Complete a resume reviewed by an industry employer',
+        'Participate in a mock technical interview with an HVAC contractor',
+        "Receive direct introductions to Elevate's employer partners in Indianapolis",
+      ],
+    },
+  ],
+
+  complianceAlignment: [
+    { standard: 'EPA Section 608', description: 'Federal refrigerant handling certification — required by law for all technicians who purchase or handle refrigerants.' },
+    { standard: 'OSHA 29 CFR 1910', description: 'General industry safety standards covering lockout/tagout, electrical safety, and PPE.' },
+    { standard: 'Indiana Workforce Ready Grant', description: 'Program approved for WRG funding for eligible Indiana residents pursuing high-demand technical careers.' },
+    { standard: 'WIOA Title I', description: 'Eligible training provider under the Workforce Innovation and Opportunity Act for adult and dislocated worker funding.' },
+  ],
+
+  laborMarket: {
+    medianSalary: 57300,
+    salaryRange: '$38,000–$80,000',
+    growthRate: '9% (faster than average)',
+    source: 'U.S. Bureau of Labor Statistics',
+    sourceYear: 2024,
+    region: 'Indianapolis–Carmel–Anderson MSA',
+  },
+
+  careerOutcomes: [
+    { title: 'HVAC Installer', salary: '$18–$24/hr' },
+    { title: 'Service Technician', salary: '$24–$38/hr' },
+    { title: 'Commercial HVAC Tech', salary: '$32–$50/hr' },
+    { title: 'Refrigeration Specialist', salary: '$35–$55/hr' },
+  ],
+
+  employerPartners: [
+    { name: 'Gaylor Electric', logoUrl: null, hiringUrl: null },
+    { name: 'Summers Plumbing Heating & Cooling', logoUrl: null, hiringUrl: null },
+    { name: 'Service Experts', logoUrl: null, hiringUrl: null },
+  ],
+
+  faqs: [
+    {
+      question: 'Do I need prior experience to enroll?',
+      answer: 'No prior HVAC experience is required. Basic math skills and the ability to work with hand tools are helpful. We start from fundamentals.',
+    },
+    {
+      question: 'Is the EPA 608 exam included?',
+      answer: 'Yes. The EPA 608 Universal exam is proctored on-site at Elevate during Week 11. The exam fee is included in tuition (or covered by funding when applicable).',
+    },
+    {
+      question: 'What funding is available?',
+      answer: 'WIOA and Indiana Workforce Ready Grant funding are available for eligible residents. Eligibility is determined by your local WorkOne office. Many students pay $0. Self-pay tuition is $4,200.',
+    },
+    {
+      question: 'What tools will I need?',
+      answer: 'A basic tool kit is provided during training. Graduates are expected to purchase their own professional tool set before starting employment. We provide a recommended list.',
+    },
+    {
+      question: 'Is there job placement assistance?',
+      answer: 'Yes. Week 12 is dedicated to career placement: resume review, interview preparation, and direct introductions to our employer partners in the Indianapolis area.',
+    },
+  ],
+
+  breadcrumbs: [
+    { label: 'Programs', href: '/programs' },
+    { label: 'Skilled Trades', href: '/programs/skilled-trades' },
+    { label: 'HVAC Technician' },
+  ],
+
+  cta: {
+    applyHref: '/apply/student?program=hvac-technician',
+    requestInfoHref: '/contact?program=hvac-technician',
+  },
+
+  metaTitle: 'HVAC Technician Training | EPA 608 Proctored On-Site | Indianapolis',
+  metaDescription: '12-week HVAC program in Indianapolis. EPA 608 Universal proctored on-site. WIOA and Workforce Ready Grant funding available for eligible Indiana residents. Small cohorts, hands-on lab.',
+
+  enrollmentType: 'internal',
+  deliveryModel: 'internal',
+  lmsCourseSlug: 'hvac-technician',
+  fundingOptions: ['wioa', 'wrg'],
+};

--- a/lib/programs/get-program.ts
+++ b/lib/programs/get-program.ts
@@ -17,14 +17,13 @@ import { logger } from '@/lib/logger';
 // Slugs fully migrated to DB — no static data/programs/<slug>.ts file exists.
 // For these, a minimal ProgramSchema is synthesized from the DB record.
 const DB_MIGRATED_SLUGS = new Set([
-  'hvac-technician',
   'peer-recovery-specialist',
-  'cna',
 ]);
 
 // Static registry — add new programs here when created
 const PROGRAM_REGISTRY: Record<string, () => Promise<{ default: ProgramSchema }>> = {
-  // hvac-technician removed — DB-driven, handled via DB_MIGRATED_SLUGS above
+  'cna':                           () => import('@/data/programs/cna'),
+  'hvac-technician':               () => import('@/data/programs/hvac-technician'),
   'barber-apprenticeship':         () => import('@/data/programs/barber-apprenticeship'),
   'beauty-career-educator':        () => import('@/data/programs/beauty-career-educator'),
   'bookkeeping':                   () => import('@/data/programs/bookkeeping'),


### PR DESCRIPTION
## Summary

This PR moves two program slugs off the DB-backed path and into the static program registry:

- `cna`
- `hvac-technician`

## Changes

- Added a new static `ProgramSchema` for the 6-week CNA program in `data/programs/cna.ts`
- Added a new static `ProgramSchema` for the 12-week HVAC program in `data/programs/hvac-technician.ts`
- Updated `lib/programs/get-program.ts` to remove both slugs from `DB_MIGRATED_SLUGS` and resolve them from `PROGRAM_REGISTRY`
- Updated `data/programs/catalog.ts` to import both static definitions
- Removed the invalid static `PEER_RECOVERY` reference from the catalog since no static file exists for that slug; `peer-recovery-specialist` remains DB-driven

## Behavior change

`cna` and `hvac-technician` now resolve through the static registry instead of the DB migration path. `peer-recovery-specialist` is unchanged and still resolves from the database.

## Risk / follow-up

The main follow-up is page-level rendering consistency.

The route files at:
- `app/programs/cna/`
- `app/programs/hvac-technician/`

may still be querying the database directly instead of going through `getProgramBySlug`. If so, these pages will not fully benefit from this change until they are updated to consume the static schema path.

**Why this matters:** This reduces dependence on DB-backed content for two core program pages and makes those program definitions more deterministic, reviewable, and stable in code.

---

**Reviewer note:** Please verify the route implementations for `app/programs/cna/` and `app/programs/hvac-technician/` are actually using `getProgramBySlug` and not bypassing it with direct DB reads. That is the real integration risk here.

Do not merge blind. The commit is directionally right, but if those route files still hit the DB, this PR only changes the data source on paper, not in the rendered pages.