### PR TITLE
Fix admin ECS boot and homepage accessibility gate

### DIFF
--- a/apps/admin/server.js
+++ b/apps/admin/server.js
@@ -4,17 +4,53 @@
  */
 'use strict';
 
+const fs = require('fs');
 const path = require('path');
 
 const dir = path.join(__dirname);
 const port = parseInt(process.env.PORT ?? '3000', 10);
 const host = process.env.HOSTNAME ?? '0.0.0.0';
 
+function loadStandaloneConfig() {
+  const existing = process.env.__NEXT_PRIVATE_STANDALONE_CONFIG;
+  if (existing && existing !== '{}') {
+    return existing;
+  }
+
+  const requiredServerFilesPath = path.join(
+    dir,
+    '.next',
+    'required-server-files.json',
+  );
+
+  let nextConfig = {};
+  try {
+    const requiredServerFiles = JSON.parse(
+      fs.readFileSync(requiredServerFilesPath, 'utf8'),
+    );
+    nextConfig = requiredServerFiles.config || {};
+  } catch (err) {
+    console.warn(
+      '[admin] failed to load required-server-files.json; using minimal standalone config:',
+      err && err.message ? err.message : err,
+    );
+  }
+
+  const distDir =
+    typeof nextConfig.distDir === 'string' && nextConfig.distDir.length > 0
+      ? nextConfig.distDir
+      : '.next';
+
+  return JSON.stringify({
+    ...nextConfig,
+    distDir,
+  });
+}
+
 process.env.NODE_ENV = 'production';
 process.chdir(dir);
 
-process.env.__NEXT_PRIVATE_STANDALONE_CONFIG =
-  process.env.__NEXT_PRIVATE_STANDALONE_CONFIG || '{}';
+process.env.__NEXT_PRIVATE_STANDALONE_CONFIG = loadStandaloneConfig();
 require('next');
 
 const { startServer } = require('next/dist/server/lib/start-server');

--- a/components/home/HomeOutcomes.tsx
+++ b/components/home/HomeOutcomes.tsx
@@ -167,12 +167,12 @@ export async function HomeOutcomes() {
           ))}
         </div>
 
-        <p className="mt-8 text-center text-slate-600 text-xs">
+        <p className="mt-8 text-center text-slate-300 text-xs">
           Figures based on internal participant and credential records. Eligibility and outcomes
           vary by program and funding source.{' '}
           <Link
             href="/impact/methodology"
-            className="underline hover:text-slate-400 transition-colors"
+            className="text-sky-200 underline underline-offset-2 decoration-sky-300/70 transition-colors hover:text-white hover:decoration-white"
           >
             See methodology
           </Link>

--- a/components/home/HomeOutcomes.tsx
+++ b/components/home/HomeOutcomes.tsx
@@ -82,7 +82,7 @@ function StoryCard({ story }: { story: Testimonial }) {
           {story.role && <p className="text-[11px] text-slate-500">{story.role}</p>}
         </div>
         {story.program && (
-          <span className="ml-auto text-[10px] font-semibold text-brand-red-600 bg-brand-red-50 px-2 py-0.5 rounded-full">
+          <span className="ml-auto text-[10px] font-semibold text-brand-red-800 bg-brand-red-50 px-2 py-0.5 rounded-full">
             {story.program}
           </span>
         )}


### PR DESCRIPTION
## Summary
- Load the real Next.js standalone config from `apps/admin/.next/required-server-files.json` before starting the custom admin server.
- Keep a minimal `.next` distDir fallback so the admin container does not boot Next with an empty standalone config.
- Restore homepage outcomes contrast for the methodology copy/link and story program badges that failed the Compliance Gate axe check.

## Root causes
- `Deploy Admin` built successfully, then ECS tasks exited with `TypeError: The "path" argument must be of type string. Received undefined` during Next startup. The custom `apps/admin/server.js` replaced the generated standalone server but forced `__NEXT_PRIVATE_STANDALONE_CONFIG` to `{}`, leaving Next without required runtime config.
- `Compliance Gate / Accessibility Tests` failed homepage axe color contrast for `.mt-8.text-slate-600.text-center`, the `/impact/methodology` link, and the small story program badges (`text-brand-red-600` on `bg-brand-red-50`, measured at 4.41:1).

## Validation
- Earlier PR run on `3b7988c` passed CI/CD, Compliance Gate, Autopilot, Lint, Pre-deploy, Integrity, Survival, Design Policy, and Dashboard Diagnostics.
- Added one follow-up commit `5087b053` to raise the story badge contrast to `text-brand-red-800`; PR checks restarted for that head SHA.
- No production deploy or merge has been performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Admin server startup path affects ECS deploy reliability; homepage changes are low-risk styling but the admin fix touches production container boot behavior.
> 
> **Overview**
> Fixes **admin ECS startup** by hydrating `__NEXT_PRIVATE_STANDALONE_CONFIG` from `required-server-files.json` (with a `.next` `distDir` fallback) instead of defaulting to `{}`, which was causing Next to crash on boot with an invalid path.
> 
> On the **homepage outcomes** section, tightens **axe color contrast**: darker program badges (`text-brand-red-800`), lighter disclaimer copy (`text-slate-300`), and a higher-contrast methodology link (`text-sky-200` with updated hover/decoration).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5087b0532d2d3014129e9fdf2eec3b9a1dfbf92f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->