### PR TITLE
fix(home): trust bar only before final CTA

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -110,11 +110,7 @@ export default async function HomePage() {
       {/* ── 1b. ROTATING MARQUEE BANNER ─────────────────────────────────── */}
       <MarqueeBanner />
 
-      {/* ── 2. TRUST BAR ────────────────────────────────────────────────── */}
-      {/* DOL registration, WIOA/ETPL approval, RAPIDS capability, partner logos */}
-      <HomeTrustBar />
-
-      {/* ── 3. HOW ELEVATE WORKS ────────────────────────────────────────── */}
+      {/* ── 2. HOW ELEVATE WORKS ────────────────────────────────────────── */}
       {/* 6-step operational pipeline: Apply → Funding → Training →
           Apprenticeship → Credential → Employment */}
       <HomeHowItWorks />


### PR DESCRIPTION
Follow-up to #173: removes duplicate HomeTrustBar under hero; keeps accreditations strip once before final CTA.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Home layout-only change: one fewer component render and comment updates, no logic or data paths.
> 
> **Overview**
> Removes the **duplicate** `HomeTrustBar` that appeared immediately after the hero and marquee, so DOL/WIOA/partner accreditations show **once**—in section **9b**, right before the final CTA (follow-up to #173).
> 
> Section comments on the home page are renumbered (e.g. “How Elevate Works” becomes section **2**).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 69ee79d3192de4ae5be57497e9eb0c36a52da93b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->