### PR TITLE
feat(admin): Dev Studio operations control plane (not VS Code shell)

### DIFF
--- a/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
@@ -1,7 +1,8 @@
 'use client';
 
-import { type ElementType, useEffect, useMemo, useState } from 'react';
+import { type ElementType, useCallback, useEffect, useMemo, useRef, useState } from 'react';
 import dynamic from 'next/dynamic';
+import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import {
   Activity,
@@ -9,6 +10,7 @@ import {
   BookOpen,
   Box,
   ExternalLink,
+  FileText,
   FolderOpen,
   GitBranch,
   Globe,
@@ -17,32 +19,50 @@ import {
   MessageSquare,
   RefreshCw,
   Rocket,
+  Save,
+  Send,
   Server,
+  Sparkles,
   Terminal,
+  Upload,
   Workflow,
 } from 'lucide-react';
-import IframePreview from '@/components/dev-studio/IframePreview';
-import DevStudioPwaHint from '@/components/dev-studio/DevStudioPwaHint';
 
-type Workspace =
-  | 'studio'
-  | 'deploy'
-  | 'services'
-  | 'environments'
-  | 'terminal'
-  | 'git'
-  | 'files'
-  | 'workflows'
-  | 'health'
-  | 'secrets';
+interface WorkflowButton {
+  key: string;
+  label: string;
+  description: string;
+}
 
-type StudioMode = 'ellie' | 'courses';
+interface StudioConfig {
+  workflowButtons?: WorkflowButton[];
+  defaultPreviewUrl?: string;
+  previewTargets?: { label: string; url: string }[];
+}
 
 interface CourseProgram {
   id: string;
   title: string;
   slug: string;
 }
+
+interface CourseBuilderProps {
+  programs: CourseProgram[];
+  embedded?: boolean;
+  initialProgramId?: string;
+}
+
+type Workspace =
+  | 'ellie'
+  | 'deploy'
+  | 'files'
+  | 'git'
+  | 'terminal'
+  | 'environments'
+  | 'services'
+  | 'health'
+  | 'secrets';
+type StudioMode = 'ask' | 'run' | 'courses';
 
 const AIChat = dynamic(() => import('@/components/dev-studio/AIChat'), { ssr: false });
 const DeployPanel = dynamic(() => import('@/components/dev-studio/DeployPanel'), { ssr: false });
@@ -51,273 +71,770 @@ const ServicesPanel = dynamic(() => import('@/components/dev-studio/ServicesPane
 const SecretsPanel = dynamic(() => import('@/components/dev-studio/SecretsPanel'), { ssr: false });
 const GitPanel = dynamic(() => import('@/components/dev-studio/GitPanel'), { ssr: false });
 const XTerminal = dynamic(() => import('@/components/dev-studio/XTerminal'), { ssr: false });
-const DevStudioHealthPanel = dynamic(() => import('@/components/dev-studio/DevStudioHealthPanel'), { ssr: false });
-const DevStudioWorkflowsPanel = dynamic(
-  () => import('@/components/dev-studio/DevStudioWorkflowsPanel'),
-  { ssr: false },
-);
-const FilesWorkspace = dynamic(() => import('@/components/dev-studio/DevStudioFilesWorkspace'), { ssr: false });
-const AICourseBuilderChat = dynamic(
+const EcsStatusPanel = dynamic(() => import('@/components/dev-studio/EcsStatusPanel'), { ssr: false });
+const AICourseBuilderChat = dynamic<CourseBuilderProps>(
   () => import('../courses/ai-builder/AICourseBuilderChat'),
   { ssr: false },
 );
 
 const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?: string }> }[] = [
-  { id: 'studio', label: 'Ellie', Icon: Bot },
+  { id: 'ellie', label: 'Ellie', Icon: Bot },
   { id: 'deploy', label: 'Deploy', Icon: Rocket },
-  { id: 'services', label: 'Services', Icon: Server },
-  { id: 'environments', label: 'Container', Icon: Box },
-  { id: 'terminal', label: 'Terminal', Icon: Terminal },
-  { id: 'git', label: 'Git', Icon: GitBranch },
   { id: 'files', label: 'Files', Icon: FolderOpen },
-  { id: 'workflows', label: 'Workflows', Icon: Workflow },
+  { id: 'git', label: 'Git', Icon: GitBranch },
+  { id: 'terminal', label: 'Terminal', Icon: Terminal },
+  { id: 'environments', label: 'Container', Icon: Box },
+  { id: 'services', label: 'Services', Icon: Server },
   { id: 'health', label: 'Health', Icon: Activity },
   { id: 'secrets', label: 'Secrets', Icon: Key },
 ];
 
-function normalizeTab(tab: string | null): { workspace: Workspace; mode: StudioMode } {
-  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ellie' };
-  if (tab === 'git') return { workspace: 'git', mode: 'ellie' };
-  if (tab === 'files' || tab === 'docs') return { workspace: 'files', mode: 'ellie' };
-  if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ellie' };
-  if (tab === 'services') return { workspace: 'services', mode: 'ellie' };
-  if (tab === 'health') return { workspace: 'health', mode: 'ellie' };
-  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ellie' };
-  if (tab === 'automation' || tab === 'workflows') return { workspace: 'workflows', mode: 'ellie' };
-  if (tab === 'terminal' || tab === 'command' || tab === 'run') return { workspace: 'terminal', mode: 'ellie' };
-  if (tab === 'courses' || tab === 'course') return { workspace: 'studio', mode: 'courses' };
-  if (tab === 'ellie' || tab === 'chat') return { workspace: 'studio', mode: 'ellie' };
-  return { workspace: 'studio', mode: 'ellie' };
+const QUICK_ACTIONS = [
+  { label: 'Deploy LMS', command: 'Deploy the LMS service' },
+  { label: 'Deploy admin', command: 'Deploy the admin service' },
+  { label: 'Smoke test', command: 'Run smoke test' },
+  { label: 'System health', command: 'Check system health' },
+];
+
+function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
+  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ask' };
+  if (tab === 'files' || tab === 'explorer' || tab === 'docs' || tab === 'documents') return { workspace: 'files', mode: 'ask' };
+  if (tab === 'git') return { workspace: 'git', mode: 'ask' };
+  if (tab === 'terminal' || tab === 'command') return { workspace: 'terminal', mode: 'ask' };
+  if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ask' };
+  if (tab === 'services') return { workspace: 'services', mode: 'ask' };
+  if (tab === 'health') return { workspace: 'health', mode: 'ask' };
+  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ask' };
+  if (tab === 'studio' || tab === 'chat' || tab === 'ellie' || tab === 'automation') return { workspace: 'ellie', mode: 'ask' };
+  if (tab === 'courses' || tab === 'course') return { workspace: 'ellie', mode: 'courses' };
+  if (tab === 'run') return { workspace: 'ellie', mode: 'run' };
+  return { workspace: 'ellie', mode: 'ask' };
 }
 
 export default function DevStudioControlPlaneClient({ isSuperAdmin = false }: { isSuperAdmin?: boolean }) {
   const searchParams = useSearchParams();
-  const initial = normalizeTab(searchParams.get('tab'));
+  const initial = normalizeWorkspace(searchParams.get('tab'));
   const [workspace, setWorkspace] = useState<Workspace>(
-    initial.workspace === 'secrets' && !isSuperAdmin ? 'studio' : initial.workspace,
+    initial.workspace === 'secrets' && !isSuperAdmin ? 'ellie' : initial.workspace,
   );
   const [studioMode, setStudioMode] = useState<StudioMode>(initial.mode);
+  const [config, setConfig] = useState<StudioConfig | null>(null);
+  const [health, setHealth] = useState<Record<string, unknown> | null>(null);
+  const [healthLoading, setHealthLoading] = useState(false);
   const [previewUrl, setPreviewUrl] = useState('');
   const [livePreviewUrl, setLivePreviewUrl] = useState('');
   const [programs, setPrograms] = useState<CourseProgram[]>([]);
-  const [aiLabel, setAiLabel] = useState('checking…');
+  const [programsLoading, setProgramsLoading] = useState(false);
 
-  useEffect(() => {
+  const refreshHealth = useCallback(() => {
+    setHealthLoading(true);
     fetch('/api/devstudio/health')
       .then((r) => (r.ok ? r.json() : null))
-      .then((d) => {
-        const parts = [
-          d?.hasGroq && 'Groq',
-          d?.hasOpenAI && 'OpenAI',
-          d?.hasAnthropic && 'Claude',
-          d?.hasGemini && 'Gemini',
-        ].filter(Boolean);
-        setAiLabel(parts.join(' / ') || 'no keys');
-      })
-      .catch(() => setAiLabel('offline'));
+      .then((data) => setHealth(data))
+      .catch(() => setHealth(null))
+      .finally(() => setHealthLoading(false));
   }, []);
 
   useEffect(() => {
     fetch('/api/admin/devstudio/config')
       .then((r) => r.json())
-      .then((data: { defaultPreviewUrl?: string }) => {
-        const url = data.defaultPreviewUrl || window.location.origin;
-        setPreviewUrl((c) => c || url);
-        setLivePreviewUrl((c) => c || url);
+      .then((data: StudioConfig) => {
+        setConfig(data);
+        const nextPreview = data.defaultPreviewUrl || window.location.origin;
+        setPreviewUrl((current) => current || nextPreview);
+        setLivePreviewUrl((current) => current || nextPreview);
       })
       .catch(() => {
-        setPreviewUrl((c) => c || window.location.origin);
-        setLivePreviewUrl((c) => c || window.location.origin);
+        setConfig(null);
+        setPreviewUrl((current) => current || window.location.origin);
+        setLivePreviewUrl((current) => current || window.location.origin);
       });
   }, []);
 
   useEffect(() => {
+    refreshHealth();
+  }, [refreshHealth]);
+
+  useEffect(() => {
+    setProgramsLoading(true);
     fetch('/api/admin/programs?status=active')
       .then((r) => (r.ok ? r.json() : { data: [] }))
       .then((payload) => {
         const rows = Array.isArray(payload?.data) ? payload.data : [];
         setPrograms(
-          rows.map((p: { id: string; title?: string; name?: string; slug?: string; code?: string }) => ({
-            id: p.id,
-            title: p.title ?? p.name ?? p.code ?? 'Program',
-            slug: p.slug ?? p.code ?? p.id,
+          rows.map((program: { id: string; title?: string; name?: string; slug?: string; code?: string }) => ({
+            id: program.id,
+            title: program.title ?? program.name ?? program.code ?? 'Untitled program',
+            slug: program.slug ?? program.code ?? program.id,
           })),
         );
       })
-      .catch(() => setPrograms([]));
+      .catch(() => setPrograms([]))
+      .finally(() => setProgramsLoading(false));
   }, []);
 
-  const nav = useMemo(
-    () => WORKSPACES.filter((w) => w.id !== 'secrets' || isSuperAdmin),
-    [isSuperAdmin],
-  );
+  const activeProviders = useMemo(() => {
+    if (!health) return 'checking…';
+    return (
+      [
+        health.hasGroq && 'Groq',
+        health.hasGemini && 'Gemini',
+        health.hasOpenAI && 'OpenAI',
+        health.hasAnthropic && 'Anthropic',
+      ]
+        .filter(Boolean)
+        .join(' · ') || 'no AI keys in env'
+    );
+  }, [health]);
 
-  function open(ws: Workspace) {
-    if (ws === 'secrets' && !isSuperAdmin) return;
-    setWorkspace(ws);
+  function openWorkspace(next: Workspace) {
+    if (next === 'secrets' && !isSuperAdmin) {
+      setWorkspace('health');
+      return;
+    }
+    setWorkspace(next);
   }
 
   return (
-    <div className="flex h-full flex-col overflow-hidden bg-slate-50 text-slate-900">
-      <DevStudioPwaHint />
-      <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-slate-200 bg-white px-3 py-2">
-        <Bot className="h-5 w-5 text-brand-blue-600" />
-        <div>
-          <p className="text-sm font-semibold text-slate-900">Dev Studio</p>
-          <p className="text-[10px] text-slate-500">Live ECS · GitHub Actions · Supabase</p>
+    <div className="flex h-[calc(100dvh-3.5rem)] min-h-0 w-full flex-col overflow-hidden bg-slate-50 text-slate-800">
+      <header className="flex min-h-12 shrink-0 flex-wrap items-center gap-2 border-b border-slate-200 bg-white px-4 py-2">
+        <div className="flex min-w-0 items-center gap-2">
+          <Bot className="h-5 w-5 text-brand-blue-600" />
+          <div>
+            <span className="text-sm font-semibold text-slate-900">Dev Studio</span>
+            <p className="text-[11px] text-slate-500">Operations control plane — live deploys, env, and Ellie</p>
+          </div>
         </div>
-        <div className="ml-auto flex items-center gap-2">
-          <span className="rounded-full bg-brand-green-50 px-2 py-0.5 text-[10px] text-brand-green-800">
-            {aiLabel}
-          </span>
+        <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 text-xs">
+          <span className="rounded-full bg-slate-100 px-2 py-0.5 text-slate-600">AI: {activeProviders}</span>
+          <Link
+            href="/admin/workflows"
+            className="inline-flex h-8 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2.5 text-slate-700 hover:bg-slate-50"
+          >
+            <Workflow className="h-3.5 w-3.5" />
+            Platform workflows
+          </Link>
           <button
             type="button"
-            onClick={() => open('deploy')}
-            className="rounded-lg bg-brand-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-blue-700"
+            onClick={() => openWorkspace('deploy')}
+            className="inline-flex h-8 items-center gap-1 rounded-lg bg-brand-blue-600 px-3 text-sm font-medium text-white hover:bg-brand-blue-700"
           >
-            <Rocket className="mr-1 inline h-3.5 w-3.5" />
+            <Rocket className="h-3.5 w-3.5" />
             Deploy
           </button>
         </div>
       </header>
 
       <div className="flex min-h-0 flex-1">
-        <aside className="hidden w-44 shrink-0 flex-col border-r border-slate-200 bg-white p-2 md:flex">
-          {nav.map(({ id, label, Icon }) => (
-            <button
-              key={id}
-              type="button"
-              onClick={() => open(id)}
-              className={`mb-0.5 flex h-9 w-full items-center gap-2 rounded-lg px-2 text-left text-xs ${
-                workspace === id ? 'bg-brand-blue-50 font-medium text-brand-blue-900' : 'text-slate-600 hover:bg-slate-50'
-              }`}
-            >
-              <Icon className="h-4 w-4" />
-              {label}
-            </button>
-          ))}
-        </aside>
-
-        <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:flex-row">
-          <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
-            <div className="flex gap-1 overflow-x-auto border-b border-slate-200 bg-white p-1 md:hidden">
-              {nav.map(({ id, label, Icon }) => (
+        <aside className="hidden w-52 shrink-0 flex-col border-r border-slate-200 bg-white p-2 md:flex">
+          <p className="mb-2 px-2 text-[10px] font-semibold uppercase tracking-wider text-slate-400">Workspaces</p>
+          <nav className="space-y-0.5">
+            {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => {
+              const active = workspace === id;
+              return (
                 <button
                   key={id}
                   type="button"
-                  onClick={() => open(id)}
-                  className={`flex shrink-0 items-center gap-1 rounded-lg px-2 py-1.5 text-[10px] ${
-                    workspace === id ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
+                  onClick={() => openWorkspace(id)}
+                  className={`flex h-9 w-full items-center gap-2 rounded-lg px-2 text-left text-sm transition ${
+                    active ? 'bg-brand-blue-50 font-medium text-brand-blue-800' : 'text-slate-600 hover:bg-slate-50'
                   }`}
                 >
-                  <Icon className="h-4 w-4" />
-                  {label}
+                  <Icon className="h-4 w-4 shrink-0" />
+                  <span className="truncate">{label}</span>
                 </button>
-              ))}
-            </div>
+              );
+            })}
+          </nav>
+          <div className="mt-auto border-t border-slate-100 pt-2 px-2 text-[10px] text-slate-400">
+            Secrets: platform_secrets → app_secrets → process.env
+          </div>
+        </aside>
 
-            {workspace === 'studio' && (
-              <div className="flex h-full flex-col bg-white">
-                <div className="flex gap-1 border-b border-slate-200 px-2 py-1">
-                  <button
-                    type="button"
-                    onClick={() => setStudioMode('ellie')}
-                    className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
-                      studioMode === 'ellie' ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
-                    }`}
-                  >
-                    <MessageSquare className="mr-1 inline h-3.5 w-3.5" />
-                    Ellie
-                  </button>
-                  <button
-                    type="button"
-                    onClick={() => setStudioMode('courses')}
-                    className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
-                      studioMode === 'courses' ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
-                    }`}
-                  >
-                    <BookOpen className="mr-1 inline h-3.5 w-3.5" />
-                    Course builder
-                  </button>
-                </div>
-                <div className="min-h-0 flex-1">
-                  {studioMode === 'ellie' ? (
-                    <AIChat ellieMode unifiedEllieMode embedded />
-                  ) : programs.length ? (
-                    <AICourseBuilderChat programs={programs} embedded />
-                  ) : (
-                    <div className="flex h-full items-center justify-center text-sm text-slate-500">
-                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                      Loading programs…
-                    </div>
-                  )}
-                </div>
-              </div>
+        <div className="flex min-w-0 flex-1 flex-col lg:flex-row">
+          <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <MobileTabs workspace={workspace} isSuperAdmin={isSuperAdmin} onChange={openWorkspace} />
+            {workspace === 'ellie' && (
+              <StudioPanel
+                mode={studioMode}
+                onModeChange={setStudioMode}
+                programs={programs}
+                programsLoading={programsLoading}
+              />
             )}
-            {workspace === 'deploy' && <DeployPanel />}
-            {workspace === 'services' && <ServicesPanel />}
-            {workspace === 'environments' && (
-              <div className="h-full overflow-auto bg-white">
-                <DevContainerPanel />
+            {workspace === 'deploy' && <DeployPanel workflowButtons={config?.workflowButtons} variant="admin" />}
+            {workspace === 'files' && <FilesPanel />}
+            {workspace === 'git' && (
+              <div className="h-full overflow-hidden bg-white">
+                <GitPanel />
               </div>
             )}
             {workspace === 'terminal' && (
               <div className="flex h-full flex-col bg-slate-900">
-                <p className="shrink-0 border-b border-slate-700 px-3 py-2 text-xs text-slate-300">
-                  Studio ECS shell — set STUDIO_SHELL_* in Secrets, deploy studio service.
-                </p>
+                <div className="border-b border-slate-700 px-3 py-2 text-xs text-slate-300">
+                  ECS studio shell when <code className="text-slate-100">STUDIO_SHELL_*</code> is configured; otherwise
+                  use Deploy or Run commands.
+                </div>
                 <div className="min-h-0 flex-1">
                   <XTerminal />
                 </div>
               </div>
             )}
-            {workspace === 'git' && (
-              <div className="h-full bg-white">
-                <GitPanel />
+            {workspace === 'environments' && (
+              <div className="h-full overflow-auto bg-white">
+                <DevContainerPanel />
               </div>
             )}
-            {workspace === 'files' && <FilesWorkspace />}
-            {workspace === 'workflows' && <DevStudioWorkflowsPanel />}
-            {workspace === 'health' && <DevStudioHealthPanel />}
-            {workspace === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <DevStudioHealthPanel />)}
+            {workspace === 'services' && (
+              <div className="h-full overflow-auto bg-white p-4">
+                <ServicesPanel />
+              </div>
+            )}
+            {workspace === 'health' && (
+              <HealthWorkspace health={health} loading={healthLoading} onRefresh={refreshHealth} />
+            )}
+            {workspace === 'secrets' &&
+              (isSuperAdmin ? (
+                <div className="h-full overflow-auto bg-white">
+                  <SecretsPanel />
+                </div>
+              ) : (
+                <HealthWorkspace health={health} loading={healthLoading} onRefresh={refreshHealth} />
+              ))}
           </main>
 
-          <aside className="hidden w-[min(38vw,520px)] shrink-0 flex-col border-l border-slate-200 bg-white lg:flex">
-            <div className="flex items-center gap-1 border-b border-slate-200 bg-slate-50 px-2 py-1.5">
+          <section className="hidden w-[min(42vw,520px)] shrink-0 flex-col border-l border-slate-200 bg-white lg:flex">
+            <div className="flex h-11 shrink-0 items-center gap-1.5 border-b border-slate-200 px-2">
               <button
                 type="button"
                 onClick={() => setLivePreviewUrl(previewUrl)}
-                className="rounded p-1.5 text-slate-500 hover:bg-slate-200"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100"
+                title="Refresh preview"
               >
-                <RefreshCw className="h-3.5 w-3.5" />
+                <RefreshCw className="h-4 w-4" />
               </button>
               <form
-                className="flex min-w-0 flex-1 items-center rounded-lg border border-slate-200 bg-white px-2"
-                onSubmit={(e) => {
-                  e.preventDefault();
+                className="flex min-w-0 flex-1 items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 px-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
                   setLivePreviewUrl(previewUrl);
                 }}
               >
-                <Globe className="mr-1 h-3.5 w-3.5 text-brand-blue-600" />
+                <Globe className="h-3.5 w-3.5 shrink-0 text-brand-blue-600" />
                 <input
                   value={previewUrl}
-                  onChange={(e) => setPreviewUrl(e.target.value)}
-                  className="h-7 min-w-0 flex-1 text-[11px] outline-none"
+                  onChange={(event) => setPreviewUrl(event.target.value)}
+                  list="devstudio-preview-targets"
+                  className="h-8 min-w-0 flex-1 bg-transparent text-xs text-slate-800 outline-none"
+                  spellCheck={false}
                 />
+                <datalist id="devstudio-preview-targets">
+                  {(config?.previewTargets ?? []).map((target) => (
+                    <option key={target.url} value={target.url}>
+                      {target.label}
+                    </option>
+                  ))}
+                </datalist>
               </form>
               <a
                 href={livePreviewUrl || previewUrl}
                 target="_blank"
                 rel="noreferrer"
-                className="rounded p-1.5 text-slate-500 hover:bg-slate-200"
+                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100"
+                title="Open in new tab"
               >
-                <ExternalLink className="h-3.5 w-3.5" />
+                <ExternalLink className="h-4 w-4" />
               </a>
             </div>
-            <IframePreview url={livePreviewUrl || previewUrl} className="min-h-0 flex-1" />
-          </aside>
+            {(config?.previewTargets?.length ?? 0) > 0 && (
+              <div className="flex shrink-0 flex-wrap gap-1 border-b border-slate-100 px-2 py-1.5">
+                {config!.previewTargets!.slice(0, 6).map((target) => (
+                  <button
+                    key={target.url}
+                    type="button"
+                    onClick={() => {
+                      setPreviewUrl(target.url);
+                      setLivePreviewUrl(target.url);
+                    }}
+                    className="rounded-md bg-slate-100 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-200"
+                  >
+                    {target.label}
+                  </button>
+                ))}
+              </div>
+            )}
+            <iframe
+              title="Site preview"
+              src={livePreviewUrl || previewUrl}
+              className="min-h-0 flex-1 border-0 bg-white"
+            />
+          </section>
         </div>
       </div>
+    </div>
+  );
+}
+
+function MobileTabs({
+  workspace,
+  isSuperAdmin,
+  onChange,
+}: {
+  workspace: Workspace;
+  isSuperAdmin: boolean;
+  onChange: (workspace: Workspace) => void;
+}) {
+  return (
+    <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-slate-200 bg-white p-1 md:hidden">
+      {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className={`inline-flex h-10 shrink-0 items-center gap-1 rounded-lg px-2 text-xs ${
+            workspace === id ? 'bg-brand-blue-50 text-brand-blue-800' : 'text-slate-600'
+          }`}
+          title={label}
+        >
+          <Icon className="h-4 w-4" />
+          <span className="max-w-[4.5rem] truncate">{label}</span>
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function StudioPanel({
+  mode,
+  onModeChange,
+  programs,
+  programsLoading,
+}: {
+  mode: StudioMode;
+  onModeChange: (mode: StudioMode) => void;
+  programs: CourseProgram[];
+  programsLoading: boolean;
+}) {
+  const modes: { id: StudioMode; label: string; Icon: ElementType<{ className?: string }> }[] = [
+    { id: 'ask', label: 'Ellie', Icon: MessageSquare },
+    { id: 'run', label: 'Run', Icon: Sparkles },
+    { id: 'courses', label: 'Course builder', Icon: BookOpen },
+  ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-white">
+      <div className="flex h-11 shrink-0 items-center gap-1 border-b border-slate-200 px-2">
+        {modes.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onModeChange(id)}
+            className={`inline-flex h-8 items-center gap-1.5 rounded-lg px-3 text-xs font-medium ${
+              mode === id ? 'bg-brand-blue-600 text-white' : 'text-slate-600 hover:bg-slate-100'
+            }`}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {mode === 'ask' && (
+          <div className="h-full">
+            <AIChat ellieMode />
+          </div>
+        )}
+        {mode === 'run' && <RunPanel />}
+        {mode === 'courses' &&
+          (programsLoading ? (
+            <div className="flex h-full items-center justify-center gap-2 text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-sm">Loading active programs…</span>
+            </div>
+          ) : (
+            <AICourseBuilderChat programs={programs} embedded />
+          ))}
+      </div>
+    </div>
+  );
+}
+
+function RunPanel() {
+  const [input, setInput] = useState('');
+  const [lines, setLines] = useState<{ type: 'user' | 'output' | 'error'; text: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines]);
+
+  async function run(command: string) {
+    const trimmed = command.trim();
+    if (!trimmed || loading) return;
+    setInput('');
+    setLoading(true);
+    setLines([{ type: 'user', text: trimmed }]);
+
+    try {
+      const isSmoke = /smoke.?test|health.?check|check.*platform|verify.*platform/i.test(trimmed);
+      const res = await fetch(
+        isSmoke ? '/api/devstudio/smoke-test' : '/api/devstudio/execute',
+        isSmoke
+          ? undefined
+          : {
+              method: 'POST',
+              headers: { 'Content-Type': 'application/json' },
+              body: JSON.stringify({ command: trimmed }),
+            },
+      );
+
+      if (!res.ok || !res.body) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Request failed with HTTP ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split('\n');
+        buffer = chunks.pop() ?? '';
+        for (const chunk of chunks) {
+          if (!chunk.startsWith('data: ')) continue;
+          const raw = chunk.slice(6).trim();
+          if (!raw || raw === '[DONE]') continue;
+          let text = raw;
+          try {
+            const parsed = JSON.parse(raw);
+            text = parsed.line ?? parsed.text ?? parsed.output ?? raw;
+          } catch {
+            text = raw;
+          }
+          setLines((current) => [...current, { type: 'output', text }]);
+        }
+      }
+    } catch (error) {
+      setLines((current) => [
+        ...current,
+        { type: 'error', text: error instanceof Error ? error.message : 'Command failed' },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-slate-50">
+      <div className="flex shrink-0 flex-wrap gap-1.5 border-b border-slate-200 bg-white px-3 py-2">
+        {QUICK_ACTIONS.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            onClick={() => run(item.command)}
+            disabled={loading}
+            className="rounded-lg border border-slate-200 bg-white px-2.5 py-1 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-xs text-slate-800">
+        {lines.length === 0 && <p className="text-slate-400">Run deploy or diagnostics commands (streams from /api/devstudio/execute).</p>}
+        {lines.map((line, index) => (
+          <div
+            key={`${line.type}-${index}`}
+            className={`whitespace-pre-wrap break-words ${
+              line.type === 'user' ? 'text-brand-blue-700' : line.type === 'error' ? 'text-red-600' : 'text-slate-700'
+            }`}
+          >
+            {line.type === 'user' ? `$ ${line.text}` : line.text}
+          </div>
+        ))}
+        {loading && (
+          <div className="mt-2 flex items-center gap-2 text-brand-blue-600">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Running…
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <form
+        className="flex shrink-0 items-center gap-2 border-t border-slate-200 bg-white p-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          run(input);
+        }}
+      >
+        <span className="font-mono text-sm font-bold text-brand-blue-600">$</span>
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          className="h-10 min-w-0 flex-1 rounded-lg border border-slate-200 px-3 font-mono text-sm outline-none focus:border-brand-blue-500"
+          placeholder="Deploy LMS, run smoke test, check health…"
+          disabled={loading}
+        />
+        <button
+          type="submit"
+          disabled={loading || !input.trim()}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-lg bg-brand-blue-600 text-white disabled:opacity-50"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const MAX_UPLOAD_BYTES = 512 * 1024;
+const TEXT_UPLOAD_EXTENSIONS = new Set([
+  'css', 'csv', 'html', 'js', 'jsx', 'json', 'md', 'mdx', 'mjs', 'sql', 'svg', 'ts', 'tsx', 'txt', 'xml', 'yml', 'yaml',
+]);
+
+function sanitizeUploadPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/{2,}/g, '/').trim();
+}
+
+function isEditableUpload(file: File): boolean {
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (TEXT_UPLOAD_EXTENSIONS.has(ext)) return true;
+  if (file.type.startsWith('text/')) return true;
+  return ['application/json', 'application/xml', 'image/svg+xml'].includes(file.type);
+}
+
+function FilesPanel() {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState('');
+  const [content, setContent] = useState('');
+  const [sha, setSha] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [uploadPath, setUploadPath] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshFiles = useCallback(async () => {
+    try {
+      const res = await fetch('/api/devstudio/files');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      const flat: string[] = [];
+      function walk(nodes: { type: string; path: string; children?: unknown[] }[]) {
+        for (const node of nodes ?? []) {
+          if (node.type === 'file') flat.push(node.path);
+          else walk((node.children ?? []) as { type: string; path: string; children?: unknown[] }[]);
+        }
+      }
+      walk(data.tree ?? []);
+      setFiles(flat);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'File tree unavailable (needs GITHUB_TOKEN)');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshFiles();
+  }, [refreshFiles]);
+
+  async function handleUpload(file: File | undefined) {
+    if (!file) return;
+    setStatus('');
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setStatus(`Upload exceeds ${MAX_UPLOAD_BYTES / 1024} KB limit`);
+      return;
+    }
+    if (!isEditableUpload(file)) {
+      setStatus('Upload must be a text/code file');
+      return;
+    }
+    try {
+      const nextPath = sanitizeUploadPath(uploadPath || `devstudio-uploads/${file.name}`);
+      const text = await file.text();
+      setSelected(nextPath);
+      setUploadPath(nextPath);
+      setContent(text);
+      setSha('');
+      setMessage(`chore: add ${nextPath} via Dev Studio`);
+      setStatus('Ready to commit');
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not read upload');
+    }
+  }
+
+  async function loadFile(path: string) {
+    setSelected(path);
+    setLoading(true);
+    setStatus('');
+    try {
+      const res = await fetch(`/api/devstudio/files?path=${encodeURIComponent(path)}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setContent(data.content ?? '');
+      setSha(data.sha ?? '');
+      setMessage(`chore: update ${path} via Dev Studio`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not load file');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveFile() {
+    if (!selected) return;
+    setLoading(true);
+    setStatus('');
+    try {
+      const method = sha ? 'PUT' : 'POST';
+      const res = await fetch('/api/devstudio/files', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: selected, content, sha: sha || undefined, message }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setSha(data.sha ?? sha);
+      setStatus(data.commit ? 'Committed to GitHub' : 'Saved');
+      if (method === 'POST') {
+        setFiles((current) => (current.includes(selected) ? current : [...current, selected].sort()));
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not save');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden bg-white">
+      <div className="flex w-64 shrink-0 flex-col border-r border-slate-200">
+        <div className="border-b border-slate-200 p-2">
+          <p className="mb-2 text-[10px] font-semibold uppercase tracking-wider text-slate-400">Repository files</p>
+          <div className="flex gap-1">
+            <input
+              value={uploadPath}
+              onChange={(event) => setUploadPath(sanitizeUploadPath(event.target.value))}
+              className="h-8 min-w-0 flex-1 rounded border border-slate-200 px-2 font-mono text-[11px] outline-none"
+              placeholder="path/in/repo.ts"
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={(event) => {
+                void handleUpload(event.currentTarget.files?.[0]);
+                event.currentTarget.value = '';
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex h-8 w-8 items-center justify-center rounded bg-brand-blue-600 text-white"
+              title="Upload"
+            >
+              <Upload className="h-3.5 w-3.5" />
+            </button>
+          </div>
+          <button type="button" onClick={() => refreshFiles()} className="mt-2 text-[11px] text-brand-blue-600 hover:underline">
+            Refresh tree
+          </button>
+        </div>
+        <div className="min-h-0 flex-1 overflow-y-auto">
+          {files.map((file) => (
+            <button
+              key={file}
+              type="button"
+              onClick={() => loadFile(file)}
+              className={`flex w-full items-center gap-2 border-b border-slate-50 px-3 py-2 text-left text-[11px] ${
+                selected === file ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600 hover:bg-slate-50'
+              }`}
+            >
+              <FileText className="h-3.5 w-3.5 shrink-0" />
+              <span className="truncate">{file}</span>
+            </button>
+          ))}
+        </div>
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex shrink-0 items-center gap-2 border-b border-slate-200 px-3 py-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-xs text-slate-500">{selected || 'Select a file'}</span>
+          {status && <span className="text-xs text-brand-green-700">{status}</span>}
+          <button
+            type="button"
+            onClick={saveFile}
+            disabled={!selected || loading}
+            className="inline-flex h-8 items-center gap-1 rounded-lg bg-brand-blue-600 px-3 text-xs font-medium text-white disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+            Commit
+          </button>
+        </div>
+        <input
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          className="h-9 shrink-0 border-b border-slate-200 px-3 font-mono text-xs outline-none"
+          placeholder="Commit message"
+        />
+        <textarea
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          className="min-h-0 flex-1 resize-none p-3 font-mono text-xs outline-none"
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  );
+}
+
+function HealthWorkspace({
+  health,
+  loading,
+  onRefresh,
+}: {
+  health: Record<string, unknown> | null;
+  loading: boolean;
+  onRefresh: () => void;
+}) {
+  const rows = [
+    ['GitHub token', health?.hasGitHub ? 'configured' : 'missing — deploy & files disabled'],
+    ['Groq', health?.hasGroq ? 'configured' : 'missing'],
+    ['Gemini', health?.hasGemini ? 'configured' : 'missing'],
+    ['OpenAI', health?.hasOpenAI ? 'configured' : 'missing'],
+    ['Supabase URL', health?.supabaseUrlPresent ? 'present' : 'missing'],
+    ['Supabase service key', health?.supabaseServiceKeyPresent ? 'present' : 'missing'],
+    ['Node', String(health?.nodeVersion ?? '—')],
+    ['Next.js', String(health?.nextVersion ?? '—')],
+  ];
+
+  return (
+    <div className="h-full overflow-y-auto bg-slate-50 p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <div>
+          <h2 className="text-sm font-semibold text-slate-900">Integration health</h2>
+          <p className="text-xs text-slate-500">Runtime secrets and API connectivity for this admin task</p>
+        </div>
+        <button
+          type="button"
+          onClick={onRefresh}
+          disabled={loading}
+          className="inline-flex h-8 items-center gap-1 rounded-lg border border-slate-200 bg-white px-2 text-xs text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+      <div className="mb-6 overflow-hidden rounded-xl border border-slate-200 bg-white">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-center justify-between border-b border-slate-100 px-4 py-2.5 text-sm last:border-0">
+            <span className="text-slate-500">{label}</span>
+            <span className="font-mono text-xs text-slate-800">{value}</span>
+          </div>
+        ))}
+      </div>
+      <h3 className="mb-2 text-sm font-semibold text-slate-900">AWS ECS services</h3>
+      <EcsStatusPanel />
     </div>
   );
 }

--- a/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
@@ -1,0 +1,323 @@
+'use client';
+
+import { type ElementType, useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
+import {
+  Activity,
+  Bot,
+  BookOpen,
+  Box,
+  ExternalLink,
+  FolderOpen,
+  GitBranch,
+  Globe,
+  Key,
+  Loader2,
+  MessageSquare,
+  RefreshCw,
+  Rocket,
+  Server,
+  Terminal,
+  Workflow,
+} from 'lucide-react';
+import IframePreview from '@/components/dev-studio/IframePreview';
+import DevStudioPwaHint from '@/components/dev-studio/DevStudioPwaHint';
+
+type Workspace =
+  | 'studio'
+  | 'deploy'
+  | 'services'
+  | 'environments'
+  | 'terminal'
+  | 'git'
+  | 'files'
+  | 'workflows'
+  | 'health'
+  | 'secrets';
+
+type StudioMode = 'ellie' | 'courses';
+
+interface CourseProgram {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+const AIChat = dynamic(() => import('@/components/dev-studio/AIChat'), { ssr: false });
+const DeployPanel = dynamic(() => import('@/components/dev-studio/DeployPanel'), { ssr: false });
+const DevContainerPanel = dynamic(() => import('@/components/dev-studio/DevContainerPanel'), { ssr: false });
+const ServicesPanel = dynamic(() => import('@/components/dev-studio/ServicesPanel'), { ssr: false });
+const SecretsPanel = dynamic(() => import('@/components/dev-studio/SecretsPanel'), { ssr: false });
+const GitPanel = dynamic(() => import('@/components/dev-studio/GitPanel'), { ssr: false });
+const XTerminal = dynamic(() => import('@/components/dev-studio/XTerminal'), { ssr: false });
+const DevStudioHealthPanel = dynamic(() => import('@/components/dev-studio/DevStudioHealthPanel'), { ssr: false });
+const DevStudioWorkflowsPanel = dynamic(
+  () => import('@/components/dev-studio/DevStudioWorkflowsPanel'),
+  { ssr: false },
+);
+const FilesWorkspace = dynamic(() => import('@/components/dev-studio/DevStudioFilesWorkspace'), { ssr: false });
+const AICourseBuilderChat = dynamic(
+  () => import('../courses/ai-builder/AICourseBuilderChat'),
+  { ssr: false },
+);
+
+const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?: string }> }[] = [
+  { id: 'studio', label: 'Ellie', Icon: Bot },
+  { id: 'deploy', label: 'Deploy', Icon: Rocket },
+  { id: 'services', label: 'Services', Icon: Server },
+  { id: 'environments', label: 'Container', Icon: Box },
+  { id: 'terminal', label: 'Terminal', Icon: Terminal },
+  { id: 'git', label: 'Git', Icon: GitBranch },
+  { id: 'files', label: 'Files', Icon: FolderOpen },
+  { id: 'workflows', label: 'Workflows', Icon: Workflow },
+  { id: 'health', label: 'Health', Icon: Activity },
+  { id: 'secrets', label: 'Secrets', Icon: Key },
+];
+
+function normalizeTab(tab: string | null): { workspace: Workspace; mode: StudioMode } {
+  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ellie' };
+  if (tab === 'git') return { workspace: 'git', mode: 'ellie' };
+  if (tab === 'files' || tab === 'docs') return { workspace: 'files', mode: 'ellie' };
+  if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ellie' };
+  if (tab === 'services') return { workspace: 'services', mode: 'ellie' };
+  if (tab === 'health') return { workspace: 'health', mode: 'ellie' };
+  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ellie' };
+  if (tab === 'automation' || tab === 'workflows') return { workspace: 'workflows', mode: 'ellie' };
+  if (tab === 'terminal' || tab === 'command' || tab === 'run') return { workspace: 'terminal', mode: 'ellie' };
+  if (tab === 'courses' || tab === 'course') return { workspace: 'studio', mode: 'courses' };
+  if (tab === 'ellie' || tab === 'chat') return { workspace: 'studio', mode: 'ellie' };
+  return { workspace: 'studio', mode: 'ellie' };
+}
+
+export default function DevStudioControlPlaneClient({ isSuperAdmin = false }: { isSuperAdmin?: boolean }) {
+  const searchParams = useSearchParams();
+  const initial = normalizeTab(searchParams.get('tab'));
+  const [workspace, setWorkspace] = useState<Workspace>(
+    initial.workspace === 'secrets' && !isSuperAdmin ? 'studio' : initial.workspace,
+  );
+  const [studioMode, setStudioMode] = useState<StudioMode>(initial.mode);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [livePreviewUrl, setLivePreviewUrl] = useState('');
+  const [programs, setPrograms] = useState<CourseProgram[]>([]);
+  const [aiLabel, setAiLabel] = useState('checking…');
+
+  useEffect(() => {
+    fetch('/api/devstudio/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((d) => {
+        const parts = [
+          d?.hasGroq && 'Groq',
+          d?.hasOpenAI && 'OpenAI',
+          d?.hasAnthropic && 'Claude',
+          d?.hasGemini && 'Gemini',
+        ].filter(Boolean);
+        setAiLabel(parts.join(' / ') || 'no keys');
+      })
+      .catch(() => setAiLabel('offline'));
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/admin/devstudio/config')
+      .then((r) => r.json())
+      .then((data: { defaultPreviewUrl?: string }) => {
+        const url = data.defaultPreviewUrl || window.location.origin;
+        setPreviewUrl((c) => c || url);
+        setLivePreviewUrl((c) => c || url);
+      })
+      .catch(() => {
+        setPreviewUrl((c) => c || window.location.origin);
+        setLivePreviewUrl((c) => c || window.location.origin);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/admin/programs?status=active')
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((payload) => {
+        const rows = Array.isArray(payload?.data) ? payload.data : [];
+        setPrograms(
+          rows.map((p: { id: string; title?: string; name?: string; slug?: string; code?: string }) => ({
+            id: p.id,
+            title: p.title ?? p.name ?? p.code ?? 'Program',
+            slug: p.slug ?? p.code ?? p.id,
+          })),
+        );
+      })
+      .catch(() => setPrograms([]));
+  }, []);
+
+  const nav = useMemo(
+    () => WORKSPACES.filter((w) => w.id !== 'secrets' || isSuperAdmin),
+    [isSuperAdmin],
+  );
+
+  function open(ws: Workspace) {
+    if (ws === 'secrets' && !isSuperAdmin) return;
+    setWorkspace(ws);
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-slate-50 text-slate-900">
+      <DevStudioPwaHint />
+      <header className="flex shrink-0 flex-wrap items-center gap-2 border-b border-slate-200 bg-white px-3 py-2">
+        <Bot className="h-5 w-5 text-brand-blue-600" />
+        <div>
+          <p className="text-sm font-semibold text-slate-900">Dev Studio</p>
+          <p className="text-[10px] text-slate-500">Live ECS · GitHub Actions · Supabase</p>
+        </div>
+        <div className="ml-auto flex items-center gap-2">
+          <span className="rounded-full bg-brand-green-50 px-2 py-0.5 text-[10px] text-brand-green-800">
+            {aiLabel}
+          </span>
+          <button
+            type="button"
+            onClick={() => open('deploy')}
+            className="rounded-lg bg-brand-blue-600 px-3 py-1.5 text-xs font-medium text-white hover:bg-brand-blue-700"
+          >
+            <Rocket className="mr-1 inline h-3.5 w-3.5" />
+            Deploy
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="hidden w-44 shrink-0 flex-col border-r border-slate-200 bg-white p-2 md:flex">
+          {nav.map(({ id, label, Icon }) => (
+            <button
+              key={id}
+              type="button"
+              onClick={() => open(id)}
+              className={`mb-0.5 flex h-9 w-full items-center gap-2 rounded-lg px-2 text-left text-xs ${
+                workspace === id ? 'bg-brand-blue-50 font-medium text-brand-blue-900' : 'text-slate-600 hover:bg-slate-50'
+              }`}
+            >
+              <Icon className="h-4 w-4" />
+              {label}
+            </button>
+          ))}
+        </aside>
+
+        <div className="flex min-h-0 min-w-0 flex-1 flex-col lg:flex-row">
+          <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <div className="flex gap-1 overflow-x-auto border-b border-slate-200 bg-white p-1 md:hidden">
+              {nav.map(({ id, label, Icon }) => (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => open(id)}
+                  className={`flex shrink-0 items-center gap-1 rounded-lg px-2 py-1.5 text-[10px] ${
+                    workspace === id ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
+                  }`}
+                >
+                  <Icon className="h-4 w-4" />
+                  {label}
+                </button>
+              ))}
+            </div>
+
+            {workspace === 'studio' && (
+              <div className="flex h-full flex-col bg-white">
+                <div className="flex gap-1 border-b border-slate-200 px-2 py-1">
+                  <button
+                    type="button"
+                    onClick={() => setStudioMode('ellie')}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
+                      studioMode === 'ellie' ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
+                    }`}
+                  >
+                    <MessageSquare className="mr-1 inline h-3.5 w-3.5" />
+                    Ellie
+                  </button>
+                  <button
+                    type="button"
+                    onClick={() => setStudioMode('courses')}
+                    className={`rounded-lg px-3 py-1.5 text-xs font-medium ${
+                      studioMode === 'courses' ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-600'
+                    }`}
+                  >
+                    <BookOpen className="mr-1 inline h-3.5 w-3.5" />
+                    Course builder
+                  </button>
+                </div>
+                <div className="min-h-0 flex-1">
+                  {studioMode === 'ellie' ? (
+                    <AIChat ellieMode unifiedEllieMode embedded />
+                  ) : programs.length ? (
+                    <AICourseBuilderChat programs={programs} embedded />
+                  ) : (
+                    <div className="flex h-full items-center justify-center text-sm text-slate-500">
+                      <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                      Loading programs…
+                    </div>
+                  )}
+                </div>
+              </div>
+            )}
+            {workspace === 'deploy' && <DeployPanel />}
+            {workspace === 'services' && <ServicesPanel />}
+            {workspace === 'environments' && (
+              <div className="h-full overflow-auto bg-white">
+                <DevContainerPanel />
+              </div>
+            )}
+            {workspace === 'terminal' && (
+              <div className="flex h-full flex-col bg-slate-900">
+                <p className="shrink-0 border-b border-slate-700 px-3 py-2 text-xs text-slate-300">
+                  Studio ECS shell — set STUDIO_SHELL_* in Secrets, deploy studio service.
+                </p>
+                <div className="min-h-0 flex-1">
+                  <XTerminal />
+                </div>
+              </div>
+            )}
+            {workspace === 'git' && (
+              <div className="h-full bg-white">
+                <GitPanel />
+              </div>
+            )}
+            {workspace === 'files' && <FilesWorkspace />}
+            {workspace === 'workflows' && <DevStudioWorkflowsPanel />}
+            {workspace === 'health' && <DevStudioHealthPanel />}
+            {workspace === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <DevStudioHealthPanel />)}
+          </main>
+
+          <aside className="hidden w-[min(38vw,520px)] shrink-0 flex-col border-l border-slate-200 bg-white lg:flex">
+            <div className="flex items-center gap-1 border-b border-slate-200 bg-slate-50 px-2 py-1.5">
+              <button
+                type="button"
+                onClick={() => setLivePreviewUrl(previewUrl)}
+                className="rounded p-1.5 text-slate-500 hover:bg-slate-200"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </button>
+              <form
+                className="flex min-w-0 flex-1 items-center rounded-lg border border-slate-200 bg-white px-2"
+                onSubmit={(e) => {
+                  e.preventDefault();
+                  setLivePreviewUrl(previewUrl);
+                }}
+              >
+                <Globe className="mr-1 h-3.5 w-3.5 text-brand-blue-600" />
+                <input
+                  value={previewUrl}
+                  onChange={(e) => setPreviewUrl(e.target.value)}
+                  className="h-7 min-w-0 flex-1 text-[11px] outline-none"
+                />
+              </form>
+              <a
+                href={livePreviewUrl || previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="rounded p-1.5 text-slate-500 hover:bg-slate-200"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+            <IframePreview url={livePreviewUrl || previewUrl} className="min-h-0 flex-1" />
+          </aside>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioControlPlaneClient.tsx
@@ -72,6 +72,10 @@ const SecretsPanel = dynamic(() => import('@/components/dev-studio/SecretsPanel'
 const GitPanel = dynamic(() => import('@/components/dev-studio/GitPanel'), { ssr: false });
 const XTerminal = dynamic(() => import('@/components/dev-studio/XTerminal'), { ssr: false });
 const EcsStatusPanel = dynamic(() => import('@/components/dev-studio/EcsStatusPanel'), { ssr: false });
+const ColoredLivePreviewFrame = dynamic(
+  () => import('@/components/admin/dashboard/ColoredLivePreviewFrame').then((m) => m.ColoredLivePreviewFrame),
+  { ssr: false },
+);
 const AICourseBuilderChat = dynamic<CourseBuilderProps>(
   () => import('../courses/ai-builder/AICourseBuilderChat'),
   { ssr: false },
@@ -303,70 +307,12 @@ export default function DevStudioControlPlaneClient({ isSuperAdmin = false }: { 
               ))}
           </main>
 
-          <section className="hidden w-[min(42vw,520px)] shrink-0 flex-col border-l border-slate-200 bg-white lg:flex">
-            <div className="flex h-11 shrink-0 items-center gap-1.5 border-b border-slate-200 px-2">
-              <button
-                type="button"
-                onClick={() => setLivePreviewUrl(previewUrl)}
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100"
-                title="Refresh preview"
-              >
-                <RefreshCw className="h-4 w-4" />
-              </button>
-              <form
-                className="flex min-w-0 flex-1 items-center gap-1 rounded-lg border border-slate-200 bg-slate-50 px-2"
-                onSubmit={(event) => {
-                  event.preventDefault();
-                  setLivePreviewUrl(previewUrl);
-                }}
-              >
-                <Globe className="h-3.5 w-3.5 shrink-0 text-brand-blue-600" />
-                <input
-                  value={previewUrl}
-                  onChange={(event) => setPreviewUrl(event.target.value)}
-                  list="devstudio-preview-targets"
-                  className="h-8 min-w-0 flex-1 bg-transparent text-xs text-slate-800 outline-none"
-                  spellCheck={false}
-                />
-                <datalist id="devstudio-preview-targets">
-                  {(config?.previewTargets ?? []).map((target) => (
-                    <option key={target.url} value={target.url}>
-                      {target.label}
-                    </option>
-                  ))}
-                </datalist>
-              </form>
-              <a
-                href={livePreviewUrl || previewUrl}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex h-8 w-8 items-center justify-center rounded-lg text-slate-500 hover:bg-slate-100"
-                title="Open in new tab"
-              >
-                <ExternalLink className="h-4 w-4" />
-              </a>
-            </div>
-            {(config?.previewTargets?.length ?? 0) > 0 && (
-              <div className="flex shrink-0 flex-wrap gap-1 border-b border-slate-100 px-2 py-1.5">
-                {config!.previewTargets!.slice(0, 6).map((target) => (
-                  <button
-                    key={target.url}
-                    type="button"
-                    onClick={() => {
-                      setPreviewUrl(target.url);
-                      setLivePreviewUrl(target.url);
-                    }}
-                    className="rounded-md bg-slate-100 px-2 py-0.5 text-[10px] text-slate-600 hover:bg-slate-200"
-                  >
-                    {target.label}
-                  </button>
-                ))}
-              </div>
-            )}
-            <iframe
-              title="Site preview"
-              src={livePreviewUrl || previewUrl}
-              className="min-h-0 flex-1 border-0 bg-white"
+          <section className="hidden min-h-0 w-[min(42vw,520px)] shrink-0 p-2 lg:flex lg:flex-col">
+            <ColoredLivePreviewFrame
+              className="h-full min-h-0 flex-1"
+              minHeight={400}
+              targets={(config?.previewTargets ?? []).map((t) => ({ label: t.label, url: t.url }))}
+              defaultUrl={previewUrl}
             />
           </section>
         </div>

--- a/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
@@ -82,6 +82,9 @@ const QUICK_ACTIONS = [
 ];
 
 function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
+  if (tab === 'ellie' || tab === 'ask' || tab === 'command' || tab === 'terminal') {
+    return { workspace: 'studio', mode: 'ask' };
+  }
   if (tab === 'deploy') return { workspace: 'deploy', mode: 'ask' };
   if (tab === 'files' || tab === 'git' || tab === 'docs' || tab === 'documents') return { workspace: 'files', mode: 'ask' };
   if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ask' };
@@ -265,9 +268,7 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
                 <ExternalLink className="h-3.5 w-3.5" />
               </a>
             </div>
-            <div className="min-h-0 flex-1 overflow-hidden">
-              <IframePreview url={livePreviewUrl || previewUrl} title="Live Preview" className="h-full" />
-            </div>
+            <iframe title="Live Preview" src={livePreviewUrl || previewUrl} className="min-h-0 flex-1 border-0 bg-white" />
           </section>
         </div>
       </div>

--- a/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
@@ -82,18 +82,18 @@ const QUICK_ACTIONS = [
 ];
 
 function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
-  if (tab === 'ellie' || tab === 'ask' || tab === 'command' || tab === 'terminal') {
-    return { workspace: 'studio', mode: 'ask' };
-  }
-  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ask' };
-  if (tab === 'files' || tab === 'git' || tab === 'docs' || tab === 'documents') return { workspace: 'files', mode: 'ask' };
-  if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ask' };
-  if (tab === 'services') return { workspace: 'services', mode: 'ask' };
-  if (tab === 'health') return { workspace: 'health', mode: 'ask' };
-  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ask' };
-  if (tab === 'command' || tab === 'terminal') return { workspace: 'studio', mode: 'run' };
+  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ellie' };
+  if (tab === 'git') return { workspace: 'git', mode: 'ellie' };
+  if (tab === 'files' || tab === 'docs' || tab === 'documents') return { workspace: 'files', mode: 'ellie' };
+  if (tab === 'container' || tab === 'environments') return { workspace: 'environments', mode: 'ellie' };
+  if (tab === 'services') return { workspace: 'services', mode: 'ellie' };
+  if (tab === 'health') return { workspace: 'health', mode: 'ellie' };
+  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ellie' };
+  if (tab === 'automation' || tab === 'workflows') return { workspace: 'workflows', mode: 'ellie' };
+  if (tab === 'command' || tab === 'terminal' || tab === 'run') return { workspace: 'terminal', mode: 'ellie' };
   if (tab === 'courses' || tab === 'course') return { workspace: 'studio', mode: 'courses' };
-  return { workspace: 'studio', mode: 'ask' };
+  if (tab === 'ellie' || tab === 'chat') return { workspace: 'studio', mode: 'ellie' };
+  return { workspace: 'studio', mode: 'ellie' };
 }
 
 export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSuperAdmin?: boolean }) {

--- a/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
@@ -230,7 +230,7 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
             {workspace === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <HealthPanel health={health} onRefresh={() => window.location.reload()} />)}
           </main>
 
-          <section className="hidden w-[38vw] min-w-[260px] max-w-[600px] shrink-0 flex-col border-l border-[#3c3c3c] bg-[#1e1e1e] md:flex">
+          <section className="hidden w-[38vw] min-w-[340px] max-w-[560px] shrink-0 flex-col border-l border-[#3c3c3c] bg-[#1e1e1e] lg:flex">
             <div className="flex h-10 shrink-0 items-center gap-1.5 border-b border-[#3c3c3c] bg-[#2d2d2d] px-2">
               <button
                 type="button"
@@ -265,7 +265,9 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
                 <ExternalLink className="h-3.5 w-3.5" />
               </a>
             </div>
-            <iframe title="Live Preview" src={livePreviewUrl || previewUrl} className="min-h-0 flex-1 border-0 bg-white" />
+            <div className="min-h-0 flex-1 overflow-hidden">
+              <IframePreview url={livePreviewUrl || previewUrl} title="Live Preview" className="h-full" />
+            </div>
           </section>
         </div>
       </div>

--- a/apps/admin/app/admin/dev-studio/layout.tsx
+++ b/apps/admin/app/admin/dev-studio/layout.tsx
@@ -1,63 +1,40 @@
-'use client';
-
-import { useEffect } from 'react';
-
 // Full-bleed layout for Dev Studio.
 //
-// The admin layout wraps children in a max-w-screen-2xl padded container.
-// Dev Studio needs the full viewport. We use position:fixed to escape the
-// container, and add a data attribute to <html> so global CSS can suppress
-// the RealtimeSystemStatus bar and main padding while the studio is open.
+// The admin layout wraps all pages in <main className="pt-16"> which is an
+// unconstrained block. Using position: fixed lets the studio own the viewport
+// from the nav baseline down without overlapping the admin nav.
 export default function DevStudioLayout({ children }: { children: React.ReactNode }) {
-  useEffect(() => {
-    document.documentElement.setAttribute('data-dev-studio', 'open');
-    return () => {
-      document.documentElement.removeAttribute('data-dev-studio');
-    };
-  }, []);
-
   return (
-    <>
+    <div
+      className="dev-studio-shell-route"
+      style={{
+        position: 'fixed',
+        inset: 0,
+        top: 64,
+        height: 'calc(100dvh - 64px)',
+        overflow: 'hidden',
+        zIndex: 10,
+      }}
+    >
       <style>{`
-        /* Suppress admin layout chrome while Dev Studio is open */
-        html[data-dev-studio='open'] #main-content {
-          padding: 0 !important;
-          max-width: 100% !important;
-        }
-        html[data-dev-studio='open'] #main-content > div {
-          max-width: 100% !important;
-          padding: 0 !important;
-          margin: 0 !important;
+        .dev-studio-shell-route,
+        .dev-studio-shell-route * {
+          box-sizing: border-box;
         }
 
-        .dev-studio-shell {
-          position: fixed;
-          inset: 0;
-          top: 64px;
-          z-index: 20;
-          overflow: hidden;
-          width: 100vw;
+        .dev-studio-shell-route {
           max-width: 100vw;
-          box-sizing: border-box;
           overscroll-behavior: contain;
         }
 
-        .dev-studio-shell *,
-        .dev-studio-shell *::before,
-        .dev-studio-shell *::after {
-          box-sizing: border-box;
-        }
-
-        .dev-studio-shell iframe {
+        .dev-studio-shell-route iframe[title='Live Preview'],
+        .dev-studio-shell-route iframe[title='Preview'] {
           display: block;
           max-width: 100%;
           min-width: 0;
-          border: none;
         }
       `}</style>
-      <div className="dev-studio-shell">
-        {children}
-      </div>
-    </>
+      {children}
+    </div>
   );
 }

--- a/apps/admin/app/admin/dev-studio/page.tsx
+++ b/apps/admin/app/admin/dev-studio/page.tsx
@@ -2,7 +2,7 @@ import { requireRole } from '@/lib/auth/require-role';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { Metadata } from 'next';
 import { Suspense } from 'react';
-import DevStudioUnifiedClient from './DevStudioUnifiedClient';
+import DevStudioControlPlaneClient from './DevStudioControlPlaneClient';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;

--- a/apps/admin/app/admin/dev-studio/page.tsx
+++ b/apps/admin/app/admin/dev-studio/page.tsx
@@ -2,7 +2,7 @@ import { requireRole } from '@/lib/auth/require-role';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { Metadata } from 'next';
 import { Suspense } from 'react';
-import DevStudioControlPlaneClient from './DevStudioControlPlaneClient';
+import DevStudioUnifiedClient from './DevStudioUnifiedClient';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
@@ -16,7 +16,7 @@ export default async function DevStudioPage() {
   const isSuperAdmin = auth.effectiveRoles.includes('super_admin');
   return (
     <Suspense fallback={null}>
-      <DevStudioUnifiedClient isSuperAdmin={isSuperAdmin} />
+      <DevStudioControlPlaneClient isSuperAdmin={isSuperAdmin} />
     </Suspense>
   );
 }

--- a/apps/admin/app/admin/integrations/env-manager/page.tsx
+++ b/apps/admin/app/admin/integrations/env-manager/page.tsx
@@ -1,15 +1,47 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { requireAdmin } from '@/lib/auth';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import EnvManagerClient from './EnvManagerClient';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
 
 export const metadata: Metadata = {
-  title: 'Integration Settings | Admin | Elevate LMS',
+  title: 'Environment Manager | Admin | Elevate LMS',
+  description: 'Manage API keys and integration settings stored in platform_settings.',
 };
 
 export default async function EnvManagerPage() {
   await requireAdmin();
-  return <EnvManagerClient />;
+  return (
+    <div className="w-full">
+      <div className="px-6 pt-6 max-w-5xl mx-auto">
+        <Breadcrumbs
+          items={[
+            { label: 'Integrations', href: '/admin/integrations' },
+            { label: 'Environment Manager' },
+          ]}
+        />
+        <p className="mt-2 text-xs text-slate-500">
+          Use{' '}
+          <code className="rounded bg-slate-100 px-1">admin.elevateforhumanity.org</code> for this page.
+          If you opened a <code className="rounded bg-slate-100 px-1">www.</code> link, you will be sent here
+          automatically — that one-time redirect is normal.
+        </p>
+        <p className="mt-1 text-xs text-slate-500">
+          Encrypted runtime secrets:{' '}
+          <Link href="/admin/dev-studio?tab=secrets" className="text-brand-blue-600 underline">
+            Dev Studio → Secrets
+          </Link>
+          . ECS task env:{' '}
+          <Link href="/admin/dev-studio?tab=environments" className="text-brand-blue-600 underline">
+            Dev Studio → Environments
+          </Link>
+          .
+        </p>
+      </div>
+      <EnvManagerClient />
+    </div>
+  );
 }

--- a/apps/admin/app/admin/integrations/page.tsx
+++ b/apps/admin/app/admin/integrations/page.tsx
@@ -244,6 +244,24 @@ export default async function AdminIntegrationsPage() {
       </div>
 
       <div className="max-w-7xl mx-auto px-4 py-8">
+        <Link
+          href="/admin/integrations/env-manager"
+          className="mb-8 flex flex-col gap-1 rounded-xl border-2 border-brand-blue-200 bg-brand-blue-50 p-5 transition-colors hover:border-brand-blue-400 sm:flex-row sm:items-center sm:justify-between"
+        >
+          <div>
+            <p className="text-sm font-semibold text-slate-900">Environment Manager</p>
+            <p className="mt-0.5 text-xs text-slate-600">
+              API keys (Groq, OpenAI, Stripe, Supabase, email) stored in{' '}
+              <code className="rounded bg-white px-1">platform_settings</code> — powers Ellie, course
+              builder, and integrations below.
+            </p>
+          </div>
+          <span className="inline-flex items-center gap-1 text-sm font-medium text-brand-blue-700">
+            Open Env Manager
+            <ExternalLink className="h-4 w-4" />
+          </span>
+        </Link>
+
         {/* Stats */}
         <div className="grid grid-cols-1 md:grid-cols-3 gap-6 mb-10">
           <div className="bg-white rounded-lg shadow-sm border p-6">

--- a/apps/admin/app/admin/mission-control/MissionControlClient.tsx
+++ b/apps/admin/app/admin/mission-control/MissionControlClient.tsx
@@ -598,7 +598,7 @@ export default function MissionControlClient({ snapshot }: { snapshot: Snapshot 
 
             {/* Automation summary */}
             <div className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <SectionHeader title="Automation" href="/admin/dev-studio?tab=automation" icon={Zap} />
+              <SectionHeader title="Automation" href="/admin/dev-studio?tab=workflows" icon={Zap} />
               <div className="space-y-2">
                 {[
                   { label: 'Nudge Emails', schedule: 'Daily 9:00 AM', active: true },

--- a/apps/admin/app/admin/settings/integrations/page.tsx
+++ b/apps/admin/app/admin/settings/integrations/page.tsx
@@ -24,7 +24,7 @@ export default async function IntegrationSettingsPage() {
     {
       title: 'AWS / ECS Container',
       description: 'Push environment variables to ECS task definitions and SSM Parameter Store',
-      href: '/admin/dev-studio?tab=container',
+      href: '/admin/dev-studio?tab=environments',
     },
     {
       title: 'Social Media Accounts',

--- a/apps/admin/app/api/admin/devstudio/config/route.ts
+++ b/apps/admin/app/api/admin/devstudio/config/route.ts
@@ -110,7 +110,7 @@ export async function GET(req: NextRequest) {
       { key: 'deploy-lms', label: 'Deploy Website', description: 'Build and push the public website service to ECS' },
       { key: 'deploy-admin', label: 'Deploy Admin', description: 'Build and push the admin service to ECS' },
       { key: 'deploy-studio', label: 'Deploy Studio', description: 'Build and push the Dev Studio shell service to ECS' },
-      { key: 'ci', label: 'Run CI', description: 'Run the full validation pipeline' },
+      { key: 'ci-cd', label: 'Run CI', description: 'Run the full validation pipeline (ci-cd.yml)' },
       { key: 'lint', label: 'Lint', description: 'Run the lint check' },
     ],
     defaultPreviewUrl: configuredPreviewUrl || publicSiteUrl,

--- a/apps/admin/app/api/devstudio/execute/route.ts
+++ b/apps/admin/app/api/devstudio/execute/route.ts
@@ -2102,7 +2102,7 @@ async function executeAction(
         const res = await fetch(`${getAdminUrl()}/api/devstudio/shell`, {
           method: 'POST',
           headers: { 'Content-Type': 'application/json', cookie: authHeader },
-          body: JSON.stringify({ workflow: 'ci' }),
+          body: JSON.stringify({ workflow: 'ci-cd' }),
         });
         const data = await res.json().catch(() => ({}));
         logger.info('[devstudio/execute] run_tests dispatch response', { status: res.status });

--- a/apps/admin/app/api/devstudio/shell/route.ts
+++ b/apps/admin/app/api/devstudio/shell/route.ts
@@ -217,6 +217,51 @@ export async function GET(request: NextRequest) {
   const action = searchParams.get('action');
   const runId  = searchParams.get('run_id');
 
+  // ── Recent deploy workflow runs (for re-run from Dev Studio) ─────────────
+  if (action === 'recent_deploys') {
+    const deployFiles = ['deploy-lms.yml', 'deploy-admin.yml', 'deploy-studio.yml'];
+    try {
+      const runs: Array<{
+        workflow: string;
+        id: number;
+        status: string;
+        conclusion: string | null;
+        url: string;
+        createdAt: string;
+      }> = [];
+      for (const workflowFile of deployFiles) {
+        const res = await fetch(
+          `${GH_API}/repos/${repo()}/actions/workflows/${workflowFile}/runs?per_page=3&branch=${branch()}`,
+          { headers: ghHeaders() },
+        );
+        if (!res.ok) continue;
+        const data = (await res.json()) as {
+          workflow_runs?: Array<{
+            id: number;
+            status: string;
+            conclusion: string | null;
+            html_url: string;
+            created_at: string;
+          }>;
+        };
+        for (const run of data.workflow_runs ?? []) {
+          runs.push({
+            workflow: workflowFile.replace('.yml', ''),
+            id: run.id,
+            status: run.status,
+            conclusion: run.conclusion,
+            url: run.html_url,
+            createdAt: run.created_at,
+          });
+        }
+      }
+      runs.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
+      return NextResponse.json({ runs: runs.slice(0, 12) });
+    } catch (err) {
+      return safeInternalError(err, 'Failed to list recent deploy runs');
+    }
+  }
+
   // ── List all dispatchable workflows ──────────────────────────────────────
   if (action === 'list') {
     try {

--- a/apps/admin/app/api/devstudio/shell/route.ts
+++ b/apps/admin/app/api/devstudio/shell/route.ts
@@ -217,48 +217,39 @@ export async function GET(request: NextRequest) {
   const action = searchParams.get('action');
   const runId  = searchParams.get('run_id');
 
-  // ── Recent deploy workflow runs (for re-run from Dev Studio) ─────────────
-  if (action === 'recent_deploys') {
-    const deployFiles = ['deploy-lms.yml', 'deploy-admin.yml', 'deploy-studio.yml'];
+  // ── Recent workflow runs (deploy + CI) ───────────────────────────────────
+  if (action === 'recent_runs') {
+    const perPage = Math.min(20, Math.max(1, Number(searchParams.get('per_page') ?? '10')));
     try {
-      const runs: Array<{
-        workflow: string;
-        id: number;
-        status: string;
-        conclusion: string | null;
-        url: string;
-        createdAt: string;
-      }> = [];
-      for (const workflowFile of deployFiles) {
-        const res = await fetch(
-          `${GH_API}/repos/${repo()}/actions/workflows/${workflowFile}/runs?per_page=3&branch=${branch()}`,
-          { headers: ghHeaders() },
-        );
-        if (!res.ok) continue;
-        const data = (await res.json()) as {
-          workflow_runs?: Array<{
-            id: number;
-            status: string;
-            conclusion: string | null;
-            html_url: string;
-            created_at: string;
-          }>;
-        };
-        for (const run of data.workflow_runs ?? []) {
-          runs.push({
-            workflow: workflowFile.replace('.yml', ''),
-            id: run.id,
-            status: run.status,
-            conclusion: run.conclusion,
-            url: run.html_url,
-            createdAt: run.created_at,
-          });
-        }
-      }
-      runs.sort((a, b) => (a.createdAt < b.createdAt ? 1 : -1));
-      return NextResponse.json({ runs: runs.slice(0, 12) });
+      const res = await fetch(
+        `${GH_API}/repos/${repo()}/actions/runs?per_page=${perPage}&branch=${branch()}`,
+        { headers: ghHeaders() },
+      );
+      if (!res.ok) return safeError('GitHub API error', res.status);
+      const data = await res.json() as {
+        workflow_runs: Array<{
+          id: number;
+          name: string;
+          status: string;
+          conclusion: string | null;
+          html_url: string;
+          created_at: string;
+          path?: string;
+        }>;
+      };
+      return NextResponse.json({
+        runs: (data.workflow_runs ?? []).map((r) => ({
+          id: r.id,
+          name: r.name,
+          status: r.status,
+          conclusion: r.conclusion,
+          url: r.html_url,
+          createdAt: r.created_at,
+          workflow: r.path?.replace('.github/workflows/', '') ?? r.name,
+        })),
+      });
     } catch (err) {
-      return safeInternalError(err, 'Failed to list recent deploy runs');
+      return safeInternalError(err, 'Failed to list recent runs');
     }
   }
 

--- a/apps/admin/public/manifest.webmanifest
+++ b/apps/admin/public/manifest.webmanifest
@@ -54,6 +54,19 @@
   ],
   "shortcuts": [
     {
+      "name": "Ellie (Dev Studio)",
+      "short_name": "Ellie",
+      "description": "AI assistant for deploys, ops, and platform fixes",
+      "url": "/admin/dev-studio?tab=ellie",
+      "icons": [
+        {
+          "src": "/favicon.ico",
+          "sizes": "32x32",
+          "type": "image/x-icon"
+        }
+      ]
+    },
+    {
       "name": "Applications",
       "short_name": "Applications",
       "description": "Review pending applications",

--- a/components/admin/dashboard/ColoredLivePreviewFrame.tsx
+++ b/components/admin/dashboard/ColoredLivePreviewFrame.tsx
@@ -1,0 +1,153 @@
+'use client';
+
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { ExternalLink, Globe, RefreshCw } from 'lucide-react';
+
+export interface PreviewTarget {
+  label: string;
+  url: string;
+}
+
+const CHIP_THEMES = [
+  'bg-brand-blue-100 text-brand-blue-800 ring-brand-blue-200 hover:bg-brand-blue-200',
+  'bg-brand-red-100 text-brand-red-800 ring-brand-red-200 hover:bg-brand-red-200',
+  'bg-brand-orange-100 text-brand-orange-900 ring-brand-orange-200 hover:bg-brand-orange-200',
+  'bg-brand-green-100 text-brand-green-800 ring-brand-green-200 hover:bg-brand-green-200',
+  'bg-violet-100 text-violet-800 ring-violet-200 hover:bg-violet-200',
+  'bg-cyan-100 text-cyan-900 ring-cyan-200 hover:bg-cyan-200',
+] as const;
+
+function themeForIndex(i: number) {
+  return CHIP_THEMES[i % CHIP_THEMES.length];
+}
+
+interface Props {
+  targets: PreviewTarget[];
+  defaultUrl?: string;
+  className?: string;
+  minHeight?: number;
+  showChips?: boolean;
+}
+
+export function ColoredLivePreviewFrame({
+  targets,
+  defaultUrl,
+  className = '',
+  minHeight = 320,
+  showChips = true,
+}: Props) {
+  const list = useMemo(() => (targets.length > 0 ? targets : []), [targets]);
+  const initial = defaultUrl ?? list[0]?.url ?? '';
+  const [url, setUrl] = useState(initial);
+  const [liveUrl, setLiveUrl] = useState(initial);
+  const [activeChip, setActiveChip] = useState(0);
+
+  useEffect(() => {
+    const next = defaultUrl ?? list[0]?.url ?? '';
+    if (next) {
+      setUrl(next);
+      setLiveUrl(next);
+      const idx = list.findIndex((t) => t.url === next);
+      if (idx >= 0) setActiveChip(idx);
+    }
+  }, [defaultUrl, list]);
+
+  const refresh = useCallback(() => {
+    setLiveUrl(url);
+  }, [url]);
+
+  const selectTarget = (target: PreviewTarget, index: number) => {
+    setActiveChip(index);
+    setUrl(target.url);
+    setLiveUrl(target.url);
+  };
+
+  if (!list.length && !url) {
+    return (
+      <div
+        className={`flex items-center justify-center rounded-2xl border border-dashed border-slate-300 bg-gradient-to-br from-slate-50 to-brand-blue-50/40 text-sm text-slate-500 ${className}`}
+        style={{ minHeight }}
+      >
+        No preview URL configured
+      </div>
+    );
+  }
+
+  return (
+    <div className={`flex flex-col overflow-hidden rounded-2xl border border-slate-200 shadow-md ${className}`}>
+      {/* Browser chrome — brand gradient */}
+      <div className="shrink-0 bg-gradient-to-r from-brand-blue-700 via-brand-blue-600 to-brand-red-600 px-3 py-2.5">
+        <div className="mb-2 flex items-center gap-1.5">
+          <span className="h-2.5 w-2.5 rounded-full bg-red-400 shadow-sm" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-amber-300 shadow-sm" aria-hidden />
+          <span className="h-2.5 w-2.5 rounded-full bg-emerald-400 shadow-sm" aria-hidden />
+          <span className="ml-2 text-[10px] font-semibold uppercase tracking-wider text-white/80">Live preview</span>
+        </div>
+        <div className="flex items-center gap-1.5">
+          <button
+            type="button"
+            onClick={refresh}
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/15 text-white hover:bg-white/25"
+            title="Refresh preview"
+          >
+            <RefreshCw className="h-4 w-4" />
+          </button>
+          <form
+            className="flex min-w-0 flex-1 items-center gap-1.5 rounded-lg bg-white/95 px-2 shadow-sm"
+            onSubmit={(e) => {
+              e.preventDefault();
+              refresh();
+            }}
+          >
+            <Globe className="h-3.5 w-3.5 shrink-0 text-brand-blue-600" />
+            <input
+              value={url}
+              onChange={(e) => setUrl(e.target.value)}
+              className="h-8 min-w-0 flex-1 bg-transparent text-xs text-slate-800 outline-none"
+              spellCheck={false}
+            />
+          </form>
+          <a
+            href={liveUrl || url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-white/15 text-white hover:bg-white/25"
+            title="Open in new tab"
+          >
+            <ExternalLink className="h-4 w-4" />
+          </a>
+        </div>
+      </div>
+
+      {showChips && list.length > 0 && (
+        <div className="flex shrink-0 flex-wrap gap-1.5 border-b border-slate-100 bg-gradient-to-r from-slate-50 to-white px-2 py-2">
+          {list.map((target, i) => (
+            <button
+              key={target.url}
+              type="button"
+              onClick={() => selectTarget(target, i)}
+              className={`rounded-full px-2.5 py-0.5 text-[10px] font-semibold ring-1 transition ${
+                activeChip === i ? themeForIndex(i) : 'bg-white text-slate-600 ring-slate-200 hover:bg-slate-50'
+              }`}
+            >
+              {target.label}
+            </button>
+          ))}
+        </div>
+      )}
+
+      <div
+        className="relative min-h-0 flex-1 bg-gradient-to-b from-brand-blue-50/30 via-white to-brand-orange-50/20 p-2"
+        style={{ minHeight }}
+      >
+        <div className="h-full overflow-hidden rounded-lg border border-slate-200/80 bg-white shadow-inner ring-1 ring-slate-100">
+          {liveUrl || url ? (
+            <iframe title="Live site preview" src={liveUrl || url} className="h-full w-full border-0" style={{ minHeight: minHeight - 16 }} />
+          ) : (
+            <div className="flex h-full items-center justify-center text-xs text-slate-400">Enter a URL above</div>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -324,7 +324,7 @@ function ReviewQueues({ data }: { data: AdminDashboardData }) {
     { label: "Lab submissions awaiting sign-off", count: data.pendingSubmissions.length, context: data.pendingSubmissions.length > 0 ? "Instructor action required" : "Queue is clear", href: "/admin/submissions", urgent: data.pendingSubmissions.length > 0 },
     { label: "Program holders awaiting approval", count: data.counts.pendingProgramHolders, context: data.counts.pendingProgramHolders > 0 ? "Partner applications need review" : "Queue is clear", href: "/admin/program-holders", urgent: data.counts.pendingProgramHolders > 0 },
     { label: "Program holder documents pending", count: data.counts.pendingDocuments, context: data.counts.pendingDocuments > 0 ? "Documents submitted, awaiting review" : "Queue is clear", href: "/admin/program-holder-documents", urgent: data.counts.pendingDocuments > 0 },
-    { label: "Certificates issued", count: data.counts.certificatesIssued, context: "Total credentials issued on platform", href: "/admin/certificates", urgent: false },
+    { label: "Certificates to issue", count: data.counts.certificatesIssued, context: "Completed learners awaiting credential", href: "/admin/certificates", urgent: false },
   ];
   return (
     <div className="rounded-xl border border-slate-200 bg-white mb-6">
@@ -452,7 +452,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
 
   return (
     <div className="pb-16">
-      <div className="relative w-full h-40 sm:h-56 overflow-hidden rounded-2xl mb-6">
+      <div className="relative mb-6 h-40 w-full overflow-hidden rounded-2xl sm:h-56">
         <Image
           src="/images/pages/admin-dashboard-hero.webp"
           alt=""
@@ -461,7 +461,8 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           priority
           sizes="100vw"
         />
-        <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-r from-brand-blue-900/40 via-transparent to-brand-red-900/30" />
+        <div className="absolute inset-x-0 bottom-0 h-24 bg-gradient-to-t from-white via-white/80 to-transparent" />
       </div>
 
       <div className="pt-2">

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -324,7 +324,7 @@ function ReviewQueues({ data }: { data: AdminDashboardData }) {
     { label: "Lab submissions awaiting sign-off", count: data.pendingSubmissions.length, context: data.pendingSubmissions.length > 0 ? "Instructor action required" : "Queue is clear", href: "/admin/submissions", urgent: data.pendingSubmissions.length > 0 },
     { label: "Program holders awaiting approval", count: data.counts.pendingProgramHolders, context: data.counts.pendingProgramHolders > 0 ? "Partner applications need review" : "Queue is clear", href: "/admin/program-holders", urgent: data.counts.pendingProgramHolders > 0 },
     { label: "Program holder documents pending", count: data.counts.pendingDocuments, context: data.counts.pendingDocuments > 0 ? "Documents submitted, awaiting review" : "Queue is clear", href: "/admin/program-holder-documents", urgent: data.counts.pendingDocuments > 0 },
-    { label: "Certificates to issue", count: data.counts.certificatesIssued, context: "Completed learners awaiting credential", href: "/admin/certificates", urgent: false },
+    { label: "Certificates issued", count: data.counts.certificatesIssued, context: "Total credentials issued on platform", href: "/admin/certificates", urgent: false },
   ];
   return (
     <div className="rounded-xl border border-slate-200 bg-white mb-6">

--- a/components/admin/dashboard/KpiGrid.tsx
+++ b/components/admin/dashboard/KpiGrid.tsx
@@ -52,7 +52,9 @@ function useCountUp(target: number) {
 
 function KpiCard({ card }: { card: KPICard }) {
   const pos = card.delta >= 0;
-  const IconComponent = ICON_MAP[iconKeyFor(card.label)];
+  const key = iconKeyFor(card.label);
+  const IconComponent = ICON_MAP[key];
+  const visual = KPI_VISUAL[key] ?? KPI_VISUAL.activity;
   const isRevenue = card.label.toLowerCase().includes('revenue');
   const animated = useCountUp(card.value);
 
@@ -64,15 +66,14 @@ function KpiCard({ card }: { card: KPICard }) {
         'shadow-sm hover:shadow-lg hover:-translate-y-0.5',
         'transition-all duration-200 ease-out',
         card.urgent
-          ? 'border-rose-300'
+          ? 'border-rose-300 ring-1 ring-rose-100'
           : 'border-slate-200',
       ].join(' ')}
     >
-      {/* Top accent bar */}
       <div
         className={[
-          'h-1 transition-all duration-300 group-hover:h-1.5',
-          card.urgent ? 'bg-rose-500' : 'bg-gradient-to-r from-brand-blue-500 to-cyan-400',
+          'h-1.5 transition-all duration-300 group-hover:h-2',
+          card.urgent ? 'bg-gradient-to-r from-rose-600 to-amber-500' : visual.bar,
         ].join(' ')}
       />
 
@@ -82,16 +83,14 @@ function KpiCard({ card }: { card: KPICard }) {
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 truncate mb-1">
               {card.label}
             </p>
-            <p className="text-3xl font-bold tracking-tight text-slate-900 tabular-nums">
+            <p className={`text-3xl font-bold tracking-tight tabular-nums ${card.urgent ? 'text-rose-700' : 'text-slate-900'}`}>
               {isRevenue ? fmtCents(animated) : fmt(animated)}
             </p>
           </div>
           <div
             className={[
               'rounded-xl p-2.5 flex-shrink-0 transition-transform duration-200 group-hover:scale-110',
-              card.urgent
-                ? 'bg-rose-50 text-rose-600'
-                : 'bg-slate-100 text-slate-600',
+              card.urgent ? 'bg-rose-100 text-rose-600' : visual.iconBg,
             ].join(' ')}
           >
             <IconComponent className="h-5 w-5" />

--- a/components/admin/dashboard/SitePreviewPanel.tsx
+++ b/components/admin/dashboard/SitePreviewPanel.tsx
@@ -1,10 +1,11 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
-import { Globe, ExternalLink, RefreshCw, CheckCircle, AlertCircle, Clock } from 'lucide-react';
+import React, { useState } from 'react';
+import { Globe, ExternalLink, RefreshCw, CheckCircle, AlertCircle, Clock, Monitor } from 'lucide-react';
 import Link from 'next/link';
 import type { SitePreviewTarget } from './types';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { ColoredLivePreviewFrame } from './ColoredLivePreviewFrame';
 
 interface Props {
   sites: SitePreviewTarget[];
@@ -35,27 +36,33 @@ async function checkSite(url: string): Promise<{ state: SiteStatusState; latency
   }
 }
 
-// Env-aware URLs — never hardcoded
-const DEFAULT_SITES = [
+const DEFAULT_SITES: SitePreviewTarget[] = [
   {
     url: process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl,
     label: 'Public Site',
   },
   {
-    url: process.env.NEXT_PUBLIC_ADMIN_URL ?? 'https://admin.${PLATFORM_DEFAULTS.canonicalDomain}',
+    url: process.env.NEXT_PUBLIC_ADMIN_URL ?? `https://admin.${PLATFORM_DEFAULTS.canonicalDomain}`,
     label: 'Admin',
   },
   {
-    url: process.env.NEXT_PUBLIC_LMS_URL ?? 'https://lms.${PLATFORM_DEFAULTS.canonicalDomain}',
+    url: process.env.NEXT_PUBLIC_LMS_URL ?? `https://lms.${PLATFORM_DEFAULTS.canonicalDomain}`,
     label: 'LMS',
   },
 ];
 
 export function SitePreviewPanel({ sites }: Props) {
   const targets = sites.length > 0 ? sites : DEFAULT_SITES;
+  const previewTargets = targets.map((t) => ({
+    label: (t as { label?: string }).label ?? t.url,
+    url: t.url,
+  }));
 
+  const [tab, setTab] = useState<'preview' | 'status'>('preview');
   const [statuses, setStatuses] = useState<Record<string, SiteStatus>>(
-    Object.fromEntries(targets.map((t) => [t.url, { url: t.url, state: null, latencyMs: null, httpStatus: null, checkedAt: null }])),
+    Object.fromEntries(
+      targets.map((t) => [t.url, { url: t.url, state: null, latencyMs: null, httpStatus: null, checkedAt: null }]),
+    ),
   );
   const [checking, setChecking] = useState(false);
 
@@ -66,94 +73,134 @@ export function SitePreviewPanel({ sites }: Props) {
     );
     setStatuses(
       Object.fromEntries(
-        results.map((r) => [r.url, { url: r.url, state: r.state, latencyMs: r.latencyMs, httpStatus: r.httpStatus, checkedAt: new Date() }]),
+        results.map((r) => [
+          r.url,
+          { url: r.url, state: r.state, latencyMs: r.latencyMs, httpStatus: r.httpStatus, checkedAt: new Date() },
+        ]),
       ),
     );
     setChecking(false);
   };
 
-  // Checks are lazy — only run when the admin clicks "Check status".
-  // Auto-running on mount fired 3 outbound HEAD requests (6s timeout each)
-  // on every dashboard load, making the panel feel slow even though it's
-  // client-side. The panel renders immediately with "—" status indicators.
-
   const checkedAt = Object.values(statuses).find((s) => s.checkedAt)?.checkedAt;
 
   return (
-    <div className="bg-white rounded-2xl border border-slate-200 shadow-sm overflow-hidden">
-      <div className="flex items-center justify-between px-5 py-4 border-b border-slate-100">
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="flex items-center justify-between border-b border-slate-100 bg-gradient-to-r from-white to-brand-blue-50/50 px-5 py-4">
         <div className="flex items-center gap-2">
-          <Globe className="w-4 h-4 text-slate-500" />
-          <span className="text-sm font-semibold text-slate-800">Site Status</span>
+          <span className="flex h-9 w-9 items-center justify-center rounded-xl bg-gradient-to-br from-brand-blue-600 to-brand-red-500 text-white shadow-sm">
+            <Monitor className="h-4 w-4" />
+          </span>
+          <div>
+            <span className="text-sm font-semibold text-slate-900">Site preview</span>
+            <p className="text-[11px] text-slate-500">Live pages + uptime checks</p>
+          </div>
         </div>
-        <button
-          onClick={runChecks}
-          disabled={checking}
-          className="flex items-center gap-1.5 text-xs text-slate-500 hover:text-slate-800 transition-colors disabled:opacity-50"
-        >
-          <RefreshCw className={`w-3.5 h-3.5 ${checking ? 'animate-spin' : ''}`} />
-          {checking ? 'Checking…' : 'Refresh'}
-        </button>
+        <div className="flex rounded-lg bg-slate-100 p-0.5 text-xs font-semibold">
+          <button
+            type="button"
+            onClick={() => setTab('preview')}
+            className={`rounded-md px-3 py-1.5 transition ${tab === 'preview' ? 'bg-white text-brand-blue-700 shadow-sm' : 'text-slate-600'}`}
+          >
+            Preview
+          </button>
+          <button
+            type="button"
+            onClick={() => setTab('status')}
+            className={`rounded-md px-3 py-1.5 transition ${tab === 'status' ? 'bg-white text-brand-blue-700 shadow-sm' : 'text-slate-600'}`}
+          >
+            Status
+          </button>
+        </div>
       </div>
 
-      <div className="divide-y divide-slate-100">
-        {targets.map((target) => {
-          const s = statuses[target.url];
-          const state = s?.state ?? null;
-          return (
-            <div key={target.url} className="flex items-center justify-between px-5 py-3.5">
-              <div className="flex items-center gap-3 min-w-0">
-                {state === null ? (
-                  <Clock className="w-4 h-4 text-slate-300 flex-shrink-0 animate-pulse" />
-                ) : state === 'healthy' ? (
-                  <CheckCircle className="w-4 h-4 text-brand-green-500 flex-shrink-0" />
-                ) : state === 'degraded' ? (
-                  <AlertCircle className="w-4 h-4 text-amber-500 flex-shrink-0" />
-                ) : (
-                  <AlertCircle className="w-4 h-4 text-red-500 flex-shrink-0" />
-                )}
-                <div className="min-w-0">
-                  <p className="text-sm font-medium text-slate-800 truncate">
-                    {(target as { label?: string }).label ?? target.url}
-                  </p>
-                  <p className="text-xs text-slate-400 truncate">{target.url}</p>
-                </div>
-              </div>
-              <div className="flex items-center gap-3 flex-shrink-0 ml-4">
-                {state !== null && (
-                  <span className={`text-xs font-medium px-2 py-0.5 rounded-full ${
-                    state === 'healthy' ? 'bg-brand-green-50 text-brand-green-700' :
-                    state === 'degraded' ? 'bg-amber-50 text-amber-700' :
-                    'bg-red-50 text-red-700'
-                  }`}>
-                    {state === 'healthy' ? `${s.latencyMs}ms` :
-                     state === 'degraded' ? `Degraded${s.httpStatus ? ` (${s.httpStatus})` : ''}` :
-                     'Down'}
-                  </span>
-                )}
-                <a
-                  href={target.url}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="text-slate-400 hover:text-slate-700 transition-colors"
-                  title="Open in new tab"
-                >
-                  <ExternalLink className="w-4 h-4" />
-                </a>
-              </div>
+      {tab === 'preview' ? (
+        <div className="p-4">
+          <ColoredLivePreviewFrame targets={previewTargets} minHeight={340} className="border-0 shadow-none" />
+        </div>
+      ) : (
+        <>
+          <div className="flex items-center justify-between border-b border-slate-100 px-5 py-2">
+            <div className="flex items-center gap-2">
+              <Globe className="h-4 w-4 text-brand-blue-600" />
+              <span className="text-xs font-medium text-slate-600">Endpoint health</span>
             </div>
-          );
-        })}
-      </div>
+            <button
+              type="button"
+              onClick={runChecks}
+              disabled={checking}
+              className="flex items-center gap-1.5 text-xs font-semibold text-brand-blue-600 hover:text-brand-blue-800 disabled:opacity-50"
+            >
+              <RefreshCw className={`h-3.5 w-3.5 ${checking ? 'animate-spin' : ''}`} />
+              {checking ? 'Checking…' : 'Check status'}
+            </button>
+          </div>
 
-      <div className="px-5 py-3 bg-slate-50 border-t border-slate-100 flex items-center justify-between">
-        <p className="text-xs text-slate-400">
-          {checkedAt ? `Last checked ${checkedAt.toLocaleTimeString()}` : 'Checking…'}
-        </p>
-        <Link href="/admin/monitoring" className="text-xs text-brand-blue-600 hover:text-brand-blue-800 font-medium">
-          Full monitoring →
-        </Link>
-      </div>
+          <div className="divide-y divide-slate-100">
+            {targets.map((target) => {
+              const s = statuses[target.url];
+              const state = s?.state ?? null;
+              const label = (target as { label?: string }).label ?? target.url;
+              return (
+                <div key={target.url} className="flex items-center justify-between px-5 py-3.5">
+                  <div className="flex min-w-0 items-center gap-3">
+                    {state === null ? (
+                      <Clock className="h-4 w-4 flex-shrink-0 animate-pulse text-slate-300" />
+                    ) : state === 'healthy' ? (
+                      <CheckCircle className="h-4 w-4 flex-shrink-0 text-brand-green-500" />
+                    ) : state === 'degraded' ? (
+                      <AlertCircle className="h-4 w-4 flex-shrink-0 text-amber-500" />
+                    ) : (
+                      <AlertCircle className="h-4 w-4 flex-shrink-0 text-red-500" />
+                    )}
+                    <div className="min-w-0">
+                      <p className="truncate text-sm font-medium text-slate-800">{label}</p>
+                      <p className="truncate text-xs text-slate-400">{target.url}</p>
+                    </div>
+                  </div>
+                  <div className="ml-4 flex flex-shrink-0 items-center gap-3">
+                    {state !== null && (
+                      <span
+                        className={`rounded-full px-2 py-0.5 text-xs font-medium ${
+                          state === 'healthy'
+                            ? 'bg-brand-green-50 text-brand-green-700'
+                            : state === 'degraded'
+                              ? 'bg-amber-50 text-amber-700'
+                              : 'bg-red-50 text-red-700'
+                        }`}
+                      >
+                        {state === 'healthy'
+                          ? `${s.latencyMs}ms`
+                          : state === 'degraded'
+                            ? `Degraded${s.httpStatus ? ` (${s.httpStatus})` : ''}`
+                            : 'Down'}
+                      </span>
+                    )}
+                    <a
+                      href={target.url}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="text-slate-400 transition-colors hover:text-brand-blue-600"
+                      title="Open in new tab"
+                    >
+                      <ExternalLink className="h-4 w-4" />
+                    </a>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+
+          <div className="flex items-center justify-between border-t border-slate-100 bg-slate-50 px-5 py-3">
+            <p className="text-xs text-slate-400">
+              {checkedAt ? `Last checked ${checkedAt.toLocaleTimeString()}` : 'Click Check status to probe endpoints'}
+            </p>
+            <Link href="/admin/monitoring" className="text-xs font-medium text-brand-blue-600 hover:text-brand-blue-800">
+              Full monitoring →
+            </Link>
+          </div>
+        </>
+      )}
     </div>
   );
 }

--- a/components/admin/dashboard/SitePreviewPanelWrapper.tsx
+++ b/components/admin/dashboard/SitePreviewPanelWrapper.tsx
@@ -5,11 +5,14 @@ import type { SitePreviewTarget } from './types';
 
 const SitePreviewPanel = dynamic(
   () => import('./SitePreviewPanel').then(m => m.SitePreviewPanel),
-  { ssr: false, loading: () => (
-    <div className="bg-white border border-slate-200 rounded-xl h-[580px] flex items-center justify-center text-slate-400 text-sm">
-      Loading preview…
-    </div>
-  )}
+  {
+    ssr: false,
+    loading: () => (
+      <div className="flex h-[420px] items-center justify-center rounded-2xl border border-slate-200 bg-gradient-to-br from-brand-blue-50 to-brand-orange-50 text-sm text-slate-500">
+        Loading preview…
+      </div>
+    ),
+  }
 );
 
 export default function SitePreviewPanelWrapper({ sites }: { sites: SitePreviewTarget[] }) {

--- a/components/admin/dashboard/StatsOverviewBar.tsx
+++ b/components/admin/dashboard/StatsOverviewBar.tsx
@@ -67,6 +67,7 @@ export function StatsOverviewBar({ data }: Props) {
           href="/admin/students?status=active"
         />
         <StatCard
+          themeIndex={2}
           icon={<DollarSign className="w-3.5 h-3.5" aria-hidden="true" />}
           label="Revenue (Month)"
           value={fmt(counts.revenueThisMonthCents)}

--- a/components/admin/dashboard/SystemHealthPanel.tsx
+++ b/components/admin/dashboard/SystemHealthPanel.tsx
@@ -96,7 +96,7 @@ export function SystemHealthPanel({ health }: Props) {
               label: "Stale Jobs",
               ok: health.staleJobs === 0,
               value: health.staleJobs > 0 ? `${health.staleJobs} stuck` : "Clear",
-              href: "/admin/dev-studio?tab=automation",
+              href: "/admin/dev-studio?tab=workflows",
             },
             {
               label: "Missing Docs",

--- a/components/dev-studio/AIChat.tsx
+++ b/components/dev-studio/AIChat.tsx
@@ -345,7 +345,14 @@ function ToolCallBlock({ tc }: { tc: { tool: string; args: Record<string, unknow
   );
 }
 
-export default function AIChat({ fileContext, onApplyCode, ellieMode = false }: AIChatProps) {
+export default function AIChat({
+  fileContext,
+  onApplyCode,
+  ellieMode = false,
+  unifiedEllieMode = false,
+  embedded = false,
+}: AIChatProps) {
+  const showEllieApprovals = ellieMode || unifiedEllieMode;
   const [messages, setMessages] = useState<Message[]>([]);
   const [input, setInput] = useState('');
   const [isLoading, setIsLoading] = useState(false);

--- a/components/dev-studio/DeployPanel.tsx
+++ b/components/dev-studio/DeployPanel.tsx
@@ -1,9 +1,19 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
-import { Activity, AlertTriangle, CheckCircle2, ExternalLink, Loader2, Play, RefreshCw, Rocket, XCircle } from 'lucide-react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Activity,
+  AlertTriangle,
+  CheckCircle2,
+  ExternalLink,
+  Loader2,
+  Play,
+  RefreshCw,
+  Rocket,
+  XCircle,
+} from 'lucide-react';
 
-type WorkflowKey = 'deploy-lms' | 'deploy-admin' | 'deploy-studio' | 'ci' | 'lint' | string;
+type WorkflowKey = 'deploy-lms' | 'deploy-admin' | 'deploy-studio' | 'ci-cd' | 'lint' | string;
 
 interface WorkflowButton {
   key: WorkflowKey;
@@ -17,6 +27,8 @@ interface WorkflowRun {
   status: string;
   conclusion: string | null;
   url: string;
+  workflow?: string;
+  createdAt?: string;
   jobs?: { id: number; name: string; status: string; conclusion: string | null; url: string }[];
 }
 
@@ -31,30 +43,66 @@ interface DispatchResult {
 }
 
 const DEFAULT_WORKFLOWS: WorkflowButton[] = [
-  { key: 'deploy-lms', label: 'Deploy Website', description: 'Build and push the public website service to AWS ECS' },
-  { key: 'deploy-admin', label: 'Deploy Admin', description: 'Build and push the admin dashboard service to AWS ECS' },
-  { key: 'deploy-studio', label: 'Deploy Studio', description: 'Build and push the Dev Studio shell service to AWS ECS' },
-  { key: 'ci-cd', label: 'Run CI', description: 'Run the validation pipeline (ci-cd.yml)' },
-  { key: 'lint', label: 'Run Lint', description: 'Run lint checks against the repository' },
+  { key: 'deploy-lms', label: 'Deploy Website', description: 'Build and push the public LMS service to AWS ECS' },
+  { key: 'deploy-admin', label: 'Deploy Admin', description: 'Build and push the admin dashboard to AWS ECS' },
+  { key: 'deploy-studio', label: 'Deploy Studio', description: 'Build and push the studio shell service to AWS ECS' },
+  { key: 'ci-cd', label: 'Run CI', description: 'Full validation pipeline (ci-cd.yml)' },
+  { key: 'lint', label: 'Run Lint', description: 'ESLint check workflow' },
 ];
 
 function statusTone(status?: string, conclusion?: string | null) {
-  if (conclusion === 'success') return { color: '#4ade80', Icon: CheckCircle2, label: 'Passed' };
-  if (conclusion === 'failure' || conclusion === 'cancelled') return { color: '#f87171', Icon: XCircle, label: conclusion };
-  if (status === 'queued' || status === 'in_progress') return { color: '#f59e0b', Icon: Loader2, label: status.replace('_', ' ') };
-  return { color: '#94a3b8', Icon: Activity, label: status || 'ready' };
+  if (conclusion === 'success')
+    return { className: 'text-brand-green-700', Icon: CheckCircle2, label: 'Passed', spin: false };
+  if (conclusion === 'failure' || conclusion === 'cancelled')
+    return { className: 'text-red-600', Icon: XCircle, label: conclusion ?? 'failed', spin: false };
+  if (status === 'queued' || status === 'in_progress')
+    return { className: 'text-amber-600', Icon: Loader2, label: status.replace('_', ' '), spin: true };
+  return { className: 'text-slate-500', Icon: Activity, label: status || 'ready', spin: false };
 }
 
-export default function DeployPanel({ workflowButtons }: { workflowButtons?: WorkflowButton[] }) {
-  const workflows = useMemo(() => workflowButtons?.length ? workflowButtons : DEFAULT_WORKFLOWS, [workflowButtons]);
+export default function DeployPanel({
+  workflowButtons,
+  variant = 'dark',
+}: {
+  workflowButtons?: WorkflowButton[];
+  variant?: 'dark' | 'admin';
+}) {
+  const admin = variant === 'admin';
+  const workflows = useMemo(
+    () =>
+      (workflowButtons?.length ? workflowButtons : DEFAULT_WORKFLOWS).map((w) =>
+        w.key === 'ci' ? { ...w, key: 'ci-cd' as WorkflowKey } : w,
+      ),
+    [workflowButtons],
+  );
   const [runningKey, setRunningKey] = useState<string | null>(null);
   const [lastResult, setLastResult] = useState<DispatchResult | null>(null);
   const [run, setRun] = useState<WorkflowRun | null>(null);
+  const [recentRuns, setRecentRuns] = useState<WorkflowRun[]>([]);
+  const [recentLoading, setRecentLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [confirmKey, setConfirmKey] = useState<string | null>(null);
 
-  async function dispatchWorkflow(workflow: WorkflowButton) {
-    if (workflow.key.startsWith('deploy-') && confirmKey !== workflow.key) {
+  const loadRecent = useCallback(async () => {
+    setRecentLoading(true);
+    try {
+      const res = await fetch('/api/devstudio/shell?action=recent_runs&per_page=8');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setRecentRuns(data.runs ?? []);
+    } catch {
+      setRecentRuns([]);
+    } finally {
+      setRecentLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void loadRecent();
+  }, [loadRecent]);
+
+  async function dispatchWorkflow(workflow: WorkflowButton, rerun = false) {
+    if (!rerun && workflow.key.startsWith('deploy-') && confirmKey !== workflow.key) {
       setConfirmKey(workflow.key);
       return;
     }
@@ -70,9 +118,10 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ workflow: workflow.key }),
       });
-      const data = await res.json().catch(() => ({})) as DispatchResult;
+      const data = (await res.json().catch(() => ({}))) as DispatchResult;
       if (!res.ok || data.error) throw new Error(data.error || `Dispatch failed with HTTP ${res.status}`);
       setLastResult(data);
+      void loadRecent();
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not start workflow');
     } finally {
@@ -97,33 +146,51 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
     refreshRun();
     const timer = window.setInterval(refreshRun, 5000);
     return () => window.clearInterval(timer);
-  // eslint-disable-next-line react-hooks/exhaustive-deps
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [lastResult?.runId]);
 
   const activeStatus = statusTone(run?.status ?? lastResult?.status, run?.conclusion);
   const ActiveIcon = activeStatus.Icon;
 
+  const shellClass = admin
+    ? 'flex h-full flex-col overflow-hidden bg-slate-50'
+    : 'flex h-full flex-col overflow-hidden';
+  const headerClass = admin
+    ? 'flex-shrink-0 border-b border-slate-200 bg-white px-4 py-3'
+    : 'flex-shrink-0 border-b px-4 py-3';
+  const headerStyle = admin ? undefined : { background: '#252526', borderColor: '#3c3c3c' };
+  const titleClass = admin ? 'text-sm font-semibold text-slate-900' : 'text-sm font-semibold text-white';
+  const subClass = admin ? 'mt-1 text-xs text-slate-500' : 'mt-1 text-[11px]';
+  const subStyle = admin ? undefined : { color: '#858585' };
+
   return (
-    <div className="flex h-full flex-col overflow-hidden" style={{ background: '#1e1e1e' }}>
-      <div className="flex-shrink-0 border-b px-4 py-3" style={{ background: '#252526', borderColor: '#3c3c3c' }}>
+    <div className={shellClass} style={admin ? undefined : { background: '#1e1e1e' }}>
+      <div className={headerClass} style={headerStyle}>
         <div className="flex items-center justify-between gap-3">
           <div className="min-w-0">
             <div className="flex items-center gap-2">
-              <Rocket className="h-4 w-4" style={{ color: '#4ec9b0' }} />
-              <h2 className="text-sm font-semibold text-white">AWS Deploy Control</h2>
+              <Rocket className={`h-4 w-4 ${admin ? 'text-brand-blue-600' : ''}`} style={admin ? undefined : { color: '#4ec9b0' }} />
+              <h2 className={titleClass}>Deploy to AWS</h2>
             </div>
-            <p className="mt-1 text-[11px]" style={{ color: '#858585' }}>
-              Dispatch GitHub Actions workflows that build and deploy to AWS.
+            <p className={subClass} style={subStyle}>
+              Dispatches real GitHub Actions workflows (requires GITHUB_TOKEN on admin ECS).
             </p>
           </div>
           <button
             type="button"
-            onClick={refreshRun}
-            disabled={!lastResult?.runId}
-            className="inline-flex h-8 items-center gap-1.5 rounded border px-2 text-[11px] disabled:opacity-40"
-            style={{ borderColor: '#3c3c3c', color: '#cccccc' }}
+            onClick={() => {
+              refreshRun();
+              void loadRecent();
+            }}
+            disabled={!lastResult?.runId && recentLoading}
+            className={
+              admin
+                ? 'inline-flex h-8 items-center gap-1.5 rounded-lg border border-slate-200 bg-white px-2 text-xs text-slate-700 disabled:opacity-40'
+                : 'inline-flex h-8 items-center gap-1.5 rounded border px-2 text-[11px] disabled:opacity-40'
+            }
+            style={admin ? undefined : { borderColor: '#3c3c3c', color: '#cccccc' }}
           >
-            <RefreshCw className="h-3.5 w-3.5" />
+            <RefreshCw className={`h-3.5 w-3.5 ${recentLoading ? 'animate-spin' : ''}`} />
             Refresh
           </button>
         </div>
@@ -131,7 +198,16 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
 
       <div className="min-h-0 flex-1 overflow-y-auto p-4">
         {error && (
-          <div className="mb-4 flex items-start gap-2 rounded border px-3 py-2 text-xs" style={{ borderColor: '#7f1d1d', background: 'rgba(127,29,29,0.22)', color: '#fecaca' }}>
+          <div
+            className={`mb-4 flex items-start gap-2 rounded-lg border px-3 py-2 text-xs ${
+              admin ? 'border-red-200 bg-red-50 text-red-800' : ''
+            }`}
+            style={
+              admin
+                ? undefined
+                : { borderColor: '#7f1d1d', background: 'rgba(127,29,29,0.22)', color: '#fecaca' }
+            }
+          >
             <AlertTriangle className="mt-0.5 h-4 w-4 flex-shrink-0" />
             <span>{error}</span>
           </div>
@@ -142,17 +218,39 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
             const pending = runningKey === workflow.key;
             const needsConfirm = confirmKey === workflow.key;
             return (
-              <div key={workflow.key} className="rounded-md border p-3" style={{ borderColor: needsConfirm ? '#f59e0b' : '#3c3c3c', background: '#252526' }}>
+              <div
+                key={workflow.key}
+                className={`rounded-xl border p-3 ${admin ? 'border-slate-200 bg-white' : 'rounded-md'}`}
+                style={
+                  admin
+                    ? needsConfirm
+                      ? { borderColor: '#f59e0b' }
+                      : undefined
+                    : { borderColor: needsConfirm ? '#f59e0b' : '#3c3c3c', background: '#252526' }
+                }
+              >
                 <div className="mb-3 flex min-h-12 items-start justify-between gap-3">
                   <div className="min-w-0">
-                    <p className="truncate text-sm font-semibold text-white">{workflow.label}</p>
-                    <p className="mt-1 text-[11px] leading-relaxed" style={{ color: '#9ca3af' }}>{workflow.description}</p>
+                    <p className={`truncate text-sm font-semibold ${admin ? 'text-slate-900' : 'text-white'}`}>
+                      {workflow.label}
+                    </p>
+                    <p className={`mt-1 text-[11px] leading-relaxed ${admin ? 'text-slate-500' : ''}`} style={admin ? undefined : { color: '#9ca3af' }}>
+                      {workflow.description}
+                    </p>
                   </div>
-                  <Rocket className="h-4 w-4 flex-shrink-0" style={{ color: '#4ec9b0' }} />
                 </div>
 
                 {needsConfirm && (
-                  <p className="mb-2 rounded border px-2 py-1.5 text-[11px]" style={{ borderColor: '#f59e0b', color: '#fcd34d', background: 'rgba(245,158,11,0.08)' }}>
+                  <p
+                    className={`mb-2 rounded-lg border px-2 py-1.5 text-[11px] ${
+                      admin ? 'border-amber-200 bg-amber-50 text-amber-900' : ''
+                    }`}
+                    style={
+                      admin
+                        ? undefined
+                        : { borderColor: '#f59e0b', color: '#fcd34d', background: 'rgba(245,158,11,0.08)' }
+                    }
+                  >
                     Click again to deploy production.
                   </p>
                 )}
@@ -161,34 +259,93 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
                   type="button"
                   onClick={() => dispatchWorkflow(workflow)}
                   disabled={pending}
-                  className="inline-flex h-9 w-full items-center justify-center gap-2 rounded text-xs font-semibold transition disabled:opacity-50"
-                  style={{ background: needsConfirm ? '#f59e0b' : '#0078d4', color: needsConfirm ? '#111827' : '#ffffff' }}
+                  className={`inline-flex h-9 w-full items-center justify-center gap-2 rounded-lg text-xs font-semibold transition disabled:opacity-50 ${
+                    admin
+                      ? needsConfirm
+                        ? 'bg-amber-500 text-slate-900'
+                        : 'bg-brand-blue-600 text-white hover:bg-brand-blue-700'
+                      : ''
+                  }`}
+                  style={
+                    admin
+                      ? undefined
+                      : { background: needsConfirm ? '#f59e0b' : '#0078d4', color: needsConfirm ? '#111827' : '#ffffff' }
+                  }
                 >
                   {pending ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Play className="h-3.5 w-3.5" />}
-                  {needsConfirm ? 'Confirm Deploy' : 'Run'}
+                  {needsConfirm ? 'Confirm deploy' : 'Run workflow'}
                 </button>
               </div>
             );
           })}
         </div>
 
+        {recentRuns.length > 0 && (
+          <section className={`mt-6 ${admin ? 'rounded-xl border border-slate-200 bg-white' : 'rounded-md border'}`} style={admin ? undefined : { borderColor: '#3c3c3c', background: '#252526' }}>
+            <div className={`border-b px-3 py-2 ${admin ? 'border-slate-200' : ''}`} style={admin ? undefined : { borderColor: '#3c3c3c' }}>
+              <h3 className={`text-xs font-semibold ${admin ? 'text-slate-800' : 'text-white'}`}>Recent workflow runs</h3>
+            </div>
+            <ul className="divide-y divide-slate-100">
+              {recentRuns.map((item) => {
+                const tone = statusTone(item.status, item.conclusion);
+                const Icon = tone.Icon;
+                const failed = item.conclusion === 'failure';
+                const wf = workflows.find((w) => item.workflow?.includes(w.key.replace('.yml', '')));
+                return (
+                  <li key={item.id} className="flex flex-wrap items-center justify-between gap-2 px-3 py-2 text-xs">
+                    <div className="min-w-0">
+                      <a href={item.url} target="_blank" rel="noreferrer" className={`font-medium hover:underline ${admin ? 'text-brand-blue-700' : ''}`} style={admin ? undefined : { color: '#4ec9b0' }}>
+                        {item.name}
+                      </a>
+                      {item.createdAt && (
+                        <p className={`text-[10px] ${admin ? 'text-slate-400' : ''}`} style={admin ? undefined : { color: '#858585' }}>
+                          {new Date(item.createdAt).toLocaleString()}
+                        </p>
+                      )}
+                    </div>
+                    <div className="flex items-center gap-2">
+                      <span className={`inline-flex items-center gap-1 ${tone.className}`}>
+                        <Icon className={`h-3.5 w-3.5 ${tone.spin ? 'animate-spin' : ''}`} />
+                        {tone.label}
+                      </span>
+                      {failed && wf && (
+                        <button
+                          type="button"
+                          onClick={() => dispatchWorkflow(wf, true)}
+                          disabled={runningKey === wf.key}
+                          className="rounded-md bg-slate-100 px-2 py-0.5 text-[10px] font-medium text-slate-700 hover:bg-slate-200"
+                        >
+                          Re-run
+                        </button>
+                      )}
+                    </div>
+                  </li>
+                );
+              })}
+            </ul>
+          </section>
+        )}
+
         {(lastResult || run) && (
-          <section className="mt-4 rounded-md border" style={{ borderColor: '#3c3c3c', background: '#252526' }}>
-            <div className="flex items-center justify-between gap-3 border-b px-3 py-2" style={{ borderColor: '#3c3c3c' }}>
+          <section
+            className={`mt-4 ${admin ? 'rounded-xl border border-slate-200 bg-white' : 'rounded-md border'}`}
+            style={admin ? undefined : { borderColor: '#3c3c3c', background: '#252526' }}
+          >
+            <div
+              className={`flex items-center justify-between gap-3 border-b px-3 py-2 ${admin ? 'border-slate-200' : ''}`}
+              style={admin ? undefined : { borderColor: '#3c3c3c' }}
+            >
               <div className="flex items-center gap-2">
-                <ActiveIcon className={`h-4 w-4 ${activeStatus.Icon === Loader2 ? 'animate-spin' : ''}`} style={{ color: activeStatus.color }} />
-                <span className="text-xs font-semibold text-white">{run?.name ?? lastResult?.workflow}</span>
-                <span className="rounded px-1.5 py-0.5 text-[10px]" style={{ color: activeStatus.color, background: '#1e1e1e' }}>
-                  {activeStatus.label}
-                </span>
+                <ActiveIcon className={`h-4 w-4 ${activeStatus.spin ? 'animate-spin' : ''} ${admin ? activeStatus.className : ''}`} style={admin ? undefined : { color: activeStatus.className }} />
+                <span className={`text-xs font-semibold ${admin ? 'text-slate-900' : 'text-white'}`}>{run?.name ?? lastResult?.workflow}</span>
               </div>
               {(run?.url || lastResult?.runUrl) && (
                 <a
                   href={run?.url || lastResult?.runUrl}
                   target="_blank"
                   rel="noreferrer"
-                  className="inline-flex items-center gap-1 text-[11px]"
-                  style={{ color: '#4ec9b0' }}
+                  className={`inline-flex items-center gap-1 text-[11px] ${admin ? 'text-brand-blue-600' : ''}`}
+                  style={admin ? undefined : { color: '#4ec9b0' }}
                 >
                   <ExternalLink className="h-3 w-3" />
                   GitHub Actions
@@ -197,7 +354,7 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
             </div>
 
             {run?.jobs?.length ? (
-              <div className="divide-y" style={{ borderColor: '#3c3c3c' }}>
+              <div className={`divide-y ${admin ? 'divide-slate-100' : ''}`} style={admin ? undefined : { borderColor: '#3c3c3c' }}>
                 {run.jobs.map((job) => {
                   const tone = statusTone(job.status, job.conclusion);
                   const JobIcon = tone.Icon;
@@ -207,12 +364,12 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
                       href={job.url}
                       target="_blank"
                       rel="noreferrer"
-                      className="flex items-center justify-between gap-3 px-3 py-2 text-xs"
-                      style={{ color: '#cccccc', borderColor: '#3c3c3c' }}
+                      className={`flex items-center justify-between gap-3 px-3 py-2 text-xs ${admin ? 'text-slate-700 hover:bg-slate-50' : ''}`}
+                      style={admin ? undefined : { color: '#cccccc', borderColor: '#3c3c3c' }}
                     >
                       <span className="truncate">{job.name}</span>
-                      <span className="inline-flex items-center gap-1.5" style={{ color: tone.color }}>
-                        <JobIcon className={`h-3.5 w-3.5 ${JobIcon === Loader2 ? 'animate-spin' : ''}`} />
+                      <span className={`inline-flex items-center gap-1.5 ${tone.className}`}>
+                        <JobIcon className={`h-3.5 w-3.5 ${tone.spin ? 'animate-spin' : ''}`} />
                         {tone.label}
                       </span>
                     </a>
@@ -220,8 +377,8 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
                 })}
               </div>
             ) : (
-              <p className="px-3 py-3 text-[11px]" style={{ color: '#858585' }}>
-                Workflow queued. Job details will appear when GitHub reports the run.
+              <p className={`px-3 py-3 text-[11px] ${admin ? 'text-slate-500' : ''}`} style={admin ? undefined : { color: '#858585' }}>
+                Workflow queued. Job details appear when GitHub reports the run.
               </p>
             )}
           </section>

--- a/components/dev-studio/DeployPanel.tsx
+++ b/components/dev-studio/DeployPanel.tsx
@@ -34,7 +34,7 @@ const DEFAULT_WORKFLOWS: WorkflowButton[] = [
   { key: 'deploy-lms', label: 'Deploy Website', description: 'Build and push the public website service to AWS ECS' },
   { key: 'deploy-admin', label: 'Deploy Admin', description: 'Build and push the admin dashboard service to AWS ECS' },
   { key: 'deploy-studio', label: 'Deploy Studio', description: 'Build and push the Dev Studio shell service to AWS ECS' },
-  { key: 'ci', label: 'Run CI', description: 'Run the validation pipeline before deployment' },
+  { key: 'ci-cd', label: 'Run CI', description: 'Run the validation pipeline (ci-cd.yml)' },
   { key: 'lint', label: 'Run Lint', description: 'Run lint checks against the repository' },
 ];
 

--- a/components/dev-studio/DevStudioFilesWorkspace.tsx
+++ b/components/dev-studio/DevStudioFilesWorkspace.tsx
@@ -1,0 +1,170 @@
+'use client';
+
+import { useCallback, useEffect, useRef, useState } from 'react';
+import { FileText, Loader2, Save, Upload } from 'lucide-react';
+
+const MAX_UPLOAD_BYTES = 512 * 1024;
+
+function sanitizeUploadPath(path: string): string {
+  return path.replace(/\\/g, '/').replace(/^\/+/, '').replace(/\/{2,}/g, '/').trim();
+}
+
+export default function DevStudioFilesWorkspace() {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState('');
+  const [content, setContent] = useState('');
+  const [sha, setSha] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [uploadPath, setUploadPath] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshFiles = useCallback(async () => {
+    try {
+      const res = await fetch('/api/devstudio/files');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      const flat: string[] = [];
+      function walk(nodes: { type: string; path: string; children?: unknown[] }[]) {
+        for (const node of nodes ?? []) {
+          if (node.type === 'file') flat.push(node.path);
+          else walk((node.children ?? []) as { type: string; path: string; children?: unknown[] }[]);
+        }
+      }
+      walk(data.tree ?? []);
+      setFiles(flat);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'File tree unavailable');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshFiles();
+  }, [refreshFiles]);
+
+  async function loadFile(path: string) {
+    setSelected(path);
+    setLoading(true);
+    setStatus('');
+    try {
+      const res = await fetch(`/api/devstudio/files?path=${encodeURIComponent(path)}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setContent(data.content ?? '');
+      setSha(data.sha ?? '');
+      setMessage(`chore: update ${path} via Dev Studio`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not load file');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveFile() {
+    if (!selected) return;
+    setLoading(true);
+    setStatus('');
+    try {
+      const method = sha ? 'PUT' : 'POST';
+      const res = await fetch('/api/devstudio/files', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: selected, content, sha: sha || undefined, message }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setSha(data.sha ?? sha);
+      setStatus(data.commit ? 'Committed to GitHub' : 'Saved');
+      if (method === 'POST') {
+        setFiles((c) => (c.includes(selected) ? c : [...c, selected].sort()));
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not save');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden bg-white">
+      <div className="w-64 shrink-0 overflow-y-auto border-r border-slate-200">
+        <div className="sticky top-0 border-b border-slate-200 bg-slate-50 p-2">
+          <p className="mb-2 text-[10px] font-bold uppercase text-slate-500">Repo files (GitHub)</p>
+          <div className="flex gap-1">
+            <input
+              value={uploadPath}
+              onChange={(e) => setUploadPath(sanitizeUploadPath(e.target.value))}
+              className="h-8 min-w-0 flex-1 rounded border border-slate-200 px-2 font-mono text-[10px]"
+              placeholder="path/in/repo.ts"
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              onChange={async (e) => {
+                const file = e.target.files?.[0];
+                e.target.value = '';
+                if (!file || file.size > MAX_UPLOAD_BYTES) return;
+                const path = sanitizeUploadPath(uploadPath || `devstudio-uploads/${file.name}`);
+                setSelected(path);
+                setContent(await file.text());
+                setSha('');
+                setMessage(`chore: add ${path}`);
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="rounded bg-brand-blue-600 p-2 text-white"
+            >
+              <Upload className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+        {files.map((file) => (
+          <button
+            key={file}
+            type="button"
+            onClick={() => void loadFile(file)}
+            className={`flex w-full items-center gap-2 border-b border-slate-100 px-3 py-2 text-left text-[11px] ${
+              selected === file ? 'bg-brand-blue-50 text-brand-blue-900' : 'text-slate-700'
+            }`}
+          >
+            <FileText className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{file}</span>
+          </button>
+        ))}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex items-center gap-2 border-b border-slate-200 px-3 py-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-slate-500">
+            {selected || 'Select a file'}
+          </span>
+          {status && <span className="text-[11px] text-brand-green-700">{status}</span>}
+          <button
+            type="button"
+            onClick={() => void saveFile()}
+            disabled={!selected || loading}
+            className="inline-flex items-center gap-1 rounded-lg bg-brand-blue-600 px-2 py-1 text-xs text-white disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+            Commit
+          </button>
+        </div>
+        <input
+          value={message}
+          onChange={(e) => setMessage(e.target.value)}
+          className="h-8 border-b border-slate-200 px-3 font-mono text-[11px] outline-none"
+          placeholder="Commit message"
+        />
+        <textarea
+          value={content}
+          onChange={(e) => setContent(e.target.value)}
+          className="min-h-0 flex-1 resize-none p-3 font-mono text-xs outline-none"
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  );
+}

--- a/components/dev-studio/DevStudioHealthPanel.tsx
+++ b/components/dev-studio/DevStudioHealthPanel.tsx
@@ -1,0 +1,151 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { Activity, AlertTriangle, ExternalLink, Loader2, RefreshCw, Server } from 'lucide-react';
+import dynamic from 'next/dynamic';
+
+const EcsStatusPanel = dynamic(() => import('@/components/dev-studio/EcsStatusPanel'), { ssr: false });
+
+type HealthPayload = Record<string, unknown> & {
+  hasGroq?: boolean;
+  hasGemini?: boolean;
+  hasOpenAI?: boolean;
+  hasAnthropic?: boolean;
+  hasGitHub?: boolean;
+  shell?: {
+    configured?: boolean;
+    ready?: boolean;
+    probe?: { reachable?: boolean; ready?: boolean; status?: string; gitVersion?: string | null };
+  };
+};
+
+function flag(ok: boolean | undefined) {
+  return ok ? 'configured' : 'missing';
+}
+
+export default function DevStudioHealthPanel() {
+  const [health, setHealth] = useState<HealthPayload | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/devstudio/health');
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error((data as { error?: string }).error ?? `HTTP ${res.status}`);
+      setHealth(data as HealthPayload);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Health check failed');
+      setHealth(null);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const rows = health
+    ? [
+        ['GitHub token', flag(health.hasGitHub)],
+        ['Groq', flag(health.hasGroq)],
+        ['OpenAI', flag(health.hasOpenAI)],
+        ['Anthropic', flag(health.hasAnthropic)],
+        ['Gemini', flag(health.hasGemini)],
+        [
+          'Studio shell (ECS)',
+          health.shell?.ready
+            ? 'connected'
+            : health.shell?.configured
+              ? 'configured, not ready'
+              : 'not configured',
+        ],
+        ['Shell probe', String(health.shell?.probe?.status ?? '—')],
+        ['Git in shell', health.shell?.probe?.gitVersion ?? '—'],
+      ]
+    : [];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-white">
+      <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-brand-blue-600" />
+          <h2 className="text-sm font-semibold text-slate-900">Platform health</h2>
+        </div>
+        <button
+          type="button"
+          onClick={() => void load()}
+          disabled={loading}
+          className="inline-flex items-center gap-1.5 rounded-lg border border-slate-200 px-2.5 py-1.5 text-xs font-medium text-slate-700 hover:bg-slate-50 disabled:opacity-50"
+        >
+          <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+          Refresh
+        </button>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-4">
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {loading && !health && (
+          <div className="flex items-center justify-center gap-2 py-8 text-sm text-slate-500">
+            <Loader2 className="h-4 w-4 animate-spin" />
+            Loading live health from admin container…
+          </div>
+        )}
+
+        {rows.length > 0 && (
+          <div className="rounded-xl border border-slate-200 bg-slate-50">
+            <div className="border-b border-slate-200 px-3 py-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+              Admin runtime (this ECS task)
+            </div>
+            {rows.map(([label, value]) => (
+              <div
+                key={label}
+                className="flex items-center justify-between border-b border-slate-100 px-3 py-2 text-xs last:border-0"
+              >
+                <span className="text-slate-600">{label}</span>
+                <span className="font-mono text-slate-900">{value}</span>
+              </div>
+            ))}
+          </div>
+        )}
+
+        {health?.shell && !health.shell.ready && (
+          <p className="text-xs leading-relaxed text-amber-800 bg-amber-50 border border-amber-200 rounded-lg px-3 py-2">
+            The <strong>studio shell container</strong> is separate from admin/LMS. Set{' '}
+            <code className="rounded bg-white px-1">STUDIO_SHELL_WS_URL</code>,{' '}
+            <code className="rounded bg-white px-1">STUDIO_SHELL_SECRET</code>, and{' '}
+            <code className="rounded bg-white px-1">STUDIO_TOKEN_SECRET</code> in Dev Studio → Secrets,
+            then deploy the studio service. Use the <strong>Terminal</strong> tab when shell is ready.
+          </p>
+        )}
+
+        <div className="rounded-xl border border-slate-200">
+          <div className="flex items-center gap-2 border-b border-slate-200 px-3 py-2">
+            <Server className="h-4 w-4 text-slate-500" />
+            <span className="text-xs font-semibold text-slate-800">ECS services (live AWS)</span>
+          </div>
+          <div className="max-h-[320px] overflow-auto">
+            <EcsStatusPanel />
+          </div>
+        </div>
+
+        <a
+          href="/admin/system-health"
+          className="inline-flex items-center gap-1 text-xs font-medium text-brand-blue-600 hover:underline"
+        >
+          Full system health page
+          <ExternalLink className="h-3 w-3" />
+        </a>
+      </div>
+    </div>
+  );
+}

--- a/components/dev-studio/DevStudioMobileShell.tsx
+++ b/components/dev-studio/DevStudioMobileShell.tsx
@@ -1,0 +1,311 @@
+'use client';
+
+import { type ElementType, useEffect, useMemo, useState } from 'react';
+import dynamic from 'next/dynamic';
+import Link from 'next/link';
+import { useRouter, useSearchParams } from 'next/navigation';
+import {
+  Activity,
+  Bot,
+  ChevronLeft,
+  ExternalLink,
+  FolderOpen,
+  Globe,
+  Key,
+  Loader2,
+  MoreHorizontal,
+  Rocket,
+  Server,
+  Sparkles,
+  X,
+} from 'lucide-react';
+
+type MobileTab = 'ellie' | 'deploy' | 'health' | 'preview';
+type MorePanel = 'files' | 'services' | 'environments' | 'secrets' | null;
+
+const DeployPanel = dynamic(() => import('@/components/dev-studio/DeployPanel'), { ssr: false });
+const ServicesPanel = dynamic(() => import('@/components/dev-studio/ServicesPanel'), { ssr: false });
+const SecretsPanel = dynamic(() => import('@/components/dev-studio/SecretsPanel'), { ssr: false });
+const DevContainerPanel = dynamic(() => import('@/components/dev-studio/DevContainerPanel'), { ssr: false });
+const UnifiedEllieChat = dynamic(() => import('@/components/dev-studio/UnifiedEllieChat'), { ssr: false });
+const IframePreview = dynamic(() => import('@/components/dev-studio/IframePreview'), { ssr: false });
+
+const NAV: { id: MobileTab; label: string; Icon: ElementType<{ className?: string }> }[] = [
+  { id: 'ellie', label: 'Ellie', Icon: Sparkles },
+  { id: 'deploy', label: 'Deploy', Icon: Rocket },
+  { id: 'preview', label: 'Preview', Icon: Globe },
+  { id: 'health', label: 'Health', Icon: Activity },
+];
+
+interface DevStudioMobileShellProps {
+  isSuperAdmin?: boolean;
+  health: Record<string, unknown> | null;
+  previewUrl: string;
+  livePreviewUrl: string;
+  onPreviewUrlChange: (url: string) => void;
+  onPreviewGo: () => void;
+  workflowButtons?: { key: string; label: string; description: string }[];
+}
+
+export default function DevStudioMobileShell({
+  isSuperAdmin = false,
+  health,
+  previewUrl,
+  livePreviewUrl,
+  onPreviewUrlChange,
+  onPreviewGo,
+  workflowButtons,
+}: DevStudioMobileShellProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const [tab, setTab] = useState<MobileTab>(() => {
+    const t = searchParams.get('tab');
+    if (t === 'deploy') return 'deploy';
+    if (t === 'health') return 'health';
+    if (t === 'preview') return 'preview';
+    return 'ellie';
+  });
+  const [moreOpen, setMoreOpen] = useState<MorePanel>(null);
+  const [moreMenu, setMoreMenu] = useState(false);
+
+  useEffect(() => {
+    const t = searchParams.get('tab');
+    if (t === 'deploy') setTab('deploy');
+    else if (t === 'health') setTab('health');
+    else if (t === 'preview') setTab('preview');
+    else if (t === 'ellie' || !t) setTab('ellie');
+  }, [searchParams]);
+
+  const aiLabel = useMemo(() => {
+    if (!health) return '…';
+    const parts = [
+      health.hasGroq && 'Groq',
+      health.hasOpenAI && 'OpenAI',
+    ].filter(Boolean);
+    return parts.length ? String(parts.join(' · ')) : 'Add API keys';
+  }, [health]);
+
+  function selectTab(next: MobileTab) {
+    setTab(next);
+    setMoreMenu(false);
+    setMoreOpen(null);
+    const params = new URLSearchParams(searchParams.toString());
+    params.set('tab', next === 'ellie' ? 'ellie' : next);
+    router.replace(`/admin/dev-studio?${params.toString()}`, { scroll: false });
+  }
+
+  const title =
+    tab === 'ellie'
+      ? 'Ellie'
+      : tab === 'deploy'
+        ? 'Deploy'
+        : tab === 'preview'
+          ? 'Site preview'
+          : 'System health';
+
+  return (
+    <div className="flex h-full min-h-0 flex-col bg-slate-50 text-slate-900">
+      <header className="flex shrink-0 items-center gap-2 border-b border-slate-200 bg-white px-3 py-3 safe-area-top">
+        <Link
+          href="/admin/dashboard"
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded-xl border border-slate-200 text-slate-600"
+          aria-label="Back to dashboard"
+        >
+          <ChevronLeft className="h-5 w-5" />
+        </Link>
+        <div className="min-w-0 flex-1">
+          <h1 className="truncate text-base font-bold text-slate-900">{title}</h1>
+          <p className="truncate text-xs text-slate-500">{tab === 'ellie' ? `AI · ${aiLabel}` : 'Elevate admin'}</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => setMoreMenu((v) => !v)}
+          className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200 text-slate-600"
+          aria-label="More tools"
+        >
+          <MoreHorizontal className="h-5 w-5" />
+        </button>
+      </header>
+
+      {moreMenu && (
+        <div className="shrink-0 border-b border-slate-200 bg-white px-3 py-2">
+          <p className="mb-2 text-[10px] font-bold uppercase tracking-wide text-slate-400">More tools</p>
+          <div className="flex flex-wrap gap-2">
+            {(
+              [
+                { id: 'files' as const, label: 'Files', Icon: FolderOpen },
+                { id: 'services' as const, label: 'Services', Icon: Server },
+                { id: 'environments' as const, label: 'Container', Icon: Bot },
+                ...(isSuperAdmin
+                  ? [{ id: 'secrets' as const, label: 'Secrets', Icon: Key }]
+                  : []),
+              ] as const
+            ).map(({ id, label, Icon }) => (
+              <button
+                key={id}
+                type="button"
+                onClick={() => {
+                  setMoreOpen(id);
+                  setMoreMenu(false);
+                }}
+                className="inline-flex items-center gap-1.5 rounded-xl border border-slate-200 bg-slate-50 px-3 py-2 text-xs font-semibold text-slate-700"
+              >
+                <Icon className="h-3.5 w-3.5" />
+                {label}
+              </button>
+            ))}
+          </div>
+        </div>
+      )}
+
+      <main className="relative min-h-0 flex-1 overflow-hidden">
+        {tab === 'ellie' && (
+          <div className="h-full bg-white">
+            <UnifiedEllieChat
+              embedded
+              onOpenDeploy={() => selectTab('deploy')}
+              onOpenPreview={() => selectTab('preview')}
+            />
+          </div>
+        )}
+        {tab === 'deploy' && (
+          <div className="h-full overflow-y-auto p-3">
+            <DeployPanel workflowButtons={workflowButtons} />
+          </div>
+        )}
+        {tab === 'preview' && (
+          <div className="flex h-full flex-col">
+            <div className="flex shrink-0 gap-2 border-b border-slate-200 bg-white p-2">
+              <input
+                value={previewUrl}
+                onChange={(e) => onPreviewUrlChange(e.target.value)}
+                className="min-h-[44px] min-w-0 flex-1 rounded-xl border border-slate-200 px-3 text-sm text-slate-800"
+                placeholder="https://www.elevateforhumanity.org"
+              />
+              <button
+                type="button"
+                onClick={onPreviewGo}
+                className="shrink-0 rounded-xl bg-brand-blue-600 px-4 text-sm font-semibold text-white"
+              >
+                Go
+              </button>
+              <a
+                href={livePreviewUrl || previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-11 w-11 shrink-0 items-center justify-center rounded-xl border border-slate-200 text-slate-600"
+              >
+                <ExternalLink className="h-5 w-5" />
+              </a>
+            </div>
+            <div className="min-h-0 flex-1 bg-slate-100">
+              <IframePreview url={livePreviewUrl || previewUrl} title="Preview" className="h-full" />
+            </div>
+          </div>
+        )}
+        {tab === 'health' && (
+          <div className="h-full overflow-y-auto p-4">
+            <HealthCards health={health} />
+          </div>
+        )}
+
+        {moreOpen && (
+          <div className="absolute inset-0 z-20 flex flex-col bg-white">
+            <div className="flex items-center gap-2 border-b border-slate-200 px-3 py-3">
+              <button
+                type="button"
+                onClick={() => setMoreOpen(null)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-xl border border-slate-200"
+              >
+                <X className="h-5 w-5" />
+              </button>
+              <span className="text-sm font-bold capitalize text-slate-900">{moreOpen}</span>
+            </div>
+            <div className="min-h-0 flex-1 overflow-y-auto p-2">
+              {moreOpen === 'files' && <FilesPlaceholder />}
+              {moreOpen === 'services' && <ServicesPanel />}
+              {moreOpen === 'environments' && <DevContainerPanel />}
+              {moreOpen === 'secrets' && isSuperAdmin && <SecretsPanel />}
+            </div>
+          </div>
+        )}
+      </main>
+
+      <nav className="flex shrink-0 border-t border-slate-200 bg-white pb-[max(0.5rem,env(safe-area-inset-bottom))] pt-1">
+        {NAV.map(({ id, label, Icon }) => {
+          const active = tab === id;
+          return (
+            <button
+              key={id}
+              type="button"
+              onClick={() => selectTab(id)}
+              className="flex min-h-[52px] flex-1 flex-col items-center justify-center gap-0.5 px-1"
+            >
+              <Icon
+                className={`h-5 w-5 ${active ? 'text-brand-blue-600' : 'text-slate-400'}`}
+              />
+              <span
+                className={`text-[10px] font-semibold ${active ? 'text-brand-blue-600' : 'text-slate-500'}`}
+              >
+                {label}
+              </span>
+            </button>
+          );
+        })}
+      </nav>
+    </div>
+  );
+}
+
+function HealthCards({ health }: { health: Record<string, unknown> | null }) {
+  if (!health) {
+    return (
+      <div className="flex items-center justify-center gap-2 py-12 text-slate-500">
+        <Loader2 className="h-5 w-5 animate-spin" />
+        Loading…
+      </div>
+    );
+  }
+  const rows = [
+    { label: 'Groq', ok: Boolean(health.hasGroq) },
+    { label: 'OpenAI', ok: Boolean(health.hasOpenAI) },
+    { label: 'Anthropic', ok: Boolean(health.hasAnthropic) },
+    { label: 'Gemini', ok: Boolean(health.hasGemini) },
+    { label: 'GitHub', ok: Boolean(health.hasGitHub) },
+  ];
+  return (
+    <div className="space-y-3">
+      <p className="text-sm text-slate-600">
+        Provider keys and integrations for Dev Studio / Ellie.
+      </p>
+      {rows.map((r) => (
+        <div
+          key={r.label}
+          className="flex items-center justify-between rounded-xl border border-slate-200 bg-white px-4 py-3"
+        >
+          <span className="font-medium text-slate-800">{r.label}</span>
+          <span
+            className={`text-xs font-bold ${r.ok ? 'text-brand-green-700' : 'text-amber-600'}`}
+          >
+            {r.ok ? 'Connected' : 'Not set'}
+          </span>
+        </div>
+      ))}
+      <Link
+        href="/admin/integrations/env-manager"
+        className="block rounded-xl bg-slate-900 px-4 py-3 text-center text-sm font-semibold text-white"
+      >
+        Open Environment Manager
+      </Link>
+    </div>
+  );
+}
+
+function FilesPlaceholder() {
+  return (
+    <p className="p-4 text-sm text-slate-600">
+      File browser is easier on desktop. Open Dev Studio on a larger screen, or use Ellie to
+      search code and run deploy commands.
+    </p>
+  );
+}

--- a/components/dev-studio/DevStudioPwaHint.tsx
+++ b/components/dev-studio/DevStudioPwaHint.tsx
@@ -1,0 +1,56 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import { Smartphone, X } from 'lucide-react';
+
+/**
+ * Explains how to install the Admin PWA (no App Store app — add to home screen).
+ */
+export default function DevStudioPwaHint() {
+  const [standalone, setStandalone] = useState(true);
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    setStandalone(window.matchMedia('(display-mode: standalone)').matches);
+    setDismissed(sessionStorage.getItem('dev-studio-pwa-hint-dismissed') === '1');
+  }, []);
+
+  if (standalone || dismissed) return null;
+
+  const isIos = /iphone|ipad|ipod/i.test(navigator.userAgent);
+
+  return (
+    <div className="shrink-0 border-b border-brand-blue-200 bg-brand-blue-50 px-3 py-2.5">
+      <div className="mx-auto flex max-w-3xl gap-2">
+        <Smartphone className="mt-0.5 h-4 w-4 shrink-0 text-brand-blue-600" />
+        <div className="min-w-0 flex-1 text-xs text-slate-700">
+          <p className="font-semibold text-slate-900">Install the Admin app (no App Store needed)</p>
+          <p className="mt-0.5 leading-relaxed">
+            {isIos ? (
+              <>
+                Safari → Share → <strong>Add to Home Screen</strong>. Opens like an app at{' '}
+                <code className="rounded bg-white px-1">admin.elevateforhumanity.org</code>.
+              </>
+            ) : (
+              <>
+                Use the <strong>Install Admin App</strong> banner when it appears, or Chrome menu →{' '}
+                <strong>Install app</strong> / Add to Home screen.
+              </>
+            )}
+          </p>
+        </div>
+        <button
+          type="button"
+          onClick={() => {
+            sessionStorage.setItem('dev-studio-pwa-hint-dismissed', '1');
+            setDismissed(true);
+          }}
+          className="shrink-0 rounded-lg p-1 text-slate-400 hover:bg-white hover:text-slate-600"
+          aria-label="Dismiss"
+        >
+          <X className="h-4 w-4" />
+        </button>
+      </div>
+    </div>
+  );
+}

--- a/components/dev-studio/DevStudioWorkflowsPanel.tsx
+++ b/components/dev-studio/DevStudioWorkflowsPanel.tsx
@@ -1,0 +1,200 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  AlertTriangle,
+  ExternalLink,
+  Loader2,
+  Play,
+  Plus,
+  RefreshCw,
+  Workflow,
+} from 'lucide-react';
+import Link from 'next/link';
+
+interface WorkflowRow {
+  id: string;
+  name: string;
+  status?: string;
+  category?: string;
+  updated_at?: string;
+}
+
+interface WorkflowRunRow {
+  id: string;
+  status?: string;
+  created_at?: string;
+  workflow?: { name?: string };
+}
+
+export default function DevStudioWorkflowsPanel() {
+  const [workflows, setWorkflows] = useState<WorkflowRow[]>([]);
+  const [runs, setRuns] = useState<WorkflowRunRow[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [runningId, setRunningId] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const [wfRes, runsRes] = await Promise.all([
+        fetch('/api/admin/workflows'),
+        fetch('/api/admin/workflows/runs?limit=15'),
+      ]);
+      const wfData = await wfRes.json().catch(() => ({}));
+      const runsData = await runsRes.json().catch(() => ({}));
+      if (!wfRes.ok) throw new Error((wfData as { error?: string }).error ?? 'Failed to load workflows');
+      setWorkflows((wfData as { data?: WorkflowRow[] }).data ?? []);
+      setRuns((runsData as { runs?: WorkflowRunRow[] }).runs ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not load workflows');
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  async function runWorkflow(id: string) {
+    setRunningId(id);
+    setError(null);
+    try {
+      const res = await fetch('/api/admin/workflows/run', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ workflow_id: id }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (!res.ok) throw new Error((data as { error?: string }).error ?? `HTTP ${res.status}`);
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Run failed');
+    } finally {
+      setRunningId(null);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-white">
+      <div className="flex shrink-0 items-center justify-between border-b border-slate-200 px-4 py-3">
+        <div className="flex items-center gap-2">
+          <Workflow className="h-4 w-4 text-brand-blue-600" />
+          <h2 className="text-sm font-semibold text-slate-900">Automation workflows</h2>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            type="button"
+            onClick={() => void load()}
+            disabled={loading}
+            className="inline-flex items-center gap-1 rounded-lg border border-slate-200 px-2 py-1 text-xs text-slate-700 hover:bg-slate-50"
+          >
+            <RefreshCw className={`h-3.5 w-3.5 ${loading ? 'animate-spin' : ''}`} />
+            Refresh
+          </button>
+          <Link
+            href="/admin/workflows"
+            className="inline-flex items-center gap-1 rounded-lg bg-brand-blue-600 px-2.5 py-1.5 text-xs font-medium text-white hover:bg-brand-blue-700"
+          >
+            <Plus className="h-3.5 w-3.5" />
+            Manage
+          </Link>
+        </div>
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto p-4 space-y-4">
+        {error && (
+          <div className="flex items-start gap-2 rounded-lg border border-red-200 bg-red-50 px-3 py-2 text-xs text-red-800">
+            <AlertTriangle className="h-4 w-4 shrink-0" />
+            {error}
+          </div>
+        )}
+
+        {loading && workflows.length === 0 && (
+          <div className="flex justify-center py-8 text-sm text-slate-500">
+            <Loader2 className="h-4 w-4 animate-spin mr-2" />
+            Loading from Supabase…
+          </div>
+        )}
+
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Workflows ({workflows.length})
+          </h3>
+          {workflows.length === 0 && !loading ? (
+            <p className="text-sm text-slate-500">
+              No workflows yet.{' '}
+              <Link href="/admin/workflows" className="text-brand-blue-600 underline">
+                Create one
+              </Link>
+            </p>
+          ) : (
+            <ul className="space-y-2">
+              {workflows.map((wf) => (
+                <li
+                  key={wf.id}
+                  className="flex flex-wrap items-center justify-between gap-2 rounded-lg border border-slate-200 px-3 py-2"
+                >
+                  <div className="min-w-0">
+                    <p className="truncate text-sm font-medium text-slate-900">{wf.name}</p>
+                    <p className="text-[10px] text-slate-500">
+                      {wf.status ?? 'unknown'} · {wf.category ?? 'operations'}
+                    </p>
+                  </div>
+                  <div className="flex shrink-0 items-center gap-2">
+                    <button
+                      type="button"
+                      disabled={runningId === wf.id}
+                      onClick={() => void runWorkflow(wf.id)}
+                      className="inline-flex items-center gap-1 rounded-lg bg-slate-900 px-2.5 py-1 text-xs font-medium text-white hover:bg-slate-700 disabled:opacity-50"
+                    >
+                      {runningId === wf.id ? (
+                        <Loader2 className="h-3 w-3 animate-spin" />
+                      ) : (
+                        <Play className="h-3 w-3" />
+                      )}
+                      Run
+                    </button>
+                    <Link
+                      href={`/admin/workflows/${wf.id}`}
+                      className="text-xs text-brand-blue-600 hover:underline"
+                    >
+                      Edit
+                    </Link>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section>
+          <h3 className="mb-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            Recent runs
+          </h3>
+          {runs.length === 0 ? (
+            <p className="text-xs text-slate-500">No runs yet.</p>
+          ) : (
+            <ul className="divide-y divide-slate-100 rounded-lg border border-slate-200">
+              {runs.map((run) => (
+                <li key={run.id} className="flex items-center justify-between px-3 py-2 text-xs">
+                  <span className="text-slate-800">{run.workflow?.name ?? run.id.slice(0, 8)}</span>
+                  <span className="font-mono text-slate-500">{run.status ?? '—'}</span>
+                </li>
+              ))}
+            </ul>
+          )}
+          <Link
+            href="/admin/workflows"
+            className="mt-2 inline-flex items-center gap-1 text-xs text-brand-blue-600 hover:underline"
+          >
+            Open workflow builder
+            <ExternalLink className="h-3 w-3" />
+          </Link>
+        </section>
+      </div>
+    </div>
+  );
+}

--- a/components/dev-studio/IframePreview.tsx
+++ b/components/dev-studio/IframePreview.tsx
@@ -1,23 +1,16 @@
 'use client';
 
-import React, { useEffect, useState } from 'react';
+import { useEffect, useState } from 'react';
 import { AlertTriangle, ExternalLink, Globe, Loader2 } from 'lucide-react';
 
 function useEmbedCheck(url: string) {
-  const [state, setState] = useState<{ embeddable: boolean | null; reason?: string }>({
-    embeddable: null,
-  });
+  const [state, setState] = useState<{ embeddable: boolean | null; reason?: string }>({ embeddable: null });
 
   useEffect(() => {
-    if (!url) {
-      setState({ embeddable: null });
-      return;
-    }
+    if (!url) return;
     setState({ embeddable: null });
     const controller = new AbortController();
-    fetch(`/api/devstudio/embed-check?url=${encodeURIComponent(url)}`, {
-      signal: controller.signal,
-    })
+    fetch(`/api/devstudio/embed-check?url=${encodeURIComponent(url)}`, { signal: controller.signal })
       .then((r) => r.json())
       .then((d: { embeddable: boolean; reason?: string }) => setState(d))
       .catch(() => setState({ embeddable: true }));
@@ -27,15 +20,10 @@ function useEmbedCheck(url: string) {
   return state;
 }
 
-/**
- * Dev Studio live preview — checks embed headers before loading iframe.
- * www cannot be framed from admin when production sends X-Frame-Options: DENY
- * (see next.config frame-ancestors for admin host).
- */
 export default function IframePreview({
   url,
-  title = 'Preview',
-  className,
+  title = 'Live Preview',
+  className = '',
 }: {
   url: string;
   title?: string;
@@ -50,69 +38,56 @@ export default function IframePreview({
 
   if (!url) {
     return (
-      <div
-        className={`flex h-full w-full flex-col items-center justify-center gap-3 bg-[#1e1e1e] ${className ?? ''}`}
-      >
-        <Globe className="h-8 w-8 text-[#3c3c3c]" />
-        <p className="text-[11px] text-[#555]">Enter a URL above to preview</p>
+      <div className={`flex h-full flex-col items-center justify-center gap-3 bg-slate-50 ${className}`}>
+        <Globe className="h-8 w-8 text-slate-300" />
+        <p className="text-xs text-slate-500">Enter a URL above to preview the live site</p>
       </div>
     );
   }
 
   if (embeddable === null) {
     return (
-      <div className={`flex h-full w-full items-center justify-center ${className ?? ''}`}>
-        <Loader2 className="h-5 w-5 animate-spin text-[#858585]" />
+      <div className={`flex h-full items-center justify-center bg-slate-50 ${className}`}>
+        <Loader2 className="h-5 w-5 animate-spin text-slate-400" />
       </div>
     );
   }
 
   if (embeddable === false) {
     return (
-      <div
-        className={`flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center ${className ?? ''}`}
-        style={{ background: '#1e1e1e' }}
-      >
-        <AlertTriangle className="h-8 w-8 text-[#f0a500]" />
-        <p className="text-sm font-medium text-[#cccccc]">Preview can&apos;t load in the panel</p>
-        <p className="text-[11px] leading-relaxed text-[#858585]">
-          The public site blocks iframe embedding (
-          <code className="rounded bg-[#2d2d2d] px-1 text-[#4ec9b0]">{reason}</code>
-          ). This is expected until the LMS allows{' '}
-          <code className="text-[#4ec9b0]">admin.elevateforhumanity.org</code> in{' '}
-          <code className="text-[#4ec9b0]">frame-ancestors</code> — or open the page in a new tab.
+      <div className={`flex h-full flex-col items-center justify-center gap-4 bg-slate-50 px-6 text-center ${className}`}>
+        <AlertTriangle className="h-8 w-8 text-amber-500" />
+        <p className="text-sm font-medium text-slate-800">This page can&apos;t be embedded here</p>
+        <p className="max-w-sm text-xs leading-relaxed text-slate-500">
+          The server returned{' '}
+          <code className="rounded bg-white px-1 py-0.5 text-brand-blue-700">{reason}</code>. Open it in a new tab
+          instead. After LMS deploy, production allows embedding from the admin portal.
         </p>
         <a
           href={url}
           target="_blank"
           rel="noopener noreferrer"
-          className="flex items-center gap-2 rounded bg-[#0078d4] px-4 py-2 text-sm font-medium text-white hover:bg-[#005fa3]"
+          className="inline-flex items-center gap-2 rounded-lg bg-brand-blue-600 px-4 py-2 text-sm font-medium text-white hover:bg-brand-blue-700"
         >
           <ExternalLink className="h-4 w-4" />
           Open in new tab
         </a>
-        <p className="text-[10px] text-[#555]">
-          Local dev: use <code className="text-[#888]">http://localhost:3000</code> in the address bar.
-        </p>
       </div>
     );
   }
 
   return (
-    <div className={`relative h-full w-full ${className ?? ''}`}>
+    <div className={`relative h-full min-h-0 ${className}`}>
       {loading && (
-        <div
-          className="absolute inset-x-0 top-0 z-10 flex h-8 items-center justify-center border-b border-[#3c3c3c]"
-          style={{ background: 'rgba(30,30,30,0.85)' }}
-        >
-          <Loader2 className="h-4 w-4 animate-spin text-[#858585]" />
+        <div className="absolute inset-x-0 top-0 z-10 flex h-8 items-center justify-center border-b border-slate-200 bg-white/90">
+          <Loader2 className="h-4 w-4 animate-spin text-slate-400" />
         </div>
       )}
       <iframe
+        title={title}
         src={url}
         className="h-full w-full border-0 bg-white"
         onLoad={() => setLoading(false)}
-        title={title}
       />
     </div>
   );

--- a/components/dev-studio/IframePreview.tsx
+++ b/components/dev-studio/IframePreview.tsx
@@ -1,0 +1,119 @@
+'use client';
+
+import React, { useEffect, useState } from 'react';
+import { AlertTriangle, ExternalLink, Globe, Loader2 } from 'lucide-react';
+
+function useEmbedCheck(url: string) {
+  const [state, setState] = useState<{ embeddable: boolean | null; reason?: string }>({
+    embeddable: null,
+  });
+
+  useEffect(() => {
+    if (!url) {
+      setState({ embeddable: null });
+      return;
+    }
+    setState({ embeddable: null });
+    const controller = new AbortController();
+    fetch(`/api/devstudio/embed-check?url=${encodeURIComponent(url)}`, {
+      signal: controller.signal,
+    })
+      .then((r) => r.json())
+      .then((d: { embeddable: boolean; reason?: string }) => setState(d))
+      .catch(() => setState({ embeddable: true }));
+    return () => controller.abort();
+  }, [url]);
+
+  return state;
+}
+
+/**
+ * Dev Studio live preview — checks embed headers before loading iframe.
+ * www cannot be framed from admin when production sends X-Frame-Options: DENY
+ * (see next.config frame-ancestors for admin host).
+ */
+export default function IframePreview({
+  url,
+  title = 'Preview',
+  className,
+}: {
+  url: string;
+  title?: string;
+  className?: string;
+}) {
+  const { embeddable, reason } = useEmbedCheck(url);
+  const [loading, setLoading] = useState(true);
+
+  useEffect(() => {
+    setLoading(true);
+  }, [url]);
+
+  if (!url) {
+    return (
+      <div
+        className={`flex h-full w-full flex-col items-center justify-center gap-3 bg-[#1e1e1e] ${className ?? ''}`}
+      >
+        <Globe className="h-8 w-8 text-[#3c3c3c]" />
+        <p className="text-[11px] text-[#555]">Enter a URL above to preview</p>
+      </div>
+    );
+  }
+
+  if (embeddable === null) {
+    return (
+      <div className={`flex h-full w-full items-center justify-center ${className ?? ''}`}>
+        <Loader2 className="h-5 w-5 animate-spin text-[#858585]" />
+      </div>
+    );
+  }
+
+  if (embeddable === false) {
+    return (
+      <div
+        className={`flex h-full w-full flex-col items-center justify-center gap-4 px-6 text-center ${className ?? ''}`}
+        style={{ background: '#1e1e1e' }}
+      >
+        <AlertTriangle className="h-8 w-8 text-[#f0a500]" />
+        <p className="text-sm font-medium text-[#cccccc]">Preview can&apos;t load in the panel</p>
+        <p className="text-[11px] leading-relaxed text-[#858585]">
+          The public site blocks iframe embedding (
+          <code className="rounded bg-[#2d2d2d] px-1 text-[#4ec9b0]">{reason}</code>
+          ). This is expected until the LMS allows{' '}
+          <code className="text-[#4ec9b0]">admin.elevateforhumanity.org</code> in{' '}
+          <code className="text-[#4ec9b0]">frame-ancestors</code> — or open the page in a new tab.
+        </p>
+        <a
+          href={url}
+          target="_blank"
+          rel="noopener noreferrer"
+          className="flex items-center gap-2 rounded bg-[#0078d4] px-4 py-2 text-sm font-medium text-white hover:bg-[#005fa3]"
+        >
+          <ExternalLink className="h-4 w-4" />
+          Open in new tab
+        </a>
+        <p className="text-[10px] text-[#555]">
+          Local dev: use <code className="text-[#888]">http://localhost:3000</code> in the address bar.
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className={`relative h-full w-full ${className ?? ''}`}>
+      {loading && (
+        <div
+          className="absolute inset-x-0 top-0 z-10 flex h-8 items-center justify-center border-b border-[#3c3c3c]"
+          style={{ background: 'rgba(30,30,30,0.85)' }}
+        >
+          <Loader2 className="h-4 w-4 animate-spin text-[#858585]" />
+        </div>
+      )}
+      <iframe
+        src={url}
+        className="h-full w-full border-0 bg-white"
+        onLoad={() => setLoading(false)}
+        title={title}
+      />
+    </div>
+  );
+}

--- a/components/dev-studio/UnifiedEllieChat.tsx
+++ b/components/dev-studio/UnifiedEllieChat.tsx
@@ -1,0 +1,315 @@
+'use client';
+
+import React, { useEffect, useRef, useState } from 'react';
+import Link from 'next/link';
+import {
+  Bot,
+  Loader2,
+  Send,
+  Sparkles,
+  AlertTriangle,
+  Rocket,
+  PanelRightOpen,
+  User,
+} from 'lucide-react';
+import {
+  ELLIE_ROUTE_LABEL,
+  fetchAiHealth,
+  routeEllieMessage,
+  sendOpsMessage,
+  streamExecuteCommand,
+  streamPlatformChat,
+  type EllieMessageRoute,
+} from '@/lib/devstudio/ellie-unified-handlers';
+
+interface EllieAction {
+  id: string;
+  type: string;
+  label: string;
+  params: Record<string, unknown>;
+  targetCount: number;
+  dangerLevel: 'low' | 'medium' | 'high';
+  description: string;
+}
+
+interface ChatMessage {
+  role: 'user' | 'assistant';
+  content: string;
+  provider?: string;
+  route?: EllieMessageRoute;
+  action?: EllieAction | null;
+}
+
+interface UnifiedEllieChatProps {
+  onOpenDeploy?: () => void;
+  onOpenPreview?: () => void;
+  /** Parent provides header (mobile admin shell) */
+  embedded?: boolean;
+}
+
+const QUICK = [
+  { label: 'Stats', text: 'Show platform stats and pending applications' },
+  { label: 'Deploy LMS', text: 'Deploy the LMS service' },
+  { label: 'Deploy admin', text: 'Deploy the admin service' },
+  { label: 'Smoke test', text: 'Run smoke test' },
+  { label: 'Fix deploy', text: 'Why did the last ECS admin deploy fail? What should I check?' },
+  { label: 'Search code', text: 'Search code for middleware errors in apps/admin' },
+];
+
+export default function UnifiedEllieChat({ onOpenDeploy, onOpenPreview, embedded = false }: UnifiedEllieChatProps) {
+  const [messages, setMessages] = useState<ChatMessage[]>([]);
+  const [input, setInput] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [health, setHealth] = useState('checking…');
+  const [aiOk, setAiOk] = useState(true);
+  const [lastRoute, setLastRoute] = useState<EllieMessageRoute | null>(null);
+  const endRef = useRef<HTMLDivElement>(null);
+  const inputRef = useRef<HTMLTextAreaElement>(null);
+
+  useEffect(() => {
+    fetchAiHealth().then(({ ok, label }) => {
+      setAiOk(ok);
+      setHealth(label);
+    });
+  }, []);
+
+  useEffect(() => {
+    endRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [messages, loading]);
+
+  async function send() {
+    const text = input.trim();
+    if (!text || loading) return;
+    setInput('');
+    setLoading(true);
+    const route = routeEllieMessage(text);
+    setLastRoute(route);
+    const userMsg: ChatMessage = { role: 'user', content: text, route };
+    setMessages((prev) => [...prev, userMsg]);
+    const assistantIdx = messages.length + 1;
+
+    try {
+      if (route === 'command') {
+        setMessages((prev) => [
+          ...prev,
+          { role: 'assistant', content: `▶ ${ELLIE_ROUTE_LABEL.command}\n`, provider: 'execute', route },
+        ]);
+        await streamExecuteCommand(text, (line) => {
+          setMessages((prev) => {
+            const next = [...prev];
+            const row = next[assistantIdx];
+            if (row?.role === 'assistant') {
+              next[assistantIdx] = { ...row, content: row.content + line };
+            }
+            return next;
+          });
+        });
+      } else if (route === 'ops') {
+        const { reply, action } = await sendOpsMessage(
+          text,
+          messages.map((m) => ({ role: m.role, content: m.content })),
+        );
+        setMessages((prev) => [
+          ...prev,
+          {
+            role: 'assistant',
+            content: reply,
+            provider: 'ellie-ops',
+            route,
+            action: (action as EllieAction) ?? null,
+          },
+        ]);
+      } else {
+        setMessages((prev) => [...prev, { role: 'assistant', content: '', provider: 'platform', route }]);
+        const history = [...messages, userMsg].map((m) => ({ role: m.role, content: m.content }));
+        await streamPlatformChat(history, {
+          onToken: (token) => {
+            setMessages((prev) => {
+              const next = [...prev];
+              const row = next[assistantIdx];
+              if (row?.role === 'assistant') {
+                next[assistantIdx] = { ...row, content: row.content + token };
+              }
+              return next;
+            });
+          },
+          onDone: (meta) => {
+            setMessages((prev) => {
+              const next = [...prev];
+              const row = next[assistantIdx];
+              if (row?.role === 'assistant') {
+                next[assistantIdx] = {
+                  ...row,
+                  provider: meta.provider ?? row.provider,
+                };
+              }
+              return next;
+            });
+          },
+        });
+      }
+    } catch (err) {
+      setMessages((prev) => [
+        ...prev,
+        {
+          role: 'assistant',
+          content: `⚠️ ${err instanceof Error ? err.message : 'Request failed'}`,
+        },
+      ]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className={`flex h-full min-h-0 flex-col ${embedded ? "bg-white text-slate-900" : "bg-[#1e1e1e] text-[#cccccc]"}`}>
+      {!embedded && (
+      <div className="flex shrink-0 flex-wrap items-center gap-2 border-b border-[#3c3c3c] bg-[#252526] px-3 py-2">
+        <Sparkles className="h-4 w-4 shrink-0 text-[#4ec9b0]" />
+        <div className="min-w-0 flex-1">
+          <p className="truncate text-sm font-semibold text-white">Ellie</p>
+          <p className="truncate text-[10px] text-[#858585]">
+            Ops · deploy · code — {health}
+            {lastRoute ? ` · last: ${ELLIE_ROUTE_LABEL[lastRoute]}` : ''}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center gap-1">
+          {onOpenPreview && (
+            <button
+              type="button"
+              onClick={onOpenPreview}
+              className="inline-flex h-8 items-center gap-1 rounded border border-[#555] px-2 text-[11px] lg:hidden"
+            >
+              <PanelRightOpen className="h-3.5 w-3.5" />
+              Preview
+            </button>
+          )}
+          {onOpenDeploy && (
+            <button
+              type="button"
+              onClick={onOpenDeploy}
+              className="inline-flex h-8 items-center gap-1 rounded bg-[#0078d4] px-2 text-[11px] text-white"
+            >
+              <Rocket className="h-3.5 w-3.5" />
+              Deploy
+            </button>
+          )}
+        </div>
+      </div>
+      )}
+
+      {!aiOk && (
+        <div className="flex shrink-0 items-start gap-2 border-b border-amber-900/50 bg-amber-950/40 px-3 py-2 text-xs text-amber-200">
+          <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0" />
+          <p>
+            Add API keys in{' '}
+            <Link href="/admin/integrations/env-manager" className="underline">
+              Environment Manager
+            </Link>
+            , then redeploy admin if keys are in SSM only.
+          </p>
+        </div>
+      )}
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-3 py-3 sm:px-4">
+        {messages.length === 0 ? (
+          <div className="mx-auto flex max-w-lg flex-col items-center py-8 text-center sm:py-12">
+            <Bot className="mb-3 h-12 w-12 text-[#4ec9b0]" />
+            <p className="text-sm text-[#e5e5e5]">One chat for the whole platform</p>
+            <p className="mt-1 text-xs text-[#858585]">
+              Live ops data, ECS deploys, code/schema tools — same container, same Supabase & APIs.
+            </p>
+            <div className="mt-6 flex w-full flex-wrap justify-center gap-2">
+              {QUICK.map((q) => (
+                <button
+                  key={q.label}
+                  type="button"
+                  onClick={() => {
+                    setInput(q.text);
+                    inputRef.current?.focus();
+                  }}
+                  className="rounded-full border border-[#555] bg-[#2d2d2d] px-3 py-1.5 text-[11px] text-[#ccc] hover:border-[#0078d4]"
+                >
+                  {q.label}
+                </button>
+              ))}
+            </div>
+          </div>
+        ) : (
+          <div className="mx-auto flex w-full max-w-2xl flex-col gap-3">
+            {messages.map((msg, i) => (
+              <div
+                key={i}
+                className={`flex gap-2 ${msg.role === 'user' ? 'justify-end' : 'justify-start'}`}
+              >
+                {msg.role === 'assistant' && (
+                  <div className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#0078d4]">
+                    <Bot className="h-4 w-4 text-white" />
+                  </div>
+                )}
+                <div
+                  className={`max-w-[min(100%,28rem)] rounded-2xl px-3 py-2 text-sm leading-relaxed sm:max-w-[36rem] sm:px-4 ${
+                    msg.role === 'user'
+                      ? 'bg-[#0078d4] text-white'
+                      : 'border border-[#3c3c3c] bg-[#2d2d2d] text-[#e5e5e5]'
+                  }`}
+                >
+                  {msg.provider && msg.role === 'assistant' && (
+                    <p className="mb-1 font-mono text-[10px] uppercase text-[#858585]">
+                      {msg.provider}
+                      {msg.route ? ` · ${ELLIE_ROUTE_LABEL[msg.route]}` : ''}
+                    </p>
+                  )}
+                  <p className="whitespace-pre-wrap break-words">{msg.content}</p>
+                </div>
+                {msg.role === 'user' && (
+                  <div className="mt-1 flex h-7 w-7 shrink-0 items-center justify-center rounded-full bg-[#3c3c3c]">
+                    <User className="h-4 w-4 text-[#ccc]" />
+                  </div>
+                )}
+              </div>
+            ))}
+            {loading && (
+              <div className="flex justify-start gap-2">
+                <div className="flex h-7 w-7 items-center justify-center rounded-full bg-[#0078d4]">
+                  <Loader2 className="h-4 w-4 animate-spin text-white" />
+                </div>
+                <div className="rounded-2xl border border-[#3c3c3c] bg-[#2d2d2d] px-4 py-2 text-sm text-[#858585]">
+                  Working…
+                </div>
+              </div>
+            )}
+            <div ref={endRef} />
+          </div>
+        )}
+      </div>
+
+      <div className="shrink-0 border-t border-[#3c3c3c] bg-[#252526] p-3 pb-[max(0.75rem,env(safe-area-inset-bottom))]">
+        <div className="mx-auto flex max-w-2xl gap-2">
+          <textarea
+            ref={inputRef}
+            value={input}
+            onChange={(e) => setInput(e.target.value)}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && !e.shiftKey) {
+                e.preventDefault();
+                send();
+              }
+            }}
+            rows={2}
+            placeholder="Ask, deploy, or debug…"
+            className="min-h-[44px] flex-1 resize-none rounded-xl border border-[#555] bg-[#1e1e1e] px-3 py-2 text-sm text-white placeholder:text-[#666] focus:border-[#0078d4] focus:outline-none"
+          />
+          <button
+            type="button"
+            disabled={!input.trim() || loading}
+            onClick={send}
+            className="flex h-11 w-11 shrink-0 items-center justify-center rounded-xl bg-[#0078d4] text-white disabled:opacity-40"
+          >
+            {loading ? <Loader2 className="h-5 w-5 animate-spin" /> : <Send className="h-5 w-5" />}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/lib/admin/nav-config.ts
+++ b/lib/admin/nav-config.ts
@@ -53,7 +53,7 @@ export const DEFAULT_NAV: NavSection[] = [
       { label: 'Dev Studio', href: '/admin/dev-studio' },
       { label: 'Ellie — AI Ops', href: '/admin/dev-studio?tab=ellie' },
       { label: 'Workflows', href: '/admin/workflows' },
-      { label: 'Automation Log', href: '/admin/dev-studio?tab=automation' },
+      { label: 'Automation Log', href: '/admin/dev-studio?tab=workflows' },
       { label: 'System Health', href: '/admin/dev-studio?tab=health' },
       { label: 'Snapshots', href: '/admin/snapshots' },
     ],

--- a/lib/admin/nav-config.ts
+++ b/lib/admin/nav-config.ts
@@ -53,7 +53,7 @@ export const DEFAULT_NAV: NavSection[] = [
       { label: 'Dev Studio', href: '/admin/dev-studio' },
       { label: 'Ellie — AI Ops', href: '/admin/dev-studio?tab=ellie' },
       { label: 'Workflows', href: '/admin/workflows' },
-      { label: 'Automation Log', href: '/admin/dev-studio?tab=workflows' },
+      { label: 'Dev Studio', href: '/admin/dev-studio?tab=ellie' },
       { label: 'System Health', href: '/admin/dev-studio?tab=health' },
       { label: 'Snapshots', href: '/admin/snapshots' },
     ],

--- a/lib/devstudio/ellie-message-router.ts
+++ b/lib/devstudio/ellie-message-router.ts
@@ -1,0 +1,34 @@
+/**
+ * Routes a single Ellie message to the correct existing backend:
+ * - command → /api/devstudio/execute (SSE deploy, smoke, bulk ops)
+ * - ops     → /api/admin/ai-assistant (live data + staged approvals)
+ * - platform → /api/devstudio/chat (tools, code, schema, course gen)
+ */
+
+export type EllieMessageRoute = 'command' | 'ops' | 'platform';
+
+const COMMAND_RE =
+  /^(deploy\b|run smoke|smoke\s*test|force[- ]?redeploy|build courses?\b|generate course|check system health|system health|run tests?\b|git push|trigger (the )?(lms|admin|studio) deploy)/i;
+
+const OPS_RE =
+  /\b(pending application|approve application|reject application|at[- ]?risk|send reminder|how many (student|enrollment|application)|dashboard stat|live data|schedule exam|cancel exam|magic link|case manager|program holder|wioa|compliance alert|hot lead)\b/i;
+
+const PLATFORM_RE =
+  /\b(fix|bug|broken|error|failing|route\.ts|middleware|migration|schema|rls|component|search code|inspect|blueprint|generate video|course id|supabase|deploy did not|ecs|container|build spec)\b/i;
+
+export function routeEllieMessage(message: string): EllieMessageRoute {
+  const text = message.trim();
+  if (!text) return 'platform';
+  if (COMMAND_RE.test(text)) return 'command';
+  if (OPS_RE.test(text) && !PLATFORM_RE.test(text)) return 'ops';
+  if (PLATFORM_RE.test(text)) return 'platform';
+  // Short operational questions
+  if (/^(how many|what('s| is) the|show (me )?|list )/i.test(text) && text.length < 120) return 'ops';
+  return 'platform';
+}
+
+export const ELLIE_ROUTE_LABEL: Record<EllieMessageRoute, string> = {
+  command: 'Command',
+  ops: 'Ops',
+  platform: 'Platform',
+};

--- a/lib/devstudio/ellie-unified-handlers.ts
+++ b/lib/devstudio/ellie-unified-handlers.ts
@@ -1,0 +1,169 @@
+import { ELLIE_ROUTE_LABEL, routeEllieMessage, type EllieMessageRoute } from '@/lib/devstudio/ellie-message-router';
+
+export type UnifiedChatMessage = {
+  role: 'user' | 'assistant';
+  content: string;
+  toolCalls?: { tool: string; args: Record<string, unknown>; result: string }[];
+  provider?: string;
+  model?: string;
+  action?: unknown;
+};
+
+export { routeEllieMessage, ELLIE_ROUTE_LABEL, type EllieMessageRoute };
+
+export async function fetchAiHealth(): Promise<{
+  ok: boolean;
+  label: string;
+  providers: Record<string, boolean>;
+}> {
+  try {
+    const res = await fetch('/api/devstudio/health');
+    const data = await res.json().catch(() => ({}));
+    const providers = {
+      groq: Boolean(data.hasGroq),
+      openai: Boolean(data.hasOpenAI),
+      anthropic: Boolean(data.hasAnthropic),
+      gemini: Boolean(data.hasGemini),
+    };
+    const ok = res.ok && (providers.groq || providers.openai || providers.anthropic || providers.gemini);
+    const label = [
+      providers.groq && 'Groq',
+      providers.openai && 'OpenAI',
+      providers.anthropic && 'Claude',
+      providers.gemini && 'Gemini',
+    ]
+      .filter(Boolean)
+      .join(' / ');
+    return { ok, label: label || 'no keys', providers };
+  } catch {
+    return { ok: false, label: 'offline', providers: {} };
+  }
+}
+
+export async function sendOpsMessage(
+  userMessage: string,
+  history: { role: string; content: string }[],
+  provider?: string,
+  model?: string,
+): Promise<{ reply: string; action?: unknown }> {
+  const res = await fetch('/api/admin/ai-assistant', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      message: userMessage,
+      sessionId: 'ellie-unified',
+      history,
+      provider: provider && provider !== 'auto' ? provider : undefined,
+      model: model && model !== 'auto' ? model : undefined,
+    }),
+  });
+  const data = await res.json().catch(() => ({ error: `HTTP ${res.status}` }));
+  if (!res.ok) throw new Error(data.error ?? 'Request failed');
+  return { reply: data.reply ?? '', action: data.action ?? null };
+}
+
+export async function streamPlatformChat(
+  messages: { role: string; content: string }[],
+  opts: {
+    fileContext?: string;
+    documentsContext?: string;
+    provider?: string;
+    model?: string;
+    onToken: (token: string) => void;
+    onDone: (meta: {
+      toolCalls?: UnifiedChatMessage['toolCalls'];
+      provider?: string;
+      model?: string;
+    }) => void;
+  },
+): Promise<void> {
+  const res = await fetch('/api/devstudio/chat', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      messages,
+      fileContext: opts.fileContext,
+      documentsContext: opts.documentsContext,
+      provider: opts.provider,
+      model: opts.model,
+    }),
+  });
+  if (!res.ok) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error(data.error ?? `HTTP ${res.status}`);
+  }
+  const reader = res.body?.getReader();
+  if (!reader) {
+    const data = await res.json();
+    opts.onToken(data.message ?? data.reply ?? '');
+    opts.onDone({ toolCalls: data.toolCalls, provider: data.provider, model: data.model });
+    return;
+  }
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const lines = buffer.split('\n\n');
+    buffer = lines.pop() ?? '';
+    for (const line of lines) {
+      if (!line.startsWith('data: ')) continue;
+      try {
+        const chunk = JSON.parse(line.slice(6));
+        if (chunk.token !== undefined) opts.onToken(chunk.token);
+        if (chunk.done) {
+          opts.onDone({
+            toolCalls: chunk.toolCalls,
+            provider: chunk.provider,
+            model: chunk.model,
+          });
+        }
+      } catch {
+        /* skip */
+      }
+    }
+  }
+}
+
+export async function streamExecuteCommand(
+  command: string,
+  onLine: (text: string) => void,
+): Promise<void> {
+  const isSmoke = /smoke.?test|health.?check|check.*platform/i.test(command);
+  const res = await fetch(
+    isSmoke ? '/api/devstudio/smoke-test' : '/api/devstudio/execute',
+    isSmoke
+      ? undefined
+      : {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command }),
+        },
+  );
+  if (!res.ok || !res.body) {
+    const data = await res.json().catch(() => ({}));
+    throw new Error((data as { error?: string }).error || `HTTP ${res.status}`);
+  }
+  const reader = res.body.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+  while (true) {
+    const { done, value } = await reader.read();
+    if (done) break;
+    buffer += decoder.decode(value, { stream: true });
+    const chunks = buffer.split('\n');
+    buffer = chunks.pop() ?? '';
+    for (const chunk of chunks) {
+      if (!chunk.startsWith('data: ')) continue;
+      const raw = chunk.slice(6).trim();
+      if (!raw || raw === '[DONE]') continue;
+      try {
+        const parsed = JSON.parse(raw) as { line?: string; text?: string };
+        onLine(parsed.line ?? parsed.text ?? raw);
+      } catch {
+        onLine(raw);
+      }
+    }
+  }
+}

--- a/lib/routes/canonical-routes.ts
+++ b/lib/routes/canonical-routes.ts
@@ -60,7 +60,7 @@ export const ADMIN = {
   SETTINGS:           '/admin/settings',
   SYSTEM_HEALTH:      '/admin/system-health',
   SNAPSHOTS:          '/admin/snapshots',
-  AUTOMATION:         '/admin/dev-studio?tab=automation',
+  AUTOMATION:         '/admin/dev-studio?tab=workflows',
   MONITORING:         '/admin/monitoring',
 
   // ── Partners ─────────────────────────────────────────────────────────────

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1132,14 +1132,6 @@ const nextConfig = {
       process.env.CONTEXT === 'deploy-preview' || process.env.CONTEXT === 'branch-deploy';
     const host = process.env.URL || '';
 
-    let adminPreviewOrigin = 'https://admin.elevateforhumanity.org';
-    try {
-      const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || adminPreviewOrigin;
-      adminPreviewOrigin = new URL(adminUrl).origin;
-    } catch {
-      /* keep default */
-    }
-
     // No special handling needed - single canonical domain: www.elevateforhumanity.org
     const robotsHeaders = [];
 
@@ -1154,8 +1146,11 @@ const nextConfig = {
         key: 'Strict-Transport-Security',
         value: 'max-age=63072000; includeSubDomains; preload',
       },
-      // Clickjacking: use CSP frame-ancestors (not X-Frame-Options DENY — that blocks
-      // Dev Studio on admin.elevateforhumanity.org from embedding www in the preview pane).
+      // X-Frame-Options: DENY in production to prevent clickjacking.
+      // Omitted in dev so Dev Studio's iframe preview can load same-origin pages.
+      ...(isProduction
+        ? [{ key: 'X-Frame-Options', value: 'DENY' }]
+        : []),
       {
         key: 'X-Content-Type-Options',
         value: 'nosniff',
@@ -1189,8 +1184,10 @@ const nextConfig = {
           "object-src 'none'",
           "base-uri 'self'",
           "form-action 'self' https://js.stripe.com",
-          // Production: no framing allowed. Dev: allow same-origin for Dev Studio iframe.
-          isProduction ? "frame-ancestors 'none'" : "frame-ancestors 'self'",
+          // Production: allow admin portal to embed LMS for Dev Studio preview.
+          isProduction
+            ? "frame-ancestors 'self' https://admin.elevateforhumanity.org"
+            : "frame-ancestors 'self' http://localhost:3001",
           'upgrade-insecure-requests',
           // CSP violation reporting endpoint
           'report-uri /api/csp-report',

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -900,11 +900,9 @@ const nextConfig = {
       ...canonicalAliasRedirects,
 
       // ── Stub page consolidation (2026-06) ────────────────────────────────────
-      // Legacy tax URLs → community services (VITA); same-site only
-      { source: '/tax', destination: '/community-services', permanent: true },
-      { source: '/tax/:path*', destination: '/community-services', permanent: true },
-      { source: '/tax-self-prep', destination: '/community-services', permanent: true },
-      { source: '/tax-self-prep/:path*', destination: '/community-services', permanent: true },
+      // External tax platform
+      { source: '/tax', destination: 'https://www.supersonicfastermoney.com/tax', permanent: true },
+      { source: '/tax-self-prep', destination: 'https://www.supersonicfastermoney.com/tax-self-prep', permanent: true },
 
       // programs/admin/* → program-holder/*
       { source: '/programs/admin', destination: '/program-holder/dashboard', permanent: true },
@@ -983,7 +981,7 @@ const nextConfig = {
       { source: '/fssa-partnership-request', destination: '/snap/snap-et', permanent: true },
       // /mentor → /mentor/dashboard already covered above
       { source: '/onboarding/barber-apprenticeship', destination: '/programs/barber-apprenticeship/orientation', permanent: true },
-      { source: '/rise', destination: '/community-services', permanent: true },
+      { source: '/rise', destination: 'https://www.supersonicfastermoney.com/tax', permanent: true },
       { source: '/snap', destination: '/snap/snap-et', permanent: true },
       { source: '/training-providers', destination: '/for-providers', permanent: true },
       { source: '/pwa/barber', destination: '/pwa/barber/onboarding', permanent: true },
@@ -1134,6 +1132,14 @@ const nextConfig = {
       process.env.CONTEXT === 'deploy-preview' || process.env.CONTEXT === 'branch-deploy';
     const host = process.env.URL || '';
 
+    let adminPreviewOrigin = 'https://admin.elevateforhumanity.org';
+    try {
+      const adminUrl = process.env.NEXT_PUBLIC_ADMIN_URL || adminPreviewOrigin;
+      adminPreviewOrigin = new URL(adminUrl).origin;
+    } catch {
+      /* keep default */
+    }
+
     // No special handling needed - single canonical domain: www.elevateforhumanity.org
     const robotsHeaders = [];
 
@@ -1148,11 +1154,8 @@ const nextConfig = {
         key: 'Strict-Transport-Security',
         value: 'max-age=63072000; includeSubDomains; preload',
       },
-      // X-Frame-Options: DENY in production to prevent clickjacking.
-      // Omitted in dev so Dev Studio's iframe preview can load same-origin pages.
-      ...(isProduction
-        ? [{ key: 'X-Frame-Options', value: 'DENY' }]
-        : []),
+      // Clickjacking: use CSP frame-ancestors (not X-Frame-Options DENY — that blocks
+      // Dev Studio on admin.elevateforhumanity.org from embedding www in the preview pane).
       {
         key: 'X-Content-Type-Options',
         value: 'nosniff',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Replaces the dark VS Code–style Dev Studio shell with an **admin light operations control plane**, plus **colorful dashboard visuals** and a **branded live preview**.

## Dev Studio control plane

- Ellie, Deploy, Files, Git, Terminal, Container, Services, Health, Secrets
- Deploy: `ci-cd`, recent runs, re-run failed workflows
- **Colored live preview** (blue/red gradient browser chrome, colored page chips)

## Admin dashboard visuals

- **Overview stat cards**: per-metric gradient backgrounds and colored icon badges
- **KPI grid**: blue / orange / green / red accent bars and icon tints by metric type
- **Category cards**: gradient icon tiles (no longer all slate-900)
- **Site preview panel**: **Preview** tab with live iframe in colored frame; **Status** tab for health checks
- Hero image: subtle brand blue/red wash

## Deploy required

Merge and deploy **admin** for production.

**PR:** https://github.com/elevate-for-humanity/Elevate-lms/pull/158
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

