### PR TITLE
fix(prod): Northflank crashes — compact header + Supabase URL ENOTFOUND

### DIFF
--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -43,7 +43,7 @@ export default function Header() {
         <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 sm:gap-1 flex-shrink-0 min-w-0">
           <div className="hidden lg:flex flex-row flex-nowrap items-center gap-1.5">
             <SearchModal />
-            <LanguageSwitcher compact />
+            <LanguageSwitcher compact={true} />
             <Link
               href="/login"
               prefetch={false}

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -189,7 +189,7 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
   return (
     <div className="lg:hidden flex flex-row flex-nowrap items-center justify-end gap-0.5 shrink-0">
       <SearchModal />
-      <LanguageSwitcher compact />
+      <LanguageSwitcher compact={true} />
       <button
         type="button"
         onClick={() => setIsOpen((open) => !open)}

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -2,6 +2,8 @@ export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
     // Load runtime secrets from Supabase into process.env.
     // Vars are injected from SSM via ECS task definition at container start.
+    const { applyNormalizedSupabaseUrlToEnv } = await import('./lib/supabase/normalize-url');
+    applyNormalizedSupabaseUrlToEnv();
     const { hydrateProcessEnv } = await import('./lib/secrets');
     await hydrateProcessEnv();
 

--- a/lib/secrets.ts
+++ b/lib/secrets.ts
@@ -38,6 +38,10 @@ import { logger } from '@/lib/logger';
 // Direct SDK import intentional: this module IS the hydration bootstrap.
 // All other files must use @/lib/supabase/* instead.
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import {
+  applyNormalizedSupabaseUrlToEnv,
+  normalizeSupabaseProjectUrl,
+} from '@/lib/supabase/normalize-url';
 
 let cache: Record<string, string> | null = null;
 let cacheTimestamp = 0;
@@ -49,7 +53,9 @@ const CACHE_TTL_MS = 5 * 60 * 1000; // 5 min — in-process cache for ECS long-r
 const SECRETS_FETCH_TIMEOUT_MS = 3000;
 
 function getBootstrapClient(): SupabaseClient | null {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+  const url = normalizeSupabaseProjectUrl(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) return null;
   return createClient(url, key, {
@@ -132,6 +138,8 @@ async function loadSecrets(): Promise<Record<string, string>> {
 export async function hydrateProcessEnv(): Promise<void> {
   if (hydrated && Date.now() - cacheTimestamp < CACHE_TTL_MS) return;
 
+  applyNormalizedSupabaseUrlToEnv();
+
   const secrets = await loadSecrets();
   for (const [key, value] of Object.entries(secrets)) {
     // Only write to process.env when the DB value is non-empty.
@@ -140,9 +148,13 @@ export async function hydrateProcessEnv(): Promise<void> {
     // This was the root cause of chat/git/shell failures: a blank row saved via
     // the admin Secrets UI would silently shadow the correct SSM value.
     if (value && value.trim().length > 0) {
-      process.env[key] = value;
+      process.env[key] =
+        key === 'NEXT_PUBLIC_SUPABASE_URL' || key === 'SUPABASE_URL'
+          ? normalizeSupabaseProjectUrl(value) ?? value
+          : value;
     }
   }
+  applyNormalizedSupabaseUrlToEnv();
   hydrated = true;
 }
 

--- a/lib/supabase/admin.ts
+++ b/lib/supabase/admin.ts
@@ -1,6 +1,7 @@
 import { timedFetch } from '@/lib/supabase/timed-fetch';
 import { logger } from '@/lib/logger';
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { normalizeSupabaseProjectUrl } from '@/lib/supabase/normalize-url';
 
 /**
  * @deprecated Use `getAdminClient()` instead in all request-time code
@@ -41,7 +42,7 @@ export function createAdminClient(): SupabaseClient<any> {
   }
   // ────────────────────────────────────────────────────────────────────────
 
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const url = normalizeSupabaseProjectUrl(process.env.NEXT_PUBLIC_SUPABASE_URL);
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
   if (!url) {

--- a/lib/supabase/db-probe.ts
+++ b/lib/supabase/db-probe.ts
@@ -4,13 +4,17 @@
  * falsely fail ECS readiness while the database is actually reachable.
  */
 
+import { normalizeSupabaseProjectUrl } from '@/lib/supabase/normalize-url';
+
 const PROBE_TIMEOUT_MS = 5_000;
 
 export async function probeSupabaseDatabase(): Promise<{
   ok: boolean;
   error?: string;
 }> {
-  const url = process.env.NEXT_PUBLIC_SUPABASE_URL?.trim();
+  const url = normalizeSupabaseProjectUrl(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY?.trim();
 
   if (!url || !key) {

--- a/lib/supabase/normalize-url.ts
+++ b/lib/supabase/normalize-url.ts
@@ -1,0 +1,51 @@
+/**
+ * Normalize Supabase project URLs from env / platform_secrets.
+ *
+ * Common misconfig (Northflank / copy-paste): `db.<ref>.supabase.co` — that host
+ * does not resolve (ENOTFOUND). Canonical API URL is `https://<ref>.supabase.co`.
+ */
+export function normalizeSupabaseProjectUrl(
+  url: string | undefined | null,
+): string | undefined {
+  if (!url?.trim()) return undefined;
+
+  let normalized = url.trim();
+
+  // Strip mistaken db. API hostname prefix
+  if (/^db\.[a-z0-9-]+\.supabase\.co\/?$/i.test(normalized)) {
+    normalized = normalized.replace(/^db\./i, '');
+  }
+
+  if (!/^https?:\/\//i.test(normalized)) {
+    normalized = `https://${normalized.replace(/^\/+/, '')}`;
+  }
+
+  try {
+    const parsed = new URL(normalized);
+    if (!parsed.hostname.endsWith('.supabase.co')) {
+      return normalized;
+    }
+    // Force https for Supabase REST
+    parsed.protocol = 'https:';
+    parsed.pathname = '';
+    parsed.search = '';
+    parsed.hash = '';
+    return parsed.origin;
+  } catch {
+    return undefined;
+  }
+}
+
+/** Apply normalized URL to process.env keys used by the app. */
+export function applyNormalizedSupabaseUrlToEnv(): void {
+  for (const key of [
+    'NEXT_PUBLIC_SUPABASE_URL',
+    'SUPABASE_URL',
+  ] as const) {
+    const current = process.env[key];
+    const fixed = normalizeSupabaseProjectUrl(current);
+    if (fixed && fixed !== current) {
+      process.env[key] = fixed;
+    }
+  }
+}

--- a/lib/supabase/public-config.ts
+++ b/lib/supabase/public-config.ts
@@ -1,3 +1,5 @@
+import { normalizeSupabaseProjectUrl } from '@/lib/supabase/normalize-url';
+
 /**
  * Public Supabase URL + anon key (safe to expose to the browser).
  *
@@ -28,9 +30,9 @@ export function isPlaceholderSupabaseConfig(
 
 /** Read from process.env (build-time inline and/or Node runtime on ECS). */
 export function getServerPublicSupabaseConfig(): SupabasePublicConfig | null {
-  const url =
-    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() ||
-    process.env.SUPABASE_URL?.trim();
+  const url = normalizeSupabaseProjectUrl(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
   const anonKey =
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
     process.env.SUPABASE_ANON_KEY?.trim();
@@ -51,9 +53,9 @@ export function getBrowserPublicSupabaseConfig(): SupabasePublicConfig | null {
     }
   }
 
-  const url =
-    process.env.NEXT_PUBLIC_SUPABASE_URL?.trim() ||
-    process.env.SUPABASE_URL?.trim();
+  const url = normalizeSupabaseProjectUrl(
+    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+  );
   const anonKey =
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
     process.env.SUPABASE_ANON_KEY?.trim();

--- a/tests/unit/supabase-normalize-url.test.ts
+++ b/tests/unit/supabase-normalize-url.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, it } from 'vitest';
+import {
+  applyNormalizedSupabaseUrlToEnv,
+  normalizeSupabaseProjectUrl,
+} from '@/lib/supabase/normalize-url';
+
+describe('normalizeSupabaseProjectUrl', () => {
+  it('fixes db. hostname misconfig', () => {
+    expect(
+      normalizeSupabaseProjectUrl('db.cuxzzpsyufcewtmicszk.supabase.co'),
+    ).toBe('https://cuxzzpsyufcewtmicszk.supabase.co');
+  });
+
+  it('adds https when missing', () => {
+    expect(normalizeSupabaseProjectUrl('cuxzzpsyufcewtmicszk.supabase.co')).toBe(
+      'https://cuxzzpsyufcewtmicszk.supabase.co',
+    );
+  });
+
+  it('preserves valid https URL', () => {
+    expect(
+      normalizeSupabaseProjectUrl('https://cuxzzpsyufcewtmicszk.supabase.co'),
+    ).toBe('https://cuxzzpsyufcewtmicszk.supabase.co');
+  });
+});
+
+describe('applyNormalizedSupabaseUrlToEnv', () => {
+  it('rewrites NEXT_PUBLIC_SUPABASE_URL in process.env', () => {
+    const prev = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'db.cuxzzpsyufcewtmicszk.supabase.co';
+    applyNormalizedSupabaseUrlToEnv();
+    expect(process.env.NEXT_PUBLIC_SUPABASE_URL).toBe(
+      'https://cuxzzpsyufcewtmicszk.supabase.co',
+    );
+    process.env.NEXT_PUBLIC_SUPABASE_URL = prev;
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root causes (from Northflank logs on `34e715b`)

1. **`ReferenceError: compact is not defined`** — `LanguageSwitcher.client.tsx` used `compact` in JSX classes but the deployed build predates commit `4f9a563`. Header passes `compact`; main already has the prop — **redeploy latest `main` required**.

2. **`ENOTFOUND db.cuxzzpsyufcewtmicszk.supabase.co`** — env uses invalid `db.<project>.supabase.co` host. Canonical URL is `https://cuxzzpsyufcewtmicszk.supabase.co`.

3. **Cascade** — failed Supabase fetch → circuit breaker → program pages / health checks fail.

## Code fixes in this PR

- `lib/supabase/normalize-url.ts` — rewrite `db.*.supabase.co` → `https://*.supabase.co` at boot (instrumentation, secrets hydration, admin/public clients, db-probe)
- Explicit `compact={true}` on header LanguageSwitcher
- Unit tests

## Northflank action required

Update service env (if set wrong):

```
NEXT_PUBLIC_SUPABASE_URL=https://cuxzzpsyufcewtmicszk.supabase.co
```

**Not** `db.cuxzzpsyufcewtmicszk.supabase.co`

Redeploy from **`main`** after merge (commit after #215), not `34e715b`.

## Other log lines (non-blocking)

- `next start` vs standalone — ensure start command is `node server.js` in standalone image (ECS/Northflank)
- `orientation-page-2.jpg` — repo uses `.webp`; stale asset reference may clear on redeploy
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

