### PR TITLE
fix(program-holder): document uploads, list view, and apply page clarity

### DIFF
--- a/app/api/program-holder/documents/upload/route.ts
+++ b/app/api/program-holder/documents/upload/route.ts
@@ -3,15 +3,18 @@ import { internalFetch } from '@/lib/api/internal-fetch';
 import { NextResponse } from 'next/server';
 
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
-import { toErrorMessage } from '@/lib/safe';
+import { getAdminClient } from '@/lib/supabase/admin';
+import {
+  isProgramHolderUploadDocumentType,
+  programHolderDocumentStatus,
+} from '@/lib/program-holder/document-requirements';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
 export const runtime = 'nodejs';
 export const maxDuration = 60;
-
 export const dynamic = 'force-dynamic';
 
 async function _POST(req: Request) {
@@ -28,7 +31,6 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
     }
 
-    // Verify user is a program holder
     const { data: profile } = await supabase
       .from('profiles')
       .select('role, organization_id')
@@ -54,37 +56,19 @@ async function _POST(req: Request) {
       );
     }
 
-    // Validate document type
-    const validTypes = [
-      'syllabus',
-      'license',
-      'insurance',
-      'accreditation',
-      'instructor_credentials',
-      'facility_photos',
-      'mou',
-      'hvac_license',
-      'w9',
-      'other',
-    ];
-
-    if (!validTypes.includes(documentType)) {
-      return NextResponse.json(
-        {
-          error: `Invalid document_type. Must be one of: ${validTypes.join(', ')}`,
-        },
-        { status: 400 },
-      );
+    if (!isProgramHolderUploadDocumentType(documentType)) {
+      return NextResponse.json({ error: 'Invalid document_type' }, { status: 400 });
     }
 
-    // Get file extension
     const fileExt = file.name.split('.').pop();
     const fileName = file.name;
-
-    // Upload to storage with organized path
     const path = `${user.id}/${documentType}/${Date.now()}.${fileExt}`;
 
-    const { data: uploadData, error: uploadError } = await supabase.storage
+    const adminDb = await getAdminClient();
+    const storageClient = adminDb ?? supabase;
+    const dbClient = adminDb ?? supabase;
+
+    const { data: uploadData, error: uploadError } = await storageClient.storage
       .from('program_holder_documents')
       .upload(path, file, {
         upsert: false,
@@ -92,16 +76,16 @@ async function _POST(req: Request) {
       });
 
     if (uploadError) {
+      logger.warn('[PH Upload] storage upload failed', uploadError);
       return NextResponse.json({ error: 'Upload failed' }, { status: 500 });
     }
 
-    // Get public URL
-    const {
-      data: { publicUrl },
-    } = supabase.storage.from('program_holder_documents').getPublicUrl(uploadData.path);
+    const { data: signedForAccess } = await storageClient.storage
+      .from('program_holder_documents')
+      .createSignedUrl(uploadData.path, 3600);
+    const fileAccessUrl = signedForAccess?.signedUrl ?? uploadData.path;
 
-    // Save document record to database
-    const { data: document, error: dbError } = await supabase
+    const { data: document, error: dbError } = await dbClient
       .from('program_holder_documents')
       .insert({
         user_id: user.id,
@@ -113,31 +97,32 @@ async function _POST(req: Request) {
         mime_type: file.type,
         description: description || null,
         uploaded_by: user.id,
-        approved: null, // null = pending review; false = rejected; true = approved
+        approved: null,
+        status: 'pending',
       })
       .select()
       .maybeSingle();
 
-    if (dbError) {
-      // Clean up uploaded file
-      await supabase.storage.from('program_holder_documents').remove([uploadData.path]);
-
+    if (dbError || !document) {
+      await storageClient.storage.from('program_holder_documents').remove([uploadData.path]);
       return NextResponse.json({ error: 'Database operation failed' }, { status: 500 });
     }
 
-    // If this is an HVAC license, write the URL to program_holders.hvac_license_url
     if (documentType === 'hvac_license') {
       try {
-        const { data: phLink } = await supabase
+        const { data: phLink } = await dbClient
           .from('profiles')
           .select('program_holder_id')
           .eq('id', user.id)
           .maybeSingle();
         const holderId = phLink?.program_holder_id;
         if (holderId) {
-          await supabase
+          await dbClient
             .from('program_holders')
-            .update({ hvac_license_url: publicUrl, hvac_license_uploaded_at: new Date().toISOString() })
+            .update({
+              hvac_license_url: fileAccessUrl,
+              hvac_license_uploaded_at: new Date().toISOString(),
+            })
             .eq('id', holderId);
         }
       } catch {
@@ -145,7 +130,6 @@ async function _POST(req: Request) {
       }
     }
 
-    // Run OCR validation for image files — non-fatal, routes to manual review on failure
     if (file.type.startsWith('image/')) {
       try {
         const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || process.env.URL || '';
@@ -161,12 +145,14 @@ async function _POST(req: Request) {
 
         if (ocrRes.ok) {
           const ocrData = await ocrRes.json();
-          // Update document record with OCR result
-          await supabase
+          await dbClient
             .from('program_holder_documents')
             .update({ ocr_text: ocrData.rawText || null })
             .eq('id', document.id)
-            .then(()=>{}, ()=>{}); // column may not exist yet — ignore
+            .then(
+              () => {},
+              () => {},
+            );
           logger.info('[PH Upload] OCR complete', { documentId: document.id, documentType });
         }
       } catch (ocrErr) {
@@ -174,9 +160,7 @@ async function _POST(req: Request) {
       }
     }
 
-    // Notify admin of new document upload
     try {
-      const admin = await requireAdminClient();
       const { data: phProfile } = await supabase
         .from('profiles')
         .select('full_name, email')
@@ -201,19 +185,21 @@ async function _POST(req: Request) {
 <p><strong>Type:</strong> ${documentType.replace(/_/g, ' ')}<br>
 <strong>File:</strong> ${fileName}<br>
 <strong>Size:</strong> ${(file.size / 1024).toFixed(0)} KB</p>
-<p><a href="${siteUrl}/admin/dashboard">Review in Admin Dashboard →</a></p>`,
+<p><a href="${siteUrl}/admin/program-holder-documents">Review program holder documents →</a></p>`,
               },
             ],
           }),
-        }).then(()=>{}, ()=>{});
+        }).then(
+          () => {},
+          () => {},
+        );
       }
     } catch {
-      // Non-fatal — don't block upload response
+      // Non-fatal
     }
 
-    // Check if all onboarding steps are now complete and fire welcome email
     try {
-      const admin = await requireAdminClient();
+      const admin = await getAdminClient();
       if (admin) {
         const { data: profileLink } = await admin
           .from('profiles')
@@ -237,7 +223,7 @@ async function _POST(req: Request) {
               .select('mou_signed, welcome_email_sent, organization_name')
               .eq('id', holderId)
               .maybeSingle()
-          : { data: null as any };
+          : { data: null as { mou_signed?: boolean; welcome_email_sent?: boolean } | null };
 
         if (holder?.mou_signed && !holder?.welcome_email_sent) {
           const { data: acks } = await admin
@@ -245,11 +231,10 @@ async function _POST(req: Request) {
             .select('document_type')
             .eq('user_id', user.id);
 
-          const hasHandbook = acks?.some((a: any) => a.document_type === 'handbook');
-          const hasRights = acks?.some((a: any) => a.document_type === 'rights');
+          const hasHandbook = acks?.some((a: { document_type: string }) => a.document_type === 'handbook');
+          const hasRights = acks?.some((a: { document_type: string }) => a.document_type === 'rights');
 
           if (hasHandbook && hasRights) {
-            // All steps done — send full welcome email inline
             const { checkAndSendOnboardingCompleteEmail } =
               await import('@/lib/program-holder/onboarding-complete');
             await checkAndSendOnboardingCompleteEmail(admin, user.id).catch((err: unknown) => {
@@ -268,7 +253,8 @@ async function _POST(req: Request) {
         id: document.id,
         document_type: document.document_type,
         file_name: document.file_name,
-        file_url: publicUrl,
+        file_url: fileAccessUrl,
+        status: programHolderDocumentStatus(document),
         approved: document.approved,
         created_at: document.created_at,
       },
@@ -277,4 +263,5 @@ async function _POST(req: Request) {
     return safeInternalError(err as Error, 'Upload failed');
   }
 }
+
 export const POST = withApiAudit('/api/program-holder/documents/upload', _POST);

--- a/app/apply/program-holder/page.tsx
+++ b/app/apply/program-holder/page.tsx
@@ -1,9 +1,8 @@
 import { Metadata } from 'next';
-import Image from 'next/image';
+import Link from 'next/link';
 import { createClient } from '@/lib/supabase/server';
 import ProgramHolderForm from './ProgramHolderForm';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,42 +14,78 @@ export const metadata: Metadata = {
   },
 };
 
+const OTHER_APPLICATION_PATHS = [
+  {
+    label: 'Barber host shop (apprenticeship)',
+    href: '/partners/barber-host-shop/apply',
+    hint: 'Licensed barbershop hosting apprentices',
+  },
+  {
+    label: 'Cosmetology host shop',
+    href: '/partners/cosmetology-host-shop/apply',
+    hint: 'Salon or school hosting cosmetology apprentices',
+  },
+  {
+    label: 'Training provider (ETPL / WIOA)',
+    href: '/partners/apply',
+    hint: 'Organizations listing programs on Indiana ETPL',
+  },
+  {
+    label: 'Student training application',
+    href: '/apply',
+    hint: 'Learners applying for funded or self-pay programs',
+  },
+] as const;
+
 export default async function ProgramHolderApplicationPage() {
   const supabase = await createClient();
 
-  // Fetch application settings
-  const { data: settings } = await supabase
+  await supabase
     .from('site_settings')
     .select('*')
     .eq('key', 'program_holder_applications')
     .maybeSingle();
+
   return (
     <div className="min-h-screen bg-white">
-      {/* Hero */}
-      <div className="relative h-[200px] sm:h-[260px]">
-        {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
-        <Image
-          src="/images/pages/admin-applicants-live-hero.webp"
-          alt="Program holder application"
-          fill
-          sizes="100vw"
-          className="object-cover"
-          priority placeholder="empty"
-        />
-        <div className="absolute top-4 left-4 bg-white/90 backdrop-blur-sm px-4 py-2 rounded">
-          <span className="text-sm font-bold text-slate-900">{PLATFORM_DEFAULTS.orgName}</span>
-        </div>
+      <div className="max-w-4xl mx-auto px-4 sm:px-6 pt-6">
+        <Breadcrumbs items={[{ label: 'Apply', href: '/apply' }, { label: 'Program Holder' }]} />
       </div>
-      <Breadcrumbs items={[{ label: 'Apply', href: '/apply' }, { label: 'Program Holder' }]} />
-      <section className="border-b border-slate-200">
-        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-12">
+
+      <section className="border-b border-slate-200 bg-slate-50">
+        <div className="max-w-4xl mx-auto px-4 sm:px-6 py-8 sm:py-10">
           <p className="text-xs font-semibold tracking-widest text-brand-blue-700 uppercase mb-2">
-            Program Holder Application
+            Program holder application
           </p>
-          <h1 className="text-3xl sm:text-4xl font-bold text-black mb-3">Partner With Us</h1>
-          <p className="text-base sm:text-lg text-black max-w-3xl">
-            Offer training programs to your community or organization through our platform.
+          <h1 className="text-3xl sm:text-4xl font-bold text-slate-900 mb-3">Partner with Elevate</h1>
+          <p className="text-base sm:text-lg text-slate-700 max-w-3xl">
+            Use this form if your organization will operate apprenticeship or training programs on
+            the platform (shop owner, school, or workforce partner). After you submit, you can
+            upload compliance documents in the program holder portal.
           </p>
+        </div>
+      </section>
+
+      <section className="max-w-4xl mx-auto px-4 sm:px-6 py-6">
+        <div className="rounded-xl border border-slate-200 bg-white p-5 sm:p-6">
+          <h2 className="text-lg font-bold text-slate-900 mb-1">Looking for a different application?</h2>
+          <p className="text-sm text-slate-600 mb-4">
+            Several partner flows exist. Pick the one that matches your role so you are not
+            duplicated in our review queue.
+          </p>
+          <ul className="space-y-3">
+            {OTHER_APPLICATION_PATHS.map((item) => (
+              <li key={item.href}>
+                <Link
+                  href={item.href}
+                  className="block rounded-lg border border-slate-200 px-4 py-3 hover:border-brand-blue-300 hover:bg-brand-blue-50/40 transition"
+                >
+                  <span className="font-semibold text-brand-blue-700">{item.label}</span>
+                  <span className="block text-sm text-slate-600 mt-0.5">{item.hint}</span>
+                </Link>
+              </li>
+            ))}
+          </ul>
         </div>
       </section>
 

--- a/app/program-holder/documents/page.tsx
+++ b/app/program-holder/documents/page.tsx
@@ -1,10 +1,14 @@
 import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import { FileText, Upload, Clock, XCircle } from 'lucide-react';
+import {
+  PROGRAM_HOLDER_DOCUMENT_REQUIREMENTS,
+  programHolderDocumentStatus,
+} from '@/lib/program-holder/document-requirements';
 
 export const dynamic = 'force-dynamic';
 
@@ -35,41 +39,39 @@ export default async function ProgramHolderDocumentsPage({
 
   const { data: profile } = await supabase
     .from('profiles')
-    .select('*')
+    .select('role')
     .eq('id', user.id)
     .maybeSingle();
 
-  if (!profile || !['program_holder', 'admin', 'super_admin', 'staff'].includes(profile.role))
+  if (!profile || !['program_holder', 'admin', 'super_admin', 'staff'].includes(profile.role)) {
     redirect('/login');
+  }
 
-  const db = await requireAdminClient();
-
-  const { data: rawDocuments } = await db
-    .from('documents')
+  const { data: rawDocuments } = await supabase
+    .from('program_holder_documents')
     .select(
-      'id, file_name, file_path, file_url, document_type, status, rejection_reason, created_at',
+      'id, file_name, file_url, document_type, status, approved, rejection_reason, created_at',
     )
     .eq('user_id', user.id)
     .order('created_at', { ascending: false });
 
-  // Generate short-lived signed URLs for all docs that have a file_path.
-  // file_url is null for docs uploaded via /api/documents/upload (private bucket).
+  const storageDb = (await getAdminClient()) ?? supabase;
+
   const documents = await Promise.all(
     (rawDocuments || []).map(async (doc) => {
-      if (doc.file_path) {
-        const { data } = await db.storage.from('documents').createSignedUrl(doc.file_path, 300); // 5-minute URL
-        return { ...doc, signedUrl: data?.signedUrl ?? null };
+      const status = programHolderDocumentStatus(doc);
+      const storagePath = doc.file_url;
+      if (storagePath && !storagePath.startsWith('http')) {
+        const { data } = await storageDb.storage
+          .from('program_holder_documents')
+          .createSignedUrl(storagePath, 300);
+        return { ...doc, status, signedUrl: data?.signedUrl ?? null };
       }
-      // Legacy rows that stored a public URL directly
-      return { ...doc, signedUrl: doc.file_url ?? null };
+      return { ...doc, status, signedUrl: storagePath?.startsWith('http') ? storagePath : null };
     }),
   );
 
-  const { data: requirements } = await supabase
-    .from('document_requirements')
-    .select('*')
-    .eq('role', 'program_holder')
-    .order('is_required', { ascending: false });
+  const requirements = PROGRAM_HOLDER_DOCUMENT_REQUIREMENTS;
 
   const getStatusIcon = (status: string) => {
     switch (status) {
@@ -97,20 +99,25 @@ export default async function ProgramHolderDocumentsPage({
     <div className="min-h-screen bg-white">
       <div className="max-w-7xl mx-auto px-4 py-4">
         <Breadcrumbs
-          items={[{ label: 'Program Holder', href: '/program-holder' }, { label: 'Documents' }]}
+          items={[
+            { label: 'Program Holder', href: '/program-holder/dashboard' },
+            { label: 'Documents' },
+          ]}
         />
       </div>
       <section className="border-b py-8">
         <div className="max-w-7xl mx-auto px-6">
-          <h1 className="text-4xl font-bold text-black mb-2">My Documents</h1>
-          <p className="text-lg text-black">Upload and manage your required documents</p>
+          <h1 className="text-4xl font-bold text-slate-900 mb-2">My Documents</h1>
+          <p className="text-lg text-slate-700">
+            Upload and manage compliance documents for your program holder account
+          </p>
         </div>
       </section>
 
       <div className="max-w-7xl mx-auto px-6 py-12">
         <div className="bg-white rounded-lg shadow-sm border p-6 mb-8">
           <div className="flex items-center justify-between mb-4">
-            <h2 className="text-2xl font-bold text-black">Upload New Document</h2>
+            <h2 className="text-2xl font-bold text-slate-900">Upload New Document</h2>
             <Link
               href="/program-holder/documents/upload"
               className="px-6 py-3 bg-brand-blue-600 text-white font-semibold rounded-lg hover:bg-brand-blue-700 transition flex items-center gap-2"
@@ -119,64 +126,62 @@ export default async function ProgramHolderDocumentsPage({
               Upload Document
             </Link>
           </div>
-          <p className="text-black">
-            Upload required documents to complete your profile and maintain compliance.
+          <p className="text-slate-700">
+            Files are stored securely and reviewed by our team. You will see status updates below.
           </p>
         </div>
 
-        {requirements && requirements.length > 0 && (
-          <div className="bg-white rounded-lg shadow-sm border p-6 mb-8">
-            <h2 className="text-2xl font-bold text-black mb-4">Required Documents</h2>
-            <div className="space-y-3">
-              {requirements.map((req) => {
-                const uploaded = documents?.find((d) => d.document_type === req.document_type);
-                return (
-                  <div
-                    key={req.id}
-                    className="flex items-center justify-between p-4 bg-white rounded-lg"
-                  >
-                    <div className="flex items-center gap-3">
-                      {uploaded ? (
-                        getStatusIcon(uploaded.status)
-                      ) : (
-                        <FileText className="w-5 h-5 text-slate-400" />
-                      )}
-                      <div>
-                        <h3 className="font-semibold text-black">
-                          {req.description}
-                          {req.is_required && <span className="text-brand-red-600 ml-1">*</span>}
-                        </h3>
-                        <p className="text-sm text-black">{req.instructions}</p>
-                      </div>
-                    </div>
-                    {uploaded && (
-                      <span
-                        className={`px-3 py-2 rounded-full text-xs font-semibold border ${getStatusBadge(uploaded.status)}`}
-                      >
-                        {uploaded.status.charAt(0).toUpperCase() + uploaded.status.slice(1)}
-                      </span>
+        <div className="bg-white rounded-lg shadow-sm border p-6 mb-8">
+          <h2 className="text-2xl font-bold text-slate-900 mb-4">Required Documents</h2>
+          <div className="space-y-3">
+            {requirements.map((req) => {
+              const uploaded = documents.find((d) => d.document_type === req.document_type);
+              return (
+                <div
+                  key={req.id}
+                  className="flex items-center justify-between p-4 bg-slate-50 rounded-lg"
+                >
+                  <div className="flex items-center gap-3">
+                    {uploaded ? (
+                      getStatusIcon(uploaded.status)
+                    ) : (
+                      <FileText className="w-5 h-5 text-slate-400" />
                     )}
+                    <div>
+                      <h3 className="font-semibold text-slate-900">
+                        {req.description}
+                        {req.is_required && <span className="text-brand-red-600 ml-1">*</span>}
+                      </h3>
+                      <p className="text-sm text-slate-600">{req.instructions}</p>
+                    </div>
                   </div>
-                );
-              })}
-            </div>
+                  {uploaded && (
+                    <span
+                      className={`px-3 py-2 rounded-full text-xs font-semibold border ${getStatusBadge(uploaded.status)}`}
+                    >
+                      {uploaded.status.charAt(0).toUpperCase() + uploaded.status.slice(1)}
+                    </span>
+                  )}
+                </div>
+              );
+            })}
           </div>
-        )}
+        </div>
 
         <div className="bg-white rounded-lg shadow-sm border p-6">
-          <h2 className="text-2xl font-bold text-black mb-4">Uploaded Documents</h2>
-          {documents && documents.length > 0 ? (
+          <h2 className="text-2xl font-bold text-slate-900 mb-4">Uploaded Documents</h2>
+          {documents.length > 0 ? (
             <div className="space-y-3">
               {documents.map((doc) => (
                 <div
                   key={doc.id}
-                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-white transition"
+                  className="flex items-center justify-between p-4 border rounded-lg hover:bg-slate-50 transition"
                 >
                   <div className="flex items-center gap-3">
                     {getStatusIcon(doc.status)}
                     <div>
-                      <h3 className="font-semibold text-black">{doc.file_name}</h3>
-                      <p className="text-sm text-black">
+                      <h3 className="font-semibold text-slate-900">{doc.file_name}</h3>
+                      <p className="text-sm text-slate-600">
                         {doc.document_type
                           .replace(/_/g, ' ')
                           .replace(/\b\w/g, (l) => l.toUpperCase())}{' '}
@@ -214,7 +219,7 @@ export default async function ProgramHolderDocumentsPage({
           ) : (
             <div className="text-center py-12">
               <FileText className="w-16 h-16 text-slate-300 mx-auto mb-4" />
-              <p className="text-black mb-4">No documents uploaded yet</p>
+              <p className="text-slate-700 mb-4">No documents uploaded yet</p>
               <Link
                 href="/program-holder/documents/upload"
                 className="inline-block px-6 py-3 bg-brand-blue-600 text-white font-semibold rounded-lg hover:bg-brand-blue-700 transition"
@@ -224,13 +229,14 @@ export default async function ProgramHolderDocumentsPage({
             </div>
           )}
         </div>
+
         {isOnboarding && nextStep === 'set-password' && (
           <div className="mt-8 bg-brand-blue-50 border-2 border-brand-blue-200 rounded-xl p-6 flex flex-col sm:flex-row items-center justify-between gap-4">
             <div>
               <h3 className="font-bold text-slate-900 text-lg mb-1">
                 Last step — create your password
               </h3>
-              <p className="text-sm text-black">
+              <p className="text-sm text-slate-700">
                 Set a permanent password so you can log in anytime without a magic link.
               </p>
             </div>

--- a/app/program-holder/documents/upload/page.tsx
+++ b/app/program-holder/documents/upload/page.tsx
@@ -2,7 +2,7 @@ import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { requireProgramHolder } from '@/lib/auth/require-program-holder';
 import { DocumentUploadForm } from '@/components/documents/DocumentUploadForm';
-import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { PROGRAM_HOLDER_DOCUMENT_REQUIREMENTS } from '@/lib/program-holder/document-requirements';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,80 +15,32 @@ export const metadata: Metadata = {
   },
 };
 
-// Program holder document types — document_requirements table is program-scoped (no role column).
-const PROGRAM_HOLDER_REQUIREMENTS = [
-  {
-    id: 'business_license',
-    document_type: 'business_license',
-    description: 'Business License',
-    instructions: 'Upload your current business license or registration.',
-    accepted_formats: ['pdf', 'jpg', 'png'],
-    max_file_size: 10485760,
-  },
-  {
-    id: 'shop_license',
-    document_type: 'shop_license',
-    description: 'Shop / Facility License',
-    instructions: 'Upload your current shop or facility operating license.',
-    accepted_formats: ['pdf', 'jpg', 'png'],
-    max_file_size: 10485760,
-  },
-  {
-    id: 'ein_verification',
-    document_type: 'ein_verification',
-    description: 'EIN Verification (IRS Letter 147C or SS-4)',
-    instructions: 'Upload your IRS EIN confirmation letter.',
-    accepted_formats: ['pdf', 'jpg', 'png'],
-    max_file_size: 10485760,
-  },
-  {
-    id: 'employer_mou',
-    document_type: 'employer_mou',
-    description: 'Signed Memorandum of Understanding',
-    instructions: `Upload the signed MOU between your program and ${PLATFORM_DEFAULTS.orgName}.`,
-    accepted_formats: ['pdf'],
-    max_file_size: 10485760,
-  },
-  {
-    id: 'supervisor_designation',
-    document_type: 'supervisor_designation',
-    description: 'Journeyworker / Supervisor Designation',
-    instructions: 'Upload documentation designating your qualified journeyworker supervisor.',
-    accepted_formats: ['pdf', 'jpg', 'png'],
-    max_file_size: 10485760,
-  },
-  {
-    id: 'ipla_packet',
-    document_type: 'ipla_packet',
-    description: 'IPLA Licensing Packet',
-    instructions: 'Upload your Indiana Professional Licensing Agency packet.',
-    accepted_formats: ['pdf'],
-    max_file_size: 10485760,
-  },
-];
-
 export default async function UploadDocumentPage() {
   await requireProgramHolder();
-
-  const requirements = PROGRAM_HOLDER_REQUIREMENTS;
 
   return (
     <div className="min-h-screen bg-white">
       <div className="max-w-7xl mx-auto px-4 py-4">
         <Breadcrumbs
-          items={[{ label: 'Program Holder', href: '/program-holder' }, { label: 'Documents' }]}
+          items={[
+            { label: 'Program Holder', href: '/program-holder/dashboard' },
+            { label: 'Documents', href: '/program-holder/documents' },
+            { label: 'Upload' },
+          ]}
         />
       </div>
       <section className="border-b py-8">
         <div className="max-w-4xl mx-auto px-6">
-          <h1 className="text-4xl font-bold text-black mb-2">Upload Document</h1>
-          <p className="text-lg text-black">Upload a required document to complete your profile</p>
+          <h1 className="text-4xl font-bold text-slate-900 mb-2">Upload Document</h1>
+          <p className="text-lg text-slate-700">
+            Upload a required document to complete your program holder profile
+          </p>
         </div>
       </section>
 
       <div className="max-w-4xl mx-auto px-6 py-12">
         <DocumentUploadForm
-          requirements={requirements || []}
+          requirements={PROGRAM_HOLDER_DOCUMENT_REQUIREMENTS}
           apiEndpoint="/api/program-holder/documents/upload"
           successRedirect="/program-holder/documents"
         />

--- a/apps/admin/app/admin/program-holder-documents/page.tsx
+++ b/apps/admin/app/admin/program-holder-documents/page.tsx
@@ -1,9 +1,10 @@
 import { Metadata } from 'next';
 import { requireRole } from '@/lib/auth/require-role';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getAdminClient } from '@/lib/supabase/admin';
 import Link from 'next/link';
 import { ChevronRight, FileText, Clock, CheckCircle, XCircle } from 'lucide-react';
 import ProgramHolderDocumentsClient from './ProgramHolderDocumentsClient';
+import { programHolderDocumentStatus } from '@/lib/program-holder/document-requirements';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 60;
@@ -11,7 +12,17 @@ export const metadata: Metadata = { title: 'Program Holder Documents | Admin | E
 
 export default async function ProgramHolderDocumentsPage() {
   await requireRole(['admin', 'super_admin', 'staff']);
-  const db = await requireAdminClient();
+  const db = await getAdminClient();
+
+  if (!db) {
+    return (
+      <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8">
+        <p className="text-slate-600">
+          Document review is temporarily unavailable (database connection). Try again shortly.
+        </p>
+      </div>
+    );
+  }
 
   const [
     { count: pending },
@@ -22,11 +33,35 @@ export default async function ProgramHolderDocumentsPage() {
     db.from('program_holder_documents').select('*', { count: 'exact', head: true }).eq('status', 'pending'),
     db.from('program_holder_documents').select('*', { count: 'exact', head: true }).eq('status', 'approved'),
     db.from('program_holder_documents').select('*', { count: 'exact', head: true }).eq('status', 'rejected'),
-    db.from('program_holder_documents')
-      .select('id, user_id, document_type, file_name, file_path, file_size, mime_type, status, reviewed_at, created_at, profiles:user_id(full_name, email)')
+    db
+      .from('program_holder_documents')
+      .select(
+        'id, user_id, document_type, file_name, file_url, file_size, mime_type, status, approved, reviewed_at, created_at',
+      )
       .order('created_at', { ascending: false })
       .limit(50),
   ]);
+
+  const userIds = [...new Set((docs ?? []).map((d) => d.user_id).filter(Boolean))];
+  const { data: profiles } = userIds.length
+    ? await db.from('profiles').select('id, full_name, email').in('id', userIds)
+    : { data: [] as { id: string; full_name: string | null; email: string | null }[] };
+
+  const profileById = new Map((profiles ?? []).map((p) => [p.id, p]));
+
+  const docsWithProfiles = (docs ?? []).map((doc) => ({
+    id: doc.id,
+    user_id: doc.user_id,
+    document_type: doc.document_type,
+    file_name: doc.file_name,
+    file_path: doc.file_url,
+    file_size: doc.file_size,
+    mime_type: doc.mime_type,
+    status: programHolderDocumentStatus(doc),
+    reviewed_at: doc.reviewed_at,
+    created_at: doc.created_at,
+    profiles: profileById.get(doc.user_id) ?? null,
+  }));
 
   const stats = [
     { label: 'Pending Review', value: pending ?? 0, icon: Clock, color: 'text-amber-600', bg: 'bg-amber-50' },
@@ -38,18 +73,24 @@ export default async function ProgramHolderDocumentsPage() {
     <div className="max-w-5xl mx-auto px-4 sm:px-6 py-8 space-y-8">
       <div>
         <nav className="flex items-center gap-1.5 text-xs text-slate-500 mb-3">
-          <Link href="/admin/dashboard" className="hover:text-slate-700">Admin</Link>
+          <Link href="/admin/dashboard" className="hover:text-slate-700">
+            Admin
+          </Link>
           <ChevronRight className="w-3 h-3" />
-          <Link href="/admin/program-holders" className="hover:text-slate-700">Program Holders</Link>
+          <Link href="/admin/program-holders" className="hover:text-slate-700">
+            Program Holders
+          </Link>
           <ChevronRight className="w-3 h-3" />
           <span className="text-slate-900 font-medium">Documents</span>
         </nav>
         <h1 className="text-2xl font-bold text-slate-900">Program Holder Documents</h1>
-        <p className="text-sm text-slate-500 mt-1">Review and approve documents submitted by program holders</p>
+        <p className="text-sm text-slate-500 mt-1">
+          Review files uploaded from the program holder portal (not generic student documents)
+        </p>
       </div>
 
       <div className="grid grid-cols-3 gap-4">
-        {stats.map(s => {
+        {stats.map((s) => {
           const Icon = s.icon;
           return (
             <div key={s.label} className="bg-white border border-slate-200 rounded-2xl p-5 shadow-sm">
@@ -63,7 +104,7 @@ export default async function ProgramHolderDocumentsPage() {
         })}
       </div>
 
-      <ProgramHolderDocumentsClient initialDocs={docs ?? []} />
+      <ProgramHolderDocumentsClient initialDocs={docsWithProfiles} />
     </div>
   );
 }

--- a/components/documents/DocumentUploadForm.tsx
+++ b/components/documents/DocumentUploadForm.tsx
@@ -37,6 +37,9 @@ export function DocumentUploadForm({ requirements, apiEndpoint, successRedirect 
   const [prefillDone, setPrefillDone] = useState(false);
   const [pendingRedirect, setPendingRedirect] = useState('');
 
+  const isProgramHolderUpload =
+    apiEndpoint?.includes('/api/program-holder/documents/upload') ?? false;
+
   // Load previously uploaded documents from DB
   useEffect(() => {
     async function loadUploadedDocs() {
@@ -45,16 +48,30 @@ export function DocumentUploadForm({ requirements, apiEndpoint, successRedirect 
       } = await supabase.auth.getUser();
       if (!user) return;
 
+      const table = isProgramHolderUpload ? 'program_holder_documents' : 'documents';
       const { data } = await supabase
-        .from('documents')
-        .select('id, document_type, file_name, status, created_at')
+        .from(table)
+        .select('id, document_type, file_name, status, created_at, approved')
         .eq('user_id', user.id)
         .order('created_at', { ascending: false });
 
-      if (data) setUploadedDocs(data);
+      if (data) {
+        setUploadedDocs(
+          data.map((row: { status?: string; approved?: boolean | null }) => ({
+            ...row,
+            status:
+              row.status ??
+              (row.approved === true
+                ? 'approved'
+                : row.approved === false
+                  ? 'rejected'
+                  : 'pending'),
+          })),
+        );
+      }
     }
     loadUploadedDocs();
-  }, [supabase]);
+  }, [supabase, isProgramHolderUpload]);
 
   const handleFileChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     if (e.target.files && e.target.files[0]) {

--- a/lib/auth/require-program-holder.ts
+++ b/lib/auth/require-program-holder.ts
@@ -1,5 +1,5 @@
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { redirect } from 'next/navigation';
 
 export interface ProgramHolderContext {

--- a/lib/program-holder/document-requirements.ts
+++ b/lib/program-holder/document-requirements.ts
@@ -1,0 +1,108 @@
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+/** Document types accepted by POST /api/program-holder/documents/upload */
+export const PROGRAM_HOLDER_UPLOAD_DOCUMENT_TYPES = [
+  'business_license',
+  'shop_license',
+  'ein_verification',
+  'employer_mou',
+  'supervisor_designation',
+  'ipla_packet',
+  'syllabus',
+  'license',
+  'insurance',
+  'accreditation',
+  'instructor_credentials',
+  'facility_photos',
+  'mou',
+  'hvac_license',
+  'w9',
+  'other',
+] as const;
+
+export type ProgramHolderUploadDocumentType =
+  (typeof PROGRAM_HOLDER_UPLOAD_DOCUMENT_TYPES)[number];
+
+export function isProgramHolderUploadDocumentType(
+  value: string,
+): value is ProgramHolderUploadDocumentType {
+  return (PROGRAM_HOLDER_UPLOAD_DOCUMENT_TYPES as readonly string[]).includes(value);
+}
+
+export interface ProgramHolderDocumentRequirement {
+  id: string;
+  document_type: ProgramHolderUploadDocumentType;
+  description: string;
+  instructions: string;
+  accepted_formats: string[];
+  max_file_size: number;
+  is_required?: boolean;
+}
+
+/** Static checklist — document_requirements has no program_holder role column in live schema. */
+export const PROGRAM_HOLDER_DOCUMENT_REQUIREMENTS: ProgramHolderDocumentRequirement[] = [
+  {
+    id: 'business_license',
+    document_type: 'business_license',
+    description: 'Business License',
+    instructions: 'Upload your current business license or registration.',
+    accepted_formats: ['pdf', 'jpg', 'png'],
+    max_file_size: 10485760,
+    is_required: true,
+  },
+  {
+    id: 'shop_license',
+    document_type: 'shop_license',
+    description: 'Shop / Facility License',
+    instructions: 'Upload your current shop or facility operating license.',
+    accepted_formats: ['pdf', 'jpg', 'png'],
+    max_file_size: 10485760,
+    is_required: true,
+  },
+  {
+    id: 'ein_verification',
+    document_type: 'ein_verification',
+    description: 'EIN Verification (IRS Letter 147C or SS-4)',
+    instructions: 'Upload your IRS EIN confirmation letter.',
+    accepted_formats: ['pdf', 'jpg', 'png'],
+    max_file_size: 10485760,
+    is_required: true,
+  },
+  {
+    id: 'employer_mou',
+    document_type: 'employer_mou',
+    description: 'Signed Memorandum of Understanding',
+    instructions: `Upload the signed MOU between your program and ${PLATFORM_DEFAULTS.orgName}.`,
+    accepted_formats: ['pdf'],
+    max_file_size: 10485760,
+    is_required: true,
+  },
+  {
+    id: 'supervisor_designation',
+    document_type: 'supervisor_designation',
+    description: 'Journeyworker / Supervisor Designation',
+    instructions: 'Upload documentation designating your qualified journeyworker supervisor.',
+    accepted_formats: ['pdf', 'jpg', 'png'],
+    max_file_size: 10485760,
+  },
+  {
+    id: 'ipla_packet',
+    document_type: 'ipla_packet',
+    description: 'IPLA Licensing Packet',
+    instructions: 'Upload your Indiana Professional Licensing Agency packet.',
+    accepted_formats: ['pdf'],
+    max_file_size: 10485760,
+  },
+];
+
+export function programHolderDocumentStatus(row: {
+  status?: string | null;
+  approved?: boolean | null;
+}): 'pending' | 'approved' | 'rejected' {
+  if (row.status === 'approved' || row.status === 'rejected' || row.status === 'pending') {
+    return row.status;
+  }
+  if (row.approved === true) return 'approved';
+  if (row.approved === false) return 'rejected';
+  return 'pending';
+}

--- a/tests/unit/program-holder-document-requirements.test.ts
+++ b/tests/unit/program-holder-document-requirements.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isProgramHolderUploadDocumentType,
+  programHolderDocumentStatus,
+  PROGRAM_HOLDER_UPLOAD_DOCUMENT_TYPES,
+} from '@/lib/program-holder/document-requirements';
+
+describe('program holder document requirements', () => {
+  it('accepts portal upload types including business_license', () => {
+    expect(isProgramHolderUploadDocumentType('business_license')).toBe(true);
+    expect(isProgramHolderUploadDocumentType('ein_verification')).toBe(true);
+    expect(isProgramHolderUploadDocumentType('not_a_real_type')).toBe(false);
+    expect(PROGRAM_HOLDER_UPLOAD_DOCUMENT_TYPES).toContain('employer_mou');
+  });
+
+  it('maps legacy approved boolean to status', () => {
+    expect(programHolderDocumentStatus({ status: 'approved' })).toBe('approved');
+    expect(programHolderDocumentStatus({ approved: true })).toBe('approved');
+    expect(programHolderDocumentStatus({ approved: false })).toBe('rejected');
+    expect(programHolderDocumentStatus({ approved: null })).toBe('pending');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Program holders reported upload failures, empty "My Documents" after successful upload, and a confusing apply header.

## Root causes

1. Upload API rejected portal document types (`business_license`, etc.)
2. List page read `documents` table while uploads wrote `program_holder_documents`
3. Apply page hero + multiple partner flows created duplicate-looking admin entries

## Fix

See commit 31854d6b0 on branch `cursor/fix-program-holder-docs-c4c6`.

## Test

`pnpm exec vitest run tests/unit/program-holder-document-requirements.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

