### PR TITLE
fix(email): correct trial welcome and password reset email templates

### DIFF
--- a/app/api/trial/start-managed/route.ts
+++ b/app/api/trial/start-managed/route.ts
@@ -73,7 +73,7 @@ async function sendTrialWelcomeEmail(
   }
 
   await resend.emails.send({
-    from: 'Elevate LMS <${PLATFORM_DEFAULTS.emailFromAddress}>',
+    from: `Elevate LMS <${PLATFORM_DEFAULTS.emailFromAddress}>`,
     to: email,
     subject: `Your 14-day trial is ready — ${orgName}`,
     headers: { 'X-Correlation-ID': correlationId },

--- a/app/forgot-password/actions.ts
+++ b/app/forgot-password/actions.ts
@@ -64,7 +64,7 @@ export async function sendRecoveryEmail(
 
     const result = await sendEmail({
       to: email,
-      subject: 'Reset Your Password — ${PLATFORM_DEFAULTS.orgName}',
+      subject: `Reset Your Password — ${PLATFORM_DEFAULTS.orgName}`,
       html: `
 <!DOCTYPE html>
 <html>


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes two production email bugs found during application flow audit:

- **Password reset** (`app/forgot-password/actions.ts`): subject line used single quotes, so recipients saw literal `${PLATFORM_DEFAULTS.orgName}` instead of the organization name.
- **14-day store trial welcome** (`app/api/trial/start-managed/route.ts`): `from` address had the same single-quote bug for `${PLATFORM_DEFAULTS.emailFromAddress}`.

## Testing

- Unit tests for auth/payments unchanged and passing locally.
- Trial API validation smoke-tested (`400` for missing/invalid fields).

## Deployment

Merges to `main` will deploy via existing GitHub Actions (`deploy-lms.yml` for main app routes).

Does **not** include broader audit items (license trial UI mismatch, onboarding migration, BNPL E2E, admin Studio smoke).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

