### PR TITLE
Hotfix: mobile site unreachable (stop apex → www redirect)

### DIFF
--- a/lib/config/platform-config.ts
+++ b/lib/config/platform-config.ts
@@ -29,7 +29,7 @@ export const PLATFORM_DEFAULTS = {
     process.env.NEXT_PUBLIC_ORG_LEGAL_NAME ??
     'Elevate for Humanity Career & Technical Institute',
   siteUrl:
-    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.elevateforhumanity.org',
+    process.env.NEXT_PUBLIC_SITE_URL ?? 'https://elevateforhumanity.org',
   supportEmail:
     process.env.NEXT_PUBLIC_SUPPORT_EMAIL ?? 'support@elevateforhumanity.org',
   supportPhone:
@@ -41,7 +41,7 @@ export const PLATFORM_DEFAULTS = {
   certificateHolder:
     process.env.NEXT_PUBLIC_CERT_HOLDER ?? 'Elevate for Humanity',
   canonicalDomain:
-    process.env.NEXT_PUBLIC_CANONICAL_DOMAIN ?? 'www.elevateforhumanity.org',
+    process.env.NEXT_PUBLIC_CANONICAL_DOMAIN ?? 'elevateforhumanity.org',
 } as const;
 
 export type PlatformConfig = typeof PLATFORM_DEFAULTS;

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -355,6 +355,19 @@ const nextConfig = {
     }));
 
     return [
+      // www has no Durable DNS — send to apex so mobile does not hit "can't be reached"
+      {
+        source: '/',
+        has: [{ type: 'host', value: 'www.elevateforhumanity.org' }],
+        destination: 'https://elevateforhumanity.org/',
+        permanent: true,
+      },
+      {
+        source: '/:path+',
+        has: [{ type: 'host', value: 'www.elevateforhumanity.org' }],
+        destination: 'https://elevateforhumanity.org/:path+',
+        permanent: true,
+      },
       // NOTE: /sign-in and /signin redirects are handled in proxy.ts (middleware)
       // so they work on the live dev-build server. No next.config.mjs entries needed.
       // ============================================

--- a/proxy.ts
+++ b/proxy.ts
@@ -395,7 +395,7 @@ export async function middleware(request: NextRequest) {
 
     const origin = request.headers.get('origin');
     const allowedOrigins = [
-      process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org',
+      process.env.NEXT_PUBLIC_SITE_URL || 'https://elevateforhumanity.org',
       'https://elevateforhumanity.org',
       'https://www.elevateforhumanity.org',
       // Allow local dev requests (Postman, dev proxy, etc.)
@@ -543,20 +543,16 @@ export async function middleware(request: NextRequest) {
 
   // All routes are served by the same AWS ECS container — no proxy needed.
 
-  // Redirect non-www .org to www .org
-  if (hostWithoutPort === 'elevateforhumanity.org') {
+  // Canonical public site is apex (mobile/desktop must not redirect to www — www has no DNS).
+  if (hostWithoutPort === 'www.elevateforhumanity.org') {
     const url = request.nextUrl.clone();
-    url.host = 'www.elevateforhumanity.org';
+    url.host = 'elevateforhumanity.org';
     url.protocol = 'https';
     url.port = '';
     return NextResponse.redirect(url, { status: 308 });
   }
 
-  // Unknown-host fallback. The LMS ALB only serves www.elevateforhumanity.org.
-  // Any other Host header that reaches this build (stale apex A records that
-  // still resolve to LMS ALB IPs, raw *.elb.amazonaws.com requests, the legacy
-  // app.elevateforhumanity.org subdomain, etc.) is force-redirected to www so
-  // traffic never gets served under the wrong host.
+  // Unknown-host fallback → apex (not www).
   // app.elevateforhumanity.org — tenant portal entry point (query-param form).
   // e.g. app.elevateforhumanity.org/admin?org=elizabeth-greene
   if (hostWithoutPort === 'app.elevateforhumanity.org') {
@@ -599,7 +595,7 @@ export async function middleware(request: NextRequest) {
   }
 
   const isCanonicalHost =
-    hostWithoutPort === 'www.elevateforhumanity.org' ||
+    hostWithoutPort === 'elevateforhumanity.org' ||
     hostWithoutPort === canonicalAdminHost ||
     hostWithoutPort === 'app.elevateforhumanity.org' ||
     hostWithoutPort.endsWith('.app.elevateforhumanity.org');
@@ -610,7 +606,7 @@ export async function middleware(request: NextRequest) {
     !isGitpodPreview
   ) {
     const url = request.nextUrl.clone();
-    url.host = 'www.elevateforhumanity.org';
+    url.host = 'elevateforhumanity.org';
     url.protocol = 'https';
     url.port = '';
     return NextResponse.redirect(url, { status: 308 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Mobile shows logo briefly then **"can't be reached"**. Desktop often still works.

**Cause:** Production on `main` **308-redirects `elevateforhumanity.org` → `www.elevateforhumanity.org`**, but **www has no DNS record** in Durable (only apex A → Northflank). Mobile carriers do a fresh DNS lookup for www and fail.

## Fix

- Redirect **www → apex** (not the reverse)
- `next.config.mjs` host-based redirects as backup
- Platform default URLs use apex

## Ops after merge

Redeploy **elevate-lms** on Northflank (build from `main`).

**Optional Durable (instant relief before deploy):** add **A** record **www** → `20.232.216.67` (same as apex) so old redirects still resolve.

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

