### PR TITLE
Fix homepage accessibility contrast gate

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,9 +122,14 @@ jobs:
 
       - name: Browser E2E (CI-safe)
         shell: bash
+        env:
+          NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+          NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+          SUPABASE_SERVICE_ROLE_KEY: ${{ secrets.SUPABASE_SERVICE_ROLE_KEY }}
+          SKIP_ENV_VALIDATION: 'true'
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
-            pnpm exec playwright test tests/e2e/live-smoke.spec.ts --config=playwright.config.ts
+            pnpm exec playwright test tests/e2e/live-smoke.spec.ts --config=playwright.live.config.ts
           else
             pnpm run test:e2e:ci
           fi

--- a/components/home/HomeOutcomes.tsx
+++ b/components/home/HomeOutcomes.tsx
@@ -82,7 +82,7 @@ function StoryCard({ story }: { story: Testimonial }) {
           {story.role && <p className="text-[11px] text-slate-500">{story.role}</p>}
         </div>
         {story.program && (
-          <span className="ml-auto text-[10px] font-semibold text-brand-red-600 bg-brand-red-50 px-2 py-0.5 rounded-full">
+          <span className="ml-auto text-[10px] font-semibold text-red-800 bg-red-50 px-2 py-0.5 rounded-full">
             {story.program}
           </span>
         )}
@@ -130,7 +130,7 @@ export async function HomeOutcomes() {
               <p className="text-slate-300 text-xs font-semibold leading-snug mb-1">
                 {item.label}
               </p>
-              <p className="text-slate-500 text-[10px]">{item.note}</p>
+              <p className="text-slate-400 text-[10px]">{item.note}</p>
             </div>
           ))}
         </div>
@@ -167,12 +167,12 @@ export async function HomeOutcomes() {
           ))}
         </div>
 
-        <p className="mt-8 text-center text-slate-600 text-xs">
+        <p className="mt-8 text-center text-slate-300 text-xs">
           Figures based on internal participant and credential records. Eligibility and outcomes
           vary by program and funding source.{' '}
           <Link
             href="/impact/methodology"
-            className="underline hover:text-slate-400 transition-colors"
+            className="font-semibold text-sky-300 underline hover:text-white transition-colors"
           >
             See methodology
           </Link>

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -5,7 +5,7 @@ export default defineConfig({
   testDir: './tests/e2e',
   // Browser E2E only. Node/DB integration tests run via dedicated scripts.
   testMatch: ['**/*.spec.ts'],
-  testIgnore: ['**/unit/**'],
+  testIgnore: ['**/unit/**', '**/live-smoke.spec.ts'],
   fullyParallel: false,
   forbidOnly: !!process.env.CI,
   retries: process.env.CI ? 2 : 1,

--- a/tests/e2e/live-smoke.spec.ts
+++ b/tests/e2e/live-smoke.spec.ts
@@ -11,8 +11,9 @@ test.describe('Live Production Smoke', () => {
     expect(linkCount).toBeGreaterThan(5);
   });
 
-  test('public API health endpoints are not 5xx', async ({ request, baseURL }) => {
-    const root = baseURL || 'https://www.elevateforhumanity.org';
+  test('public API health endpoints are not 5xx', async ({ request }) => {
+    const root =
+      process.env.PLAYWRIGHT_SMOKE_API_ROOT || 'https://www.elevateforhumanity.org';
     const candidates = ['/api/enrollment-count', '/api/public/metrics'];
 
     for (const path of candidates) {


### PR DESCRIPTION
## Summary
- Raise contrast on homepage outcome story program badges.
- Raise contrast on the dark outcomes methodology copy and link.
- Improve stat note contrast inside the dark outcomes cards.
- Keep live production smoke isolated from the full localhost E2E suite and run it with its own Playwright config.
- Pass Supabase CI secrets into the Browser E2E step so local API-backed checks do not run with missing env.

## Root cause
Current `main` (`6f84f440bae119d8551b520cd84ae0ea08e8cecb`) has two post-merge blockers:

1. `Compliance Gate` failed in `Accessibility Tests` job `78814346078` because axe reported WCAG color-contrast violations on the homepage outcomes section. The failing elements were the `text-brand-red-600 bg-brand-red-50` program badges and the `text-slate-600` methodology copy/link on the dark `bg-slate-900` outcomes section.
2. `CI/CD Pipeline` failed in `test-and-build` job `78814345904` at `Browser E2E (CI-safe)`. The full suite was running `live-smoke.spec.ts` through the normal localhost Playwright config while API-backed checks were missing the CI env needed by local Supabase-backed routes. The live smoke now has `playwright.live.config.ts`, the normal E2E suite ignores it, and the workflow supplies the required env to Browser E2E.

## Validation
- Opened from current main `6f84f440bae119d8551b520cd84ae0ea08e8cecb`.
- PR checks are running on the repair branch.

No production deploy or merge is included.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Visual token tweaks and CI/E2E wiring only; no auth, data, or business-logic changes.
> 
> **Overview**
> Fixes **WCAG color-contrast** failures on the homepage outcomes section by darkening program badges (`text-red-800` / `bg-red-50`), lightening stat footnotes and methodology disclaimer copy on the dark band, and styling the methodology link for stronger contrast (`text-sky-300`, bolder hover).
> 
> **CI / Playwright:** PR browser E2E now runs only `live-smoke.spec.ts` via `playwright.live.config.ts`, injects Supabase secrets and `SKIP_ENV_VALIDATION` into that step, and excludes live smoke from the default `playwright.config.ts` suite. The live API smoke test hits production (or `PLAYWRIGHT_SMOKE_API_ROOT`) instead of deriving the host from `baseURL`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9748c72de4e787c04386a48ec1e6329eacf07efc. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->