### PR TITLE
fix(northflank): admin Docker ws bundle (no runtime npm install)

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -42,8 +42,12 @@ ENV SKIP_ENV_VALIDATION=true
 
 RUN cd apps/admin && pnpm exec next build
 
-# Bundle ws for runtime (avoid npm install in slim image — npm peer-resolve fails in CI)
-RUN mkdir -p /export && cp -rL apps/admin/node_modules/ws /export/ws
+# Bundle ws for runtime (custom server.js). Do NOT npm install ws in slim stage — peer-resolve fails.
+RUN set -eux; \
+  mkdir -p /export/ws; \
+  WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")"; \
+  cp -a "${WS_DIR}/." /export/ws/; \
+  test -f /export/ws/package.json
 
 # --- runtime (same as Dockerfile.admin) ---
 FROM public.ecr.aws/docker/library/node:20-bookworm-slim
@@ -72,7 +76,9 @@ COPY --from=builder /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=builder /app/apps/admin/.next/required-server-files.json ./apps/admin/.next/required-server-files.json
 COPY --from=builder /app/public ./apps/admin/public
 COPY --from=builder /app/apps/admin/server.js ./apps/admin/server.js
+RUN mkdir -p apps/admin/node_modules
 COPY --from=builder /export/ws ./apps/admin/node_modules/ws
+RUN test -f apps/admin/node_modules/ws/package.json
 
 RUN addgroup --gid 1001 nodejs && \
     adduser --uid 1001 --ingroup nodejs --disabled-password --gecos "" nextjs && \


### PR DESCRIPTION
Hardens Dockerfile.northflank-admin: copy ws from builder via require.resolve + verify package.json. Removes reliance on runtime npm install ws that fails on Northflank.

**Also required:** point elevate-admin service at `main` (was building `cursor/northflank-setup-c4c6` with old Dockerfile).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build/packaging-only change for the admin container; no application auth or business logic touched.
> 
> **Overview**
> **Northflank admin image:** `ws` is now copied into the runtime image using **`require.resolve('ws/package.json')`** from the `apps/admin` install tree, archived under `/export/ws`, and verified with **`test -f .../package.json`** in both builder and slim stages. The runtime stage also **`mkdir -p apps/admin/node_modules`** before copying the bundle.
> 
> This replaces a brittle **`cp -rL apps/admin/node_modules/ws`** path and keeps **`ws` out of runtime `npm install`**, which was failing peer resolution on Northflank while still supporting the custom **`server.js`** WebSocket path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cc6cf9cffcc985166f3107967cfc3915e2db5293. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->