### PR TITLE
fix(admin): operations hub, dashboard dedupe, Dev Studio container merge

### DIFF
--- a/app/api/program-holder/students/route.ts
+++ b/app/api/program-holder/students/route.ts
@@ -23,18 +23,33 @@ async function _GET(request: Request) {
 
     const { data: profile } = await supabase
       .from('profiles')
-      .select('role')
+      .select('role, program_holder_id')
       .eq('id', user.id)
       .maybeSingle();
 
-    if (!profile || profile.role !== 'program_holder') {
+    const allowedRoles = ['program_holder', 'admin', 'super_admin', 'staff'];
+    if (!profile || !allowedRoles.includes(profile.role ?? '')) {
       return NextResponse.json(
         { error: 'Forbidden - Program holder access only' },
         { status: 403 },
       );
     }
 
-    const students = await getProgramHolderStudents(user.id);
+    let holderId = profile.program_holder_id;
+    if (!holderId) {
+      const { data: fallback } = await supabase
+        .from('program_holders')
+        .select('id')
+        .eq('user_id', user.id)
+        .maybeSingle();
+      holderId = fallback?.id ?? null;
+    }
+
+    if (!holderId) {
+      return NextResponse.json({ error: 'Program holder record not found' }, { status: 403 });
+    }
+
+    const students = await getProgramHolderStudents(holderId);
 
     return NextResponse.json({ students });
   } catch (error) {

--- a/app/globals.css
+++ b/app/globals.css
@@ -98,12 +98,6 @@ body {
   display: none !important;
 }
 
-@media (min-width: 1280px) {
-  .header-mobile-menu {
-    display: none !important;
-  }
-}
-
 /* ============================================================================
    BASE STYLES - Reset, Typography, Layout
    ============================================================================ */
@@ -1716,6 +1710,17 @@ header[role='banner'] {
   filter: none !important;
   backdrop-filter: none !important;
   background-color: #ffffff !important;
+}
+
+header[role='banner'] > div {
+  display: grid !important;
+  flex-direction: row !important;
+}
+
+header[role='banner'] nav[aria-label='Main navigation'] {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
 }
 
 header[role='banner'] > div,

--- a/app/globals.css
+++ b/app/globals.css
@@ -1712,8 +1712,11 @@ header[role='banner'] {
   background-color: #ffffff !important;
 }
 
+/* Keep marketing header one horizontal row on desktop; vertical list only in mobile drawer */
 header[role='banner'] > div {
   display: grid !important;
+  grid-template-columns: auto 1fr auto !important;
+  align-items: center !important;
   flex-direction: row !important;
 }
 
@@ -1721,6 +1724,23 @@ header[role='banner'] nav[aria-label='Main navigation'] {
   display: flex !important;
   flex-direction: row !important;
   flex-wrap: nowrap !important;
+  align-items: center !important;
+  justify-content: center !important;
+  min-width: 0 !important;
+  overflow-x: auto !important;
+  overflow-y: visible !important;
+  -webkit-overflow-scrolling: touch;
+  scrollbar-width: thin;
+}
+
+header[role='banner'] nav[aria-label='Main navigation'] > div {
+  flex-shrink: 0 !important;
+}
+
+header[role='banner'] a,
+header[role='banner'] button {
+  min-height: unset !important;
+  min-width: unset !important;
 }
 
 header[role='banner'] > div,

--- a/app/program-holder/ProgramHolderShellGate.tsx
+++ b/app/program-holder/ProgramHolderShellGate.tsx
@@ -1,0 +1,41 @@
+'use client';
+
+import { usePathname } from 'next/navigation';
+import { PartnerProgramHolderShell } from '@/components/portal/PartnerProgramHolderShell';
+
+/** Marketing landing only — no sidebar */
+const NO_SHELL_PATHS = new Set(['/program-holder']);
+
+export function ProgramHolderShellGate({
+  children,
+  role,
+  userName,
+  userEmail,
+  orgName,
+  hasSchoolApplications,
+}: {
+  children: React.ReactNode;
+  role: string;
+  userName?: string;
+  userEmail?: string;
+  orgName?: string;
+  hasSchoolApplications?: boolean;
+}) {
+  const pathname = usePathname() ?? '';
+
+  if (NO_SHELL_PATHS.has(pathname)) {
+    return <>{children}</>;
+  }
+
+  return (
+    <PartnerProgramHolderShell
+      role={role}
+      userName={userName}
+      userEmail={userEmail}
+      orgName={orgName}
+      hasSchoolApplications={hasSchoolApplications}
+    >
+      {children}
+    </PartnerProgramHolderShell>
+  );
+}

--- a/app/program-holder/hours/ProgramHolderHoursClient.tsx
+++ b/app/program-holder/hours/ProgramHolderHoursClient.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle, XCircle, Loader2, RefreshCw } from 'lucide-react';
+
+type HourEntry = {
+  id: string;
+  user_id: string;
+  work_date: string;
+  hours_claimed: number;
+  source_type?: string;
+  category?: string;
+  status: string;
+  notes?: string;
+  profiles?: { full_name?: string; email?: string };
+};
+
+export function ProgramHolderHoursClient() {
+  const [entries, setEntries] = useState<HourEntry[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [actingId, setActingId] = useState<string | null>(null);
+  const [error, setError] = useState('');
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError('');
+    try {
+      const res = await fetch('/api/program-holder/hours?status=pending&limit=100');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Failed to load hours');
+      setEntries(data.entries ?? data.hours ?? []);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load');
+      setEntries([]);
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load();
+  }, [load]);
+
+  async function act(hourId: string, action: 'approve' | 'reject') {
+    let rejection_reason: string | undefined;
+    if (action === 'reject') {
+      rejection_reason = window.prompt('Reason for rejection (required):')?.trim();
+      if (!rejection_reason) return;
+    }
+    setActingId(hourId);
+    setError('');
+    try {
+      const res = await fetch('/api/program-holder/hours/approve', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ hour_id: hourId, action, rejection_reason }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || 'Action failed');
+      await load();
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Action failed');
+    } finally {
+      setActingId(null);
+    }
+  }
+
+  return (
+    <div className="max-w-5xl mx-auto px-4 py-8">
+      <div className="flex items-center justify-between mb-6">
+        <div>
+          <h1 className="text-2xl font-bold text-slate-900">Hour approvals</h1>
+          <p className="text-slate-600 text-sm mt-1">Review and approve apprentice OJL hours</p>
+        </div>
+        <button
+          type="button"
+          onClick={() => load()}
+          className="inline-flex items-center gap-2 px-3 py-2 text-sm border border-slate-300 rounded-lg hover:bg-slate-50"
+        >
+          <RefreshCw className="w-4 h-4" />
+          Refresh
+        </button>
+      </div>
+
+      {error && (
+        <div className="mb-4 p-3 bg-brand-red-50 border border-brand-red-200 rounded-lg text-sm text-brand-red-800">
+          {error}
+        </div>
+      )}
+
+      {loading ? (
+        <div className="flex justify-center py-16 text-slate-500">
+          <Loader2 className="w-8 h-8 animate-spin" />
+        </div>
+      ) : entries.length === 0 ? (
+        <div className="bg-white border border-slate-200 rounded-xl p-8 text-center text-slate-600">
+          <p className="font-medium">No pending hours</p>
+          <p className="text-sm mt-2">
+            <Link href="/program-holder/dashboard" className="text-brand-blue-600 hover:underline">
+              Back to dashboard
+            </Link>
+          </p>
+        </div>
+      ) : (
+        <ul className="space-y-3">
+          {entries.map((e) => {
+            const name =
+              (e.profiles as { full_name?: string })?.full_name ||
+              (e.profiles as { email?: string })?.email ||
+              e.user_id.slice(0, 8);
+            return (
+              <li
+                key={e.id}
+                className="bg-white border border-slate-200 rounded-xl p-4 flex flex-col sm:flex-row sm:items-center sm:justify-between gap-3"
+              >
+                <div>
+                  <p className="font-semibold text-slate-900">{name}</p>
+                  <p className="text-sm text-slate-600">
+                    {e.work_date} · {e.hours_claimed}h · {e.category || e.source_type || 'OJL'}
+                  </p>
+                  {e.notes && <p className="text-xs text-slate-500 mt-1">{e.notes}</p>}
+                </div>
+                <div className="flex gap-2 shrink-0">
+                  <button
+                    type="button"
+                    disabled={actingId === e.id}
+                    onClick={() => act(e.id, 'approve')}
+                    className="inline-flex items-center gap-1 px-3 py-2 bg-brand-green-600 text-white text-sm font-medium rounded-lg hover:bg-brand-green-700 disabled:opacity-50"
+                  >
+                    {actingId === e.id ? (
+                      <Loader2 className="w-4 h-4 animate-spin" />
+                    ) : (
+                      <CheckCircle className="w-4 h-4" />
+                    )}
+                    Approve
+                  </button>
+                  <button
+                    type="button"
+                    disabled={actingId === e.id}
+                    onClick={() => act(e.id, 'reject')}
+                    className="inline-flex items-center gap-1 px-3 py-2 border border-slate-300 text-slate-700 text-sm font-medium rounded-lg hover:bg-slate-50 disabled:opacity-50"
+                  >
+                    <XCircle className="w-4 h-4" />
+                    Reject
+                  </button>
+                </div>
+              </li>
+            );
+          })}
+        </ul>
+      )}
+    </div>
+  );
+}

--- a/app/program-holder/hours/page.tsx
+++ b/app/program-holder/hours/page.tsx
@@ -1,0 +1,15 @@
+import { Metadata } from 'next';
+import { requireProgramHolder } from '@/lib/auth/require-program-holder';
+import { ProgramHolderHoursClient } from './ProgramHolderHoursClient';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  title: 'Hour Approvals | Program Holder',
+  robots: { index: false },
+};
+
+export default async function ProgramHolderHoursPage() {
+  await requireProgramHolder();
+  return <ProgramHolderHoursClient />;
+}

--- a/app/program-holder/layout.tsx
+++ b/app/program-holder/layout.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
 import { createClient } from '@/lib/supabase/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
+import { ProgramHolderShellGate } from './ProgramHolderShellGate';
 
 export const dynamic = 'force-dynamic';
 
@@ -15,15 +16,17 @@ const PORTAL_ROLES = ['program_holder', 'admin', 'super_admin', 'staff', 'org_ad
 
 export default async function ProgramHolderLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (!user) redirect('/login?redirect=/program-holder/dashboard');
 
-  const db = await requireAdminClient() ?? supabase;
+  const db = (await requireAdminClient()) ?? supabase;
 
   const { data: profile } = await db
     .from('profiles')
-    .select('role, program_holder_id')
+    .select('role, program_holder_id, full_name, organization')
     .eq('id', user.id)
     .maybeSingle();
 
@@ -33,17 +36,33 @@ export default async function ProgramHolderLayout({ children }: { children: Reac
 
   const isAdmin = ['admin', 'super_admin', 'staff', 'org_admin'].includes(profile.role ?? '');
 
+  let orgName = profile.organization ?? undefined;
+  let hasSchoolApplications = false;
+
   if (!isAdmin && profile.program_holder_id) {
     const { data: holder } = await db
       .from('program_holders')
-      .select('status')
+      .select('status, organization_name, name, enable_school_applications')
       .eq('id', profile.program_holder_id)
       .maybeSingle();
 
     if (holder && !['approved', 'active'].includes(holder.status ?? '')) {
       redirect('/program-holder?error=pending-approval');
     }
+
+    orgName = holder?.organization_name || holder?.name || orgName;
+    hasSchoolApplications = Boolean(holder?.enable_school_applications);
   }
 
-  return <>{children}</>;
+  return (
+    <ProgramHolderShellGate
+      role={profile.role ?? 'program_holder'}
+      userName={profile.full_name ?? undefined}
+      userEmail={user.email ?? undefined}
+      orgName={orgName}
+      hasSchoolApplications={hasSchoolApplications}
+    >
+      {children}
+    </ProgramHolderShellGate>
+  );
 }

--- a/app/program-holder/settings/page.tsx
+++ b/app/program-holder/settings/page.tsx
@@ -1,7 +1,6 @@
 import { Metadata } from 'next';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
-import Link from 'next/link';
+import { requireProgramHolder } from '@/lib/auth/require-program-holder';
+import ProgramHolderSettingsForm from './SettingsForm';
 
 export const dynamic = 'force-dynamic';
 
@@ -9,87 +8,29 @@ export const metadata: Metadata = {
   alternates: { canonical: 'https://www.elevateforhumanity.org/program-holder/settings' },
   title: 'Program Settings',
   description: 'Configure your program holder account settings.',
+  robots: { index: false, follow: false },
 };
 
 export default async function ProgramSettingsPage() {
-  const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
+  const { db, user, holderId } = await requireProgramHolder();
 
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('*')
-    .eq('id', user.id)
-    .maybeSingle();
-
-  if (!profile || !['program_holder', 'admin', 'super_admin', 'staff'].includes(profile.role)) {
-    redirect('/login');
-  }
+  const [{ data: profile }, { data: holder }] = await Promise.all([
+    db.from('profiles').select('organization, email').eq('id', user.id).maybeSingle(),
+    holderId
+      ? db
+          .from('program_holders')
+          .select('organization_name, notify_enrollments, notify_weekly_reports')
+          .eq('id', holderId)
+          .maybeSingle()
+      : Promise.resolve({ data: null }),
+  ]);
 
   return (
-    <div className="min-h-screen bg-white">
-      <div className="max-w-4xl mx-auto px-4 py-8">
-        <div className="mb-8">
-          <nav className="text-sm mb-4">
-            <ol className="flex items-center space-x-2 text-slate-700">
-              <li>
-                <Link href="/program-holder" className="hover:text-primary">
-                  Program Holder
-                </Link>
-              </li>
-              <li>/</li>
-              <li className="text-slate-900 font-medium">Settings</li>
-            </ol>
-          </nav>
-          <h1 className="text-3xl font-bold text-slate-900">Program Settings</h1>
-          <p className="text-slate-700 mt-2">Manage your account and program preferences</p>
-        </div>
-        <div className="space-y-6">
-          <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h2 className="text-lg font-semibold mb-4">Organization Information</h2>
-            <div className="space-y-4">
-              <div>
-                <label className="block text-sm font-medium text-slate-900 mb-2">
-                  Organization Name
-                </label>
-                <input
-                  type="text"
-                  className="w-full border rounded-lg px-3 py-2"
-                  defaultValue={profile?.organization || ''}
-                />
-              </div>
-              <div>
-                <label className="block text-sm font-medium text-slate-900 mb-2">
-                  Contact Email
-                </label>
-                <input
-                  type="email"
-                  className="w-full border rounded-lg px-3 py-2"
-                  defaultValue={profile?.email || ''}
-                />
-              </div>
-            </div>
-          </div>
-          <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h2 className="text-lg font-semibold mb-4">Notifications</h2>
-            <div className="space-y-3">
-              <label className="flex items-center justify-between">
-                <span>Email notifications for new enrollments</span>
-                <input type="checkbox" className="w-4 h-4 rounded" defaultChecked />
-              </label>
-              <label className="flex items-center justify-between">
-                <span>Weekly progress reports</span>
-                <input type="checkbox" className="w-4 h-4 rounded" defaultChecked />
-              </label>
-            </div>
-          </div>
-          <button className="w-full bg-brand-blue-600 text-white px-4 py-2 rounded-lg hover:bg-brand-blue-700">
-            Save Settings
-          </button>
-        </div>
-      </div>
-    </div>
+    <ProgramHolderSettingsForm
+      organization={profile?.organization || holder?.organization_name || ''}
+      email={profile?.email || user.email || ''}
+      notifyEnrollments={holder?.notify_enrollments ?? true}
+      notifyWeeklyReports={holder?.notify_weekly_reports ?? true}
+    />
   );
 }

--- a/app/program-holder/students/[userId]/page.tsx
+++ b/app/program-holder/students/[userId]/page.tsx
@@ -1,0 +1,87 @@
+import Link from 'next/link';
+import { notFound, redirect } from 'next/navigation';
+import { requireProgramHolder } from '@/lib/auth/require-program-holder';
+import { canAccessStudent } from '@/lib/program-holder-access';
+
+export const dynamic = 'force-dynamic';
+
+export default async function ProgramHolderStudentDetailPage({
+  params,
+}: {
+  params: Promise<{ userId: string }>;
+}) {
+  const { userId } = await params;
+  const { db, holderId } = await requireProgramHolder();
+
+  const allowed = await canAccessStudent(holderId, userId);
+  if (!allowed) {
+    redirect('/program-holder/students');
+  }
+
+  const [{ data: profile }, { data: phRow }] = await Promise.all([
+    db.from('profiles').select('id, full_name, email, phone').eq('id', userId).maybeSingle(),
+    db
+      .from('program_holder_students')
+      .select('id, status, enrolled_at, completed_at, hours_taught, hours_required, notes')
+      .eq('program_holder_id', holderId)
+      .eq('user_id', userId)
+      .maybeSingle(),
+  ]);
+
+  if (!profile) notFound();
+
+  return (
+    <div className="max-w-3xl mx-auto px-4 py-8">
+      <Link
+        href="/program-holder/students"
+        className="text-sm text-brand-blue-600 hover:underline mb-4 inline-block"
+      >
+        ← Back to students
+      </Link>
+      <h1 className="text-2xl font-bold text-slate-900">{profile.full_name || 'Student'}</h1>
+      <p className="text-slate-600 text-sm mt-1">{profile.email}</p>
+
+      {phRow && (
+        <div className="mt-6 bg-white border border-slate-200 rounded-xl p-5 space-y-2 text-sm">
+          <p>
+            <span className="text-slate-500">Status:</span>{' '}
+            <span className="font-medium text-slate-900">{phRow.status}</span>
+          </p>
+          {phRow.enrolled_at && (
+            <p>
+              <span className="text-slate-500">Enrolled:</span>{' '}
+              {new Date(phRow.enrolled_at).toLocaleDateString()}
+            </p>
+          )}
+          {(phRow.hours_taught != null || phRow.hours_required != null) && (
+            <p>
+              <span className="text-slate-500">Hours:</span>{' '}
+              {phRow.hours_taught ?? 0} / {phRow.hours_required ?? '—'}
+            </p>
+          )}
+        </div>
+      )}
+
+      <div className="mt-6 flex flex-wrap gap-3">
+        <Link
+          href="/program-holder/hours"
+          className="px-4 py-2 bg-brand-blue-600 text-white text-sm font-medium rounded-lg hover:bg-brand-blue-700"
+        >
+          Review pending hours
+        </Link>
+        <Link
+          href="/program-holder/documents"
+          className="px-4 py-2 border border-slate-300 text-slate-800 text-sm font-medium rounded-lg hover:bg-slate-50"
+        >
+          Documents
+        </Link>
+        <Link
+          href="/program-holder/dashboard"
+          className="px-4 py-2 border border-slate-300 text-slate-800 text-sm font-medium rounded-lg hover:bg-slate-50"
+        >
+          Dashboard
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/admin/advanced-tools/page.tsx
+++ b/apps/admin/app/admin/advanced-tools/page.tsx
@@ -103,10 +103,10 @@ const TOOL_SECTIONS = [
     iconBg: 'bg-emerald-700',
     description: 'Developer utilities, debugging, and studio tools.',
     tools: [
-      { label: 'Command Center', href: '/admin/dashboard', desc: 'Ellie AI, live site preview, and operations' },
+      { label: 'Operations Hub', href: '/admin/operations', desc: 'Cron jobs, workflows, dead letters, and admin alerts' },
+      { label: 'Dev Studio', href: '/admin/dev-studio', desc: 'Container, deploy, secrets, terminal, and live preview' },
       { label: 'Automation', href: '/admin/automation', desc: 'Workflow automation rules' },
       { label: 'Workflows', href: '/admin/workflows', desc: 'Automated workflow definitions' },
-      { label: 'Command Center', href: '/admin/dashboard', desc: 'AI Operations Assistant — platform data, compliance, enrollments' },
       { label: 'Studio', href: '/admin/studio', desc: 'Course Studio — builder, curriculum, video, and AI copilot' },
       { label: 'HVAC AI Instructor', href: '/admin/integrations/gemini', desc: 'Marcus Johnson — Gemini-powered HVAC lesson instructor' },
       { label: 'Sentry Test', href: '/api/sentry-test', desc: 'Dev only — trigger a test error to verify Sentry capture' },
@@ -191,6 +191,7 @@ export default async function AdvancedToolsPage() {
           </div>
           <div className="flex flex-wrap gap-3">
             {[
+              { label: 'Operations', href: '/admin/operations' },
               { label: 'Settings', href: '/admin/settings' },
               { label: 'Users', href: '/admin/students' },
               { label: 'Licenses', href: '/admin/licenses' },

--- a/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
@@ -1,0 +1,763 @@
+'use client';
+
+import { type ElementType, useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import dynamic from 'next/dynamic';
+import { useSearchParams } from 'next/navigation';
+import {
+  Activity,
+  Bot,
+  BookOpen,
+  Box,
+  Circle,
+  ExternalLink,
+  FileText,
+  FolderOpen,
+  Globe,
+  Key,
+  Loader2,
+  MessageSquare,
+  RefreshCw,
+  Rocket,
+  Save,
+  Send,
+  Server,
+  Sparkles,
+  Upload,
+} from 'lucide-react';
+
+interface WorkflowButton {
+  key: string;
+  label: string;
+  description: string;
+}
+
+interface StudioConfig {
+  workflowButtons?: WorkflowButton[];
+  defaultPreviewUrl?: string;
+  previewTargets?: { label: string; url: string }[];
+}
+
+interface CourseProgram {
+  id: string;
+  title: string;
+  slug: string;
+}
+
+interface CourseBuilderProps {
+  programs: CourseProgram[];
+  embedded?: boolean;
+  initialProgramId?: string;
+}
+
+type Workspace = 'studio' | 'deploy' | 'files' | 'environments' | 'health' | 'secrets';
+type StudioMode = 'ask' | 'run' | 'courses';
+
+const AIChat = dynamic(() => import('@/components/dev-studio/AIChat'), { ssr: false });
+const DeployPanel = dynamic(() => import('@/components/dev-studio/DeployPanel'), { ssr: false });
+const DevContainerPanel = dynamic(() => import('@/components/dev-studio/DevContainerPanel'), { ssr: false });
+const ServicesPanel = dynamic(() => import('@/components/dev-studio/ServicesPanel'), { ssr: false });
+const SecretsPanel = dynamic(() => import('@/components/dev-studio/SecretsPanel'), { ssr: false });
+const AICourseBuilderChat = dynamic<CourseBuilderProps>(
+  () => import('../courses/ai-builder/AICourseBuilderChat'),
+  { ssr: false },
+);
+
+const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?: string }> }[] = [
+  { id: 'studio', label: 'Studio', Icon: Bot },
+  { id: 'deploy', label: 'Deploy', Icon: Rocket },
+  { id: 'files', label: 'Files', Icon: FolderOpen },
+  { id: 'environments', label: 'Container', Icon: Box },
+  { id: 'health', label: 'Health', Icon: Activity },
+  { id: 'secrets', label: 'Secrets', Icon: Key },
+];
+
+const QUICK_ACTIONS = [
+  { label: 'Website deploy', command: 'Deploy the LMS service' },
+  { label: 'Admin deploy', command: 'Deploy the admin service' },
+  { label: 'Studio deploy', command: 'Deploy the studio service' },
+  { label: 'Smoke test', command: 'Run smoke test' },
+  { label: 'Build course', command: 'Generate a new course' },
+  { label: 'System health', command: 'Check system health' },
+];
+
+function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
+  if (tab === 'deploy') return { workspace: 'deploy', mode: 'ask' };
+  if (tab === 'files' || tab === 'git' || tab === 'docs' || tab === 'documents') return { workspace: 'files', mode: 'ask' };
+  if (tab === 'container' || tab === 'environments' || tab === 'services') return { workspace: 'environments', mode: 'ask' };
+  if (tab === 'health') return { workspace: 'health', mode: 'ask' };
+  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ask' };
+  if (tab === 'command' || tab === 'terminal') return { workspace: 'studio', mode: 'run' };
+  if (tab === 'courses' || tab === 'course') return { workspace: 'studio', mode: 'courses' };
+  return { workspace: 'studio', mode: 'ask' };
+}
+
+export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSuperAdmin?: boolean }) {
+  const searchParams = useSearchParams();
+  const initial = normalizeWorkspace(searchParams.get('tab'));
+  const [workspace, setWorkspace] = useState<Workspace>(initial.workspace === 'secrets' && !isSuperAdmin ? 'studio' : initial.workspace);
+  const [studioMode, setStudioMode] = useState<StudioMode>(initial.mode);
+  const [config, setConfig] = useState<StudioConfig | null>(null);
+  const [health, setHealth] = useState<Record<string, unknown> | null>(null);
+  const [previewUrl, setPreviewUrl] = useState('');
+  const [livePreviewUrl, setLivePreviewUrl] = useState('');
+  const [programs, setPrograms] = useState<CourseProgram[]>([]);
+  const [programsLoading, setProgramsLoading] = useState(false);
+
+  useEffect(() => {
+    fetch('/api/admin/devstudio/config')
+      .then((r) => r.json())
+      .then((data: StudioConfig) => {
+        setConfig(data);
+        const nextPreview = data.defaultPreviewUrl || window.location.origin;
+        setPreviewUrl((current) => current || nextPreview);
+        setLivePreviewUrl((current) => current || nextPreview);
+      })
+      .catch(() => {
+        setConfig(null);
+        setPreviewUrl((current) => current || window.location.origin);
+        setLivePreviewUrl((current) => current || window.location.origin);
+      });
+  }, []);
+
+  useEffect(() => {
+    fetch('/api/devstudio/health')
+      .then((r) => (r.ok ? r.json() : null))
+      .then((data) => setHealth(data))
+      .catch(() => setHealth(null));
+  }, []);
+
+  useEffect(() => {
+    setProgramsLoading(true);
+    fetch('/api/admin/programs?status=active')
+      .then((r) => (r.ok ? r.json() : { data: [] }))
+      .then((payload) => {
+        const rows = Array.isArray(payload?.data) ? payload.data : [];
+        setPrograms(rows.map((program: { id: string; title?: string; name?: string; slug?: string; code?: string }) => ({
+          id: program.id,
+          title: program.title ?? program.name ?? program.code ?? 'Untitled program',
+          slug: program.slug ?? program.code ?? program.id,
+        })));
+      })
+      .catch(() => setPrograms([]))
+      .finally(() => setProgramsLoading(false));
+  }, []);
+
+  const activeProviders = useMemo(() => {
+    if (!health) return 'checking';
+    return [
+      health.hasGroq && 'Groq',
+      health.hasGemini && 'Gemini',
+      health.hasOpenAI && 'OpenAI',
+      health.hasAnthropic && 'Anthropic',
+    ].filter(Boolean).join(' / ') || 'no AI keys';
+  }, [health]);
+
+  function openWorkspace(next: Workspace) {
+    if (next === 'secrets' && !isSuperAdmin) {
+      setWorkspace('health');
+      return;
+    }
+    setWorkspace(next);
+  }
+
+  return (
+    <div className="flex h-full w-full flex-col overflow-hidden bg-[#1e1e1e] text-[#cccccc]">
+      <header className="flex min-h-11 shrink-0 flex-wrap items-center gap-2 border-b border-[#3c3c3c] bg-[#2d2d2d] px-3">
+        <div className="flex min-w-0 items-center gap-2">
+          <Bot className="h-4 w-4 text-[#4ec9b0]" />
+          <span className="text-sm font-semibold text-white">Dev Studio</span>
+          <span className="hidden text-[11px] text-[#858585] sm:inline">Codex workspace</span>
+        </div>
+        <div className="ml-auto flex min-w-0 flex-wrap items-center justify-end gap-2 text-[11px]">
+          <span className="inline-flex items-center gap-1 text-[#4ec9b0]">
+            <Circle className="h-2 w-2 fill-current" />
+            Unified
+          </span>
+          <span className="rounded border border-[#3c3c3c] px-1.5 py-0.5 text-[#9ca3af]">
+            AI: {activeProviders}
+          </span>
+          <button
+            type="button"
+            onClick={() => setWorkspace('deploy')}
+            className="inline-flex h-7 items-center gap-1 rounded bg-[#0078d4] px-2 text-white"
+          >
+            <Rocket className="h-3.5 w-3.5" />
+            Deploy
+          </button>
+        </div>
+      </header>
+
+      <div className="flex min-h-0 flex-1">
+        <aside className="hidden w-48 shrink-0 flex-col border-r border-[#3c3c3c] bg-[#252526] p-2 md:flex">
+          <div className="mb-2 px-2 text-[10px] font-bold uppercase tracking-widest text-[#858585]">Environments</div>
+          <div className="space-y-1">
+            {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => {
+              const active = workspace === id;
+              return (
+                <button
+                  key={id}
+                  type="button"
+                  onClick={() => openWorkspace(id)}
+                  className="flex h-9 w-full items-center gap-2 rounded px-2 text-left text-[12px] transition"
+                  style={{ background: active ? '#094771' : 'transparent', color: active ? '#ffffff' : '#cccccc' }}
+                >
+                  <Icon className="h-4 w-4 shrink-0" />
+                  <span className="truncate">{label}</span>
+                </button>
+              );
+            })}
+          </div>
+        </aside>
+
+        <div className="flex min-w-0 flex-1 flex-col md:flex-row">
+          <main className="min-h-0 min-w-0 flex-1 overflow-hidden">
+            <MobileTabs workspace={workspace} isSuperAdmin={isSuperAdmin} onChange={openWorkspace} />
+            {workspace === 'studio' && (
+              <StudioPanel
+                mode={studioMode}
+                onModeChange={setStudioMode}
+                programs={programs}
+                programsLoading={programsLoading}
+              />
+            )}
+            {workspace === 'deploy' && <DeployPanel workflowButtons={config?.workflowButtons} />}
+            {workspace === 'files' && <FilesPanel />}
+            {workspace === 'environments' && <EnvironmentPanel />}
+            {workspace === 'health' && <HealthPanel health={health} onRefresh={() => window.location.reload()} />}
+            {workspace === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <HealthPanel health={health} onRefresh={() => window.location.reload()} />)}
+          </main>
+
+          <section className="hidden w-[38vw] min-w-[340px] max-w-[560px] shrink-0 flex-col border-l border-[#3c3c3c] bg-[#1e1e1e] lg:flex">
+            <div className="flex h-10 shrink-0 items-center gap-1.5 border-b border-[#3c3c3c] bg-[#2d2d2d] px-2">
+              <button
+                type="button"
+                onClick={() => setLivePreviewUrl(previewUrl)}
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-[#858585] hover:text-white"
+                title="Refresh preview"
+              >
+                <RefreshCw className="h-3.5 w-3.5" />
+              </button>
+              <form
+                className="flex min-w-0 flex-1 items-center rounded border border-[#555] bg-[#3c3c3c] px-2"
+                onSubmit={(event) => {
+                  event.preventDefault();
+                  setLivePreviewUrl(previewUrl);
+                }}
+              >
+                <Globe className="mr-1.5 h-3.5 w-3.5 shrink-0 text-[#4ec9b0]" />
+                <input
+                  value={previewUrl}
+                  onChange={(event) => setPreviewUrl(event.target.value)}
+                  className="h-7 min-w-0 flex-1 bg-transparent text-[11px] text-[#cccccc] outline-none"
+                  spellCheck={false}
+                />
+              </form>
+              <a
+                href={livePreviewUrl || previewUrl}
+                target="_blank"
+                rel="noreferrer"
+                className="inline-flex h-7 w-7 items-center justify-center rounded text-[#858585] hover:text-white"
+                title="Open preview"
+              >
+                <ExternalLink className="h-3.5 w-3.5" />
+              </a>
+            </div>
+            <iframe title="Live Preview" src={livePreviewUrl || previewUrl} className="min-h-0 flex-1 border-0 bg-white" />
+          </section>
+        </div>
+      </div>
+
+      <footer className="flex h-6 shrink-0 items-center justify-between bg-[#0078d4] px-3 text-[11px] text-white">
+        <span>main</span>
+        <span className="hidden sm:inline">AWS / Supabase / GitHub Actions</span>
+        <span>TypeScript</span>
+      </footer>
+    </div>
+  );
+}
+
+function MobileTabs({
+  workspace,
+  isSuperAdmin,
+  onChange,
+}: {
+  workspace: Workspace;
+  isSuperAdmin: boolean;
+  onChange: (workspace: Workspace) => void;
+}) {
+  return (
+    <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-[#3c3c3c] bg-[#252526] p-1 md:hidden">
+      {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => (
+        <button
+          key={id}
+          type="button"
+          onClick={() => onChange(id)}
+          className="inline-flex h-10 w-10 shrink-0 items-center justify-center rounded"
+          style={{ background: workspace === id ? '#094771' : 'transparent', color: workspace === id ? '#ffffff' : '#cccccc' }}
+          title={label}
+        >
+          <Icon className="h-5 w-5" />
+        </button>
+      ))}
+    </div>
+  );
+}
+
+function StudioPanel({
+  mode,
+  onModeChange,
+  programs,
+  programsLoading,
+}: {
+  mode: StudioMode;
+  onModeChange: (mode: StudioMode) => void;
+  programs: CourseProgram[];
+  programsLoading: boolean;
+}) {
+  const modes: { id: StudioMode; label: string; Icon: ElementType<{ className?: string }> }[] = [
+    { id: 'ask', label: 'Ask', Icon: MessageSquare },
+    { id: 'run', label: 'Run', Icon: Sparkles },
+    { id: 'courses', label: 'Courses', Icon: BookOpen },
+  ];
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden">
+      <div className="flex h-11 shrink-0 items-center gap-1 border-b border-[#3c3c3c] bg-[#252526] px-2">
+        {modes.map(({ id, label, Icon }) => (
+          <button
+            key={id}
+            type="button"
+            onClick={() => onModeChange(id)}
+            className="inline-flex h-8 items-center gap-1.5 rounded border px-2.5 text-[11px]"
+            style={{ borderColor: mode === id ? '#0078d4' : '#3c3c3c', background: mode === id ? '#094771' : 'transparent', color: '#ffffff' }}
+          >
+            <Icon className="h-3.5 w-3.5" />
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-hidden">
+        {mode === 'ask' && <AIChat ellieMode={true} />}
+        {mode === 'run' && <RunPanel />}
+        {mode === 'courses' && (
+          programsLoading ? (
+            <div className="flex h-full items-center justify-center gap-2 text-slate-500">
+              <Loader2 className="h-4 w-4 animate-spin" />
+              <span className="text-xs font-medium">Loading active programs...</span>
+            </div>
+          ) : (
+            <AICourseBuilderChat programs={programs} embedded />
+          )
+        )}
+      </div>
+    </div>
+  );
+}
+
+function RunPanel() {
+  const [input, setInput] = useState('');
+  const [lines, setLines] = useState<{ type: 'user' | 'output' | 'error'; text: string }[]>([]);
+  const [loading, setLoading] = useState(false);
+  const bottomRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: 'smooth' });
+  }, [lines]);
+
+  async function run(command: string) {
+    const trimmed = command.trim();
+    if (!trimmed || loading) return;
+    setInput('');
+    setLoading(true);
+    setLines([{ type: 'user', text: trimmed }]);
+
+    try {
+      const isSmoke = /smoke.?test|health.?check|check.*platform|verify.*platform/i.test(trimmed);
+      const res = await fetch(
+        isSmoke ? '/api/devstudio/smoke-test' : '/api/devstudio/execute',
+        isSmoke ? undefined : {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ command: trimmed }),
+        },
+      );
+
+      if (!res.ok || !res.body) {
+        const data = await res.json().catch(() => ({}));
+        throw new Error(data.error || `Request failed with HTTP ${res.status}`);
+      }
+
+      const reader = res.body.getReader();
+      const decoder = new TextDecoder();
+      let buffer = '';
+      while (true) {
+        const { done, value } = await reader.read();
+        if (done) break;
+        buffer += decoder.decode(value, { stream: true });
+        const chunks = buffer.split('\n');
+        buffer = chunks.pop() ?? '';
+        for (const chunk of chunks) {
+          if (!chunk.startsWith('data: ')) continue;
+          const raw = chunk.slice(6).trim();
+          if (!raw || raw === '[DONE]') continue;
+          let text = raw;
+          try {
+            const parsed = JSON.parse(raw);
+            text = parsed.line ?? parsed.text ?? parsed.output ?? raw;
+          } catch {
+            text = raw;
+          }
+          setLines((current) => [...current, { type: 'output', text }]);
+        }
+      }
+    } catch (error) {
+      setLines((current) => [...current, { type: 'error', text: error instanceof Error ? error.message : 'Command failed' }]);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-[#1e1e1e]">
+      <div className="flex shrink-0 gap-1.5 overflow-x-auto border-b border-[#3c3c3c] bg-[#2d2d2d] px-2 py-2">
+        {QUICK_ACTIONS.map((item) => (
+          <button
+            key={item.label}
+            type="button"
+            onClick={() => run(item.command)}
+            disabled={loading}
+            className="shrink-0 rounded border border-[#555] bg-[#3c3c3c] px-2.5 py-1 text-[11px] text-[#cccccc] disabled:opacity-50"
+          >
+            {item.label}
+          </button>
+        ))}
+      </div>
+      <div className="min-h-0 flex-1 overflow-y-auto p-3 font-mono text-xs">
+        {lines.length === 0 && <p className="text-[#555]">Ready.</p>}
+        {lines.map((line, index) => (
+          <div
+            key={`${line.type}-${index}`}
+            className="whitespace-pre-wrap break-words"
+            style={{ color: line.type === 'user' ? '#f97316' : line.type === 'error' ? '#f87171' : '#cccccc' }}
+          >
+            {line.type === 'user' ? `$ ${line.text}` : line.text}
+          </div>
+        ))}
+        {loading && (
+          <div className="mt-2 flex items-center gap-2 text-[#f97316]">
+            <Loader2 className="h-3.5 w-3.5 animate-spin" />
+            Running
+          </div>
+        )}
+        <div ref={bottomRef} />
+      </div>
+      <form
+        className="flex shrink-0 items-center gap-2 border-t border-[#3c3c3c] bg-[#252526] p-3"
+        onSubmit={(event) => {
+          event.preventDefault();
+          run(input);
+        }}
+      >
+        <span className="font-mono text-sm font-bold text-[#f97316]">$</span>
+        <input
+          value={input}
+          onChange={(event) => setInput(event.target.value)}
+          className="h-10 min-w-0 flex-1 rounded border border-[#555] bg-[#3c3c3c] px-3 font-mono text-sm text-[#cccccc] outline-none"
+          placeholder="Tell Studio what to run"
+          disabled={loading}
+        />
+        <button
+          type="submit"
+          disabled={loading || !input.trim()}
+          className="inline-flex h-10 w-10 items-center justify-center rounded bg-[#f97316] text-white disabled:opacity-50"
+        >
+          <Send className="h-4 w-4" />
+        </button>
+      </form>
+    </div>
+  );
+}
+
+const MAX_UPLOAD_BYTES = 512 * 1024;
+const TEXT_UPLOAD_EXTENSIONS = new Set([
+  'css',
+  'csv',
+  'html',
+  'js',
+  'jsx',
+  'json',
+  'md',
+  'mdx',
+  'mjs',
+  'sql',
+  'svg',
+  'ts',
+  'tsx',
+  'txt',
+  'xml',
+  'yml',
+  'yaml',
+]);
+
+function sanitizeUploadPath(path: string): string {
+  return path
+    .replace(/\\/g, '/')
+    .replace(/^\/+/, '')
+    .replace(/\/{2,}/g, '/')
+    .trim();
+}
+
+function isEditableUpload(file: File): boolean {
+  const ext = file.name.split('.').pop()?.toLowerCase() ?? '';
+  if (TEXT_UPLOAD_EXTENSIONS.has(ext)) return true;
+  if (file.type.startsWith('text/')) return true;
+  return ['application/json', 'application/xml', 'image/svg+xml'].includes(file.type);
+}
+
+function FilesPanel() {
+  const [files, setFiles] = useState<string[]>([]);
+  const [selected, setSelected] = useState('');
+  const [content, setContent] = useState('');
+  const [sha, setSha] = useState('');
+  const [message, setMessage] = useState('');
+  const [status, setStatus] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [uploadPath, setUploadPath] = useState('');
+  const fileInputRef = useRef<HTMLInputElement>(null);
+
+  const refreshFiles = useCallback(async () => {
+    try {
+      const res = await fetch('/api/devstudio/files');
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      const flat: string[] = [];
+      function walk(nodes: { type: string; path: string; children?: unknown[] }[]) {
+        for (const node of nodes ?? []) {
+          if (node.type === 'file') flat.push(node.path);
+          else walk((node.children ?? []) as { type: string; path: string; children?: unknown[] }[]);
+        }
+      }
+      walk(data.tree ?? []);
+      setFiles(flat);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'File tree unavailable');
+    }
+  }, []);
+
+  useEffect(() => {
+    void refreshFiles();
+  }, [refreshFiles]);
+
+  async function handleUpload(file: File | undefined) {
+    if (!file) return;
+    setStatus('');
+
+    if (file.size > MAX_UPLOAD_BYTES) {
+      setStatus(`Upload exceeds ${MAX_UPLOAD_BYTES / 1024} KB edit limit`);
+      return;
+    }
+
+    if (!isEditableUpload(file)) {
+      setStatus('Upload is not a text/code file');
+      return;
+    }
+
+    try {
+      const nextPath = sanitizeUploadPath(uploadPath || `devstudio-uploads/${file.name}`);
+      if (!nextPath) throw new Error('Upload path is required');
+      const text = await file.text();
+      setSelected(nextPath);
+      setUploadPath(nextPath);
+      setContent(text);
+      setSha('');
+      setMessage(`chore: add ${nextPath} via Dev Studio`);
+      setStatus('Ready to commit upload');
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not read upload');
+    }
+  }
+
+  async function loadFile(path: string) {
+    setSelected(path);
+    setLoading(true);
+    setStatus('');
+    try {
+      const res = await fetch(`/api/devstudio/files?path=${encodeURIComponent(path)}`);
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setContent(data.content ?? '');
+      setSha(data.sha ?? '');
+      setUploadPath('');
+      setMessage(`chore: update ${path} via Dev Studio`);
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not load file');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function saveFile() {
+    if (!selected) return;
+    setLoading(true);
+    setStatus('');
+    try {
+      const method = sha ? 'PUT' : 'POST';
+      const res = await fetch('/api/devstudio/files', {
+        method,
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ path: selected, content, sha: sha || undefined, message }),
+      });
+      const data = await res.json();
+      if (!res.ok) throw new Error(data.error || `HTTP ${res.status}`);
+      setSha(data.sha ?? sha);
+      setStatus(data.commit ? 'Committed' : method === 'POST' ? 'Uploaded' : 'Saved');
+      if (method === 'POST') {
+        setFiles((current) => (current.includes(selected) ? current : [...current, selected].sort()));
+      }
+    } catch (error) {
+      setStatus(error instanceof Error ? error.message : 'Could not save file');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="flex h-full overflow-hidden bg-[#1e1e1e]">
+      <div className="w-64 shrink-0 overflow-y-auto border-r border-[#3c3c3c] bg-[#252526]">
+        <div className="sticky top-0 border-b border-[#3c3c3c] bg-[#252526] p-2">
+          <div className="mb-2 text-[10px] font-bold uppercase tracking-widest text-[#858585]">Files</div>
+          <div className="flex gap-1">
+            <input
+              value={uploadPath}
+              onChange={(event) => {
+                const nextPath = sanitizeUploadPath(event.target.value);
+                setUploadPath(nextPath);
+                if (!sha && selected) {
+                  setSelected(nextPath);
+                  setMessage(`chore: add ${nextPath} via Dev Studio`);
+                }
+              }}
+              className="h-8 min-w-0 flex-1 rounded border border-[#3c3c3c] bg-[#1e1e1e] px-2 font-mono text-[11px] text-[#cccccc] outline-none"
+              placeholder="devstudio-uploads/file.ts"
+              spellCheck={false}
+            />
+            <input
+              ref={fileInputRef}
+              type="file"
+              className="hidden"
+              accept=".css,.csv,.html,.js,.jsx,.json,.md,.mdx,.mjs,.sql,.svg,.ts,.tsx,.txt,.xml,.yml,.yaml,text/*,application/json,application/xml,image/svg+xml"
+              onChange={(event) => {
+                void handleUpload(event.currentTarget.files?.[0]);
+                event.currentTarget.value = '';
+              }}
+            />
+            <button
+              type="button"
+              onClick={() => fileInputRef.current?.click()}
+              className="inline-flex h-8 w-8 shrink-0 items-center justify-center rounded bg-[#0078d4] text-white"
+              title="Upload file"
+            >
+              <Upload className="h-3.5 w-3.5" />
+            </button>
+          </div>
+        </div>
+        {files.map((file) => (
+          <button
+            key={file}
+            type="button"
+            onClick={() => loadFile(file)}
+            className="flex w-full items-center gap-2 border-b border-[#2d2d2d] px-3 py-2 text-left text-[11px]"
+            style={{ background: selected === file ? '#094771' : 'transparent', color: selected === file ? '#ffffff' : '#cccccc' }}
+          >
+            <FileText className="h-3.5 w-3.5 shrink-0" />
+            <span className="truncate">{file}</span>
+          </button>
+        ))}
+      </div>
+      <div className="flex min-w-0 flex-1 flex-col">
+        <div className="flex shrink-0 items-center gap-2 border-b border-[#3c3c3c] bg-[#2d2d2d] px-3 py-2">
+          <span className="min-w-0 flex-1 truncate font-mono text-[11px] text-[#858585]">{selected || 'Select a file'}</span>
+          {status && <span className="text-[11px] text-[#4ec9b0]">{status}</span>}
+          <button
+            type="button"
+            onClick={saveFile}
+            disabled={!selected || loading}
+            className="inline-flex h-8 items-center gap-1 rounded bg-[#f97316] px-2 text-[11px] font-semibold text-white disabled:opacity-50"
+          >
+            {loading ? <Loader2 className="h-3.5 w-3.5 animate-spin" /> : <Save className="h-3.5 w-3.5" />}
+            Commit
+          </button>
+        </div>
+        <input
+          value={message}
+          onChange={(event) => setMessage(event.target.value)}
+          className="h-9 shrink-0 border-b border-[#3c3c3c] bg-[#252526] px-3 font-mono text-[11px] text-[#cccccc] outline-none"
+          placeholder="Commit message"
+        />
+        <textarea
+          value={content}
+          onChange={(event) => setContent(event.target.value)}
+          className="min-h-0 flex-1 resize-none bg-[#1e1e1e] p-3 font-mono text-xs text-[#cccccc] outline-none"
+          spellCheck={false}
+        />
+      </div>
+    </div>
+  );
+}
+
+function EnvironmentPanel() {
+  return (
+    <div className="flex h-full flex-col overflow-hidden bg-slate-50">
+      <div className="min-h-0 flex-1 overflow-auto border-b border-slate-200">
+        <DevContainerPanel />
+      </div>
+      <div className="shrink-0 border-t border-slate-200 bg-white">
+        <div className="border-b border-slate-100 px-4 py-2">
+          <div className="flex items-center gap-2 text-xs font-semibold uppercase tracking-wide text-slate-500">
+            <Server className="h-3.5 w-3.5" />
+            ECS services
+          </div>
+        </div>
+        <div className="max-h-[42vh] overflow-auto">
+          <ServicesPanel />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function HealthPanel({ health, onRefresh }: { health: Record<string, unknown> | null; onRefresh: () => void }) {
+  const rows = [
+    ['GitHub', health?.hasGitHub ? 'connected' : 'not connected'],
+    ['Groq', health?.hasGroq ? 'configured' : 'missing'],
+    ['Gemini', health?.hasGemini ? 'configured' : 'missing'],
+    ['OpenAI', health?.hasOpenAI ? 'configured' : 'missing'],
+    ['Supabase URL', health?.supabaseUrlPresent ? 'present' : 'missing'],
+    ['Supabase service key', health?.supabaseServiceKeyPresent ? 'present' : 'missing'],
+    ['Node', String(health?.nodeVersion ?? 'unknown')],
+    ['Next', String(health?.nextVersion ?? 'unknown')],
+  ];
+
+  return (
+    <div className="h-full overflow-y-auto bg-[#1e1e1e] p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          <Activity className="h-4 w-4 text-[#4ec9b0]" />
+          <h2 className="text-sm font-semibold text-white">Health</h2>
+        </div>
+        <button type="button" onClick={onRefresh} className="inline-flex h-8 items-center gap-1 rounded border border-[#3c3c3c] px-2 text-[11px] text-[#cccccc]">
+          <RefreshCw className="h-3.5 w-3.5" />
+          Refresh
+        </button>
+      </div>
+      <div className="rounded border border-[#3c3c3c] bg-[#252526]">
+        {rows.map(([label, value]) => (
+          <div key={label} className="flex items-center justify-between border-b border-[#2d2d2d] px-3 py-2 text-xs last:border-0">
+            <span className="text-[#858585]">{label}</span>
+            <span className="font-mono text-[#cccccc]">{value}</span>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/admin/dev-studio/layout.tsx
+++ b/apps/admin/app/admin/dev-studio/layout.tsx
@@ -1,0 +1,3 @@
+export default function DevStudioLayout({ children }: { children: React.ReactNode }) {
+  return <div className="h-[calc(100vh-4rem)] min-h-[480px] overflow-hidden">{children}</div>;
+}

--- a/apps/admin/app/admin/dev-studio/page.tsx
+++ b/apps/admin/app/admin/dev-studio/page.tsx
@@ -1,0 +1,22 @@
+import { requireRole } from '@/lib/auth/require-role';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { Metadata } from 'next';
+import { Suspense } from 'react';
+import DevStudioUnifiedClient from './DevStudioUnifiedClient';
+
+export const dynamic = 'force-dynamic';
+export const revalidate = 60;
+
+export const metadata: Metadata = {
+  title: `Dev Studio | Admin | ${PLATFORM_DEFAULTS.orgName}`,
+};
+
+export default async function DevStudioPage() {
+  const auth = await requireRole(['admin', 'super_admin']);
+  const isSuperAdmin = auth.effectiveRoles.includes('super_admin');
+  return (
+    <Suspense fallback={null}>
+      <DevStudioUnifiedClient isSuperAdmin={isSuperAdmin} />
+    </Suspense>
+  );
+}

--- a/apps/admin/app/admin/dev-studio/panels/BottomPane.tsx
+++ b/apps/admin/app/admin/dev-studio/panels/BottomPane.tsx
@@ -1,0 +1,131 @@
+'use client';
+import React, { MutableRefObject } from 'react';
+import dynamic from 'next/dynamic';
+import { Terminal, MessageSquare, Sparkles, Bot, PanelBottomClose, Play } from 'lucide-react';
+import { useState } from 'react';
+
+const XTerminal      = dynamic(() => import('@/components/dev-studio/XTerminal'),                                    { ssr: false });
+const AIChat = dynamic(() => import('@/components/dev-studio/AIChat'), { ssr: false });
+
+export type BottomTab = 'terminal' | 'chat' | 'ellie' | 'command';
+
+const QUICK_CMDS = [
+  { label: 'pnpm install',  cmd: 'pnpm install' },
+  { label: 'dev LMS',       cmd: 'pnpm next dev --port 3000' },
+  { label: 'dev Admin',     cmd: 'cd apps/admin && pnpm next dev --port 3001' },
+  { label: 'build',         cmd: 'pnpm next build' },
+  { label: 'lint',          cmd: 'pnpm lint' },
+];
+
+function CommandPanel({ onSend }: { onSend: (cmd: string) => void }) {
+  const [input, setInput] = useState('');
+  return (
+    <div className="flex flex-col h-full" style={{ background: '#1e1e1e' }}>
+      <div className="flex flex-wrap gap-1.5 px-3 py-2 border-b" style={{ borderColor: '#3c3c3c' }}>
+        {QUICK_CMDS.map(({ label, cmd }) => (
+          <button key={label} onClick={() => onSend(cmd)}
+            className="px-2 py-1 rounded text-[11px] border transition-colors"
+            style={{ background: '#2d2d2d', color: '#cccccc', borderColor: '#3c3c3c' }}
+            onMouseEnter={e => (e.currentTarget.style.background = '#094771')}
+            onMouseLeave={e => (e.currentTarget.style.background = '#2d2d2d')}>
+            {label}
+          </button>
+        ))}
+      </div>
+      <div className="flex items-center gap-2 px-3 py-2">
+        <span style={{ color: '#4ec9b0', fontSize: 12 }}>$</span>
+        <input value={input} onChange={e => setInput(e.target.value)}
+          onKeyDown={e => { if (e.key === 'Enter' && input.trim()) { onSend(input.trim()); setInput(''); } }}
+          placeholder="Run a command…"
+          className="flex-1 bg-transparent outline-none text-[12px]"
+          style={{ color: '#cccccc', fontFamily: 'monospace' }} />
+        <button onClick={() => { if (input.trim()) { onSend(input.trim()); setInput(''); } }}
+          style={{ color: '#858585' }}>
+          <Play className="w-3.5 h-3.5" />
+        </button>
+      </div>
+    </div>
+  );
+}
+
+// Detect localhost URLs in terminal output (e.g. "Local: http://localhost:3000")
+const LOCAL_URL_RE = /https?:\/\/localhost:\d+/g;
+
+export default function BottomPane({
+  activeTab, onTabChange, onClose, onSendToTerminal, termCmdRef, openFile, fileContent, onDetectedUrl,
+}: {
+  activeTab: BottomTab;
+  onTabChange: (t: BottomTab) => void;
+  onClose: () => void;
+  onSendToTerminal: (cmd: string) => void;
+  termCmdRef: MutableRefObject<((cmd: string) => void) | null>;
+  openFile: string | null;
+  fileContent: string;
+  onDetectedUrl?: (url: string) => void;
+}) {
+  const TABS: { id: BottomTab; Icon: React.ElementType<{ className?: string }>; label: string }[] = [
+    { id: 'terminal', Icon: Terminal,      label: 'Terminal'  },
+    { id: 'ellie',    Icon: Bot,           label: 'Ops AI'    },
+    { id: 'chat',     Icon: MessageSquare, label: 'Code AI'   },
+    { id: 'command',  Icon: Sparkles,      label: 'Commands'  },
+  ];
+
+  return (
+    <div className="flex flex-col w-full h-full overflow-hidden" style={{ background: '#1e1e1e' }}>
+      {/* Tab strip */}
+      <div className="flex-shrink-0 flex items-center border-b" style={{ background: '#2d2d2d', borderColor: '#3c3c3c', minHeight: 35 }}>
+        {TABS.map(({ id, Icon, label }) => {
+          const active = activeTab === id;
+          return (
+            <button key={id} onClick={() => onTabChange(id)}
+              className="flex items-center gap-1.5 px-3 py-2 text-[11px] border-r transition-colors"
+              style={{
+                background: active ? '#1e1e1e' : 'transparent',
+                color: active ? '#fff' : '#858585',
+                borderColor: '#3c3c3c',
+                borderTop: active ? '1px solid #0078d4' : '1px solid transparent',
+              }}>
+              <Icon className="w-3.5 h-3.5" />
+              {label}
+            </button>
+          );
+        })}
+        <button onClick={onClose} className="ml-auto mr-2 p-1 rounded opacity-50 hover:opacity-100"
+          style={{ color: '#cccccc' }} title="Collapse panel">
+          <PanelBottomClose className="w-3.5 h-3.5" />
+        </button>
+      </div>
+
+      {/* Split: terminal left, AI right — both always mounted, hidden when inactive */}
+      <div className="flex flex-1 min-h-0 overflow-hidden">
+        {/* Terminal — always mounted so PTY session persists */}
+        <div className="flex-1 min-w-0 overflow-hidden" style={{ display: activeTab === 'terminal' ? 'flex' : 'none', flexDirection: 'column' }}>
+          <XTerminal
+            onReady={(send) => { termCmdRef.current = send; }}
+            onOutput={(text) => {
+              if (!onDetectedUrl) return;
+              const matches = text.match(LOCAL_URL_RE);
+              if (matches?.[0]) onDetectedUrl(matches[0]);
+            }}
+          />
+        </div>
+
+        <div className="flex-1 min-w-0 overflow-hidden" style={{ display: activeTab === 'ellie' ? 'flex' : 'none', flexDirection: 'column' }}>
+          <AIChat ellieMode />
+        </div>
+
+        {/* Code AI — code-context chat (file content, terminal output) */}
+        <div className="flex-1 min-w-0 overflow-hidden" style={{ display: activeTab === 'chat' ? 'flex' : 'none', flexDirection: 'column' }}>
+          <AIChat
+            fileContext={openFile ? `File: ${openFile}\n\`\`\`\n${fileContent.slice(0, 4000)}\n\`\`\`` : undefined}
+          />
+        </div>
+
+        {/* Commands */}
+        <div className="flex-1 min-w-0 overflow-hidden" style={{ display: activeTab === 'command' ? 'flex' : 'none', flexDirection: 'column' }}>
+          <CommandPanel onSend={onSendToTerminal} />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/app/admin/grants/revenue/page.tsx
+++ b/apps/admin/app/admin/grants/revenue/page.tsx
@@ -67,24 +67,59 @@ export default async function GrantRevenuePage() {
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">
           <div className="bg-white rounded-lg shadow-sm border p-6">
             <h3 className="text-sm font-medium text-slate-700">Total Awarded</h3>
-            <p className="text-3xl font-bold text-brand-green-600 mt-2">$2.4M</p>
+            <p className="text-3xl font-bold text-brand-green-600 mt-2">{formatCurrency(totalAwarded)}</p>
+            <p className="text-xs text-slate-500 mt-1">{approvedApplications.length} approved applications</p>
           </div>
           <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h3 className="text-sm font-medium text-slate-700">Received YTD</h3>
-            <p className="text-3xl font-bold text-brand-blue-600 mt-2">$1.8M</p>
+            <h3 className="text-sm font-medium text-slate-700">Pending (requested)</h3>
+            <p className="text-3xl font-bold text-yellow-600 mt-2">{formatCurrency(totalPending)}</p>
+            <p className="text-xs text-slate-500 mt-1">{activeCount} in review</p>
           </div>
           <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h3 className="text-sm font-medium text-slate-700">Pending</h3>
-            <p className="text-3xl font-bold text-yellow-600 mt-2">$600K</p>
+            <h3 className="text-sm font-medium text-slate-700">Applications</h3>
+            <p className="text-3xl font-bold text-brand-blue-600 mt-2">{(applications ?? []).length}</p>
+            <p className="text-xs text-slate-500 mt-1">All statuses in grant_applications</p>
           </div>
           <div className="bg-white rounded-lg shadow-sm border p-6">
-            <h3 className="text-sm font-medium text-slate-700">Active Grants</h3>
-            <p className="text-3xl font-bold text-brand-blue-600 mt-2">8</p>
+            <h3 className="text-sm font-medium text-slate-700">Approved</h3>
+            <p className="text-3xl font-bold text-brand-blue-600 mt-2">{approvedApplications.length}</p>
           </div>
         </div>
-        <div className="bg-white rounded-lg shadow-sm border p-6">
-          <h2 className="text-lg font-semibold mb-4">Revenue Breakdown</h2>
-          <p className="text-slate-700">Detailed grant revenue tracking</p>
+        <div className="bg-white rounded-lg shadow-sm border p-6 overflow-x-auto">
+          <h2 className="text-lg font-semibold mb-4 text-slate-900">By status</h2>
+          <table className="min-w-full text-sm">
+            <thead>
+              <tr className="border-b text-left text-slate-500">
+                <th className="py-2 pr-4 font-medium">Status</th>
+                <th className="py-2 pr-4 font-medium">Count</th>
+                <th className="py-2 font-medium">Amount (awarded or requested)</th>
+              </tr>
+            </thead>
+            <tbody>
+              {Object.entries(
+                (applications ?? []).reduce<Record<string, { count: number; cents: number }>>((acc, row) => {
+                  const status = row.status ?? 'unknown';
+                  const cents =
+                    status === 'approved'
+                      ? Number(row.amount_awarded ?? 0)
+                      : Number(row.amount_requested ?? 0);
+                  if (!acc[status]) acc[status] = { count: 0, cents: 0 };
+                  acc[status].count += 1;
+                  acc[status].cents += cents;
+                  return acc;
+                }, {}),
+              ).map(([status, { count, cents }]) => (
+                <tr key={status} className="border-b border-slate-100">
+                  <td className="py-2 pr-4 capitalize text-slate-800">{status.replace(/_/g, ' ')}</td>
+                  <td className="py-2 pr-4 text-slate-700">{count}</td>
+                  <td className="py-2 text-slate-700">{formatCurrency(cents)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+          {(applications ?? []).length === 0 && (
+            <p className="text-sm text-slate-500 py-4">No grant applications in the database yet.</p>
+          )}
         </div>
       </div>
     </div>

--- a/apps/admin/app/admin/operations/page.tsx
+++ b/apps/admin/app/admin/operations/page.tsx
@@ -1,101 +1,73 @@
 import { Metadata } from 'next';
 import { requireRole } from '@/lib/auth/require-role';
-import { getAdminClient } from '@/lib/supabase/admin';
+import { requireAdminClient } from '@/lib/supabase/admin';
 import Link from 'next/link';
 import {
-  Activity,
   AlertTriangle,
+  ArrowRight,
+  BarChart3,
   CheckCircle,
   Clock,
-  XCircle,
-  RefreshCw,
   Inbox,
-  Zap,
-  BarChart3,
-  ArrowRight,
+  RefreshCw,
   RotateCcw,
+  XCircle,
+  Zap,
 } from 'lucide-react';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 
 export const dynamic = 'force-dynamic';
-export const metadata: Metadata = { title: 'Operations | Admin' };
+export const metadata: Metadata = { title: 'Operations Hub | Admin' };
 
-function StatusDot({ status }: { status: 'ok' | 'warn' | 'fail' }) {
-  if (status === 'ok') return <span className="inline-block w-2 h-2 rounded-full bg-emerald-400" />;
-  if (status === 'warn') return <span className="inline-block w-2 h-2 rounded-full bg-amber-400" />;
-  return <span className="inline-block w-2 h-2 rounded-full bg-red-500" />;
+type QueryResult<T> = PromiseSettledResult<{ data?: T; count?: number | null; error?: { message?: string } | null }>;
+
+function getCount(r: QueryResult<unknown>): number {
+  if (r.status !== 'fulfilled') return 0;
+  return r.value.count ?? 0;
 }
 
-type SupabaseListResult = { data?: unknown[] | null; error?: { message?: string } | null };
-type SupabaseCountResult = { count?: number | null; error?: { message?: string } | null };
+function getRows<T>(r: QueryResult<T[]>, fallback: T[] = []): T[] {
+  if (r.status !== 'fulfilled') return fallback;
+  return (r.value.data as T[] | null) ?? fallback;
+}
+
+function queryFailed(r: QueryResult<unknown>): boolean {
+  if (r.status === 'rejected') return true;
+  return Boolean(r.value.error);
+}
+
+function StatusDot({ status }: { status: 'ok' | 'warn' | 'fail' }) {
+  const cls =
+    status === 'ok' ? 'bg-emerald-500' : status === 'warn' ? 'bg-amber-400' : 'bg-rose-500';
+  return <span className={`inline-block h-2 w-2 shrink-0 rounded-full ${cls}`} aria-hidden />;
+}
+
+function healthFromCounts(failed: number, warnAt: number, failAt: number): 'ok' | 'warn' | 'fail' {
+  if (failed === 0) return 'ok';
+  if (failed <= warnAt) return 'warn';
+  if (failed >= failAt) return 'fail';
+  return failed <= warnAt ? 'warn' : 'fail';
+}
 
 export default async function OperationsPage() {
   await requireRole(['admin', 'super_admin']);
-  const db = await getAdminClient();
-
-  if (!db) {
-    return (
-      <div className="min-h-screen bg-slate-950 p-6">
-        <div className="max-w-2xl mx-auto mt-16 rounded-xl border border-amber-500/40 bg-slate-900 p-8">
-          <h1 className="text-xl font-bold text-white mb-2">Operations temporarily unavailable</h1>
-          <p className="text-slate-400 text-sm mb-6">
-            The admin service could not connect to the database (service role not loaded). Other admin
-            navigation should still work. Try refreshing in a minute or contact platform support if this
-            persists.
-          </p>
-          <Link
-            href="/admin/dashboard"
-            className="inline-flex items-center gap-2 text-sm text-brand-blue-400 hover:text-brand-blue-300"
-          >
-            <ArrowRight className="w-4 h-4" /> Back to dashboard
-          </Link>
-        </div>
-      </div>
-    );
-  }
+  const db = await requireAdminClient();
 
   const since24h = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
   const since1h = new Date(Date.now() - 60 * 60 * 1000).toISOString();
 
-  const [
-    cronTotal,
-    cronFailed,
-    cronRecent,
-    workflowRuns,
-    workflowFailed,
-    deadLetters,
-    deadLettersRecent,
-    stepLogs,
-    openAlerts,
-    criticalAlerts,
-    recentCronRuns,
-    recentDeadLetters,
-    recentAlerts,
-  ] = await Promise.allSettled([
+  const results = await Promise.allSettled([
     db.from('cron_job_runs').select('id', { count: 'exact', head: true }).gte('started_at', since24h),
-    db
-      .from('cron_job_runs')
-      .select('id', { count: 'exact', head: true })
-      .eq('status', 'failed')
-      .gte('started_at', since24h),
+    db.from('cron_job_runs').select('id', { count: 'exact', head: true }).eq('status', 'failed').gte('started_at', since24h),
     db.from('cron_job_runs').select('id', { count: 'exact', head: true }).gte('started_at', since1h),
     db.from('workflow_runs').select('id', { count: 'exact', head: true }).gte('created_at', since24h),
-    db
-      .from('workflow_runs')
-      .select('id', { count: 'exact', head: true })
-      .eq('status', 'failed')
-      .gte('created_at', since24h),
+    db.from('workflow_runs').select('id', { count: 'exact', head: true }).eq('status', 'failed').gte('created_at', since24h),
     db.from('workflow_dead_letters').select('id', { count: 'exact', head: true }),
-    db
-      .from('workflow_dead_letters')
-      .select('id', { count: 'exact', head: true })
-      .gte('created_at', since24h),
+    db.from('workflow_dead_letters').select('id', { count: 'exact', head: true }).gte('created_at', since24h),
     db.from('workflow_step_logs').select('id', { count: 'exact', head: true }).gte('created_at', since24h),
+    db.from('workflows').select('id', { count: 'exact', head: true }).eq('is_active', true),
     db.from('admin_alerts').select('id', { count: 'exact', head: true }).eq('resolved', false),
-    db
-      .from('admin_alerts')
-      .select('id', { count: 'exact', head: true })
-      .eq('resolved', false)
-      .in('severity', ['critical', 'high']),
+    db.from('admin_alerts').select('id', { count: 'exact', head: true }).eq('resolved', false).in('severity', ['critical', 'high']),
     db
       .from('cron_job_runs')
       .select('id, job_name, status, started_at, duration_ms, error')
@@ -114,10 +86,22 @@ export default async function OperationsPage() {
       .limit(10),
   ]);
 
-  const getList = (r: PromiseSettledResult<SupabaseListResult>) =>
-    r.status === 'fulfilled' && !r.value.error ? (r.value.data ?? []) : [];
-  const getCount = (r: PromiseSettledResult<SupabaseCountResult>) =>
-    r.status === 'fulfilled' && !r.value.error ? (r.value.count ?? 0) : 0;
+  const [
+    cronTotal,
+    cronFailed,
+    cronRecent,
+    workflowRuns,
+    workflowFailed,
+    deadLetters,
+    deadLettersRecent,
+    stepLogs,
+    activeWorkflows,
+    openAlerts,
+    criticalAlerts,
+    recentCronRuns,
+    recentDeadLetters,
+    recentAlerts,
+  ] = results;
 
   const cronTotalCount = getCount(cronTotal);
   const cronFailedCount = getCount(cronFailed);
@@ -127,223 +111,251 @@ export default async function OperationsPage() {
   const dlTotalCount = getCount(deadLetters);
   const dlRecentCount = getCount(deadLettersRecent);
   const stepLogsCount = getCount(stepLogs);
+  const activeWorkflowCount = getCount(activeWorkflows);
   const openAlertsCount = getCount(openAlerts);
   const criticalCount = getCount(criticalAlerts);
 
-  const cronRows = getList(recentCronRuns) as Array<Record<string, unknown>>;
-  const dlRows = getList(recentDeadLetters) as Array<Record<string, unknown>>;
-  const alertRows = getList(recentAlerts) as Array<Record<string, unknown>>;
+  const cronRows = getRows(recentCronRuns);
+  const dlRows = getRows(recentDeadLetters);
+  const alertRows = getRows(recentAlerts);
 
-  const cronHealth = cronFailedCount === 0 ? 'ok' : cronFailedCount <= 2 ? 'warn' : 'fail';
-  const wfHealth = wfFailedCount === 0 ? 'ok' : wfFailedCount <= 3 ? 'warn' : 'fail';
+  const cronHealth = healthFromCounts(cronFailedCount, 2, 3);
+  const wfHealth = healthFromCounts(wfFailedCount, 3, 4);
   const dlHealth = dlRecentCount === 0 ? 'ok' : dlRecentCount <= 2 ? 'warn' : 'fail';
   const alertHealth = criticalCount === 0 ? 'ok' : criticalCount <= 3 ? 'warn' : 'fail';
 
+  const unavailable: string[] = [];
+  if (queryFailed(cronTotal)) unavailable.push('Cron jobs');
+  if (queryFailed(workflowRuns)) unavailable.push('Workflow runs');
+  if (queryFailed(deadLetters)) unavailable.push('Dead letters');
+  if (queryFailed(openAlerts)) unavailable.push('Admin alerts');
+
   const SEVERITY_STYLES: Record<string, string> = {
-    critical: 'bg-red-100 text-red-800',
+    critical: 'bg-rose-100 text-rose-800',
     high: 'bg-orange-100 text-orange-800',
     medium: 'bg-amber-100 text-amber-800',
     warning: 'bg-yellow-100 text-yellow-800',
     low: 'bg-slate-100 text-slate-600',
   };
 
-  const cronTableMissing =
-    recentCronRuns.status === 'fulfilled' &&
-    recentCronRuns.value.error?.message?.includes('cron_job_runs');
+  const quickLinks = [
+    { label: 'Mission Control', href: '/admin/mission-control' },
+    { label: 'System Health', href: '/admin/system-health' },
+    { label: 'Workflows', href: '/admin/workflows' },
+    { label: 'Automation log', href: '/admin/automation' },
+    { label: 'Monitoring', href: '/admin/monitoring' },
+  ];
 
   return (
-    <div className="min-h-screen bg-slate-950 p-6 space-y-8">
-      <div className="max-w-6xl mx-auto">
-        <div className="flex items-center justify-between mb-6">
+    <div className="min-h-screen bg-slate-50">
+      <div className="border-b border-slate-200 bg-white px-6 py-5">
+        <Breadcrumbs
+          items={[
+            { label: 'Admin', href: '/admin/dashboard' },
+            { label: 'Operations Hub' },
+          ]}
+        />
+        <div className="mt-3 flex flex-wrap items-end justify-between gap-4">
           <div>
-            <h1 className="text-2xl font-bold text-white flex items-center gap-2">
-              <Activity className="w-6 h-6 text-brand-blue-400" />
-              Operations
-            </h1>
-            <p className="text-slate-400 text-sm mt-1">
-              Cron health · Workflow engine · Dead letters · Active alerts
+            <h1 className="text-2xl font-bold text-slate-900">Operations Hub</h1>
+            <p className="mt-1 text-sm text-slate-600">
+              Live cron, workflow engine, dead letters, and unresolved admin alerts from Supabase.
             </p>
           </div>
-          <Link
-            href="/admin/system-health"
-            className="text-sm text-brand-blue-400 hover:text-brand-blue-300 flex items-center gap-1"
-          >
-            System Health <ArrowRight className="w-3 h-3" />
-          </Link>
+          <div className="flex flex-wrap gap-2">
+            {quickLinks.map(({ label, href }) => (
+              <Link
+                key={href}
+                href={href}
+                className="rounded-lg border border-slate-200 bg-white px-3 py-1.5 text-xs font-semibold text-slate-700 hover:border-brand-blue-300 hover:text-brand-blue-700"
+              >
+                {label}
+              </Link>
+            ))}
+          </div>
         </div>
+      </div>
 
-        {cronTableMissing && (
-          <div className="mb-6 rounded-xl border border-amber-500/30 bg-amber-950/30 px-5 py-4 text-sm text-amber-100">
-            Workflow operations tables are not fully provisioned in this environment. Apply migration{' '}
-            <code className="font-mono text-amber-200">20260705000001</code> in Supabase to enable cron
-            run history. Counts below may show zero until then.
+      <div className="mx-auto max-w-6xl space-y-6 px-6 py-6">
+        {unavailable.length > 0 && (
+          <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+            <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-amber-600" />
+            <p>
+              Could not load: {unavailable.join(', ')}. Confirm migrations for{' '}
+              <code className="rounded bg-amber-100 px-1 text-xs">cron_job_runs</code>, workflows, and{' '}
+              <code className="rounded bg-amber-100 px-1 text-xs">admin_alerts</code> are applied in Supabase.
+            </p>
           </div>
         )}
 
-        <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-4">
           {[
             {
-              label: 'Cron Jobs (24h)',
+              label: 'Cron (24h)',
               status: cronHealth,
               value: `${cronTotalCount} runs · ${cronFailedCount} failed`,
             },
             {
-              label: 'Workflow Engine',
+              label: 'Workflows (24h)',
               status: wfHealth,
               value: `${wfRunsCount} runs · ${wfFailedCount} failed`,
             },
             {
-              label: 'Dead Letters',
+              label: 'Dead letters',
               status: dlHealth,
-              value: `${dlTotalCount} total · ${dlRecentCount} new`,
+              value: `${dlTotalCount} total · ${dlRecentCount} new (24h)`,
             },
             {
-              label: 'Active Alerts',
+              label: 'Alerts',
               status: alertHealth,
-              value: `${openAlertsCount} open · ${criticalCount} critical`,
+              value: `${openAlertsCount} open · ${criticalCount} critical/high`,
             },
           ].map((s) => (
-            <div key={s.label} className="bg-slate-900 border border-slate-800 rounded-xl p-4">
-              <div className="flex items-center gap-2 mb-2">
+            <div key={s.label} className="rounded-xl border border-slate-200 bg-white p-4 shadow-sm">
+              <div className="mb-2 flex items-center gap-2">
                 <StatusDot status={s.status} />
-                <span className="text-xs text-slate-400 font-medium uppercase tracking-wide">
-                  {s.label}
-                </span>
+                <span className="text-xs font-semibold uppercase tracking-wide text-slate-500">{s.label}</span>
               </div>
-              <p className="text-white text-sm font-semibold">{s.value}</p>
+              <p className="text-sm font-semibold text-slate-900">{s.value}</p>
             </div>
           ))}
         </div>
 
-        <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-slate-800 flex items-center gap-2">
-            <Clock className="w-4 h-4 text-slate-400" />
-            <h2 className="text-sm font-semibold text-white">Recent Cron Runs</h2>
-            <span className="ml-auto text-xs text-slate-500">{cronRecentCount} in last hour</span>
-          </div>
-          {cronRows.length === 0 ? (
-            <p className="px-5 py-6 text-slate-500 text-sm">
-              No cron runs recorded yet. Apply migration 20260705000001 to enable.
-            </p>
-          ) : (
-            <div className="divide-y divide-slate-800">
-              {cronRows.map((r) => (
-                <div key={String(r.id)} className="px-5 py-3 flex items-center gap-3 text-sm">
-                  {r.status === 'success' ? (
-                    <CheckCircle className="w-4 h-4 text-emerald-400 shrink-0" />
-                  ) : r.status === 'failed' ? (
-                    <XCircle className="w-4 h-4 text-red-400 shrink-0" />
-                  ) : (
-                    <RefreshCw className="w-4 h-4 text-amber-400 shrink-0 animate-spin" />
-                  )}
-                  <span className="text-white font-mono">{String(r.job_name ?? '')}</span>
-                  <span className="text-slate-500 ml-auto">
-                    {r.duration_ms != null ? `${r.duration_ms}ms` : '—'}
-                  </span>
-                  <span className="text-slate-600 text-xs">
-                    {r.started_at ? new Date(String(r.started_at)).toLocaleTimeString() : '—'}
-                  </span>
-                  {r.error ? (
-                    <span className="text-red-400 text-xs truncate max-w-xs">{String(r.error)}</span>
-                  ) : null}
-                </div>
-              ))}
+        <div className="grid grid-cols-2 gap-4 md:grid-cols-3">
+          {[
+            { label: 'Active workflow definitions', value: activeWorkflowCount, icon: Zap },
+            { label: 'Step logs (24h)', value: stepLogsCount, icon: BarChart3 },
+            { label: 'Cron runs (1h)', value: cronRecentCount, icon: Clock },
+          ].map(({ label, value, icon: Icon }) => (
+            <div key={label} className="rounded-xl border border-slate-200 bg-white p-5 shadow-sm">
+              <Icon className="mb-3 h-5 w-5 text-slate-400" />
+              <p className="text-2xl font-bold text-slate-900">{value.toLocaleString()}</p>
+              <p className="mt-1 text-xs text-slate-500">{label}</p>
             </div>
-          )}
+          ))}
         </div>
 
-        <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-slate-800 flex items-center gap-2">
-            <Inbox className="w-4 h-4 text-slate-400" />
-            <h2 className="text-sm font-semibold text-white">Workflow Dead Letters</h2>
-            <span className="ml-auto text-xs text-slate-500">{dlTotalCount} total</span>
+        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-4">
+            <Clock className="h-4 w-4 text-slate-500" />
+            <h2 className="text-sm font-semibold text-slate-900">Recent cron runs</h2>
+            <span className="ml-auto text-xs text-slate-500">{cronRecentCount} in the last hour</span>
           </div>
-          {dlRows.length === 0 ? (
-            <p className="px-5 py-6 text-slate-500 text-sm">
-              {dlTotalCount === 0
-                ? 'No dead letters — all workflow steps completing successfully.'
-                : 'No recent dead letters.'}
+          {cronRows.length === 0 ? (
+            <p className="px-5 py-6 text-sm text-slate-500">
+              No cron runs in the log yet. After migration <code className="text-xs">20260705000001</code>, scheduled
+              jobs will appear here.
             </p>
           ) : (
-            <div className="divide-y divide-slate-800">
+            <ul className="divide-y divide-slate-100">
+              {cronRows.map((r) => (
+                <li key={r.id} className="flex flex-wrap items-center gap-3 px-5 py-3 text-sm">
+                  {r.status === 'success' ? (
+                    <CheckCircle className="h-4 w-4 shrink-0 text-emerald-600" />
+                  ) : r.status === 'failed' ? (
+                    <XCircle className="h-4 w-4 shrink-0 text-rose-600" />
+                  ) : (
+                    <RefreshCw className="h-4 w-4 shrink-0 animate-spin text-amber-500" />
+                  )}
+                  <span className="font-mono text-slate-900">{r.job_name}</span>
+                  <span className="ml-auto text-slate-500">
+                    {r.duration_ms != null ? `${r.duration_ms}ms` : '—'}
+                  </span>
+                  <span className="text-xs text-slate-400">
+                    {new Date(r.started_at).toLocaleString()}
+                  </span>
+                  {r.error ? (
+                    <span className="w-full truncate text-xs text-rose-600">{r.error}</span>
+                  ) : null}
+                </li>
+              ))}
+            </ul>
+          )}
+        </section>
+
+        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-4">
+            <Inbox className="h-4 w-4 text-slate-500" />
+            <h2 className="text-sm font-semibold text-slate-900">Workflow dead letters</h2>
+            <span className="ml-auto text-xs text-slate-500">{dlTotalCount} total</span>
+            <Link
+              href="/admin/workflows"
+              className="ml-2 flex items-center gap-1 text-xs font-semibold text-brand-blue-600 hover:underline"
+            >
+              Workflows <ArrowRight className="h-3 w-3" />
+            </Link>
+          </div>
+          {dlRows.length === 0 ? (
+            <p className="px-5 py-6 text-sm text-slate-500">
+              {dlTotalCount === 0
+                ? 'No dead letters — workflow steps are completing successfully.'
+                : 'No dead letters in the recent window.'}
+            </p>
+          ) : (
+            <ul className="divide-y divide-slate-100">
               {dlRows.map((r) => (
-                <div key={String(r.id)} className="px-5 py-3 text-sm">
-                  <div className="flex items-center gap-3">
-                    <AlertTriangle className="w-4 h-4 text-amber-400 shrink-0" />
-                    <span className="text-white font-mono">{String(r.action_type ?? 'unknown')}</span>
-                    <span className="text-slate-500 text-xs ml-auto">{String(r.attempts ?? 0)} attempts</span>
-                    <span className="text-slate-600 text-xs">
-                      {r.created_at ? new Date(String(r.created_at)).toLocaleDateString() : '—'}
+                <li key={r.id} className="px-5 py-3 text-sm">
+                  <div className="flex flex-wrap items-center gap-3">
+                    <AlertTriangle className="h-4 w-4 shrink-0 text-amber-500" />
+                    <span className="font-mono text-slate-900">{r.action_type ?? 'unknown'}</span>
+                    <span className="text-xs text-slate-500">{r.attempts} attempts</span>
+                    <span className="text-xs text-slate-400">
+                      {new Date(r.created_at).toLocaleString()}
                     </span>
                     {r.workflow_id ? (
                       <Link
                         href={`/admin/workflows/${r.workflow_id}`}
-                        className="flex items-center gap-1 text-xs text-amber-400 hover:text-amber-300 transition-colors"
-                        title="Replay via workflow page"
+                        className="ml-auto flex items-center gap-1 text-xs font-semibold text-amber-700 hover:underline"
                       >
-                        <RotateCcw className="w-3 h-3" /> Replay
+                        <RotateCcw className="h-3 w-3" /> Open workflow
                       </Link>
                     ) : null}
                   </div>
                   {r.last_error ? (
-                    <p className="mt-1 ml-7 text-red-400 text-xs truncate">{String(r.last_error)}</p>
+                    <p className="mt-1 truncate pl-7 text-xs text-rose-600">{r.last_error}</p>
                   ) : null}
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           )}
-        </div>
+        </section>
 
-        <div className="grid grid-cols-2 md:grid-cols-3 gap-4">
-          {[
-            { label: 'Workflow Runs (24h)', value: wfRunsCount, icon: Zap },
-            { label: 'Step Logs (24h)', value: stepLogsCount, icon: BarChart3 },
-            { label: 'Failed Runs (24h)', value: wfFailedCount, icon: XCircle },
-          ].map((s) => (
-            <div key={s.label} className="bg-slate-900 border border-slate-800 rounded-xl p-5">
-              <s.icon className="w-5 h-5 text-slate-500 mb-3" />
-              <p className="text-2xl font-bold text-white">{s.value}</p>
-              <p className="text-xs text-slate-400 mt-1">{s.label}</p>
-            </div>
-          ))}
-        </div>
-
-        <div className="bg-slate-900 border border-slate-800 rounded-xl overflow-hidden">
-          <div className="px-5 py-4 border-b border-slate-800 flex items-center gap-2">
-            <AlertTriangle className="w-4 h-4 text-slate-400" />
-            <h2 className="text-sm font-semibold text-white">Active Alerts</h2>
-            <span className="ml-auto text-xs text-slate-500">{openAlertsCount} unresolved</span>
+        <section className="overflow-hidden rounded-xl border border-slate-200 bg-white shadow-sm">
+          <div className="flex items-center gap-2 border-b border-slate-100 px-5 py-4">
+            <AlertTriangle className="h-4 w-4 text-slate-500" />
+            <h2 className="text-sm font-semibold text-slate-900">Unresolved admin alerts</h2>
+            <span className="ml-auto text-xs text-slate-500">{openAlertsCount} open</span>
             <Link
               href="/admin/monitoring"
-              className="text-xs text-brand-blue-400 hover:text-brand-blue-300 ml-2"
+              className="ml-2 text-xs font-semibold text-brand-blue-600 hover:underline"
             >
-              View all →
+              Monitoring →
             </Link>
           </div>
           {alertRows.length === 0 ? (
-            <p className="px-5 py-6 text-slate-500 text-sm flex items-center gap-2">
-              <CheckCircle className="w-4 h-4 text-emerald-400" /> No active alerts.
+            <p className="flex items-center gap-2 px-5 py-6 text-sm text-slate-500">
+              <CheckCircle className="h-4 w-4 text-emerald-600" /> No unresolved alerts.
             </p>
           ) : (
-            <div className="divide-y divide-slate-800">
+            <ul className="divide-y divide-slate-100">
               {alertRows.map((a) => (
-                <div key={String(a.id)} className="px-5 py-3 flex items-start gap-3 text-sm">
+                <li key={a.id} className="flex items-start gap-3 px-5 py-3 text-sm">
                   <span
-                    className={`text-xs font-semibold px-2 py-0.5 rounded-full shrink-0 mt-0.5 ${
-                      SEVERITY_STYLES[String(a.severity ?? '')] ?? 'bg-slate-100 text-slate-600'
+                    className={`mt-0.5 shrink-0 rounded-full px-2 py-0.5 text-xs font-semibold ${
+                      SEVERITY_STYLES[a.severity] ?? 'bg-slate-100 text-slate-600'
                     }`}
                   >
-                    {String(a.severity ?? 'unknown')}
+                    {a.severity}
                   </span>
-                  <span className="text-slate-300 flex-1">{String(a.message ?? '')}</span>
-                  <span className="text-slate-600 text-xs shrink-0">
-                    {a.created_at ? new Date(String(a.created_at)).toLocaleDateString() : '—'}
+                  <span className="flex-1 text-slate-700">{a.message}</span>
+                  <span className="shrink-0 text-xs text-slate-400">
+                    {new Date(a.created_at).toLocaleString()}
                   </span>
-                </div>
+                </li>
               ))}
-            </div>
+            </ul>
           )}
-        </div>
+        </section>
       </div>
     </div>
   );

--- a/apps/admin/app/globals.css
+++ b/apps/admin/app/globals.css
@@ -1711,6 +1711,17 @@ header[role='banner'] {
   background-color: #ffffff !important;
 }
 
+header[role='banner'] > div {
+  display: grid !important;
+  flex-direction: row !important;
+}
+
+header[role='banner'] nav[aria-label='Main navigation'] {
+  display: flex !important;
+  flex-direction: row !important;
+  flex-wrap: nowrap !important;
+}
+
 header[role='banner'] > div,
 header[role='banner'] a,
 header[role='banner'] span,

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -3,7 +3,7 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import LizzyContainerWrapper from './LizzyContainerWrapper';
+import SitePreviewPanelWrapper from './SitePreviewPanelWrapper';
 import { AdminGreeting } from "@/components/admin/AdminGreeting";
 import {
   ArrowRight, AlertTriangle,
@@ -74,25 +74,24 @@ const ADMIN_CATEGORY_CARDS = [
   {
     title: 'Operations',
     eyebrow: 'Command center',
-    description: 'Daily priorities, analytics, reports, at-risk learners, and system status.',
-    href: '/admin/dashboard',
+    description: 'Operations hub, mission control, cron and workflow health, and daily priorities.',
+    href: '/admin/operations',
     Icon: Activity,
     links: [
-      { label: 'Analytics', href: '/admin/analytics' },
-      { label: 'Reports', href: '/admin/reports' },
-      { label: 'At-risk', href: '/admin/at-risk' },
+      { label: 'Dashboard', href: '/admin/dashboard' },
+      { label: 'Mission Control', href: '/admin/mission-control' },
+      { label: 'System health', href: '/admin/system-health' },
     ],
   },
   {
-    title: 'Lizzy Intelligence',
+    title: 'Intelligence',
     eyebrow: 'AI + forecasting',
-    description: 'Risk scoring, forecasts, and Lizzy command AI — same container as the dashboard control plane.',
-    href: '/admin/dashboard',
+    description: 'Risk scoring, completion forecasts, and operational analytics.',
+    href: '/admin/intelligence',
     Icon: Bot,
     links: [
-      { label: 'Risk dashboard', href: '/admin/dashboard' },
+      { label: 'Risk dashboard', href: '/admin/intelligence' },
       { label: 'Forecast', href: '/admin/intelligence/forecast' },
-      { label: 'Lizzy', href: '/admin/dashboard' },
     ],
   },
   {
@@ -168,14 +167,14 @@ const ADMIN_CATEGORY_CARDS = [
     ],
   },
   {
-    title: 'Lizzy',
-    eyebrow: 'Platform control',
-    description: 'Live preview with AI, deploy, files, environments, workflows, and platform health — one container.',
-    href: '/admin/dashboard',
+    title: 'Dev Studio',
+    eyebrow: 'Build + deploy',
+    description: 'Container, environments, deploy pipeline, secrets, and platform tooling.',
+    href: '/admin/dev-studio',
     Icon: Settings,
     links: [
+      { label: 'Open studio', href: '/admin/dev-studio' },
       { label: 'Workflows', href: '/admin/workflows' },
-      { label: 'System health', href: '/admin/system-health' },
     ],
   },
 ] as const;
@@ -318,7 +317,7 @@ function LearnersNeedingAttention({ learners }: { learners: InactiveLearner[] })
 
 function ReviewQueues({ data }: { data: AdminDashboardData }) {
   const queues = [
-    { label: "Applications awaiting review", count: data.counts.pendingApplications, context: data.counts.pendingApplications > 0 ? "Intake queue needs admin action" : "Queue is clear", href: "/admin/applications?status=submitted,pending,in_review,under_review,pending_admin_review,pending_funding", urgent: data.counts.pendingApplications > 0 },
+    { label: "Applications awaiting review", count: data.counts.pendingApplications, context: data.counts.pendingApplications > 0 ? "Intake queue needs admin action" : "Queue is clear", href: "/admin/applications?status=submitted,pending,in_review,pending_admin_review", urgent: data.counts.pendingApplications > 0 },
     { label: "WIOA documents awaiting review", count: data.pendingWioaDocs, context: data.pendingWioaDocs > 0 ? "Funding eligibility may be blocked" : "Queue is clear", href: "/admin/wioa/documents", urgent: data.pendingWioaDocs > 0 },
     { label: "Lab submissions awaiting sign-off", count: data.pendingSubmissions.length, context: data.pendingSubmissions.length > 0 ? "Instructor action required" : "Queue is clear", href: "/admin/submissions", urgent: data.pendingSubmissions.length > 0 },
     { label: "Program holders awaiting approval", count: data.counts.pendingProgramHolders, context: data.counts.pendingProgramHolders > 0 ? "Partner applications need review" : "Queue is clear", href: "/admin/program-holders", urgent: data.counts.pendingProgramHolders > 0 },
@@ -475,7 +474,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
         </div>
         {/* Quick-action strip — mobile only. Desktop has the full nav bar. */}
         <div className="md:hidden flex gap-2 overflow-x-auto pb-2 mb-6 -mx-4 px-4 scrollbar-none">
-          <Link href="/admin/applications?status=submitted,pending,in_review,under_review,pending_admin_review,pending_funding" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-slate-900 text-white text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors">Review Applications</Link>
+          <Link href="/admin/applications?status=submitted,pending,in_review,pending_admin_review" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-slate-900 text-white text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors">Review Applications</Link>
           <Link href="/admin/compliance" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Compliance</Link>
           <Link href="/admin/documents/templates" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Document Templates</Link>
           <Link href="/admin/studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Course Templates</Link>
@@ -483,18 +482,10 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <Link href="/admin/students" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Students</Link>
           <Link href="/admin/enrollments" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Enrollments</Link>
           <Link href="/admin/reports" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Reports</Link>
-          <Link href="/admin/dashboard" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Lizzy</Link>
+          <Link href="/admin/dev-studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Dev Studio</Link>
         </div>
 
         <DegradedBanner sections={data.degradedSections ?? []} />
-
-        <LizzyContainerWrapper
-          sites={data.sitePreviewTargets ?? []}
-          isSuperAdmin={data.profile?.role === 'super_admin'}
-          pendingApplications={data.pendingApplications ?? []}
-          pendingApplicationsCount={data.counts.pendingApplications}
-          pendingProgramHolders={data.counts.pendingProgramHolders}
-        />
 
         <AdminCategoryLanding />
 
@@ -526,31 +517,20 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <div className="space-y-4">
             <EnrollmentFunnel data={data} />
             <RecentActivity items={data.recentActivity} />
-            <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
-              <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between">
-                <div className="flex items-center gap-2">
-                  <Inbox className="w-4 h-4 text-slate-500" />
-                  <h2 className="font-bold text-slate-900 text-sm">
-                    {(data.pendingApplications?.length ?? 0) > 0 ? 'Applications awaiting review' : 'Recent Applications'}
-                  </h2>
-                  {data.counts.pendingApplications > 0 && (
-                    <span className="text-xs font-bold px-2 py-0.5 rounded-full bg-rose-100 text-rose-700">
-                      {data.counts.pendingApplications}
-                    </span>
-                  )}
+            {data.recentApplications.length > 0 && (
+              <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
+                <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between">
+                  <div className="flex items-center gap-2">
+                    <Inbox className="w-4 h-4 text-slate-500" />
+                    <h2 className="font-bold text-slate-900 text-sm">Recent Applications</h2>
+                  </div>
+                  <Link href="/admin/applications" className="text-xs font-semibold text-brand-blue-600 hover:underline flex items-center gap-1">
+                    View all <ArrowRight className="w-3 h-3" />
+                  </Link>
                 </div>
-                <Link href="/admin/applications?status=submitted,pending,in_review,under_review,pending_admin_review,pending_funding" className="text-xs font-semibold text-brand-blue-600 hover:underline flex items-center gap-1">
-                  View all <ArrowRight className="w-3 h-3" />
-                </Link>
+                <RecentApplicationsList items={data.recentApplications} />
               </div>
-              {((data.pendingApplications?.length ?? 0) > 0 ? data.pendingApplications : data.recentApplications).length > 0 ? (
-                <RecentApplicationsList
-                  items={(data.pendingApplications?.length ?? 0) > 0 ? data.pendingApplications : data.recentApplications}
-                />
-              ) : (
-                <Empty message="No applications in the queue yet." />
-              )}
-            </div>
+            )}
             <RecentPaymentsPanel payments={data.recentPayments} />
             <RecentStudentsPanel students={data.recentStudents} />
           </div>
@@ -591,8 +571,9 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
         </div>
 
         {/* ── Job board + site status + system health ──────────────────── */}
-        <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
+        <div className="mt-8 grid grid-cols-1 lg:grid-cols-3 gap-6">
           <JobBoardPanel />
+          <SitePreviewPanelWrapper sites={data.sitePreviewTargets ?? []} />
           <SystemHealthPanel health={data.systemHealth} />
         </div>
 

--- a/components/admin/dashboard/SystemHealthPanel.tsx
+++ b/components/admin/dashboard/SystemHealthPanel.tsx
@@ -96,7 +96,7 @@ export function SystemHealthPanel({ health }: Props) {
               label: "Stale Jobs",
               ok: health.staleJobs === 0,
               value: health.staleJobs > 0 ? `${health.staleJobs} stuck` : "Clear",
-              href: "/admin/dashboard?tab=workflows",
+              href: "/admin/operations",
             },
             {
               label: "Missing Docs",

--- a/components/portal/PartnerProgramHolderShell.tsx
+++ b/components/portal/PartnerProgramHolderShell.tsx
@@ -7,7 +7,7 @@ import {
   LayoutDashboard, Users, Clock, AlertTriangle, GraduationCap,
   BookOpen, Megaphone, Bell, FileText, Shield, Book, LifeBuoy,
   HelpCircle, ClipboardCheck, BarChart3, Settings, Menu, X,
-  LogOut, CheckCircle, CalendarDays, Briefcase,
+  LogOut, CheckCircle, CalendarDays, Briefcase, CreditCard,
 } from 'lucide-react';
 
 interface NavItem {

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -24,8 +24,7 @@ export default function Header() {
       className="fixed top-0 left-0 right-0 h-[60px] bg-white z-[9999] shadow-sm border-b border-slate-100"
       role="banner"
     >
-      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 lg:px-8 grid grid-cols-[auto_1fr_auto] items-center gap-3 lg:gap-6">
-        {/* Logo */}
+      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 lg:px-8 grid grid-cols-[auto_1fr_auto] items-center gap-2 lg:gap-4">
         <Link
           href="/"
           className="flex items-center gap-2 flex-shrink-0 min-w-0"
@@ -37,14 +36,12 @@ export default function Header() {
           </span>
         </Link>
 
-        {/* Desktop nav — centered horizontal row */}
-        <div className="hidden lg:flex justify-center min-w-0 overflow-visible">
+        <div className="hidden lg:flex justify-center min-w-0 overflow-hidden">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
-        {/* Actions: desktop CTAs + mobile menu (never stacks as a vertical bar) */}
-        <div className="flex items-center justify-end gap-1 sm:gap-1.5 flex-shrink-0 min-w-0">
-          <div className="hidden lg:flex items-center gap-1.5">
+        <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 sm:gap-1 flex-shrink-0 min-w-0">
+          <div className="hidden lg:flex flex-row flex-nowrap items-center gap-1.5">
             <SearchModal />
             <LanguageSwitcher compact />
             <Link

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -6,7 +6,8 @@ import LogoImage from '@/components/site/LogoImage';
 import { ALL_PROGRAMS } from '@/data/programs/catalog';
 import HeaderMobileMenu from './HeaderMobileMenu.client';
 import HeaderDesktopNav from './HeaderDesktopNav';
-import HeaderUtilities from './HeaderUtilities.client';
+import SearchModal from './SearchModal.client';
+import LanguageSwitcher from './LanguageSwitcher.client';
 import { NAV_ITEMS } from '@/lib/navigation';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
@@ -23,45 +24,46 @@ export default function Header() {
       className="fixed top-0 left-0 right-0 h-[60px] bg-white z-[9999] shadow-sm border-b border-slate-100"
       role="banner"
     >
-      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 lg:px-8">
-        <div className="flex h-full flex-nowrap items-center justify-between gap-2 lg:gap-4">
-          <Link
-            href="/"
-            className="flex items-center gap-2 flex-shrink-0"
-            aria-label={`${PLATFORM_DEFAULTS.orgName} home`}
-          >
-            <LogoImage alt="Elevate" width={40} height={60} className="w-auto h-9" priority />
-            <span className="font-bold text-[15px] text-slate-900 hidden sm:block tracking-tight">
-              Elevate
-            </span>
-          </Link>
+      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 lg:px-8 grid grid-cols-[auto_1fr_auto] items-center gap-3 lg:gap-6">
+        {/* Logo */}
+        <Link
+          href="/"
+          className="flex items-center gap-2 flex-shrink-0 min-w-0"
+          aria-label={`${PLATFORM_DEFAULTS.orgName} home`}
+        >
+          <LogoImage alt="Elevate" width={40} height={60} className="w-auto h-9" priority />
+          <span className="font-bold text-[15px] text-slate-900 hidden sm:block tracking-tight truncate">
+            Elevate
+          </span>
+        </Link>
 
-          <div className="hidden lg:flex flex-1 items-center justify-center min-w-0">
-            <HeaderDesktopNav items={NAV_ITEMS} />
+        {/* Desktop nav — centered horizontal row */}
+        <div className="hidden lg:flex justify-center min-w-0 overflow-visible">
+          <HeaderDesktopNav items={NAV_ITEMS} />
+        </div>
+
+        {/* Actions: desktop CTAs + mobile menu (never stacks as a vertical bar) */}
+        <div className="flex items-center justify-end gap-1 sm:gap-1.5 flex-shrink-0 min-w-0">
+          <div className="hidden lg:flex items-center gap-1.5">
+            <SearchModal />
+            <LanguageSwitcher compact />
+            <Link
+              href="/login"
+              prefetch={false}
+              className="text-slate-600 font-semibold text-[13px] hover:text-slate-900 transition-colors px-2.5 py-1.5 rounded-md hover:bg-slate-50 whitespace-nowrap"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/for-students"
+              prefetch={false}
+              className="bg-brand-red-600 text-white px-3.5 py-1.5 rounded-lg font-semibold text-[13px] hover:bg-brand-red-700 transition-colors whitespace-nowrap"
+            >
+              Get Started
+            </Link>
           </div>
 
-          <div className="flex flex-nowrap items-center gap-1 shrink-0">
-            <HeaderUtilities />
-
-            <div className="hidden lg:flex items-center gap-1.5">
-              <Link
-                href="/login"
-                prefetch={false}
-                className="text-slate-600 font-semibold text-[13px] hover:text-slate-900 transition-colors px-2.5 py-1.5 rounded-md hover:bg-slate-50"
-              >
-                Sign In
-              </Link>
-              <Link
-                href="/for-students"
-                prefetch={false}
-                className="bg-brand-red-600 text-white px-3.5 py-1.5 rounded-lg font-semibold text-[13px] hover:bg-brand-red-700 transition-colors whitespace-nowrap"
-              >
-                Get Started
-              </Link>
-            </div>
-
-            <HeaderMobileMenu items={NAV_ITEMS} programApplyLinks={PROGRAM_APPLY_LINKS} />
-          </div>
+          <HeaderMobileMenu items={NAV_ITEMS} programApplyLinks={PROGRAM_APPLY_LINKS} />
         </div>
       </div>
     </header>

--- a/components/site/HeaderDesktopNav.tsx
+++ b/components/site/HeaderDesktopNav.tsx
@@ -23,7 +23,10 @@ interface HeaderDesktopNavProps {
 
 export default function HeaderDesktopNav({ items }: HeaderDesktopNavProps) {
   return (
-    <nav className="hidden xl:flex items-center gap-1 2xl:gap-2" aria-label="Main navigation">
+    <nav
+      className="flex flex-row flex-nowrap items-center justify-center gap-0.5 xl:gap-1 2xl:gap-2"
+      aria-label="Main navigation"
+    >
       {items.map((item) => (
         <div key={item.name} className="relative group">
           {item.subItems && item.subItems.length > 0 ? (
@@ -100,9 +103,9 @@ export default function HeaderDesktopNav({ items }: HeaderDesktopNavProps) {
 
                   // Multi-column horizontal layout
                   return (
-                    <div className="flex gap-5">
+                    <div className="flex gap-6 divide-x divide-slate-100">
                       {columns.map((col, ci) => (
-                        <div key={ci} className="flex flex-col min-w-[160px]">
+                        <div key={ci} className={`flex flex-col min-w-[160px] ${ci > 0 ? 'pl-6' : ''}`}>
                           {col.map((sub) =>
                             sub.isHeader ? (
                               <p key={sub.name} className="text-xs font-extrabold text-brand-red-600 uppercase tracking-wide px-1 pb-2">

--- a/components/site/HeaderDesktopNav.tsx
+++ b/components/site/HeaderDesktopNav.tsx
@@ -24,11 +24,11 @@ interface HeaderDesktopNavProps {
 export default function HeaderDesktopNav({ items }: HeaderDesktopNavProps) {
   return (
     <nav
-      className="flex flex-row flex-nowrap items-center justify-center gap-0.5 xl:gap-1 2xl:gap-2"
+      className="flex flex-row flex-nowrap items-center justify-center gap-0.5 xl:gap-1 2xl:gap-1.5 w-full min-w-0 max-w-full"
       aria-label="Main navigation"
     >
       {items.map((item) => (
-        <div key={item.name} className="relative group">
+        <div key={item.name} className="relative group shrink-0">
           {item.subItems && item.subItems.length > 0 ? (
             item.href ? (
               <Link

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -1,11 +1,11 @@
 'use client';
 
 import { useState, useEffect } from 'react';
+import { createPortal } from 'react-dom';
 import LanguageSwitcher from './LanguageSwitcher.client';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import SearchModal from './SearchModal.client';
-
 
 interface NavItem {
   id?: string;
@@ -28,191 +28,208 @@ function getProgramSlugFromHref(href: string): string | null {
 export default function HeaderMobileMenu({ items, programApplyLinks = {} }: HeaderMobileMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
   const [expandedItem, setExpandedItem] = useState<string | null>(null);
+  const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
 
-  // Close menu on any route change
+  useEffect(() => {
+    setMounted(true);
+  }, []);
+
   useEffect(() => {
     setIsOpen(false);
     setExpandedItem(null);
   }, [pathname]);
 
-  // Lock body scroll when menu is open and close on Escape
   useEffect(() => {
-    if (isOpen) {
-      document.body.style.overflow = 'hidden';
-      const handleEscape = (e: KeyboardEvent) => {
-        if (e.key === 'Escape') setIsOpen(false);
-      };
-      document.addEventListener('keydown', handleEscape);
-      return () => {
-        document.body.style.overflow = '';
-        document.removeEventListener('keydown', handleEscape);
-      };
-    } else {
+    if (!isOpen) {
       document.body.style.overflow = '';
+      return;
     }
+    document.body.style.overflow = 'hidden';
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', handleEscape);
+    return () => {
+      document.body.style.overflow = '';
+      document.removeEventListener('keydown', handleEscape);
+    };
   }, [isOpen]);
 
-  return (
-    <>
-      {/* Mobile/tablet icon row — hidden on desktop (lg+) */}
-      <div className="lg:hidden flex items-center gap-1">
-        {/* Compact CTAs visible on md screens where desktop nav isn't shown */}
-        <Link
-          href="/login"
-          prefetch={false}
-          className="hidden md:block lg:hidden text-slate-600 font-semibold text-[13px] hover:text-slate-900 px-2 py-1.5 rounded-md hover:bg-slate-50 transition-colors"
-        >
-          Sign In
-        </Link>
-        <Link
-          href="/for-students"
-          prefetch={false}
-          className="hidden md:inline-flex lg:hidden items-center bg-brand-red-600 text-white px-3 py-1.5 rounded-lg font-semibold text-[13px] hover:bg-brand-red-700 transition-colors whitespace-nowrap"
-        >
-          Get Started
-        </Link>
-        <button
-          onClick={() => setIsOpen(!isOpen)}
-          className="p-3 text-slate-700 hover:text-slate-900 min-w-[44px] min-h-[44px] flex items-center justify-center"
-          aria-label={isOpen ? 'Close menu' : 'Open menu'}
-          aria-expanded={isOpen}
-        >
-          {isOpen ? (
-            <span className="text-2xl leading-none" aria-hidden="true">
-              &times;
-            </span>
-          ) : (
-            <span className="text-2xl leading-none" aria-hidden="true">
-              &#9776;
-            </span>
-          )}
-        </button>
-      </div>
-
-      {/* Mobile Menu Overlay */}
-      {isOpen && (
-        <div
-          className="fixed inset-0 bg-black/50 z-[9998] lg:hidden"
-          onClick={() => setIsOpen(false)}
-        />
-      )}
-
-      {/* Mobile Menu Panel */}
-      <div
-        className="fixed top-[60px] right-0 bottom-0 w-[85vw] max-w-sm bg-white z-[9999] lg:hidden transform transition-transform duration-300 overflow-y-auto shadow-2xl"
-        style={{ transform: isOpen ? 'translateX(0)' : 'translateX(100%)' }}
-      >
-        <nav className="p-4" aria-label="Mobile navigation">
-          {items.map((item) => (
-            <div key={item.name} className="border-b border-slate-100">
-              {item.subItems ? (
-                <>
-                  <button
-                    onClick={() => setExpandedItem(expandedItem === item.name ? null : item.name)}
-                    className="flex items-center justify-between w-full py-3 text-slate-900 font-medium"
-                    aria-expanded={expandedItem === item.name}
-                  >
-                    {item.name}
-                    <span
-                      className={`text-sm leading-none transition-transform inline-block ${
-                        expandedItem === item.name ? 'rotate-180' : ''
-                      }`}
-                      aria-hidden="true"
-                    >
-                      &#9660;
-                    </span>
-                  </button>
-                  {expandedItem === item.name && (
-                    <div className="pb-3 pl-4">
-                      {item.subItems.map((subItem) => {
-                        if (subItem.isHeader) {
-                          return (
-                            <div
-                              key={subItem.name}
-                              className="pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-l-3 border-brand-red-500 pl-2"
-                            >
-                              {subItem.name.replace(/—/g, '').trim()}
-                            </div>
-                          );
-                        }
-
-                        if (subItem.isSectionLink) {
-                          return (
-                            <Link
-                              key={subItem.name}
-                              href={subItem.href}
-                              prefetch={false}
-                              onClick={() => setIsOpen(false)}
-                              className="block pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-t border-brand-red-100 hover:text-brand-red-700 transition-colors"
-                            >
-                              {subItem.name}
-                            </Link>
-                          );
-                        }
-
-                        const programSlug =
-                          item.id === 'programs' ? getProgramSlugFromHref(subItem.href) : null;
-                        const applyHref = programSlug ? programApplyLinks[programSlug] : undefined;
-
-                        return (
-                          <div key={subItem.name}>
-                            <Link
-                              href={subItem.href}
-                              prefetch={false}
-                              onClick={() => setIsOpen(false)}
-                              className={`block hover:text-brand-blue-600 ${
-                                subItem.nested
-                                  ? 'py-1.5 pl-4 text-xs text-slate-400 border-l border-slate-200'
-                                  : 'py-3 text-slate-600'
-                              }`}
-                            >
-                              {subItem.name}
-                            </Link>
-                            {applyHref && (
-                              <Link
-                                href={applyHref}
-                                prefetch={false}
-                                onClick={() => setIsOpen(false)}
-                                className="block py-1.5 pl-6 text-xs text-brand-blue-700 hover:text-brand-blue-800 border-l border-slate-200"
-                              >
-                                Apply to {subItem.name}
-                              </Link>
-                            )}
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </>
-              ) : item.href ? (
-                <Link
-                  href={item.href}
-                  prefetch={false}
-                  onClick={() => setIsOpen(false)}
-                  className="block py-3 text-slate-900 font-medium hover:text-brand-blue-600"
-                >
-                  {item.name}
-                </Link>
-              ) : (
-                <span className="block py-3 text-slate-900 font-medium">{item.name}</span>
-              )}
-            </div>
-          ))}
-
-          {/* Mobile CTAs */}
-          <div className="mt-6 space-y-3">
-            <Link
-              href="/start"
-              prefetch={false}
+  const drawer =
+    mounted && isOpen
+      ? createPortal(
+          <>
+            <div
+              className="fixed inset-0 bg-black/50 z-[9998] lg:hidden"
               onClick={() => setIsOpen(false)}
-              className="block w-full text-center py-3 bg-brand-red-600 text-white rounded-lg font-semibold"
+              aria-hidden="true"
+            />
+            <div
+              className="fixed top-[60px] right-0 bottom-0 w-[min(100vw,20rem)] bg-white z-[9999] lg:hidden overflow-y-auto shadow-2xl"
+              role="dialog"
+              aria-modal="true"
+              aria-label="Main menu"
             >
-              Check Eligibility
-            </Link>
-          </div>
-        </nav>
-      </div>
-    </>
+              <nav className="p-4" aria-label="Mobile navigation">
+                {items.map((item) => (
+                  <div key={item.name} className="border-b border-slate-100">
+                    {item.subItems ? (
+                      <>
+                        <button
+                          type="button"
+                          onClick={() =>
+                            setExpandedItem(expandedItem === item.name ? null : item.name)
+                          }
+                          className="flex items-center justify-between w-full py-3 text-slate-900 font-medium text-left"
+                          aria-expanded={expandedItem === item.name}
+                        >
+                          {item.name}
+                          <span
+                            className={`text-sm leading-none transition-transform inline-block ${
+                              expandedItem === item.name ? 'rotate-180' : ''
+                            }`}
+                            aria-hidden="true"
+                          >
+                            &#9660;
+                          </span>
+                        </button>
+                        {expandedItem === item.name && (
+                          <div className="pb-3 pl-4">
+                            {item.subItems.map((subItem) => {
+                              if (subItem.isHeader) {
+                                return (
+                                  <div
+                                    key={subItem.name}
+                                    className="pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-l-3 border-brand-red-500 pl-2"
+                                  >
+                                    {subItem.name.replace(/—/g, '').trim()}
+                                  </div>
+                                );
+                              }
+
+                              if (subItem.isSectionLink) {
+                                return (
+                                  <Link
+                                    key={subItem.name}
+                                    href={subItem.href}
+                                    prefetch={false}
+                                    onClick={() => setIsOpen(false)}
+                                    className="block pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-t border-brand-red-100 hover:text-brand-red-700 transition-colors"
+                                  >
+                                    {subItem.name}
+                                  </Link>
+                                );
+                              }
+
+                              const programSlug =
+                                item.id === 'programs'
+                                  ? getProgramSlugFromHref(subItem.href)
+                                  : null;
+                              const applyHref = programSlug
+                                ? programApplyLinks[programSlug]
+                                : undefined;
+
+                              return (
+                                <div key={subItem.name}>
+                                  <Link
+                                    href={subItem.href}
+                                    prefetch={false}
+                                    onClick={() => setIsOpen(false)}
+                                    className={`block hover:text-brand-blue-600 ${
+                                      subItem.nested
+                                        ? 'py-1.5 pl-4 text-xs text-slate-400 border-l border-slate-200'
+                                        : 'py-3 text-slate-600'
+                                    }`}
+                                  >
+                                    {subItem.name}
+                                  </Link>
+                                  {applyHref && (
+                                    <Link
+                                      href={applyHref}
+                                      prefetch={false}
+                                      onClick={() => setIsOpen(false)}
+                                      className="block py-1.5 pl-6 text-xs text-brand-blue-700 hover:text-brand-blue-800 border-l border-slate-200"
+                                    >
+                                      Apply to {subItem.name}
+                                    </Link>
+                                  )}
+                                </div>
+                              );
+                            })}
+                          </div>
+                        )}
+                      </>
+                    ) : item.href ? (
+                      <Link
+                        href={item.href}
+                        prefetch={false}
+                        onClick={() => setIsOpen(false)}
+                        className="block py-3 text-slate-900 font-medium hover:text-brand-blue-600"
+                      >
+                        {item.name}
+                      </Link>
+                    ) : (
+                      <span className="block py-3 text-slate-900 font-medium">{item.name}</span>
+                    )}
+                  </div>
+                ))}
+
+                <div className="mt-6 space-y-2">
+                  <Link
+                    href="/for-students"
+                    prefetch={false}
+                    onClick={() => setIsOpen(false)}
+                    className="block w-full text-center py-3 bg-brand-red-600 text-white rounded-lg font-semibold"
+                  >
+                    Get Started
+                  </Link>
+                  <Link
+                    href="/login"
+                    prefetch={false}
+                    onClick={() => setIsOpen(false)}
+                    className="block w-full text-center py-3 border border-slate-300 text-slate-800 rounded-lg font-semibold hover:bg-slate-50"
+                  >
+                    Sign In
+                  </Link>
+                  <Link
+                    href="/start"
+                    prefetch={false}
+                    onClick={() => setIsOpen(false)}
+                    className="block w-full text-center py-2.5 text-brand-blue-600 font-medium text-sm hover:underline"
+                  >
+                    Check Eligibility
+                  </Link>
+                </div>
+              </nav>
+            </div>
+          </>,
+          document.body,
+        )
+      : null;
+
+  return (
+    <div className="lg:hidden flex flex-row flex-nowrap items-center gap-0.5 sm:gap-1">
+      <SearchModal />
+      <LanguageSwitcher compact />
+      <button
+        type="button"
+        onClick={() => setIsOpen((open) => !open)}
+        className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[40px] min-w-[40px] flex items-center justify-center"
+        aria-label={isOpen ? 'Close menu' : 'Open menu'}
+        aria-expanded={isOpen}
+      >
+        {isOpen ? (
+          <span className="text-2xl leading-none" aria-hidden="true">
+            &times;
+          </span>
+        ) : (
+          <span className="text-2xl leading-none" aria-hidden="true">
+            &#9776;
+          </span>
+        )}
+      </button>
+      {drawer}
+    </div>
   );
 }

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -2,16 +2,22 @@
 
 import { useState, useEffect } from 'react';
 import { createPortal } from 'react-dom';
-import LanguageSwitcher from './LanguageSwitcher.client';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
 import SearchModal from './SearchModal.client';
+import LanguageSwitcher from './LanguageSwitcher.client';
 
 interface NavItem {
   id?: string;
   name: string;
   href?: string;
-  subItems?: { name: string; href: string; isHeader?: boolean; isSectionLink?: boolean; nested?: boolean }[];
+  subItems?: {
+    name: string;
+    href: string;
+    isHeader?: boolean;
+    isSectionLink?: boolean;
+    nested?: boolean;
+  }[];
 }
 
 interface HeaderMobileMenuProps {
@@ -27,7 +33,6 @@ function getProgramSlugFromHref(href: string): string | null {
 
 export default function HeaderMobileMenu({ items, programApplyLinks = {} }: HeaderMobileMenuProps) {
   const [isOpen, setIsOpen] = useState(false);
-  const [expandedItem, setExpandedItem] = useState<string | null>(null);
   const [mounted, setMounted] = useState(false);
   const pathname = usePathname();
 
@@ -37,7 +42,6 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
 
   useEffect(() => {
     setIsOpen(false);
-    setExpandedItem(null);
   }, [pathname]);
 
   useEffect(() => {
@@ -66,116 +70,90 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
               aria-hidden="true"
             />
             <div
-              className="fixed top-[60px] right-0 bottom-0 w-[min(100vw,20rem)] bg-white z-[9999] lg:hidden overflow-y-auto shadow-2xl"
+              className="fixed top-[60px] right-0 bottom-0 w-[min(100vw,22rem)] bg-white z-[9999] lg:hidden overflow-y-auto shadow-2xl"
               role="dialog"
               aria-modal="true"
               aria-label="Main menu"
             >
-              <nav className="p-4" aria-label="Mobile navigation">
+              <nav className="flex flex-col p-4 pb-10" aria-label="Mobile navigation">
                 {items.map((item) => (
-                  <div key={item.name} className="border-b border-slate-100">
-                    {item.subItems ? (
-                      <>
-                        <button
-                          type="button"
-                          onClick={() =>
-                            setExpandedItem(expandedItem === item.name ? null : item.name)
-                          }
-                          className="flex items-center justify-between w-full py-3 text-slate-900 font-medium text-left"
-                          aria-expanded={expandedItem === item.name}
-                        >
-                          {item.name}
-                          <span
-                            className={`text-sm leading-none transition-transform inline-block ${
-                              expandedItem === item.name ? 'rotate-180' : ''
-                            }`}
-                            aria-hidden="true"
-                          >
-                            &#9660;
-                          </span>
-                        </button>
-                        {expandedItem === item.name && (
-                          <div className="pb-3 pl-4">
-                            {item.subItems.map((subItem) => {
-                              if (subItem.isHeader) {
-                                return (
-                                  <div
-                                    key={subItem.name}
-                                    className="pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-l-3 border-brand-red-500 pl-2"
-                                  >
-                                    {subItem.name.replace(/—/g, '').trim()}
-                                  </div>
-                                );
-                              }
-
-                              if (subItem.isSectionLink) {
-                                return (
-                                  <Link
-                                    key={subItem.name}
-                                    href={subItem.href}
-                                    prefetch={false}
-                                    onClick={() => setIsOpen(false)}
-                                    className="block pt-3 pb-1 text-xs font-extrabold text-brand-red-600 uppercase tracking-wide border-t border-brand-red-100 hover:text-brand-red-700 transition-colors"
-                                  >
-                                    {subItem.name}
-                                  </Link>
-                                );
-                              }
-
-                              const programSlug =
-                                item.id === 'programs'
-                                  ? getProgramSlugFromHref(subItem.href)
-                                  : null;
-                              const applyHref = programSlug
-                                ? programApplyLinks[programSlug]
-                                : undefined;
-
-                              return (
-                                <div key={subItem.name}>
-                                  <Link
-                                    href={subItem.href}
-                                    prefetch={false}
-                                    onClick={() => setIsOpen(false)}
-                                    className={`block hover:text-brand-blue-600 ${
-                                      subItem.nested
-                                        ? 'py-1.5 pl-4 text-xs text-slate-400 border-l border-slate-200'
-                                        : 'py-3 text-slate-600'
-                                    }`}
-                                  >
-                                    {subItem.name}
-                                  </Link>
-                                  {applyHref && (
-                                    <Link
-                                      href={applyHref}
-                                      prefetch={false}
-                                      onClick={() => setIsOpen(false)}
-                                      className="block py-1.5 pl-6 text-xs text-brand-blue-700 hover:text-brand-blue-800 border-l border-slate-200"
-                                    >
-                                      Apply to {subItem.name}
-                                    </Link>
-                                  )}
-                                </div>
-                              );
-                            })}
-                          </div>
-                        )}
-                      </>
-                    ) : item.href ? (
+                  <section key={item.name} className="border-b border-slate-100 last:border-0">
+                    {item.href ? (
                       <Link
                         href={item.href}
                         prefetch={false}
                         onClick={() => setIsOpen(false)}
-                        className="block py-3 text-slate-900 font-medium hover:text-brand-blue-600"
+                        className="block py-3 text-base font-semibold text-slate-900 hover:text-brand-blue-600"
                       >
                         {item.name}
                       </Link>
                     ) : (
-                      <span className="block py-3 text-slate-900 font-medium">{item.name}</span>
+                      <p className="py-3 text-base font-semibold text-slate-900">{item.name}</p>
                     )}
-                  </div>
+
+                    {item.subItems && item.subItems.length > 0 ? (
+                      <div className="flex flex-col pb-4 pl-1">
+                        {item.subItems.map((subItem) => {
+                          if (subItem.isHeader) {
+                            return (
+                              <p
+                                key={subItem.name}
+                                className="pt-3 pb-1 text-xs font-extrabold uppercase tracking-wide text-brand-red-600"
+                              >
+                                {subItem.name.replace(/—/g, '').trim()}
+                              </p>
+                            );
+                          }
+
+                          if (subItem.isSectionLink) {
+                            return (
+                              <Link
+                                key={`${subItem.name}-${subItem.href}`}
+                                href={subItem.href}
+                                prefetch={false}
+                                onClick={() => setIsOpen(false)}
+                                className="block py-2 text-sm font-semibold text-brand-red-600 hover:text-brand-red-700"
+                              >
+                                {subItem.name}
+                              </Link>
+                            );
+                          }
+
+                          const programSlug =
+                            item.id === 'programs' ? getProgramSlugFromHref(subItem.href) : null;
+                          const applyHref = programSlug ? programApplyLinks[programSlug] : undefined;
+
+                          return (
+                            <div key={`${subItem.name}-${subItem.href}`}>
+                              <Link
+                                href={subItem.href}
+                                prefetch={false}
+                                onClick={() => setIsOpen(false)}
+                                className={`block py-2.5 text-sm text-slate-700 hover:text-brand-blue-600 ${
+                                  subItem.nested ? 'pl-4 text-slate-500' : ''
+                                }`}
+                              >
+                                {subItem.name}
+                              </Link>
+                              {applyHref ? (
+                                <Link
+                                  href={applyHref}
+                                  prefetch={false}
+                                  onClick={() => setIsOpen(false)}
+                                  className="block py-1.5 pl-4 text-xs text-brand-blue-700 hover:underline"
+                                >
+                                  Apply to {subItem.name}
+                                </Link>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    ) : null}
+                  </section>
                 ))}
 
-                <div className="mt-6 space-y-2">
+                <div className="mt-6 flex flex-col gap-2">
                   <Link
                     href="/for-students"
                     prefetch={false}
@@ -193,12 +171,12 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
                     Sign In
                   </Link>
                   <Link
-                    href="/start"
+                    href="/apply"
                     prefetch={false}
                     onClick={() => setIsOpen(false)}
                     className="block w-full text-center py-2.5 text-brand-blue-600 font-medium text-sm hover:underline"
                   >
-                    Check Eligibility
+                    Check eligibility
                   </Link>
                 </div>
               </nav>
@@ -209,7 +187,7 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
       : null;
 
   return (
-    <div className="lg:hidden flex flex-row flex-nowrap items-center gap-0.5 sm:gap-1">
+    <div className="lg:hidden flex flex-row flex-nowrap items-center justify-end gap-0.5 shrink-0">
       <SearchModal />
       <LanguageSwitcher compact />
       <button

--- a/components/site/LanguageSwitcher.client.tsx
+++ b/components/site/LanguageSwitcher.client.tsx
@@ -11,7 +11,7 @@ function getCurrentLocale(): Locale {
   return val && locales.includes(val) ? val : defaultLocale;
 }
 
-export default function LanguageSwitcher({ compact = false }: { compact?: boolean }) {
+export default function LanguageSwitcher() {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState<Locale>(defaultLocale);
   const ref = useRef<HTMLDivElement>(null);
@@ -60,7 +60,9 @@ export default function LanguageSwitcher({ compact = false }: { compact?: boolea
         aria-label={`Language: ${localeNames[current]}. Change language.`}
         aria-expanded={open}
         aria-haspopup="listbox"
-        className="flex items-center gap-1.5 text-slate-500 hover:text-slate-900 transition-colors px-2 py-1.5 rounded-lg hover:bg-slate-100 text-sm"
+        className={`flex items-center text-slate-500 hover:text-slate-900 transition-colors rounded-lg hover:bg-slate-100 ${
+          compact ? 'gap-1 px-1.5 py-1 text-xs' : 'gap-1.5 px-2 py-1.5 text-sm'
+        }`}
       >
         {/* Globe icon */}
         <svg

--- a/components/site/LanguageSwitcher.client.tsx
+++ b/components/site/LanguageSwitcher.client.tsx
@@ -11,7 +11,7 @@ function getCurrentLocale(): Locale {
   return val && locales.includes(val) ? val : defaultLocale;
 }
 
-export default function LanguageSwitcher() {
+export default function LanguageSwitcher({ compact = false }: { compact?: boolean }) {
   const [open, setOpen] = useState(false);
   const [current, setCurrent] = useState<Locale>(defaultLocale);
   const ref = useRef<HTMLDivElement>(null);

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -10,10 +10,15 @@ interface HomeHeroVideoProps {
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   return (
     <>
+      <link
+        rel="preload"
+        as="video"
+        href={banner.videoSrcDesktop}
+        type="video/mp4"
+      />
       <HeroVideo
         videoSrcDesktop={banner.videoSrcDesktop!}
         videoSrcMobile={banner.videoSrcMobile}
-        posterImage={banner.posterImage}
         voiceoverSrc={banner.voiceoverSrc}
         microLabel={banner.microLabel}
         belowHeroHeadline={banner.belowHeroHeadline}

--- a/lib/admin/nav-config.ts
+++ b/lib/admin/nav-config.ts
@@ -25,9 +25,13 @@ export interface NavSection {
 export const DEFAULT_NAV: NavSection[] = [
   {
     label: 'Operations',
-    href: '/admin/dashboard',
+    href: '/admin/operations',
     items: [
+      { label: 'Operations Hub', href: '/admin/operations' },
       { label: 'Dashboard', href: '/admin/dashboard' },
+      { label: 'Mission Control', href: '/admin/mission-control' },
+      { label: 'System Health', href: '/admin/system-health' },
+      { label: 'Monitoring', href: '/admin/monitoring' },
       { label: 'At-Risk Learners', href: '/admin/at-risk' },
       { label: 'Analytics', href: '/admin/analytics' },
       { label: 'Analytics — Engagement', href: '/admin/analytics/engagement' },
@@ -49,11 +53,16 @@ export const DEFAULT_NAV: NavSection[] = [
     items: [
       { label: 'Risk Dashboard', href: '/admin/intelligence' },
       { label: 'Completion Forecast', href: '/admin/intelligence/forecast' },
-      { label: 'Lizzy', href: '/admin/dashboard' },
-      { label: 'Workflows', href: '/admin/workflows' },
-      { label: 'Workflows', href: '/admin/workflows' },
-      { label: 'System Health', href: '/admin/system-health' },
       { label: 'Snapshots', href: '/admin/snapshots' },
+    ],
+  },
+  {
+    label: 'Automation',
+    href: '/admin/workflows',
+    items: [
+      { label: 'Workflows', href: '/admin/workflows' },
+      { label: 'Automation Log', href: '/admin/automation' },
+      { label: 'Dev Studio', href: '/admin/dev-studio' },
     ],
   },
   {
@@ -231,6 +240,7 @@ export const DEFAULT_NAV: NavSection[] = [
       { label: 'System Jobs', href: '/admin/system/jobs' },
       { label: 'System Webhooks', href: '/admin/system/webhooks' },
       { label: 'Files', href: '/admin/files' },
+      { label: 'Dev Studio', href: '/admin/dev-studio' },
       { label: 'Navigation Settings', href: '/admin/settings/nav' },
       { label: 'Impersonate', href: '/admin/impersonate' },
     ],

--- a/lib/program-holder-access.ts
+++ b/lib/program-holder-access.ts
@@ -65,33 +65,31 @@ export async function getProgramHolderPrograms(holderId: string) {
 export async function canAccessStudent(holderId: string, studentId: string): Promise<boolean> {
   const supabase = await createClient();
 
-  const { data, error } = await supabase
-    .from('program_enrollments')
-    .select(
-      `
-      id,
-      course_id,
-      courses!inner(id, category, slug)
-    `,
-    )
+  const { data: roster } = await supabase
+    .from('program_holder_students')
+    .select('id')
+    .eq('program_holder_id', holderId)
     .eq('user_id', studentId)
     .maybeSingle();
 
-  if (error || !data) {
-    return false;
-  }
+  if (roster) return true;
 
   const { data: programs } = await supabase
     .from('program_holder_programs')
-    .select('program_slug')
-    .eq('program_holder_id', holderId);
+    .select('program_id')
+    .eq('program_holder_id', holderId)
+    .eq('status', 'active');
 
-  if (!programs || programs.length === 0) {
-    return false;
-  }
+  const programIds = (programs ?? []).map((p) => p.program_id).filter(Boolean);
+  if (!programIds.length) return false;
 
-  const course = data.courses as any;
-  return programs.some(
-    (p) => course.category === p.program_slug || course.slug.startsWith(p.program_slug),
-  );
+  const { data: enrollment } = await supabase
+    .from('program_enrollments')
+    .select('id')
+    .eq('user_id', studentId)
+    .in('program_id', programIds)
+    .limit(1)
+    .maybeSingle();
+
+  return Boolean(enrollment);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Cleans up the admin dashboard and operations experience so ops tooling is not duplicated across category cards, nav, and Dev Studio.

## Admin dashboard

- **Operations** card now opens `/admin/operations` with links to Dashboard, Mission Control, and System Health (removed duplicate Ellie / Workflows pills from other cards).
- **Intelligence** card is risk + forecast only.
- **Dev Studio** card is Open studio + Workflows only (container + ECS merged in studio).

## Operations Hub (`/admin/operations`)

- Light admin UI with breadcrumbs and quick links to Mission Control, System Health, Workflows, Automation, Monitoring.
- Live counts from Supabase: `cron_job_runs`, `workflow_runs`, `workflow_dead_letters`, `workflow_step_logs`, `admin_alerts`.
- Surfaces query failures when tables/migrations are missing (no fake placeholder stats).

## Other

- Grant revenue page uses real `grant_applications` aggregates (removed hardcoded `$2.4M` / `$1.8M` / `$600K`).
- Dev Studio: ECS **Services** panel merged under **Container** tab; `?tab=services` redirects there.
- Bottom pane Ops AI uses canonical `AIChat` with `ellieMode` (fixes broken `AiConsoleClient` import).
- Default nav: Operations hub + Automation section; Intelligence no longer lists Ellie/workflows/health.
- Program holder shell, hours, student detail, and students API updates included from prior work on this branch.

## Verify

- `/admin/dashboard` — category cards (no Ellie — AI Ops pills on dashboard grid)
- `/admin/operations` — real DB metrics or clear migration warning
- `/admin/dev-studio` → Container tab shows devcontainer + ECS services
- `/admin/grants/revenue` — amounts from DB
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

