### PR TITLE
Fix program page imports on current main

### DIFF
--- a/app/programs/cna/page.tsx
+++ b/app/programs/cna/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/cna';
+import { CNA } from '@/data/programs/cna';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(CNA);

--- a/app/programs/cosmetology-apprenticeship/page.tsx
+++ b/app/programs/cosmetology-apprenticeship/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/cosmetology-apprenticeship';
+import { COSMETOLOGY } from '@/data/programs/cosmetology-apprenticeship';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(COSMETOLOGY);

--- a/app/programs/electrical/page.tsx
+++ b/app/programs/electrical/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/electrical';
+import { ELECTRICAL } from '@/data/programs/electrical';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(ELECTRICAL);

--- a/app/programs/hvac-technician/page.tsx
+++ b/app/programs/hvac-technician/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/hvac-technician';
+import { HVAC_TECHNICIAN } from '@/data/programs/hvac-technician';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(HVAC_TECHNICIAN);

--- a/app/programs/medical-assistant/page.tsx
+++ b/app/programs/medical-assistant/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/medical-assistant';
+import { MEDICAL_ASSISTANT } from '@/data/programs/medical-assistant';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(MEDICAL_ASSISTANT);

--- a/app/programs/nail-technician-apprenticeship/page.tsx
+++ b/app/programs/nail-technician-apprenticeship/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/nail-technician-apprenticeship';
+import { NAIL_TECH } from '@/data/programs/nail-technician-apprenticeship';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(NAIL_TECH);

--- a/app/programs/plumbing/page.tsx
+++ b/app/programs/plumbing/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-import { importName } from '@/data/programs/plumbing';
+import { PLUMBING } from '@/data/programs/plumbing';
 import { buildProgramMetadata, ProgramMarketingPage } from '@/lib/programs/program-page';
 
 export const metadata = buildProgramMetadata(PLUMBING);


### PR DESCRIPTION
## Summary
- Rebase the program import repair onto current main `bfa9c9f`
- Replace generated `importName` placeholders with the exported program constants used by each page
- Keep the change scoped to the seven failing program marketing routes

## Root cause
Main builds were failing while collecting `/programs/cosmetology-apprenticeship` because the page used `COSMETOLOGY` but imported `{ importName }`. The same generated placeholder pattern existed across related program pages.

## Validation
- Awaiting fresh GitHub Actions on head `e27fec1`
- Previous main failures: Autopilot and Compliance Gate both failed at Next page-data collection with `ReferenceError: COSMETOLOGY is not defined`

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Import-only fixes on static marketing pages; no auth, data, or business-logic changes.
> 
> **Overview**
> Repairs broken imports on **seven** program marketing routes (`cna`, `cosmetology-apprenticeship`, `electrical`, `hvac-technician`, `medical-assistant`, `nail-technician-apprenticeship`, `plumbing`).
> 
> Each page was importing a generated placeholder `importName` while metadata and JSX already referenced the real program constants (e.g. `COSMETOLOGY`, `CNA`). Imports now pull the matching exported symbols from each `@/data/programs/*` module so Next.js page collection no longer throws `ReferenceError` for undefined identifiers.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27fec1c7e36c4bac1c51b1825c20463475929c5. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->