### PR TITLE
Barber: Prestige RTI branding and WIOA/WRG application funding

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -815,13 +815,6 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
   SKIP_ENV_VALIDATION=true
   ```
 
-### Barber apprenticeship apply URLs
-
-- **Apprentice enrollment form:** `/programs/barber-apprenticeship/apply/apprentice` (canonical)
-- **Apply chooser (apprentice vs partner shop):** `/programs/barber-apprenticeship/apply`
-- Legacy `/programs/barber-apprenticeship/apply?type=apprentice` and `?payment=*` redirect to `/apply/apprentice` with query preserved
-- `/apply/barber` redirects to apprentice apply (not partner shop)
-
 ### Running services
 
 | Service | Command | Port |
@@ -860,4 +853,6 @@ Precedence at runtime: `platform_secrets > app_secrets > process.env`
 **AI Console vs Dev Studio Command tab:** both use `/api/devstudio/execute` — AI Console is the standalone page, Dev Studio embeds the same in an IDE-like shell. Not a conflict.
 
 **Dev Studio AI Chat** (`/api/devstudio/chat`) uses Groq/Gemini with tool calling for platform operations. This is separate from `lib/ai/ai-service.ts` (`aiChat()`) which is for course content generation.
+
+**Barber apprentice apply:** RTI is branded **Prestige Elevation Barber Curriculum** (`lib/barber/branding.ts`). WIOA/WRG/FSSA funding uses `FundingEligibilityFlow` with `program="barber"` on `ApprenticeForm`; funded applicants skip Stripe (`?funded=1` on success). Apply index uses `FundingGateCard` with `routeFundedToEnrollment` so WIOA/WRG go to `/apply/apprentice?funding=…`.
 

--- a/app/programs/barber-apprenticeship/BarberChatAssistant.tsx
+++ b/app/programs/barber-apprenticeship/BarberChatAssistant.tsx
@@ -22,7 +22,7 @@ const BARBER_FAQ: Record<string, string> = {
   // Program basics
   'hours': `The Barber Apprenticeship requires **2,000 hours** of training:
 • On-the-job training (OJT) at a licensed barbershop
-• Related instruction (Milady theory curriculum)
+• Related instruction (Prestige Elevation Barber Curriculum on Elevate LMS)
 
 At 40 hours/week, this takes about 50 weeks (12-15 months).
 At 30 hours/week, it takes about 67 weeks (15-18 months).`,
@@ -165,7 +165,7 @@ export default function BarberChatAssistant() {
       if (data.error) {
         setMessages(prev => [...prev, {
           role: 'assistant',
-          content: `I'm not sure about that. For specific questions, please contact us at ${PLATFORM_DEFAULTS.supportPhone} or email our contact form.`,
+          content: "I'm not sure about that. For specific questions, please contact us at ${PLATFORM_DEFAULTS.supportPhone} or email our contact form.",
         }]);
       } else {
         setMessages(prev => [...prev, {
@@ -176,7 +176,7 @@ export default function BarberChatAssistant() {
     } catch {
       setMessages(prev => [...prev, {
         role: 'assistant',
-        content: `I'm having trouble connecting. Please try again or contact us at ${PLATFORM_DEFAULTS.supportPhone}.`,
+        content: "I'm having trouble connecting. Please try again or contact us at ${PLATFORM_DEFAULTS.supportPhone}.",
       }]);
     } finally {
       setIsLoading(false);

--- a/app/programs/barber-apprenticeship/apply/ApprenticeForm.tsx
+++ b/app/programs/barber-apprenticeship/apply/ApprenticeForm.tsx
@@ -3,7 +3,10 @@ import Turnstile from '@/components/Turnstile';
 
 import { useState, useEffect } from 'react';
 import Link from 'next/link';
-import { ArrowLeft, Loader2, CreditCard, Calculator, Info } from 'lucide-react';
+import { ArrowLeft, Loader2, CreditCard, Calculator, Info, Shield } from 'lucide-react';
+import FundingEligibilityFlow, {
+  type EligibilityStatus,
+} from '@/components/programs/FundingEligibilityFlow';
 import LazyVideo from '@/components/ui/LazyVideo';
 import BnplOptions from '@/components/checkout/BnplOptions';
 import { BARBER_PRICING } from '@/lib/programs/pricing';
@@ -67,15 +70,18 @@ type TransferHoursChoice = 'undecided' | 'yes' | 'no';
 
 export default function ApprenticeForm({
   initialPayment,
+  initialFunding,
   initialEmail,
   initialName,
   initialApplicationId,
 }: {
   initialPayment?: string | null;
+  initialFunding?: string;
   initialEmail?: string;
   initialName?: string;
   initialApplicationId?: string;
 }) {
+  const completingExistingPayment = Boolean(initialApplicationId);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState('');
   const [errorSeverity, setErrorSeverity] = useState<'info' | 'critical'>('info');
@@ -118,10 +124,13 @@ export default function ApprenticeForm({
       phone: '',
       hasHostShop: '',
       hostShopName: '',
+      fundingInterest: initialFunding ?? '',
     };
   });
   const [smsConsent, setSmsConsent] = useState(false);
   const [turnstileToken, setTurnstileToken] = useState<string>('');
+  const [fundingEligibilityStatus, setFundingEligibilityStatus] =
+    useState<EligibilityStatus | null>(null);
 
   // Calculate next Friday on client only to avoid hydration mismatch
   useEffect(() => {
@@ -136,6 +145,20 @@ export default function ApprenticeForm({
   const updateField = (field: string, value: string) => {
     setFormData((prev) => ({ ...prev, [field]: value }));
   };
+
+  const handleFundingChange = (value: string) => {
+    updateField('fundingInterest', value);
+    setFundingEligibilityStatus(null);
+  };
+
+  const fundedOptionsReady =
+    formData.fundingInterest === 'employer' ||
+    formData.fundingInterest === 'unsure' ||
+    ((['wioa', 'wrg', 'fssa'] as string[]).includes(formData.fundingInterest) &&
+      fundingEligibilityStatus !== null);
+
+  const isSelfPay =
+    completingExistingPayment || formData.fundingInterest === 'self-pay';
 
   const handlePayNow = async () => {
     if (!formData.email || !formData.firstName || !formData.lastName || !formData.phone) {
@@ -185,10 +208,18 @@ export default function ApprenticeForm({
           phone: formData.phone,
           program: 'barber-apprenticeship',
           programSlug: 'barber-apprenticeship',
-          fundingType: paymentOption === 'full' ? 'self-pay-full' : 'self-pay-plan',
+          fundingType: isSelfPay
+            ? paymentOption === 'full'
+              ? 'self-pay-full'
+              : 'self-pay-plan'
+            : formData.fundingInterest,
+          fundingEligibilityStatus: !isSelfPay
+            ? (fundingEligibilityStatus ?? undefined)
+            : undefined,
           source: 'barber-apply-page',
-          paymentOption,
-          turnstileToken,
+          paymentOption: isSelfPay ? paymentOption : undefined,
+          turnstileToken: isSelfPay ? turnstileToken : undefined,
+          transfer_hours_claimed: transferHours > 0 ? transferHours : undefined,
           transferHours,
           transfer_hours_claimed: transferHours,
           support_notes: [
@@ -237,6 +268,14 @@ export default function ApprenticeForm({
         }
       }
       } // end if (!applicationId)
+
+      if (!isSelfPay) {
+        const successQs = new URLSearchParams();
+        if (applicationId) successQs.set('id', applicationId);
+        successQs.set('funded', '1');
+        window.location.href = `/programs/barber-apprenticeship/apply/success?${successQs.toString()}`;
+        return;
+      }
 
       let checkoutResponse;
       const basePayload = {
@@ -560,8 +599,15 @@ export default function ApprenticeForm({
               {/* Pricing */}
               <div className="bg-white/10 rounded-xl p-4">
                 <div className="text-center">
-                  <div className="text-white text-xs uppercase mb-1">Program Tuition</div>
-                  <div className="text-3xl font-black">${PRICING.fullPrice.toLocaleString()}</div>
+                  <div className="text-white text-xs uppercase mb-1">{isSelfPay ? 'Program Tuition' : 'Tuition'}</div>
+                  {isSelfPay ? (
+                    <div className="text-3xl font-black">${PRICING.fullPrice.toLocaleString()}</div>
+                  ) : (
+                    <>
+                      <div className="text-2xl font-black">May be covered</div>
+                      <p className="text-xs text-white/80 mt-2">WIOA, WRG, and FSSA may cover tuition for eligible Indiana residents.</p>
+                    </>
+                  )}
                 </div>
               </div>
 
@@ -781,7 +827,68 @@ export default function ApprenticeForm({
                   </div>
                 )}
 
-                {/* Payment Options */}
+
+                {!completingExistingPayment && (
+                  <div className="border-t border-slate-200 pt-6 mt-6">
+                    <label className="block text-sm font-bold text-slate-800 mb-3">
+                      How do you plan to pay for training? *
+                    </label>
+                    <div className="space-y-2">
+                      {[
+                        { value: 'self-pay', label: 'Self-pay', sub: 'Card, BNPL, or weekly payment plan — pay at checkout' },
+                        { value: 'wioa', label: 'WIOA Funding', sub: 'WorkOne — no tuition if eligible' },
+                        { value: 'wrg', label: 'Workforce Ready Grant / Next Level Jobs', sub: 'Indiana state grant — no tuition if eligible' },
+                        { value: 'fssa', label: 'FSSA IMPACT', sub: 'SNAP/TANF recipients referred by your case worker' },
+                        { value: 'employer', label: 'Employer-sponsored', sub: 'Host shop or employer pays tuition' },
+                        { value: 'unsure', label: 'Not sure', sub: 'Enrollment team will help you find funding' },
+                      ].map((opt) => (
+                        <label
+                          key={opt.value}
+                          className={`flex items-start gap-3 p-3 rounded-xl border-2 cursor-pointer transition-colors ${
+                            formData.fundingInterest === opt.value
+                              ? 'border-brand-blue-500 bg-brand-blue-50'
+                              : 'border-slate-200 bg-white hover:border-slate-300'
+                          }`}
+                        >
+                          <input
+                            type="radio"
+                            name="fundingInterest"
+                            value={opt.value}
+                            checked={formData.fundingInterest === opt.value}
+                            onChange={(e) => handleFundingChange(e.target.value)}
+                            className="mt-0.5 w-4 h-4 text-brand-blue-600"
+                          />
+                          <div>
+                            <p className="text-sm font-semibold text-slate-800">{opt.label}</p>
+                            <p className="text-xs text-slate-500 mt-0.5">{opt.sub}</p>
+                          </div>
+                        </label>
+                      ))}
+                    </div>
+                    {(formData.fundingInterest === 'wioa' || formData.fundingInterest === 'wrg' || formData.fundingInterest === 'fssa') && (
+                      <div className="mt-4">
+                        <FundingEligibilityFlow
+                          fundingType={formData.fundingInterest as 'wioa' | 'wrg' | 'fssa'}
+                          program="barber"
+                          onReady={(status) => setFundingEligibilityStatus(status)}
+                        />
+                      </div>
+                    )}
+                    {(formData.fundingInterest === 'employer' || formData.fundingInterest === 'unsure') && (
+                      <div className="mt-4 bg-brand-green-50 border border-brand-green-200 rounded-xl p-4 flex items-start gap-3">
+                        <Shield className="w-5 h-5 text-brand-green-600 flex-shrink-0 mt-0.5" />
+                        <div>
+                          <p className="text-sm font-bold text-brand-green-800">No payment required today</p>
+                          <p className="text-sm text-brand-green-700 mt-1">
+                            Submit your application and our enrollment team will contact you within 2 business days.
+                          </p>
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {isSelfPay && (
                 <div className="border-t border-black pt-6 mt-6">
                   <p className="text-lg text-black font-bold mb-4">Choose Payment Option</p>
 
@@ -997,6 +1104,7 @@ export default function ApprenticeForm({
                     </p>
                   </div>
                 </div>
+                )}
 
                 {/* Embedded Stripe Checkout — Klarna / Afterpay */}
                 {embeddedClientSecret && (
@@ -1022,14 +1130,16 @@ export default function ApprenticeForm({
                   </div>
                 )}
 
-                {/* Pay Button — hidden while embedded checkout is open */}
+                {/* Submit — hidden while embedded checkout is open */}
                 {!embeddedClientSecret && (
                   <>
-                    <Turnstile
-                      onVerify={(token) => setTurnstileToken(token)}
-                      onExpire={() => setTurnstileToken('')}
-                      formId="barber-apply"
-                    />
+                    {isSelfPay && (
+                      <Turnstile
+                        onVerify={(token) => setTurnstileToken(token)}
+                        onExpire={() => setTurnstileToken('')}
+                        formId="barber-apply"
+                      />
+                    )}
                     <button
                       onClick={handlePayNow}
                       disabled={
@@ -1037,7 +1147,10 @@ export default function ApprenticeForm({
                         !formData.email ||
                         !formData.firstName ||
                         !formData.lastName ||
-                        !formData.phone
+                        !formData.phone ||
+                        (!completingExistingPayment && !formData.fundingInterest) ||
+                        (isSelfPay && !turnstileToken) ||
+                        (!isSelfPay && !completingExistingPayment && !fundedOptionsReady)
                       }
                       className="w-full py-4 bg-brand-blue-600 hover:bg-brand-blue-700 disabled:bg-slate-300 text-white font-bold rounded-lg transition-colors flex items-center justify-center gap-2 text-lg"
                     >
@@ -1048,18 +1161,26 @@ export default function ApprenticeForm({
                         </>
                       ) : (
                         <>
-                          <CreditCard className="w-5 h-5" />
-                          {paymentOption === 'stripe_bnpl'
-                            ? 'Open Klarna / Afterpay'
-                            : 'Continue to Payment'}
+                          {isSelfPay ? (
+                            <CreditCard className="w-5 h-5" />
+                          ) : (
+                            <Shield className="w-5 h-5" />
+                          )}
+                          {!isSelfPay
+                            ? 'Submit Application'
+                            : paymentOption === 'stripe_bnpl'
+                              ? 'Open Klarna / Afterpay'
+                              : 'Continue to Payment'}
                         </>
                       )}
                     </button>
 
-                    <p className="text-center text-sm text-black mt-4">
-                      Secure payment via Stripe. Card, Apple Pay, Google Pay, PayPal, Venmo, Cash
-                      App accepted.
-                    </p>
+                    {isSelfPay && (
+                      <p className="text-center text-sm text-black mt-4">
+                        Secure payment via Stripe. Card, Apple Pay, Google Pay, PayPal, Venmo, Cash
+                        App accepted.
+                      </p>
+                    )}
                   </>
                 )}
               </div>

--- a/app/programs/barber-apprenticeship/apply/BarberApplyClient.tsx
+++ b/app/programs/barber-apprenticeship/apply/BarberApplyClient.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
+import { mapApplyFundingParam } from '@/lib/barber/apply-funding';
 import ApprenticeForm from './ApprenticeForm';
 
 // Reads ?payment=, ?reason=, ?email=, ?name=, ?application_id= from the URL.

--- a/app/programs/barber-apprenticeship/apply/BarberApprenticeApplyForm.tsx
+++ b/app/programs/barber-apprenticeship/apply/BarberApprenticeApplyForm.tsx
@@ -1,0 +1,18 @@
+'use client';
+
+import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
+import { mapApplyFundingParam } from '@/lib/barber/apply-funding';
+import ApprenticeForm from './ApprenticeForm';
+
+export default function BarberApprenticeApplyForm() {
+  const searchParams = useSafeSearchParams();
+  return (
+    <ApprenticeForm
+      initialPayment={searchParams.get('payment')}
+      initialFunding={mapApplyFundingParam(searchParams.get('funding'))}
+      initialEmail={searchParams.get('email') ?? undefined}
+      initialName={searchParams.get('name') ?? undefined}
+      initialApplicationId={searchParams.get('application_id') ?? undefined}
+    />
+  );
+}

--- a/app/programs/barber-apprenticeship/apply/apprentice/page.tsx
+++ b/app/programs/barber-apprenticeship/apply/apprentice/page.tsx
@@ -1,17 +1,52 @@
 export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
-import BarberApplyClient from '../BarberApplyClient';
+import Link from 'next/link';
+import { ArrowLeft } from 'lucide-react';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import ApprenticeForm from '../ApprenticeForm';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const metadata: Metadata = {
   title: 'Barber Apprentice Application',
   description:
     `Apply to enroll in the ${PLATFORM_DEFAULTS.orgName} DOL-registered barber apprenticeship program.`,
-  alternates: {
-    canonical: 'https://www.elevateforhumanity.org/programs/barber-apprenticeship/apply/apprentice',
-  },
+  alternates: { canonical: 'https://www.elevateforhumanity.org/programs/barber-apprenticeship/apply/apprentice' },
 };
 
 export default function BarberApprenticeApplyPage() {
-  return <BarberApplyClient />;
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="bg-white border-b">
+        <div className="max-w-4xl mx-auto px-4 py-4">
+          <Breadcrumbs
+            items={[
+              { label: 'Programs', href: '/programs' },
+              { label: 'Barber Apprenticeship', href: '/programs/barber-apprenticeship' },
+              { label: 'Apply', href: '/programs/barber-apprenticeship/apply' },
+              { label: 'Apprentice' },
+            ]}
+          />
+          <div className="mt-4">
+            <Link
+              href="/programs/barber-apprenticeship/apply"
+              className="inline-flex items-center gap-1 text-sm text-slate-500 hover:text-slate-800 transition-colors"
+            >
+              <ArrowLeft className="w-4 h-4" />
+              Back
+            </Link>
+          </div>
+          <h1 className="text-3xl font-bold text-slate-900 mt-4">
+            Barber Apprentice Application
+          </h1>
+          <p className="text-slate-600 mt-1">
+            Complete the form below to apply as a barber apprentice.
+          </p>
+        </div>
+      </div>
+
+      <div className="max-w-4xl mx-auto px-4 py-8">
+        <BarberApprenticeApplyForm />
+      </div>
+    </div>
+  );
 }

--- a/app/programs/barber-apprenticeship/apply/page.tsx
+++ b/app/programs/barber-apprenticeship/apply/page.tsx
@@ -14,42 +14,7 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://www.elevateforhumanity.org/programs/barber-apprenticeship/apply' },
 };
 
-type SearchParams = Record<string, string | string[] | undefined>;
-
-function shouldRouteToApprenticeForm(searchParams: SearchParams): boolean {
-  return APPRENTICE_APPLY_QUERY_KEYS.some((key) => {
-    const value = searchParams[key];
-    if (value == null) return false;
-    if (key === 'type') {
-      const v = Array.isArray(value) ? value[0] : value;
-      return v === 'apprentice';
-    }
-    return String(Array.isArray(value) ? value[0] : value).trim() !== '';
-  });
-}
-
-function apprenticeApplyUrl(searchParams: SearchParams): string {
-  const qs = new URLSearchParams();
-  for (const [key, raw] of Object.entries(searchParams)) {
-    if (raw == null) continue;
-    const val = Array.isArray(raw) ? raw[0] : raw;
-    if (val) qs.set(key, val);
-  }
-  const query = qs.toString();
-  return query
-    ? `/programs/barber-apprenticeship/apply/apprentice?${query}`
-    : '/programs/barber-apprenticeship/apply/apprentice';
-}
-
-export default function BarberApplyIndexPage({
-  searchParams,
-}: {
-  searchParams: SearchParams;
-}) {
-  if (shouldRouteToApprenticeForm(searchParams)) {
-    redirect(apprenticeApplyUrl(searchParams));
-  }
-
+export default function BarberApplyIndexPage() {
   return (
     <div className="min-h-screen bg-white">
       <div className="bg-white border-b">
@@ -96,6 +61,7 @@ export default function BarberApplyIndexPage({
             description="I want to enroll in the barber apprenticeship program as a student."
             enrollHref="/programs/barber-apprenticeship/apply/apprentice"
             inquiryHref="/programs/barber-apprenticeship/request-info"
+            routeFundedToEnrollment
             accentColor="brand-red"
           />
 

--- a/app/programs/barber-apprenticeship/apply/success/BarberApplySuccessClient.tsx
+++ b/app/programs/barber-apprenticeship/apply/success/BarberApplySuccessClient.tsx
@@ -1,0 +1,85 @@
+'use client';
+
+import Link from 'next/link';
+import { CheckCircle, Scissors, LogIn } from 'lucide-react';
+import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
+
+export default function BarberApplySuccessClient() {
+  const searchParams = useSafeSearchParams();
+  const isFunded = searchParams.get('funded') === '1';
+
+  return (
+    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4 py-12">
+      <div className="max-w-lg w-full">
+        <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
+          <div className="w-16 h-16 bg-brand-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
+            <CheckCircle className="w-9 h-9 text-brand-green-600" />
+          </div>
+
+          <h1 className="text-2xl font-bold text-slate-900 mb-2">Application Received!</h1>
+          <p className="text-slate-600 mb-6">
+            {isFunded
+              ? 'Our enrollment team will contact you within 2 business days to verify your funding and finalize enrollment.'
+              : "Check your email — we've sent a confirmation with your enrollment details and next steps."}
+          </p>
+
+          {!isFunded && (
+            <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-left">
+              <div className="flex gap-3">
+                <Scissors className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
+                <div>
+                  <p className="text-sm font-semibold text-amber-900 mb-1">
+                    Automatic Weekly Billing
+                  </p>
+                  <p className="text-sm text-amber-800">
+                    Your card on file will be charged automatically every Friday until your balance
+                    is paid in full. If a payment fails you will receive an email and have 7 days to
+                    update your card.
+                  </p>
+                </div>
+              </div>
+            </div>
+          )}
+
+          {isFunded && (
+            <div className="bg-brand-blue-50 border border-brand-blue-200 rounded-xl p-4 mb-6 text-left text-sm text-brand-blue-900">
+              <p className="font-semibold mb-1">Next steps</p>
+              <ul className="list-disc pl-5 space-y-1 text-brand-blue-800">
+                <li>Keep your WorkOne, ICC, or FSSA approval letters handy if you have them.</li>
+                <li>Watch for email from our enrollment team with document requests.</li>
+                <li>Do not pay tuition until your funding path is confirmed.</li>
+              </ul>
+            </div>
+          )}
+
+          <div className="space-y-3 mb-8">
+            <Link
+              href="/programs/barber-apprenticeship/orientation"
+              className="w-full flex items-center justify-center gap-2 bg-brand-blue-600 hover:bg-brand-blue-700 text-white font-bold py-3 px-6 rounded-xl transition-colors"
+            >
+              <Scissors className="w-5 h-5" />
+              Continue to Orientation
+            </Link>
+            <Link
+              href="/login?redirect=/programs/barber-apprenticeship/orientation"
+              className="w-full flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-800 font-semibold py-3 px-6 rounded-xl transition-colors"
+            >
+              <LogIn className="w-5 h-5" />
+              Sign In to Your Account
+            </Link>
+          </div>
+
+          <p className="text-xs text-slate-400">
+            Questions? Email us at{' '}
+            <a
+              href="mailto:elevate4humanityedu@gmail.com"
+              className="text-brand-blue-600 hover:underline"
+            >
+              elevate4humanityedu@gmail.com
+            </a>
+          </p>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/programs/barber-apprenticeship/apply/success/page.tsx
+++ b/app/programs/barber-apprenticeship/apply/success/page.tsx
@@ -1,7 +1,6 @@
 export const dynamic = 'force-dynamic';
-import Link from 'next/link';
-import { CheckCircle, Scissors, LogIn } from 'lucide-react';
 import type { Metadata } from 'next';
+import BarberApplySuccessClient from './BarberApplySuccessClient';
 
 export const metadata: Metadata = {
   title: 'Application Received | Barber Apprenticeship',
@@ -10,61 +9,5 @@ export const metadata: Metadata = {
 };
 
 export default function BarberApplySuccessPage() {
-  return (
-    <div className="min-h-screen bg-slate-50 flex items-center justify-center px-4 py-12">
-      <div className="max-w-lg w-full">
-        {/* Success card */}
-        <div className="bg-white rounded-2xl shadow-lg p-8 text-center">
-          <div className="w-16 h-16 bg-brand-green-100 rounded-full flex items-center justify-center mx-auto mb-4">
-            <CheckCircle className="w-9 h-9 text-brand-green-600" />
-          </div>
-
-          <h1 className="text-2xl font-bold text-slate-900 mb-2">Application Received!</h1>
-          <p className="text-slate-600 mb-6">
-            Check your email — we've sent a confirmation with your enrollment details and next steps.
-          </p>
-
-          {/* Autopay reminder */}
-          <div className="bg-amber-50 border border-amber-200 rounded-xl p-4 mb-6 text-left">
-            <div className="flex gap-3">
-              <Scissors className="w-5 h-5 text-amber-600 flex-shrink-0 mt-0.5" />
-              <div>
-                <p className="text-sm font-semibold text-amber-900 mb-1">Automatic Weekly Billing</p>
-                <p className="text-sm text-amber-800">
-                  Your card on file will be charged automatically every Friday until your balance
-                  is paid in full. No action needed — charges happen automatically. If a payment fails
-                  you will receive an email and have 7 days to update your card.
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* Next steps */}
-          <div className="space-y-3 mb-8">
-            <Link
-              href="/programs/barber-apprenticeship/orientation"
-              className="w-full flex items-center justify-center gap-2 bg-brand-blue-600 hover:bg-brand-blue-700 text-white font-bold py-3 px-6 rounded-xl transition-colors"
-            >
-              <Scissors className="w-5 h-5" />
-              Continue to Orientation
-            </Link>
-            <Link
-              href="/login?redirect=/programs/barber-apprenticeship/orientation"
-              className="w-full flex items-center justify-center gap-2 bg-slate-100 hover:bg-slate-200 text-slate-800 font-semibold py-3 px-6 rounded-xl transition-colors"
-            >
-              <LogIn className="w-5 h-5" />
-              Sign In to Your Account
-            </Link>
-          </div>
-
-          <p className="text-xs text-slate-400">
-            Questions? Email us at{' '}
-            <a href="mailto:elevate4humanityedu@gmail.com" className="text-brand-blue-600 hover:underline">
-              elevate4humanityedu@gmail.com
-            </a>
-          </p>
-        </div>
-      </div>
-    </div>
-  );
+  return <BarberApplySuccessClient />;
 }

--- a/app/programs/barber-apprenticeship/eligibility/page.tsx
+++ b/app/programs/barber-apprenticeship/eligibility/page.tsx
@@ -24,7 +24,7 @@ export default function BarberEligibilityPage() {
         microLabel="Barber Apprenticeship"
         analyticsName="barber-eligibility"
         belowHeroHeadline="Funding & Enrollment"
-        belowHeroSubheadline="The Barber Apprenticeship is not on Indiana's ETPL — it does not qualify for WIOA or Workforce Ready Grant. FSSA IMPACT (SNAP/TANF), employer sponsorship, and self-pay are all available."
+        belowHeroSubheadline="Indiana residents may qualify for WIOA, Workforce Ready Grant, or FSSA IMPACT. Employer sponsorship and self-pay with flexible weekly payments are also available."
         ctas={[
           {
             label: '← Back to Program',

--- a/app/programs/barber-apprenticeship/host-shops/page.tsx
+++ b/app/programs/barber-apprenticeship/host-shops/page.tsx
@@ -206,7 +206,7 @@ export default function HostShopsPage() {
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="font-bold text-xl">•</span>
-                  <span className="text-lg">Related instruction (Milady curriculum)</span>
+                  <span className="text-lg">Related instruction (Prestige Elevation Barber Curriculum)</span>
                 </li>
                 <li className="flex items-start gap-3">
                   <span className="font-bold text-xl">•</span>

--- a/app/programs/barber-apprenticeship/orientation/OrientationClient.tsx
+++ b/app/programs/barber-apprenticeship/orientation/OrientationClient.tsx
@@ -27,7 +27,7 @@ const HANDBOOK_SLIDES = [
     title: 'Your Apprenticeship',
     content: [
       'This is a U.S. Department of Labor Registered Apprenticeship — a nationally recognized credential.',
-      'You must complete 2,000 apprenticeship hours total: 1,500 on-the-job training (OJT) hours at your host barbershop and 500 related technical instruction (RTI) hours via Milady online coursework.',
+      'You must complete 2,000 apprenticeship hours total: 1,500 on-the-job training (OJT) hours at your host barbershop and `You must complete 2,000 apprenticeship hours total: 1,500 on-the-job training (OJT) hours at your host barbershop and 500 related technical instruction (RTI) hours through the ${PRESTIGE_ELEVATION_BARBER_CURRICULUM} on Elevate LMS.`',
       'Upon completion you are eligible to sit for the Indiana Barber License exam.',
       'Your host shop supervisor signs off on your hours weekly. Hours not signed off do not count.',
     ],
@@ -57,15 +57,15 @@ const HANDBOOK_SLIDES = [
     ],
   },
   {
-    id: 'milady',
+    id: 'prestige-rti',
     icon: BookOpen,
-    title: 'Milady Online Coursework',
+    title: PRESTIGE_ELEVATION_BARBER_CURRICULUM,
     content: [
-      'Your Milady account will be activated within 24 hours of completing this orientation.',
-      'You will receive a separate email with your Milady login credentials.',
-      'Milady coursework counts toward your 2,000 hour total. You must complete all assigned modules.',
-      'Do not share your Milady login. Each account is tied to your enrollment record.',
-      'Milady progress is reviewed monthly. Falling behind on coursework may affect your program standing.',
+      `Your ${PRESTIGE_ELEVATION_BARBER_CURRICULUM} access on Elevate LMS is activated after enrollment and orientation.`,
+      'Sign in at elevateforhumanity.org and open your program from the apprentice dashboard.',
+      'RTI coursework counts toward your 2,000 hour total. You must complete all assigned modules.',
+      'Do not share your login. Each account is tied to your enrollment record.',
+      'Course progress is reviewed monthly. Falling behind on RTI may affect your program standing.',
     ],
   },
   {
@@ -208,7 +208,7 @@ export default function BarberOrientationClient({ payment }: { payment: BarberPa
                   <Play className="w-7 h-7 text-white fill-white ml-1" />
                 </div>
                 <span className="text-white font-semibold text-sm">Watch your orientation video</span>
-                <span className="text-slate-300 text-xs">Covers: program overview · clocking in/out · Milady · payment terms</span>
+                <span className="text-slate-300 text-xs">Covers: program overview · clocking in/out · RTI curriculum · payment terms</span>
               </button>
             )}
           </div>
@@ -363,7 +363,7 @@ export default function BarberOrientationClient({ payment }: { payment: BarberPa
               className="w-5 h-5 mt-0.5 rounded border-slate-500 text-brand-blue-600 focus:ring-brand-blue-500 flex-shrink-0"
             />
             <span className="text-slate-300 text-sm leading-relaxed">
-              I have watched the orientation video and read all sections of the student handbook. I understand the clocking requirements, auto clock-out rules, Milady coursework expectations, payment auto-draft schedule, and the consequences of missed payments or conduct violations. I agree to proceed.
+              I have watched the orientation video and read all sections of the student handbook. I understand the clocking requirements, auto clock-out rules, Prestige Elevation Barber Curriculum (RTI) expectations, payment auto-draft schedule, and the consequences of missed payments or conduct violations. I agree to proceed.
             </span>
           </label>
           <button

--- a/components/programs/FundingEligibilityFlow.tsx
+++ b/components/programs/FundingEligibilityFlow.tsx
@@ -32,9 +32,13 @@ export type FundingType = 'wioa' | 'wrg' | 'fssa';
 
 export type EligibilityStatus = 'approved' | 'in_process' | 'needs_appointment' | 'not_resident';
 
+export type FundingEligibilityProgram = 'hvac' | 'barber';
+
 interface Props {
   fundingType: FundingType;
   onReady: (status: EligibilityStatus) => void;
+  /** ICC search label and WRG/FSSA copy (default: HVAC) */
+  program?: FundingEligibilityProgram;
 }
 
 const CFG = {

--- a/components/programs/FundingGateCard.tsx
+++ b/components/programs/FundingGateCard.tsx
@@ -51,6 +51,7 @@ export default function FundingGateCard({
   description,
   enrollHref,
   inquiryHref,
+  routeFundedToEnrollment = false,
   accentColor = 'brand-red',
 }: Props) {
   const router = useRouter();

--- a/components/programs/ProgramFundingGate.tsx
+++ b/components/programs/ProgramFundingGate.tsx
@@ -4,7 +4,9 @@
  * ProgramFundingGate
  *
  * Pre-selection questionnaire shown before a learner picks a funding path.
- * Handles programs that are NOT WIOA/WRG eligible (e.g. barber, cosmetology,
+ * Handles programs with mixed funding (e.g. cosmetology, esthetician) or routes
+ * barber WIOA/WRG to the apprentice application when `routeFundedToEnrollment` is set.
+ * Legacy: programs that are NOT WIOA/WRG eligible (e.g. nail
  * esthetician, nail) — routes to FSSA/IMPACT, employer-paid, or self-pay.
  *
  * Flow:

--- a/data/programs/barber-apprenticeship.ts
+++ b/data/programs/barber-apprenticeship.ts
@@ -273,13 +273,13 @@ export const BARBER_APPRENTICESHIP: ProgramSchema = {
   enrollmentType: 'internal',
   partnerCourses: [
     {
-      courseId: 'milady-barbering',
-      label: 'Milady Standard Barbering',
-      partnerName: 'Milady/Cengage',
-      credentialIssued: 'Barbering Certificate',
+      courseId: 'prestige-elevation-barber-curriculum',
+      label: 'Prestige Elevation Barber Curriculum',
+      partnerName: 'Elevate for Humanity',
+      credentialIssued: 'RTI completion (500 hours)',
       duration: '500 hours RTI',
       required: true,
-      enrollmentUrl: 'https://www.milady.com/barbering',
+      enrollmentUrl: '/lms/courses/3fb5ce19-1cde-434c-a8c6-f138d7d7aa17',
     },
   ],
   microCourses: [

--- a/lib/barber/apply-funding.ts
+++ b/lib/barber/apply-funding.ts
@@ -1,0 +1,13 @@
+/** Map FundingGateCard / URL params to ApprenticeForm fundingInterest values */
+export function mapApplyFundingParam(param: string | null | undefined): string {
+  if (!param) return '';
+  const normalized: Record<string, string> = {
+    'workforce-ready-grant': 'wrg',
+    'employer-sponsored': 'employer',
+    'not-sure': 'unsure',
+    jri: 'unsure',
+    'payment-plan': 'self-pay',
+    'self-pay': 'self-pay',
+  };
+  return normalized[param] ?? param;
+}

--- a/lib/barber/branding.ts
+++ b/lib/barber/branding.ts
@@ -1,0 +1,10 @@
+/**
+ * Public-facing names for barber RTI (Related Technical Instruction).
+ * Do not use third-party curriculum vendor names in learner UI.
+ */
+
+export const PRESTIGE_ELEVATION_BARBER_CURRICULUM =
+  'Prestige Elevation Barber Curriculum';
+
+/** Short label for nav tabs and compact UI */
+export const PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT = 'Barber Curriculum';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

- Replaces learner-facing **Milady** references with **Prestige Elevation Barber Curriculum** (orientation, host shops, chat, program data).
- Adds **WIOA / WRG / FSSA / employer / unsure** funding selection to the barber **ApprenticeForm**, matching the HVAC apply pattern.
- Funded applicants submit without Stripe checkout; success page shows funding-specific next steps (`?funded=1`).
- Apply index **FundingGateCard** now routes WIOA/WRG to `/apply/apprentice?funding=…` instead of inquiry-only.
- Eligibility page updated to reflect that barbers **may** qualify for WIOA/WRG.
- `FundingEligibilityFlow` accepts `program="barber"` for ICC/WRG copy.

## Test plan

- [ ] `/programs/barber-apprenticeship/apply` → select WIOA → lands on apprentice form with funding pre-selected
- [ ] Complete WIOA eligibility flow → Submit Application (no payment section)
- [ ] Self-pay path still shows payment options and Turnstile
- [ ] Orientation handbook slide titles use Prestige Elevation Barber Curriculum
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

