### PR TITLE
fix(ui): Tighter desktop heroes and homepage card images

### DIFF
--- a/components/ProgramHeroBanner.tsx
+++ b/components/ProgramHeroBanner.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import CanonicalVideo from '@/components/video/CanonicalVideo';
+import { hero } from '@/lib/page-design-tokens';
 interface ProgramHeroBannerProps {
   videoSrc: string;
   /** @deprecated Posters are not used — video-only hero frame. */
@@ -14,10 +15,7 @@ export default function ProgramHeroBanner({
   videoSrc,
 }: ProgramHeroBannerProps) {
   return (
-    <div
-      className="relative w-full overflow-hidden bg-slate-900"
-      style={{ height: 'clamp(320px, 45vw, 560px)' }}
-    >
+    <div className={`relative w-full overflow-hidden bg-slate-900 ${hero.imageWrap}`}>
       <CanonicalVideo
         src={videoSrc}
         className="absolute inset-0 w-full h-full object-cover"

--- a/components/home/HomeApprenticeshipInfra.tsx
+++ b/components/home/HomeApprenticeshipInfra.tsx
@@ -32,7 +32,7 @@ const LEARNER_CAPABILITIES = [
 export function HomeApprenticeshipInfra() {
   return (
     <section
-      className="bg-slate-50 py-16 px-4 border-t border-slate-100"
+      className="bg-slate-50 py-12 sm:py-14 lg:py-12 px-4 border-t border-slate-100"
       aria-labelledby="apprenticeship-heading"
     >
       <div className="max-w-6xl mx-auto">
@@ -58,7 +58,7 @@ export function HomeApprenticeshipInfra() {
         <div className="grid md:grid-cols-2 gap-6 mb-12">
           {/* Learner side */}
           <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden">
-            <div className="relative h-48 w-full">
+            <div className="relative h-40 lg:h-44 w-full">
               <Image
                 src="/images/learners/coaching-session.webp"
                 alt="Learner in apprenticeship training session"
@@ -93,7 +93,7 @@ export function HomeApprenticeshipInfra() {
 
           {/* Employer side */}
           <div className="bg-white rounded-2xl border border-slate-200 overflow-hidden">
-            <div className="relative h-48 w-full">
+            <div className="relative h-40 lg:h-44 w-full">
               <Image
                 src="/images/pages/about-employer-partners.webp"
                 alt="Employer partner working with Elevate team"

--- a/components/home/HomeCareerPathways.tsx
+++ b/components/home/HomeCareerPathways.tsx
@@ -11,6 +11,7 @@ import Image from 'next/image';
 import { ArrowRight } from 'lucide-react';
 import { ALL_PROGRAMS } from '@/data/programs/catalog';
 import type { ProgramSchema } from '@/lib/programs/program-schema';
+import { card, layout } from '@/lib/page-design-tokens';
 
 // Featured programs shown on homepage - ordered by demand/visibility
 const FEATURED_SLUGS = [
@@ -52,7 +53,7 @@ function PathwayCard({ prog }: { prog: ProgramSchema }) {
   return (
     <article className="group flex flex-col rounded-2xl overflow-hidden bg-white border border-slate-200 hover:border-brand-red-300 hover:shadow-lg transition-all hover:-translate-y-0.5">
       {/* Image */}
-      <div className="relative w-full aspect-[16/9] overflow-hidden bg-slate-100">
+      <div className={card.image16x9Desktop}>
         <Image
           src={prog.heroImage}
           alt={prog.heroImageAlt || prog.title}
@@ -138,7 +139,7 @@ export function HomeCareerPathways() {
 
   return (
     <section
-      className="bg-white py-16 px-4"
+      className={`bg-white ${layout.sectionTight} px-4`}
       aria-labelledby="career-pathways-heading"
     >
       <div className="max-w-6xl mx-auto">

--- a/components/home/HomeFunding.tsx
+++ b/components/home/HomeFunding.tsx
@@ -119,7 +119,7 @@ export function HomeFunding() {
           </div>
 
           {/* Right: image */}
-          <div className="relative h-56 lg:h-64 rounded-2xl overflow-hidden">
+          <div className="relative h-48 lg:h-52 rounded-2xl overflow-hidden">
             <Image
               src="/images/pages/funding-impact-1.webp"
               alt="Funding advisor helping a student navigate WIOA eligibility"

--- a/components/home/HomeHowItWorks.tsx
+++ b/components/home/HomeHowItWorks.tsx
@@ -9,6 +9,7 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { ArrowRight } from 'lucide-react';
+import { card, layout } from '@/lib/page-design-tokens';
 
 const STEPS = [
   {
@@ -70,7 +71,7 @@ const STEPS = [
 export function HomeHowItWorks() {
   return (
     <section
-      className="bg-slate-950 py-16 px-4"
+      className={`bg-slate-950 ${layout.sectionTight} px-4`}
       aria-labelledby="how-it-works-heading"
     >
       <div className="max-w-6xl mx-auto">
@@ -91,7 +92,7 @@ export function HomeHowItWorks() {
         </div>
 
         {/* Step grid — 1 col mobile, 2 col sm, 3 col md, 6 col lg */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-6 gap-3 mb-10">
+        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-6 gap-3 mb-10">
           {STEPS.map((step, i) => (
             <Link
               key={step.n}
@@ -99,7 +100,7 @@ export function HomeHowItWorks() {
               className={`group relative flex flex-col rounded-2xl overflow-hidden bg-slate-900 border-t-4 ${step.accent} hover:ring-1 hover:ring-slate-600 transition-all hover:-translate-y-0.5`}
             >
               {/* Photo */}
-              <div className="relative w-full aspect-[16/9] sm:aspect-[3/2] overflow-hidden">
+              <div className={`${card.image16x9Desktop} sm:aspect-[3/2] lg:h-32`}>
                 <Image
                   src={step.img}
                   alt={step.imgAlt}

--- a/components/home/HomeSegmentedCTA.tsx
+++ b/components/home/HomeSegmentedCTA.tsx
@@ -101,7 +101,7 @@ export function HomeSegmentedCTA() {
               className={`group flex flex-col rounded-2xl border bg-white overflow-hidden transition-all hover:shadow-lg hover:-translate-y-0.5 ${seg.accent}`}
             >
               {/* Photo */}
-              <div className="relative w-full aspect-[16/10] max-h-52 overflow-hidden bg-slate-100">
+              <div className="relative w-full aspect-[16/10] max-h-44 lg:max-h-40 overflow-hidden bg-slate-100">
                 <Image
                   src={seg.img}
                   alt={seg.alt}

--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -275,14 +275,14 @@ export default function HeroVideo({
       {/* BELOW-HERO CONTENT */}
       {/* All primary messaging lives here — never on the video */}
       {(belowHeroHeadline || belowHeroSubheadline || ctas || trustIndicators || children) && (
-        <section className="border-b border-slate-100 py-8 sm:py-14">
+        <section className={heroTokens.belowPanel}>
           <div className="max-w-4xl mx-auto px-4 sm:px-6">
             {children ? (
               children
             ) : (
               <>
                 {belowHeroHeadline && (
-                  <h1 className="text-2xl sm:text-4xl lg:text-5xl font-extrabold text-slate-900 leading-tight mb-3 sm:mb-4">
+                  <h1 className={heroTokens.belowHeadline}>
                     {belowHeroHeadline}
                   </h1>
                 )}

--- a/docs/page-design-standard.md
+++ b/docs/page-design-standard.md
@@ -52,7 +52,7 @@ Pages that omit sections 3–8 are considered incomplete and must be expanded.
 
 ## 3. Hero Rules
 
-- Hero height: `h-[38vh] min-h-[220px] max-h-[420px]` (see `hero.imageWrap` in `lib/page-design-tokens.ts`)
+- Hero height: use `hero.imageWrap` from `lib/page-design-tokens.ts` (do not use `45vw` / `560px` clamps)
 - No gradient overlay on the hero image or video
 - No text, badges, or CTAs rendered on top of the hero media
 - All identity content goes in the white panel **below** the hero
@@ -61,7 +61,7 @@ Pages that omit sections 3–8 are considered incomplete and must be expanded.
 **Correct:**
 
 ```tsx
-<section className="relative h-[45vh] min-h-[280px] max-h-[560px] w-full overflow-hidden">
+<section className={hero.imageWrap}>
   <Image src="..." alt="..." fill className="object-cover" priority />
 </section>
 <section className="bg-white border-b border-slate-100 py-10 px-4">

--- a/lib/page-design-tokens.ts
+++ b/lib/page-design-tokens.ts
@@ -57,7 +57,13 @@ export const hero = {
    * No gradient overlay. No text on top of image.
    * Content goes in a white panel BELOW the image.
    */
-  imageWrap: 'relative h-[32vh] min-h-[200px] max-h-[360px] w-full overflow-hidden',
+  /** Video/image band — capped lower on large screens so copy appears above the fold */
+  imageWrap:
+    'relative h-[30vh] min-h-[180px] max-h-[300px] sm:max-h-[320px] lg:max-h-[280px] w-full overflow-hidden',
+  /** Below-hero white panel (headline, CTAs) */
+  belowPanel: 'border-b border-slate-100 py-8 sm:py-10 lg:py-8',
+  belowHeadline:
+    'text-2xl sm:text-3xl lg:text-4xl font-extrabold text-slate-900 leading-tight mb-3 sm:mb-4',
   /** Responsive sizes for next/image fill heroes — caps decoded width for LCP */
   imageSizes: '(max-width: 768px) 100vw, (max-width: 1200px) 720px, 960px',
   /** Content panel that sits below the hero image — white background */
@@ -71,6 +77,9 @@ export const card = {
   base: 'bg-white border border-slate-200 rounded-2xl overflow-hidden hover:shadow-md hover:-translate-y-0.5 transition-all',
   /** Card image container — 16:9 */
   image16x9: 'relative aspect-[16/9] overflow-hidden',
+  /** Homepage / pathway cards — shorter image band on desktop */
+  image16x9Desktop:
+    'relative aspect-[16/9] lg:aspect-auto lg:h-36 overflow-hidden bg-slate-100',
   /** Card image container — 4:3 */
   image4x3: 'relative aspect-[4/3] overflow-hidden',
   /** Card body padding */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses feedback that homepage blocks and photos feel oversized on **desktop** (not mobile).

## Root cause

Several systems were fighting each other:

- **Home hero** (`HeroVideo`) already used `hero.imageWrap`, but the **below-hero panel** used `lg:text-5xl` and `sm:py-14`, which reads huge on wide screens.
- **Legacy program heroes** (`ProgramHeroBanner`) still used `clamp(320px, 45vw, 560px)` — up to **560px** tall on desktop.
- **Homepage cards** used full **16:9** aspect images with **py-16** sections, so pathway / how-it-works / segmented CTA bands dominate the viewport.

## Changes

- Tighten `hero.imageWrap`, add `hero.belowPanel` / `hero.belowHeadline` tokens
- `HeroVideo` + `ProgramHeroBanner` use shared tokens
- Homepage: shorter card images on `lg+`, tighter section padding, 3-column how-it-works grid until `xl`
- Docs: point to tokens instead of deprecated `45vw` / `560px` example

## Testing

- `vitest` hero unit tests pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

