### PR TITLE
feat(trial): tenant subdomains, public sites, and website builder wiring

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -800,13 +800,11 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
 
 ## Cursor Cloud specific instructions
 
-> **Operator workflow:** localhost + **admin dashboard** (`pnpm dev:admin` → http://localhost:3001). Gitpod is not required. See `docs/LOCAL_DEVELOPMENT.md`.
-
 ### Environment setup
 
 - **Node.js 20.19.2** required (pinned in `.node-version`). Use `nvm use 20.19.2`.
 - **pnpm 10.28.2** is the package manager — `corepack enable` activates it.
-- **No local database** — hosted Supabase. Use real keys in `.env.local` for full admin features; placeholders only boot the servers.
+- **No local database** — the app connects to hosted Supabase. A `.env.local` with placeholder keys is enough to start the dev server; DB-dependent features fail gracefully at runtime.
 - Minimum `.env.local` for dev server startup:
   ```
   NEXT_PUBLIC_SUPABASE_URL=https://cuxzzpsyufcewtmicszk.supabase.co
@@ -855,4 +853,13 @@ Precedence at runtime: `platform_secrets > app_secrets > process.env`
 **AI Console vs Dev Studio Command tab:** both use `/api/devstudio/execute` — AI Console is the standalone page, Dev Studio embeds the same in an IDE-like shell. Not a conflict.
 
 **Dev Studio AI Chat** (`/api/devstudio/chat`) uses Groq/Gemini with tool calling for platform operations. This is separate from `lib/ai/ai-service.ts` (`aiChat()`) which is for course content generation.
+
+### Managed trial + tenant public sites
+
+- **Trial start:** `POST /api/trial/start-managed` provisions org + `managed_licenses` + published `user_websites` via `lib/tenant/provision-trial-website.ts` (skipped for `websiteMode=api_embed`).
+- **Public URL:** `https://{slug}.app.elevateforhumanity.org` — `proxy.ts` sets `x-tenant-slug` and rewrites non-admin paths to `app/tenant-site/[[...slug]]`.
+- **Publish / edit:** `POST /api/websites/[id]/publish`, `PATCH /api/websites/[id]/config`, editor at `/apps/website-builder/edit/[websiteId]`.
+- **AI → builder:** `POST /api/ai/generate-site` with `websiteId` persists into `site_config`.
+- **DB:** Migration `20260530000001_tenant_website_builder.sql` must be applied manually before new columns work in production.
+- **Docs:** `docs/store-14-day-trial.md`
 

--- a/app/api/ai/generate-site/route.ts
+++ b/app/api/ai/generate-site/route.ts
@@ -5,6 +5,8 @@ import { getRecommendedTemplate } from '@/lib/templates/designs';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { apiAuthGuard } from '@/lib/admin/guards';
+import { saveWebsiteConfig } from '@/lib/websites/save-site-config';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
 
 /**
  * POST /api/ai/generate-site

--- a/app/api/trial/start-managed/route.ts
+++ b/app/api/trial/start-managed/route.ts
@@ -73,7 +73,7 @@ async function sendTrialWelcomeEmail(
   }
 
   await resend.emails.send({
-    from: `Elevate LMS <${PLATFORM_DEFAULTS.emailFromAddress}>`,
+    from: 'Elevate LMS <${PLATFORM_DEFAULTS.emailFromAddress}>',
     to: email,
     subject: `Your 14-day trial is ready — ${orgName}`,
     headers: { 'X-Correlation-ID': correlationId },
@@ -81,12 +81,13 @@ async function sendTrialWelcomeEmail(
       <h1>Your trial is live.</h1>
       <p>Organization: <strong>${orgName}</strong></p>
       <p><a href="${dashboardUrl}" style="display:inline-block;padding:12px 24px;background:#dc2626;color:#fff;font-weight:bold;text-decoration:none;border-radius:6px;">Open Your Dashboard</a></p>
+      <p>Your public site: <a href="${publicSiteUrl}">${publicSiteUrl}</a></p>
       <h2>What to do now:</h2>
       <ol>
-        <li>Log in at the link above</li>
-        <li>Configure your organization settings</li>
-        <li>Add your first course or program</li>
-        <li>Invite your team</li>
+        <li>Visit your public site and share it with your team</li>
+        <li>Log in to the admin dashboard to add programs and courses</li>
+        <li>Customize your site in Website Builder</li>
+        <li>Invite instructors and test enrollment</li>
       </ol>
       <p>Your trial runs for 14 days with full platform access. No credit card required.</p>
       <p>Questions? Reply to this email or visit <a href="${PLATFORM_DEFAULTS.siteUrl}/contact">our contact page</a>.</p>

--- a/app/api/websites/[websiteId]/config/route.ts
+++ b/app/api/websites/[websiteId]/config/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { saveWebsiteConfig } from '@/lib/websites/save-site-config';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { safeError } from '@/lib/api/safe-error';
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+type RouteContext = { params: Promise<{ websiteId: string }> };
+
+async function _PATCH(request: NextRequest, context: RouteContext) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  const { websiteId } = await context.params;
+  const body = await request.json();
+
+  const db = await requireAdminClient();
+  const { data: site } = await db
+    .from('user_websites')
+    .select('id, user_id')
+    .eq('id', websiteId)
+    .maybeSingle();
+
+  if (!site) return safeError('Website not found', 404);
+  if (site.user_id && site.user_id !== auth.id) return safeError('Forbidden', 403);
+
+  const result = await saveWebsiteConfig(websiteId, {
+    ...(body.config ?? {}),
+    siteName: body.siteName,
+  });
+
+  if (!result.ok) return safeError(result.error, 500);
+  return NextResponse.json({ ok: true });
+}
+
+export const PATCH = withRuntime(withApiAudit('/api/websites/[websiteId]/config', _PATCH));

--- a/app/api/websites/[websiteId]/publish/route.ts
+++ b/app/api/websites/[websiteId]/publish/route.ts
@@ -1,0 +1,51 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { safeError } from '@/lib/api/safe-error';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { publishWebsite } from '@/lib/websites/publish-website';
+
+type RouteContext = { params: Promise<{ websiteId: string }> };
+
+async function _POST(request: NextRequest, context: RouteContext) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  const { websiteId } = await context.params;
+  const body = await request.json().catch(() => ({}));
+  const requestedSubdomain =
+    typeof body.subdomain === 'string' ? body.subdomain.trim().toLowerCase() : '';
+
+  const db = await requireAdminClient();
+  const { data: site } = await db
+    .from('user_websites')
+    .select('id, user_id, organization_id, subdomain')
+    .eq('id', websiteId)
+    .maybeSingle();
+
+  if (!site) return safeError('Website not found', 404);
+  if (site.user_id && site.user_id !== auth.id) return safeError('Forbidden', 403);
+
+  let subdomain = requestedSubdomain || (site.subdomain as string | null);
+  if (!subdomain && site.organization_id) {
+    const { data: org } = await db
+      .from('organizations')
+      .select('slug')
+      .eq('id', site.organization_id)
+      .maybeSingle();
+    subdomain = org?.slug ?? undefined;
+  }
+
+  if (!subdomain) return safeError('Subdomain is required to publish', 400);
+
+  const result = await publishWebsite(websiteId, subdomain);
+  if (!result.ok) {
+    const status = result.error.includes('in use') ? 409 : 500;
+    return safeError(result.error, status);
+  }
+
+  return NextResponse.json({ ok: true, subdomain, publicUrl: result.publicUrl });
+}
+
+export const POST = withRuntime(withApiAudit('/api/websites/[websiteId]/publish', _POST));

--- a/app/apps/website-builder/WebsiteBuilderApp.tsx
+++ b/app/apps/website-builder/WebsiteBuilderApp.tsx
@@ -7,15 +7,12 @@ import {
   Layout,
   Settings,
   Plus,
-  Globe,
   Eye,
   Trash2,
   Edit,
-  Monitor,
-  Smartphone,
-  ChevronRight,
   X,
 } from 'lucide-react';
+import { tenantPublicSiteUrl } from '@/lib/tenant/public-site-url';
 
 interface Props {
   user: any;

--- a/app/apps/website-builder/edit/[websiteId]/WebsiteEditorClient.tsx
+++ b/app/apps/website-builder/edit/[websiteId]/WebsiteEditorClient.tsx
@@ -1,0 +1,184 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Loader2, Sparkles, Globe, ArrowLeft } from 'lucide-react';
+import { tenantPublicSiteUrl } from '@/lib/tenant/public-site-url';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
+
+type Props = {
+  websiteId: string;
+  siteName: string;
+  subdomain: string | null;
+  isPublished: boolean;
+  initialConfig: TenantSiteConfig;
+};
+
+export function WebsiteEditorClient({
+  websiteId,
+  siteName: initialName,
+  subdomain: initialSubdomain,
+  isPublished: initialPublished,
+  initialConfig,
+}: Props) {
+  const [siteName, setSiteName] = useState(initialName);
+  const [heroTitle, setHeroTitle] = useState(initialConfig.homepage.heroTitle);
+  const [heroSubtitle, setHeroSubtitle] = useState(initialConfig.homepage.heroSubtitle);
+  const [subdomain, setSubdomain] = useState(initialSubdomain ?? '');
+  const [isPublished, setIsPublished] = useState(initialPublished);
+  const [busy, setBusy] = useState(false);
+  const [message, setMessage] = useState<string | null>(null);
+
+  const saveConfig = async () => {
+    setBusy(true);
+    setMessage(null);
+    const res = await fetch(`/api/websites/${websiteId}/config`, {
+      method: 'PATCH',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        siteName,
+        config: {
+          homepage: { heroTitle, heroSubtitle },
+          branding: { logoText: siteName },
+        },
+      }),
+    });
+    setBusy(false);
+    setMessage(res.ok ? 'Saved.' : 'Save failed.');
+  };
+
+  const runAiGenerate = async () => {
+    setBusy(true);
+    setMessage(null);
+    const res = await fetch('/api/ai/generate-site', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        organizationName: siteName,
+        organizationType: 'Training Provider',
+        websiteId,
+      }),
+    });
+    const data = await res.json();
+    setBusy(false);
+    if (!res.ok) {
+      setMessage(data.error ?? 'AI generation failed');
+      return;
+    }
+    if (data.config?.homepage?.heroTitle) setHeroTitle(data.config.homepage.heroTitle);
+    if (data.config?.homepage?.heroSubtitle) setHeroSubtitle(data.config.homepage.heroSubtitle);
+    setMessage('AI content generated and saved.');
+  };
+
+  const publish = async () => {
+    setBusy(true);
+    setMessage(null);
+    const res = await fetch(`/api/websites/${websiteId}/publish`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ subdomain }),
+    });
+    const data = await res.json();
+    setBusy(false);
+    if (!res.ok) {
+      setMessage(data.error ?? 'Publish failed');
+      return;
+    }
+    setIsPublished(true);
+    setMessage(`Live at ${data.publicUrl}`);
+  };
+
+  const previewUrl = subdomain ? tenantPublicSiteUrl(subdomain) : null;
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="max-w-3xl mx-auto px-4 py-8">
+        <Link
+          href="/apps/website-builder"
+          className="inline-flex items-center gap-2 text-sm text-slate-600 mb-6"
+        >
+          <ArrowLeft className="w-4 h-4" /> Back to sites
+        </Link>
+        <h1 className="text-2xl font-bold mb-6">Edit website</h1>
+
+        <div className="bg-white rounded-xl border p-6 space-y-4">
+          <div>
+            <label className="block text-sm font-medium mb-1">Site name</label>
+            <input
+              className="w-full border rounded-lg px-3 py-2"
+              value={siteName}
+              onChange={(e) => setSiteName(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Hero headline</label>
+            <input
+              className="w-full border rounded-lg px-3 py-2"
+              value={heroTitle}
+              onChange={(e) => setHeroTitle(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Hero subheadline</label>
+            <textarea
+              className="w-full border rounded-lg px-3 py-2"
+              rows={3}
+              value={heroSubtitle}
+              onChange={(e) => setHeroSubtitle(e.target.value)}
+            />
+          </div>
+          <div>
+            <label className="block text-sm font-medium mb-1">Subdomain</label>
+            <div className="flex items-center gap-2">
+              <input
+                className="flex-1 border rounded-lg px-3 py-2"
+                value={subdomain}
+                onChange={(e) => setSubdomain(e.target.value.toLowerCase().replace(/[^a-z0-9-]/g, ''))}
+                placeholder="acme-training"
+              />
+              <span className="text-sm text-slate-500">.app.elevateforhumanity.org</span>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap gap-3 pt-2">
+            <button
+              type="button"
+              onClick={saveConfig}
+              disabled={busy}
+              className="px-4 py-2 bg-brand-blue-600 text-white rounded-lg text-sm font-medium disabled:opacity-50"
+            >
+              {busy ? <Loader2 className="w-4 h-4 animate-spin" /> : 'Save'}
+            </button>
+            <button
+              type="button"
+              onClick={runAiGenerate}
+              disabled={busy}
+              className="px-4 py-2 border rounded-lg text-sm font-medium flex items-center gap-2"
+            >
+              <Sparkles className="w-4 h-4" /> Generate with AI
+            </button>
+            <button
+              type="button"
+              onClick={publish}
+              disabled={busy || !subdomain}
+              className="px-4 py-2 bg-brand-green-600 text-white rounded-lg text-sm font-medium flex items-center gap-2 disabled:opacity-50"
+            >
+              <Globe className="w-4 h-4" /> {isPublished ? 'Update publish' : 'Publish'}
+            </button>
+            {previewUrl && isPublished && (
+              <a
+                href={previewUrl}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="px-4 py-2 border rounded-lg text-sm font-medium"
+              >
+                View live site
+              </a>
+            )}
+          </div>
+          {message && <p className="text-sm text-slate-600">{message}</p>}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/apps/website-builder/edit/[websiteId]/page.tsx
+++ b/app/apps/website-builder/edit/[websiteId]/page.tsx
@@ -1,0 +1,43 @@
+import { redirect, notFound } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { WebsiteEditorClient } from './WebsiteEditorClient';
+import { buildDefaultSiteConfig, mergeSiteConfig } from '@/lib/tenant/default-site-config';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
+
+export const dynamic = 'force-dynamic';
+
+type Props = { params: Promise<{ websiteId: string }> };
+
+export default async function WebsiteEditorPage({ params }: Props) {
+  const { websiteId } = await params;
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) redirect(`/login?redirect=/apps/website-builder/edit/${websiteId}`);
+
+  const { data: site } = await supabase
+    .from('user_websites')
+    .select('id, user_id, site_name, subdomain, is_published, site_config')
+    .eq('id', websiteId)
+    .maybeSingle();
+
+  if (!site || (site.user_id && site.user_id !== user.id)) notFound();
+
+  const name = (site.site_name as string | null) ?? 'My Site';
+  const base = buildDefaultSiteConfig({ organizationName: name });
+  const config =
+    site.site_config && typeof site.site_config === 'object'
+      ? mergeSiteConfig(base, site.site_config as Partial<TenantSiteConfig>)
+      : base;
+
+  return (
+    <WebsiteEditorClient
+      websiteId={site.id}
+      siteName={name}
+      subdomain={(site.subdomain as string | null) ?? null}
+      isPublished={Boolean(site.is_published)}
+      initialConfig={config}
+    />
+  );
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,8 +40,8 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
 
   title: {
-    default: `${PLATFORM_DEFAULTS.orgName} | Career Training at No Cost for Eligible Participants`,
-    template: `%s | ${PLATFORM_DEFAULTS.orgName}`,
+    default: '${PLATFORM_DEFAULTS.orgName} | Career Training at No Cost for Eligible Participants',
+    template: '%s | ${PLATFORM_DEFAULTS.orgName}',
   },
 
   description:
@@ -168,8 +168,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               '@type': 'Organization',
               name: PLATFORM_DEFAULTS.orgName,
               url: PLATFORM_DEFAULTS.siteUrl,
-              logo: '${PLATFORM_DEFAULTS.siteUrl}/logo.png',
-              image: 'https://${PLATFORM_DEFAULTS.canonicalDomain}/images/og-image.jpg',
+              logo: `${PLATFORM_DEFAULTS.siteUrl}/logo.png`,
+              image: `https://${PLATFORM_DEFAULTS.canonicalDomain}/images/og-image.jpg`,
               sameAs: [
                 'https://www.facebook.com/elevateforhumanity',
                 'https://www.linkedin.com/company/elevate-for-humanity',

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -40,8 +40,8 @@ export const metadata: Metadata = {
   metadataBase: new URL(SITE_URL),
 
   title: {
-    default: '${PLATFORM_DEFAULTS.orgName} | Career Training at No Cost for Eligible Participants',
-    template: '%s | ${PLATFORM_DEFAULTS.orgName}',
+    default: `${PLATFORM_DEFAULTS.orgName} | Career Training at No Cost for Eligible Participants`,
+    template: `%s | ${PLATFORM_DEFAULTS.orgName}`,
   },
 
   description:
@@ -168,8 +168,8 @@ export default function RootLayout({ children }: { children: React.ReactNode }) 
               '@type': 'Organization',
               name: PLATFORM_DEFAULTS.orgName,
               url: PLATFORM_DEFAULTS.siteUrl,
-              logo: `${PLATFORM_DEFAULTS.siteUrl}/logo.png`,
-              image: `https://${PLATFORM_DEFAULTS.canonicalDomain}/images/og-image.jpg`,
+              logo: '${PLATFORM_DEFAULTS.siteUrl}/logo.png',
+              image: 'https://${PLATFORM_DEFAULTS.canonicalDomain}/images/og-image.jpg',
               sameAs: [
                 'https://www.facebook.com/elevateforhumanity',
                 'https://www.linkedin.com/company/elevate-for-humanity',

--- a/app/tenant-site/[[...slug]]/page.tsx
+++ b/app/tenant-site/[[...slug]]/page.tsx
@@ -1,0 +1,30 @@
+import { Metadata } from 'next';
+import { notFound } from 'next/navigation';
+import { PublicTenantSite } from '@/components/tenant/PublicTenantSite';
+import { getTenantSlugFromHeaders } from '@/lib/tenant/get-tenant-slug';
+import { loadPublishedSiteBySubdomain } from '@/lib/tenant/load-published-site';
+
+export const dynamic = 'force-dynamic';
+
+type Props = { params: Promise<{ slug?: string[] }> };
+
+export async function generateMetadata({ params }: Props): Promise<Metadata> {
+  const tenantSlug = await getTenantSlugFromHeaders();
+  if (!tenantSlug) return { title: 'Site' };
+  const site = await loadPublishedSiteBySubdomain(tenantSlug);
+  if (!site) return { title: 'Site not found' };
+  return {
+    title: site.config.seo?.title ?? site.siteName,
+    description: site.config.seo?.description,
+  };
+}
+
+export default async function TenantSitePage({ params }: Props) {
+  const tenantSlug = await getTenantSlugFromHeaders();
+  if (!tenantSlug) notFound();
+  const site = await loadPublishedSiteBySubdomain(tenantSlug);
+  if (!site) notFound();
+  const { slug: segments } = await params;
+  const pathname = '/' + (segments?.join('/') ?? '');
+  return <PublicTenantSite site={site} pathname={pathname} />;
+}

--- a/app/tenant-site/layout.tsx
+++ b/app/tenant-site/layout.tsx
@@ -1,0 +1,3 @@
+export default function TenantSiteLayout({ children }: { children: React.ReactNode }) {
+  return children;
+}

--- a/components/tenant/PublicTenantSite.tsx
+++ b/components/tenant/PublicTenantSite.tsx
@@ -1,0 +1,128 @@
+'use client';
+
+import Link from 'next/link';
+import type { PublishedTenantSite } from '@/lib/tenant/site-types';
+
+type PageKey = 'home' | 'programs' | 'about' | 'contact';
+
+function resolvePage(pathname: string): PageKey {
+  const p = pathname.replace(/\/$/, '') || '/';
+  if (p === '/programs') return 'programs';
+  if (p === '/about') return 'about';
+  if (p === '/contact') return 'contact';
+  return 'home';
+}
+
+export function PublicTenantSite({
+  site,
+  pathname = '/',
+}: {
+  site: PublishedTenantSite;
+  pathname?: string;
+}) {
+  const { config } = site;
+  const page = resolvePage(pathname);
+  const primary = config.branding.primaryColor;
+
+  return (
+    <div className="min-h-screen bg-white text-slate-900">
+      <header className="border-b border-slate-200 bg-white sticky top-0 z-20">
+        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between gap-4">
+          <Link href="/" className="font-bold text-lg" style={{ color: primary }}>
+            {config.branding.logoText}
+          </Link>
+          <nav className="flex flex-wrap gap-4 text-sm font-medium">
+            {config.navigation.map((item) => (
+              <Link
+                key={item.href}
+                href={item.href}
+                className={
+                  resolvePage(item.href) === page ? 'text-slate-900' : 'text-slate-600 hover:text-slate-900'
+                }
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+          <Link
+            href="/admin"
+            className="hidden sm:inline-flex px-3 py-1.5 rounded-lg text-sm font-medium text-white"
+            style={{ backgroundColor: primary }}
+          >
+            Admin
+          </Link>
+        </div>
+      </header>
+
+      <main>
+        {page === 'home' && (
+          <>
+            <section className="px-4 py-16 md:py-24 bg-slate-50">
+              <div className="max-w-4xl mx-auto text-center">
+                <p className="text-sm font-semibold uppercase tracking-wide text-slate-600 mb-3">
+                  {config.branding.tagline}
+                </p>
+                <h1 className="text-3xl md:text-5xl font-bold text-slate-900 mb-4">
+                  {config.homepage.heroTitle}
+                </h1>
+                <p className="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
+                  {config.homepage.heroSubtitle}
+                </p>
+                <Link
+                  href="/programs"
+                  className="inline-flex px-6 py-3 rounded-lg font-semibold text-white"
+                  style={{ backgroundColor: primary }}
+                >
+                  {config.homepage.heroCtaText}
+                </Link>
+              </div>
+            </section>
+            <section className="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-3 gap-8">
+              {config.homepage.features.map((f) => (
+                <div key={f.title} className="rounded-xl border border-slate-200 p-6">
+                  <h2 className="font-bold text-lg mb-2">{f.title}</h2>
+                  <p className="text-slate-600 text-sm">{f.description}</p>
+                </div>
+              ))}
+            </section>
+          </>
+        )}
+        {page === 'programs' && (
+          <section className="max-w-6xl mx-auto px-4 py-12">
+            <h1 className="text-3xl font-bold mb-8">Training Programs</h1>
+            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
+              {config.programs.map((prog) => (
+                <article key={prog.name} className="border border-slate-200 rounded-xl p-6">
+                  <h2 className="font-bold text-lg mb-2">{prog.name}</h2>
+                  <p className="text-slate-600 text-sm mb-4">{prog.description}</p>
+                </article>
+              ))}
+            </div>
+          </section>
+        )}
+        {page === 'about' && (
+          <section className="max-w-3xl mx-auto px-4 py-12">
+            <h1 className="text-3xl font-bold mb-4">About {config.branding.logoText}</h1>
+            <p className="text-slate-600 leading-relaxed">{config.footer.description}</p>
+          </section>
+        )}
+        {page === 'contact' && (
+          <section className="max-w-3xl mx-auto px-4 py-12">
+            <h1 className="text-3xl font-bold mb-4">Contact</h1>
+            {config.footer.contactEmail && (
+              <p className="text-slate-800">
+                Email:{' '}
+                <a href={`mailto:${config.footer.contactEmail}`} className="underline font-medium">
+                  {config.footer.contactEmail}
+                </a>
+              </p>
+            )}
+          </section>
+        )}
+      </main>
+      <footer className="border-t border-slate-200 mt-12 py-8 bg-slate-50 text-center text-sm text-slate-600">
+        <p>{config.footer.description}</p>
+      </footer>
+    </div>
+  );
+}

--- a/docs/store-14-day-trial.md
+++ b/docs/store-14-day-trial.md
@@ -1,0 +1,47 @@
+# 14-day managed trial — what subscribers get
+
+## Managed trial (`POST /api/trial/start-managed`, `/store/trial`)
+
+| Item | Included |
+|------|----------|
+| **Organization** | `organizations` row with unique `slug` |
+| **Subdomain** | `{slug}.app.elevateforhumanity.org` (ALB/proxy routing — no per-customer DNS record) |
+| **Public website** | Published `user_websites` row with starter template + AI-ready `site_config` (home, programs, about, contact) |
+| **Admin** | `{slug}.app.elevateforhumanity.org/admin` → org-scoped admin dashboard |
+| **License** | `managed_licenses` tier `trial`, 14-day `trial_ends_at` |
+| **Email** | Welcome email with dashboard + public site links |
+
+### Not included until upgrade
+
+- Stripe / payment processing
+- Custom apex domain (subdomain only)
+- SLA or dedicated support
+- Automatic course/program seeding (org starts empty in LMS)
+
+### `websiteMode` intake
+
+| Mode | Behavior |
+|------|----------|
+| `new` | Provisions published starter public site |
+| `existing` | Same site provision; CTA copy tuned for embed/enrollment |
+| `api_embed` | No public site row; intake logged in `license_events` only |
+
+## App-specific trial (`lib/trial/start-app-trial.ts`)
+
+Used by Website Builder, SAM.gov, Grants, etc. Creates `user_app_subscriptions` (`plan: starter`, `status: trial`, 14 days). Does not create an `organizations` subdomain unless the user also starts a managed trial.
+
+## Lifecycle (`GET /api/cron/trial-lifecycle`)
+
+- Day 7: warning email (orgs with `plan=trial` and `trial_started_at` in window)
+- Day 14: `status` → `trial_expired`
+- Day 30: archive expired orgs
+
+## Subdomain rules
+
+- Slug derived from org name; collision suffix `-xxxx`
+- Reserved: `www`, `app`, `api`, `admin`, `dashboard`, `mail`, `support`, `help`, `docs`, `demo`
+- Publish API enforces unique published `subdomain` on `user_websites`
+
+## Required migration
+
+Apply `supabase/migrations/20260530000001_tenant_website_builder.sql` in Supabase SQL Editor before provisioning will persist `site_config` / `subdomain` columns.

--- a/lib/tenant/default-site-config.ts
+++ b/lib/tenant/default-site-config.ts
@@ -1,0 +1,126 @@
+import { getRecommendedTemplate } from '@/lib/templates/designs';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
+
+export function buildDefaultSiteConfig(params: {
+  organizationName: string;
+  organizationType?: string;
+  industry?: string;
+  contactEmail?: string;
+}): TenantSiteConfig {
+  const { organizationName, organizationType = 'Training Provider', industry = 'General' } =
+    params;
+  const template = getRecommendedTemplate(industry, organizationType);
+  const contactEmail =
+    params.contactEmail ??
+    `info@${organizationName.toLowerCase().replace(/[^a-z0-9]+/g, '')}.org`;
+
+  return {
+    template: {
+      id: template.id,
+      name: template.name,
+      fonts: template.fonts,
+      colors: template.colors as unknown as Record<string, string>,
+      style: template.style as unknown as Record<string, string>,
+    },
+    branding: {
+      primaryColor: template.colors.primary,
+      secondaryColor: template.colors.secondary,
+      accentColor: template.colors.accent,
+      backgroundColor: template.colors.background,
+      textColor: template.colors.text,
+      logoText: organizationName,
+      tagline: 'Quality training for career advancement',
+    },
+    homepage: {
+      heroTitle: `Welcome to ${organizationName}`,
+      heroSubtitle:
+        'Industry-recognized training programs designed to help learners build skills and advance their careers.',
+      heroCtaText: 'View Programs',
+      features: [
+        {
+          title: 'Expert-Led Training',
+          description: 'Learn from instructors with real-world experience in your field.',
+        },
+        {
+          title: 'Flexible Learning',
+          description: 'Programs designed for working adults and career changers.',
+        },
+        {
+          title: 'Career Support',
+          description: 'Guidance from enrollment through completion and job placement.',
+        },
+      ],
+    },
+    programs: [
+      {
+        name: 'Foundations',
+        description: 'Core skills and safety fundamentals for new learners.',
+        duration: '4 weeks',
+        level: 'Beginner',
+      },
+      {
+        name: 'Professional Track',
+        description: 'Hands-on training aligned with employer expectations.',
+        duration: '8 weeks',
+        level: 'Intermediate',
+      },
+      {
+        name: 'Certification Prep',
+        description: 'Exam-ready preparation with practice assessments.',
+        duration: '12 weeks',
+        level: 'Advanced',
+      },
+    ],
+    stats: { students: 250, completionRate: '92%', employers: 40, rating: '4.8' },
+    testimonial: {
+      quote:
+        'The training team helped me move from entry-level work into a skilled role with clear next steps.',
+      author: 'Program Graduate',
+    },
+    navigation: [
+      { label: 'Home', href: '/' },
+      { label: 'Programs', href: '/programs' },
+      { label: 'About', href: '/about' },
+      { label: 'Contact', href: '/contact' },
+    ],
+    footer: {
+      description: `${organizationName} provides workforce training and education.`,
+      contactEmail,
+    },
+    seo: {
+      title: `${organizationName} | Training Programs`,
+      description: `${organizationName} offers professional training and certification pathways.`,
+      keywords: ['training', 'workforce', 'certification', organizationName],
+    },
+    meta: {
+      organizationName,
+      organizationType,
+      industry,
+      generatedAt: new Date().toISOString(),
+      source: 'default-site-config',
+    },
+  };
+}
+
+export function mergeSiteConfig(
+  base: TenantSiteConfig,
+  partial: Partial<TenantSiteConfig> & {
+    homepage?: Partial<TenantSiteConfig['homepage']>;
+    branding?: Partial<TenantSiteConfig['branding']>;
+  },
+): TenantSiteConfig {
+  return {
+    ...base,
+    ...partial,
+    branding: { ...base.branding, ...partial.branding },
+    homepage: { ...base.homepage, ...partial.homepage },
+    programs: partial.programs ?? base.programs,
+    stats: partial.stats ?? base.stats,
+    testimonial: partial.testimonial ?? base.testimonial,
+    navigation: partial.navigation ?? base.navigation,
+    footer: { ...base.footer, ...partial.footer },
+    seo: { ...base.seo, ...partial.seo },
+    template: partial.template ?? base.template,
+    meta: { ...base.meta, ...partial.meta },
+  };
+}

--- a/lib/tenant/get-tenant-slug.ts
+++ b/lib/tenant/get-tenant-slug.ts
@@ -1,0 +1,7 @@
+import { headers } from 'next/headers';
+
+export async function getTenantSlugFromHeaders(): Promise<string | null> {
+  const h = await headers();
+  const slug = h.get('x-tenant-slug');
+  return slug?.trim() || null;
+}

--- a/lib/tenant/load-published-site.ts
+++ b/lib/tenant/load-published-site.ts
@@ -1,0 +1,83 @@
+import { requireAdminClient } from '@/lib/supabase/admin';
+import type { PublishedTenantSite, TenantSiteConfig } from '@/lib/tenant/site-types';
+import { buildDefaultSiteConfig } from '@/lib/tenant/default-site-config';
+
+type WebsiteRow = {
+  id: string;
+  subdomain: string | null;
+  site_name: string | null;
+  organization_id: string | null;
+  site_config: unknown;
+  is_published: boolean | null;
+};
+
+function parseConfig(raw: unknown, fallbackName: string): TenantSiteConfig {
+  if (raw && typeof raw === 'object' && !Array.isArray(raw)) {
+    const cfg = raw as TenantSiteConfig;
+    if (cfg.homepage?.heroTitle && cfg.branding?.primaryColor) return cfg;
+  }
+  return buildDefaultSiteConfig({ organizationName: fallbackName });
+}
+
+export async function loadPublishedSiteBySubdomain(
+  subdomain: string,
+): Promise<PublishedTenantSite | null> {
+  const db = await requireAdminClient();
+  const slug = subdomain.trim().toLowerCase();
+  if (!slug) return null;
+
+  const { data: site, error } = await db
+    .from('user_websites')
+    .select('id, subdomain, site_name, organization_id, site_config, is_published')
+    .eq('subdomain', slug)
+    .eq('is_published', true)
+    .maybeSingle();
+
+  if (!error && site) {
+    const row = site as WebsiteRow;
+    return {
+      id: row.id,
+      subdomain: row.subdomain ?? slug,
+      siteName: row.site_name ?? slug,
+      organizationId: row.organization_id,
+      config: parseConfig(row.site_config, row.site_name ?? slug),
+    };
+  }
+
+  const { data: org } = await db
+    .from('organizations')
+    .select('id, name, slug, status')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (!org || org.status === 'trial_expired' || org.status === 'archived') return null;
+
+  const { data: orgSite } = await db
+    .from('user_websites')
+    .select('id, subdomain, site_name, organization_id, site_config, is_published')
+    .eq('organization_id', org.id)
+    .order('updated_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (orgSite) {
+    const row = orgSite as WebsiteRow;
+    if (row.is_published) {
+      return {
+        id: row.id,
+        subdomain: row.subdomain ?? slug,
+        siteName: row.site_name ?? org.name,
+        organizationId: org.id,
+        config: parseConfig(row.site_config, org.name),
+      };
+    }
+  }
+
+  return {
+    id: `org-${org.id}`,
+    subdomain: slug,
+    siteName: org.name,
+    organizationId: org.id,
+    config: buildDefaultSiteConfig({ organizationName: org.name }),
+  };
+}

--- a/lib/tenant/provision-trial-website.ts
+++ b/lib/tenant/provision-trial-website.ts
@@ -1,0 +1,98 @@
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { buildDefaultSiteConfig } from '@/lib/tenant/default-site-config';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
+
+export type ProvisionTrialWebsiteParams = {
+  organizationId: string;
+  organizationName: string;
+  subdomain: string;
+  trialEndsAt: string;
+  contactEmail?: string;
+  industry?: string;
+  websiteMode?: 'new_site' | 'existing_site' | 'api_embed';
+  siteConfig?: TenantSiteConfig;
+};
+
+export type ProvisionTrialWebsiteResult =
+  | { ok: true; websiteId: string; publicUrl: string }
+  | { ok: false; error: string };
+
+export async function provisionTrialWebsite(
+  params: ProvisionTrialWebsiteParams,
+): Promise<ProvisionTrialWebsiteResult> {
+  const {
+    organizationId,
+    organizationName,
+    subdomain,
+    trialEndsAt,
+    contactEmail,
+    industry,
+    websiteMode = 'new_site',
+    siteConfig: overrideConfig,
+  } = params;
+
+  const db = await requireAdminClient();
+  const slug = subdomain.trim().toLowerCase();
+  const config =
+    overrideConfig ??
+    buildDefaultSiteConfig({
+      organizationName,
+      industry: industry ?? 'General',
+      contactEmail,
+    });
+
+  if (websiteMode === 'existing_site') {
+    config.homepage.heroCtaText = 'Enroll Now';
+    config.homepage.heroSubtitle =
+      'Connect your existing website to Elevate enrollment and learner management.';
+  }
+
+  const payload: Record<string, unknown> = {
+    organization_id: organizationId,
+    subdomain: slug,
+    site_name: organizationName,
+    template_id: config.template.id,
+    is_published: true,
+    status: 'published',
+    site_config: config,
+    trial_ends_at: trialEndsAt,
+    updated_at: new Date().toISOString(),
+  };
+
+  const { data: existing } = await db
+    .from('user_websites')
+    .select('id')
+    .eq('organization_id', organizationId)
+    .maybeSingle();
+
+  try {
+    if (existing?.id) {
+      const { error } = await db.from('user_websites').update(payload).eq('id', existing.id);
+      if (error) throw error;
+      return { ok: true, websiteId: existing.id, publicUrl: `https://${slug}.app.elevateforhumanity.org` };
+    }
+
+    const { data: inserted, error } = await db
+      .from('user_websites')
+      .insert({ ...payload, created_at: new Date().toISOString() })
+      .select('id')
+      .maybeSingle();
+
+    if (error || !inserted?.id) {
+      return { ok: false, error: error?.message ?? 'insert returned no row' };
+    }
+
+    return {
+      ok: true,
+      websiteId: inserted.id,
+      publicUrl: `https://${slug}.app.elevateforhumanity.org`,
+    };
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    logger.error('[provisionTrialWebsite] failed', err instanceof Error ? err : undefined, {
+      organizationId,
+    });
+    return { ok: false, error: msg };
+  }
+}

--- a/lib/tenant/public-site-url.ts
+++ b/lib/tenant/public-site-url.ts
@@ -1,0 +1,11 @@
+const TENANT_HOST_SUFFIX = '.app.elevateforhumanity.org';
+
+export function tenantPublicSiteUrl(subdomain: string, path = '/'): string {
+  const base = `https://${subdomain}${TENANT_HOST_SUFFIX}`;
+  if (!path || path === '/') return base;
+  return `${base}${path.startsWith('/') ? path : `/${path}`}`;
+}
+
+export function tenantAdminUrl(subdomain: string, path = '/admin/dashboard'): string {
+  return tenantPublicSiteUrl(subdomain, path);
+}

--- a/lib/tenant/site-types.ts
+++ b/lib/tenant/site-types.ts
@@ -1,0 +1,49 @@
+export type TenantSiteConfig = {
+  template: {
+    id: string;
+    name: string;
+    fonts?: { heading: string; body: string; googleFontsUrl?: string };
+    colors?: Record<string, string>;
+    style?: Record<string, string>;
+  };
+  branding: {
+    primaryColor: string;
+    secondaryColor: string;
+    accentColor: string;
+    backgroundColor?: string;
+    textColor?: string;
+    logoText: string;
+    tagline?: string;
+  };
+  homepage: {
+    heroTitle: string;
+    heroSubtitle: string;
+    heroCtaText: string;
+    features: Array<{ title: string; description: string }>;
+  };
+  programs: Array<{
+    name: string;
+    description: string;
+    duration?: string;
+    level?: string;
+  }>;
+  stats?: {
+    students?: number;
+    completionRate?: string;
+    employers?: number;
+    rating?: string;
+  };
+  testimonial?: { quote: string; author: string };
+  navigation: Array<{ label: string; href: string }>;
+  footer: { description: string; contactEmail?: string };
+  seo?: { title: string; description: string; keywords?: string[] };
+  meta?: Record<string, unknown>;
+};
+
+export type PublishedTenantSite = {
+  id: string;
+  subdomain: string;
+  siteName: string;
+  organizationId: string | null;
+  config: TenantSiteConfig;
+};

--- a/lib/websites/publish-website.ts
+++ b/lib/websites/publish-website.ts
@@ -1,0 +1,34 @@
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { tenantPublicSiteUrl } from '@/lib/tenant/public-site-url';
+
+export async function publishWebsite(
+  websiteId: string,
+  subdomain: string,
+): Promise<{ ok: true; publicUrl: string } | { ok: false; error: string }> {
+  const db = await requireAdminClient();
+  const slug = subdomain.trim().toLowerCase();
+  if (!slug) return { ok: false, error: 'Subdomain required' };
+
+  const { data: taken } = await db
+    .from('user_websites')
+    .select('id')
+    .eq('subdomain', slug)
+    .eq('is_published', true)
+    .neq('id', websiteId)
+    .maybeSingle();
+
+  if (taken) return { ok: false, error: 'Subdomain already in use' };
+
+  const { error } = await db
+    .from('user_websites')
+    .update({
+      subdomain: slug,
+      is_published: true,
+      status: 'published',
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', websiteId);
+
+  if (error) return { ok: false, error: error.message };
+  return { ok: true, publicUrl: tenantPublicSiteUrl(slug) };
+}

--- a/lib/websites/save-site-config.ts
+++ b/lib/websites/save-site-config.ts
@@ -1,0 +1,38 @@
+import { requireAdminClient } from '@/lib/supabase/admin';
+import type { TenantSiteConfig } from '@/lib/tenant/site-types';
+import { mergeSiteConfig, buildDefaultSiteConfig } from '@/lib/tenant/default-site-config';
+
+export async function saveWebsiteConfig(
+  websiteId: string,
+  partial: Partial<TenantSiteConfig> & { siteName?: string },
+): Promise<{ ok: true } | { ok: false; error: string }> {
+  const db = await requireAdminClient();
+
+  const { data: row, error: fetchErr } = await db
+    .from('user_websites')
+    .select('id, site_name, site_config')
+    .eq('id', websiteId)
+    .maybeSingle();
+
+  if (fetchErr || !row) {
+    return { ok: false, error: fetchErr?.message ?? 'Website not found' };
+  }
+
+  const name = (row.site_name as string | null) ?? 'My Site';
+  const base = buildDefaultSiteConfig({ organizationName: name });
+  const existing =
+    row.site_config && typeof row.site_config === 'object'
+      ? mergeSiteConfig(base, row.site_config as Partial<TenantSiteConfig>)
+      : base;
+  const merged = mergeSiteConfig(existing, partial);
+
+  const update: Record<string, unknown> = {
+    site_config: merged,
+    updated_at: new Date().toISOString(),
+  };
+  if (partial.siteName) update.site_name = partial.siteName;
+
+  const { error } = await db.from('user_websites').update(update).eq('id', websiteId);
+  if (error) return { ok: false, error: error.message };
+  return { ok: true };
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -575,15 +575,12 @@ export async function middleware(request: NextRequest) {
       });
     }
 
-    if (tenantSlug) {
-      const publicRewrite = rewriteTenantPublicSite(pathname, request, requestHeadersWithTenant);
-      if (publicRewrite) return publicRewrite;
-    }
-
     return NextResponse.next({ request: { headers: requestHeadersWithTenant } });
   }
 
-  // {subdomain}.app.elevateforhumanity.org — public site + admin on same host
+  // {subdomain}.app.elevateforhumanity.org — tenant portal subdomain form.
+  // e.g. elizabeth-greene-kkx3.app.elevateforhumanity.org/admin
+  // Tenant slug is extracted from the subdomain prefix.
   if (hostWithoutPort.endsWith('.app.elevateforhumanity.org')) {
     const tenantSlug = hostWithoutPort.replace('.app.elevateforhumanity.org', '');
     const requestHeadersWithTenant = new Headers(requestHeaders);

--- a/proxy.ts
+++ b/proxy.ts
@@ -544,23 +544,6 @@ export async function middleware(request: NextRequest) {
 
   // All routes are served by the same AWS ECS container — no proxy needed.
 
-  // Legacy / alternate domains — always 308 to canonical www (no Elevate content on tax/legacy hosts)
-  const legacyHosts = new Set([
-    'supersonicfastermoney.com',
-    'www.supersonicfastermoney.com',
-    'supersonicfastcash.com',
-    'www.supersonicfastcash.com',
-    'elevateforhumanity.com',
-    'www.elevateforhumanity.com',
-  ]);
-  if (legacyHosts.has(hostWithoutPort)) {
-    const url = request.nextUrl.clone();
-    url.host = 'www.elevateforhumanity.org';
-    url.protocol = 'https';
-    url.port = '';
-    return NextResponse.redirect(url, { status: 308 });
-  }
-
   // Redirect non-www .org to www .org
   if (hostWithoutPort === 'elevateforhumanity.org') {
     const url = request.nextUrl.clone();
@@ -592,12 +575,15 @@ export async function middleware(request: NextRequest) {
       });
     }
 
+    if (tenantSlug) {
+      const publicRewrite = rewriteTenantPublicSite(pathname, request, requestHeadersWithTenant);
+      if (publicRewrite) return publicRewrite;
+    }
+
     return NextResponse.next({ request: { headers: requestHeadersWithTenant } });
   }
 
-  // {subdomain}.app.elevateforhumanity.org — tenant portal subdomain form.
-  // e.g. elizabeth-greene-kkx3.app.elevateforhumanity.org/admin
-  // Tenant slug is extracted from the subdomain prefix.
+  // {subdomain}.app.elevateforhumanity.org — public site + admin on same host
   if (hostWithoutPort.endsWith('.app.elevateforhumanity.org')) {
     const tenantSlug = hostWithoutPort.replace('.app.elevateforhumanity.org', '');
     const requestHeadersWithTenant = new Headers(requestHeaders);
@@ -612,6 +598,9 @@ export async function middleware(request: NextRequest) {
         request: { headers: requestHeadersWithTenant },
       });
     }
+
+    const publicRewrite = rewriteTenantPublicSite(pathname, request, requestHeadersWithTenant);
+    if (publicRewrite) return publicRewrite;
 
     return NextResponse.next({ request: { headers: requestHeadersWithTenant } });
   }

--- a/proxy.ts
+++ b/proxy.ts
@@ -45,6 +45,18 @@ const LEGACY_ADMIN_PATH_REDIRECTS: Record<string, string> = {
   '/admin/video-manager':        '/admin/studio',
   '/admin/course-builder':       '/admin/studio',
 };
+function rewriteTenantPublicSite(
+  pathname: string,
+  request: NextRequest,
+  requestHeaders: Headers,
+): NextResponse | null {
+  if (pathname.startsWith('/_next') || pathname.startsWith('/api') || pathname.includes('.')) {
+    return null;
+  }
+  const rewriteUrl = request.nextUrl.clone();
+  rewriteUrl.pathname = pathname === '/' ? '/tenant-site' : `/tenant-site${pathname}`;
+  return NextResponse.rewrite(rewriteUrl, { request: { headers: requestHeaders } });
+}
 
 // Webhook paths bypass auth — Stripe signature verification handles security.
 const WEBHOOK_PATHS = [
@@ -544,6 +556,23 @@ export async function middleware(request: NextRequest) {
 
   // All routes are served by the same AWS ECS container — no proxy needed.
 
+
+  const legacyHosts = new Set([
+    'supersonicfastermoney.com',
+    'www.supersonicfastermoney.com',
+    'supersonicfastcash.com',
+    'www.supersonicfastcash.com',
+    'elevateforhumanity.com',
+    'www.elevateforhumanity.com',
+  ]);
+  if (legacyHosts.has(hostWithoutPort)) {
+    const url = request.nextUrl.clone();
+    url.host = 'www.elevateforhumanity.org';
+    url.protocol = 'https';
+    url.port = '';
+    return NextResponse.redirect(url, { status: 308 });
+  }
+
   // Redirect non-www .org to www .org
   if (hostWithoutPort === 'elevateforhumanity.org') {
     const url = request.nextUrl.clone();
@@ -575,12 +604,15 @@ export async function middleware(request: NextRequest) {
       });
     }
 
+    if (tenantSlug) {
+      const publicRewrite = rewriteTenantPublicSite(pathname, request, requestHeadersWithTenant);
+      if (publicRewrite) return publicRewrite;
+    }
+
     return NextResponse.next({ request: { headers: requestHeadersWithTenant } });
   }
 
-  // {subdomain}.app.elevateforhumanity.org — tenant portal subdomain form.
-  // e.g. elizabeth-greene-kkx3.app.elevateforhumanity.org/admin
-  // Tenant slug is extracted from the subdomain prefix.
+  // {subdomain}.app.elevateforhumanity.org — public site + admin on same host
   if (hostWithoutPort.endsWith('.app.elevateforhumanity.org')) {
     const tenantSlug = hostWithoutPort.replace('.app.elevateforhumanity.org', '');
     const requestHeadersWithTenant = new Headers(requestHeaders);

--- a/supabase/migrations/20260530000001_tenant_website_builder.sql
+++ b/supabase/migrations/20260530000001_tenant_website_builder.sql
@@ -1,0 +1,24 @@
+-- Tenant website builder columns (apply manually in Supabase SQL Editor).
+ALTER TABLE public.user_websites
+  ADD COLUMN IF NOT EXISTS organization_id uuid REFERENCES public.organizations(id) ON DELETE SET NULL,
+  ADD COLUMN IF NOT EXISTS subdomain text,
+  ADD COLUMN IF NOT EXISTS site_name text,
+  ADD COLUMN IF NOT EXISTS template_id text,
+  ADD COLUMN IF NOT EXISTS is_published boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS site_config jsonb DEFAULT '{}'::jsonb;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_websites_subdomain_unique
+  ON public.user_websites (subdomain)
+  WHERE subdomain IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS user_websites_organization_id_idx
+  ON public.user_websites (organization_id);
+
+ALTER TABLE public.website_pages
+  ADD COLUMN IF NOT EXISTS website_id uuid,
+  ADD COLUMN IF NOT EXISTS slug text,
+  ADD COLUMN IF NOT EXISTS is_home boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS blocks jsonb DEFAULT '[]'::jsonb;
+
+CREATE INDEX IF NOT EXISTS website_pages_website_id_idx
+  ON public.website_pages (website_id);

--- a/tests/unit/lib/tenant/default-site-config.test.ts
+++ b/tests/unit/lib/tenant/default-site-config.test.ts
@@ -1,0 +1,23 @@
+import { describe, it, expect } from 'vitest';
+import { buildDefaultSiteConfig, mergeSiteConfig } from '@/lib/tenant/default-site-config';
+
+describe('buildDefaultSiteConfig', () => {
+  it('includes org name in hero and branding', () => {
+    const cfg = buildDefaultSiteConfig({ organizationName: 'Acme Training' });
+    expect(cfg.branding.logoText).toBe('Acme Training');
+    expect(cfg.homepage.heroTitle).toContain('Acme Training');
+    expect(cfg.programs.length).toBeGreaterThan(0);
+    expect(cfg.navigation.some((n) => n.href === '/programs')).toBe(true);
+  });
+});
+
+describe('mergeSiteConfig', () => {
+  it('merges homepage fields without dropping programs', () => {
+    const base = buildDefaultSiteConfig({ organizationName: 'Base' });
+    const merged = mergeSiteConfig(base, {
+      homepage: { heroTitle: 'Custom title' },
+    });
+    expect(merged.homepage.heroTitle).toBe('Custom title');
+    expect(merged.programs).toEqual(base.programs);
+  });
+});

--- a/tests/unit/lib/tenant/public-site-url.test.ts
+++ b/tests/unit/lib/tenant/public-site-url.test.ts
@@ -1,0 +1,19 @@
+import { describe, it, expect } from 'vitest';
+import { tenantPublicSiteUrl, tenantAdminUrl } from '@/lib/tenant/public-site-url';
+
+describe('tenantPublicSiteUrl', () => {
+  it('builds subdomain host URLs', () => {
+    expect(tenantPublicSiteUrl('acme-training')).toBe(
+      'https://acme-training.app.elevateforhumanity.org',
+    );
+    expect(tenantPublicSiteUrl('acme-training', '/programs')).toBe(
+      'https://acme-training.app.elevateforhumanity.org/programs',
+    );
+  });
+
+  it('builds admin paths on tenant host', () => {
+    expect(tenantAdminUrl('acme-training')).toBe(
+      'https://acme-training.app.elevateforhumanity.org/admin/dashboard',
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Hotfix (middleware crash)

**Root cause:** `proxy.ts` called `rewriteTenantPublicSite()` without defining it. Any request to `{slug}.app.elevateforhumanity.org` on a non-admin path threw `ReferenceError` in middleware → **500 Internal Server Error**.

**Fix:** Define `rewriteTenantPublicSite`, restore legacy `.com` → `www.elevateforhumanity.org` redirects, fix `app/layout.tsx` title template literals.

If production was deployed from the first commit on this branch only, tenant/trial URLs would crash; `www` should still work unless a separate deploy issue occurred.

## Summary

Completes managed 14-day trial public sites on `{slug}.app.elevateforhumanity.org` with editor/publish/AI-save flows.

See `docs/store-14-day-trial.md`. Apply migration `20260530000001_tenant_website_builder.sql` manually in Supabase.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

