### PR TITLE
fix(studio): reconnect Dev Studio terminal container

### DIFF
--- a/.github/workflows/deploy-studio.yml
+++ b/.github/workflows/deploy-studio.yml
@@ -145,6 +145,71 @@ jobs:
           cluster:          ${{ env.ECS_CLUSTER }}
           wait-for-service-stability: true
 
+      - name: Diagnose Studio ECS failure
+        if: failure()
+        run: |
+          set +e
+          echo "### Studio Shell ECS diagnostics" >> $GITHUB_STEP_SUMMARY
+          echo "Deploy failed before ECS reported a stable service. Recent service events, stopped tasks, and container logs follow." >> $GITHUB_STEP_SUMMARY
+
+          echo "::group::ECS service events"
+          aws ecs describe-services \
+            --cluster "$ECS_CLUSTER" \
+            --services "$ECS_SERVICE" \
+            --query 'services[0].events[0:20].[createdAt,message]' \
+            --output table
+          echo "::endgroup::"
+
+          RUNNING_TASKS=$(aws ecs list-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --service-name "$ECS_SERVICE" \
+            --desired-status RUNNING \
+            --query 'taskArns[]' \
+            --output text 2>/dev/null)
+          STOPPED_TASKS=$(aws ecs list-tasks \
+            --cluster "$ECS_CLUSTER" \
+            --service-name "$ECS_SERVICE" \
+            --desired-status STOPPED \
+            --query 'taskArns[]' \
+            --output text 2>/dev/null)
+          TASKS="$RUNNING_TASKS $STOPPED_TASKS"
+
+          if [ -n "$(echo "$TASKS" | xargs)" ]; then
+            echo "::group::ECS task details"
+            aws ecs describe-tasks \
+              --cluster "$ECS_CLUSTER" \
+              --tasks $TASKS \
+              --query 'tasks[].{taskArn:taskArn,lastStatus:lastStatus,desiredStatus:desiredStatus,healthStatus:healthStatus,stoppedReason:stoppedReason,containers:containers[].{name:name,lastStatus:lastStatus,healthStatus:healthStatus,exitCode:exitCode,reason:reason}}' \
+              --output json
+            echo "::endgroup::"
+          else
+            echo "No running or stopped Studio tasks found."
+          fi
+
+          LOG_STREAMS=$(aws logs describe-log-streams \
+            --log-group-name /ecs/elevate-studio \
+            --log-stream-name-prefix ecs/elevate-studio \
+            --order-by LastEventTime \
+            --descending \
+            --max-items 5 \
+            --query 'logStreams[].logStreamName' \
+            --output text 2>/dev/null)
+
+          if [ -n "$LOG_STREAMS" ]; then
+            for stream in $LOG_STREAMS; do
+              echo "::group::CloudWatch logs: $stream"
+              aws logs get-log-events \
+                --log-group-name /ecs/elevate-studio \
+                --log-stream-name "$stream" \
+                --limit 80 \
+                --query 'events[].message' \
+                --output text
+              echo "::endgroup::"
+            done
+          else
+            echo "No CloudWatch log streams found for /ecs/elevate-studio."
+          fi
+
       - name: Update public Studio shell URL
         run: |
           INTERNAL_URL="ws://elevate-studio.elevate.local:8888"

--- a/Dockerfile.studio
+++ b/Dockerfile.studio
@@ -30,8 +30,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     # node-pty needs a C++ build toolchain
     && rm -rf /var/lib/apt/lists/*
 
-# pnpm
-RUN corepack enable && corepack prepare pnpm@latest --activate
+# pnpm must match the workspace packageManager so frozen installs are stable.
+RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
 # Non-root user
 RUN useradd -m -s /bin/bash studio
@@ -43,7 +43,7 @@ COPY studio-shell/src ./studio-shell/src/
 
 RUN cd studio-shell && npm install --production=false && npm run build
 
-# Entrypoint: clone repo then start shell server
+# Entrypoint: start shell server, clone repo, then install dependencies
 COPY studio-shell/entrypoint.sh /entrypoint.sh
 RUN chmod +x /entrypoint.sh
 
@@ -59,7 +59,7 @@ ENV NODE_ENV=production
 
 EXPOSE 8888
 
-HEALTHCHECK --interval=30s --timeout=10s --start-period=180s --retries=3 \
-  CMD curl -f http://localhost:8888/health || exit 1
+HEALTHCHECK --interval=30s --timeout=10s --start-period=60s --retries=3 \
+  CMD curl -f http://localhost:8888/live || exit 1
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/aws/ecs-task-studio.json
+++ b/aws/ecs-task-studio.json
@@ -138,12 +138,12 @@
       "healthCheck": {
         "command": [
           "CMD-SHELL",
-          "curl -sf http://localhost:8888/health || exit 1"
+          "curl -sf http://localhost:8888/live || exit 1"
         ],
         "interval": 30,
         "timeout": 10,
         "retries": 3,
-        "startPeriod": 180
+        "startPeriod": 60
       },
       "ulimits": [
         {

--- a/studio-shell/entrypoint.sh
+++ b/studio-shell/entrypoint.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # entrypoint.sh - start PTY shell server and initialize the mounted repo.
 #
-# The HTTP server starts immediately so the container can expose diagnostics, but
-# /health only reports ready after Git, the repo clone, and pnpm install succeed.
+# The HTTP server starts immediately so ECS can check liveness. The terminal is
+# ready after the repo is cloned and core tools are available. Dependency install
+# runs after that and reports status without blocking access to the shell.
 
 set -uo pipefail
 
@@ -12,7 +13,16 @@ BRANCH="${BRANCH:-main}"
 GITHUB_REPO="${GITHUB_REPO:-elevate-for-humanity/Elevate-lms}"
 WORKDIR="${WORKDIR:-/repo}"
 
-echo "starting" > "$STATUS_FILE"
+write_status() {
+  printf '%s\n' "$1" > "$STATUS_FILE"
+  echo "[entrypoint] $1"
+}
+
+fail_setup() {
+  write_status "setup failed: $1"
+}
+
+write_status "starting"
 rm -f "$READY_FILE"
 
 echo "[entrypoint] starting shell server on :${SHELL_PORT:-8888}"
@@ -20,31 +30,43 @@ node /home/studio/studio-shell/dist/server.js &
 SERVER_PID=$!
 
 (
-  set -e
+  set -uo pipefail
 
-  echo "checking tools" > "$STATUS_FILE"
-  command -v git >/dev/null
-  command -v pnpm >/dev/null
-  command -v psql >/dev/null
+  write_status "checking tools"
+  for tool in git pnpm psql; do
+    if ! command -v "$tool" >/dev/null 2>&1; then
+      fail_setup "$tool is missing"
+      exit 0
+    fi
+  done
 
   if [ -z "${GITHUB_TOKEN:-}" ]; then
-    echo "missing GITHUB_TOKEN" > "$STATUS_FILE"
+    fail_setup "missing GITHUB_TOKEN"
     echo "[entrypoint] GITHUB_TOKEN is required to clone ${GITHUB_REPO}" >&2
-    exit 1
+    exit 0
   fi
 
-  echo "cloning ${GITHUB_REPO}@${BRANCH}" > "$STATUS_FILE"
+  write_status "cloning ${GITHUB_REPO}@${BRANCH}"
   REPO_URL="https://x-access-token:${GITHUB_TOKEN}@github.com/${GITHUB_REPO}.git"
 
   if [ -d "${WORKDIR}/.git" ]; then
-    cd "$WORKDIR"
-    git fetch origin "$BRANCH" 2>&1
-    git reset --hard "origin/${BRANCH}" 2>&1
+    cd "$WORKDIR" || { fail_setup "cannot enter ${WORKDIR}"; exit 0; }
+    if ! git fetch origin "$BRANCH"; then
+      fail_setup "git fetch failed"
+      exit 0
+    fi
+    if ! git reset --hard "origin/${BRANCH}"; then
+      fail_setup "git reset failed"
+      exit 0
+    fi
   else
     mkdir -p "$WORKDIR"
     find "$WORKDIR" -mindepth 1 -maxdepth 1 -exec rm -rf {} + 2>/dev/null || true
-    git clone --depth=1 --branch "$BRANCH" "$REPO_URL" "$WORKDIR" 2>&1
-    cd "$WORKDIR"
+    if ! git clone --depth=1 --branch "$BRANCH" "$REPO_URL" "$WORKDIR"; then
+      fail_setup "git clone failed"
+      exit 0
+    fi
+    cd "$WORKDIR" || { fail_setup "cannot enter ${WORKDIR}"; exit 0; }
   fi
 
   git config user.email "studio@elevateforhumanity.org"
@@ -53,15 +75,21 @@ SERVER_PID=$!
   printf 'https://x-access-token:%s@github.com\n' "$GITHUB_TOKEN" > ~/.git-credentials
   chmod 600 ~/.git-credentials
 
-  echo "installing dependencies" > "$STATUS_FILE"
-  cd "$WORKDIR"
-  pnpm install --frozen-lockfile 2>&1 | tail -10
-
-  echo "ready" > "$STATUS_FILE"
+  write_status "repo ready; installing dependencies"
   touch "$READY_FILE"
-  echo "[entrypoint] repo ready"
+  echo "[entrypoint] repo ready - terminal can connect while dependencies install"
+
+  cd "$WORKDIR" || { fail_setup "cannot enter ${WORKDIR}"; exit 0; }
+  if pnpm install --frozen-lockfile; then
+    write_status "ready"
+    echo "[entrypoint] dependencies installed"
+  else
+    install_code=$?
+    write_status "ready; dependency install failed (exit ${install_code})"
+    echo "[entrypoint] pnpm install failed with exit ${install_code}; terminal remains available for repair" >&2
+  fi
 ) &
 SETUP_PID=$!
 
-wait $SERVER_PID
+wait "$SERVER_PID"
 kill "$SETUP_PID" 2>/dev/null || true

--- a/studio-shell/src/server.ts
+++ b/studio-shell/src/server.ts
@@ -75,13 +75,28 @@ function getReadiness() {
   };
 }
 
+function sendJson(res: http.ServerResponse, statusCode: number, payload: unknown) {
+  res.writeHead(statusCode, {
+    'Content-Type': 'application/json',
+    'Cache-Control': 'no-store',
+  });
+  res.end(JSON.stringify(payload));
+}
+
 const httpServer = http.createServer((req, res) => {
-  if (req.url === '/health') {
-    const health = getReadiness();
-    res.writeHead(health.ready ? 200 : 503, { 'Content-Type': 'application/json' });
-    res.end(JSON.stringify(health));
+  const pathname = (req.url ?? '/').split('?')[0];
+
+  if (pathname === '/live') {
+    sendJson(res, 200, { alive: true, ...getReadiness() });
     return;
   }
+
+  if (pathname === '/health') {
+    const health = getReadiness();
+    sendJson(res, health.ready ? 200 : 503, health);
+    return;
+  }
+
   res.writeHead(404);
   res.end();
 });


### PR DESCRIPTION
## Summary
- Separate Studio Shell liveness from readiness so ECS stops killing the container while the repo initializes.
- Mark the shell ready as soon as Git/pnpm are available and the repo clone succeeds; dependency install continues in the background and reports status instead of blocking terminal access.
- Pin pnpm in the Studio image to the workspace package manager version.
- Add ECS/CloudWatch diagnostics to the Studio deploy workflow when service stabilization fails.

## Root Cause
The Studio ECS task health check was pointed at `/health`, which only returns 200 after repo clone and dependency install complete. If `pnpm install` is slow or fails, ECS treats the container as unhealthy, restarts it, and the admin terminal proxy has no stable shell to connect to.

## Validation
- Confirmed the last `Deploy Studio Shell` run failed at the ECS service stability step after the image built and pushed successfully.
- PR is mergeable against `main` and changes are scoped to 5 Studio/deploy files.
- Passing so far: Lint, Pre-deploy Check, Survival Guard, Integrity Gate, Dashboard Diagnostics.
- CI/CD has passed unit tests, smoke tests, garbage audit, admin route audit, dashboard audit, TypeScript, route governance, SEO governance, quality gates, and Playwright browser install. Browser E2E/build are still running.
- Compliance Gate has passed compliance files and security audit. Accessibility and enrollment jobs are still building/running.

Do not merge/deploy without explicit production confirmation.