### PR TITLE
fix(northflank): PATCH combined service API path (scripts only)

### DIFF
--- a/scripts/northflank/deploy-live.ts
+++ b/scripts/northflank/deploy-live.ts
@@ -6,10 +6,10 @@
  *   DEPLOY_BRANCH=cursor/fix-header-mobile-desktop-c4c6 pnpm tsx scripts/northflank/deploy-live.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function setBranch(projectId: string, serviceId: string, branch: string) {
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({ vcsData: { projectBranch: branch } }),
   });

--- a/scripts/northflank/ensure-build-cache.ts
+++ b/scripts/northflank/ensure-build-cache.ts
@@ -6,7 +6,7 @@
  *   pnpm tsx scripts/northflank/ensure-build-cache.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, resolveProjectId } from './lib';
 
 const SERVICES = [
   {
@@ -45,7 +45,7 @@ async function main() {
     };
     console.log(`${dryRun ? '[dry-run]' : '[patch]'} ${id} → ${dockerfile} cache ${BUILDKIT.cacheStorageSize}MB`);
     if (!dryRun) {
-      await nfFetch(projectApiPath(projectId, `/services/${id}`), {
+      await nfFetch(combinedServicePath(projectId, id), {
         method: 'PATCH',
         body: JSON.stringify(patch),
       });

--- a/scripts/northflank/lib.ts
+++ b/scripts/northflank/lib.ts
@@ -74,3 +74,8 @@ export function projectApiPath(projectId: string, suffix: string): string {
   }
   return `/projects/${projectId}${suffix}`;
 }
+
+/** PATCH/GET combined CI/CD service (elevate-lms, elevate-admin). */
+export function combinedServicePath(projectId: string, serviceId: string): string {
+  return projectApiPath(projectId, `/services/combined/${serviceId}`);
+}

--- a/scripts/northflank/set-service-branch.ts
+++ b/scripts/northflank/set-service-branch.ts
@@ -5,7 +5,7 @@
  *   pnpm tsx scripts/northflank/set-service-branch.ts elevate-lms cursor/northflank-setup-c4c6 --build
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function main() {
   const serviceId = process.argv[2];
@@ -23,7 +23,7 @@ async function main() {
     process.exit(1);
   }
 
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({
       vcsData: {


### PR DESCRIPTION
Northflank branch/dockerfile updates were 405 on `/services/{id}`. Use `/services/combined/{id}` per API docs. No app/runtime code.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only internal Northflank CLI scripts change API paths; no production app, auth, or data paths are affected.
> 
> **Overview**
> Northflank **PATCH** calls for combined CI/CD services (`elevate-lms`, `elevate-admin`) were hitting `/services/{id}` and returning **405**. This PR routes those updates through **`/services/combined/{id}`**, matching the documented API for combined services.
> 
> A shared **`combinedServicePath`** helper in `scripts/northflank/lib.ts` centralizes the path. **Deploy**, **ensure-build-cache**, and **set-service-branch** scripts now use it for branch and BuildKit cache patches. **Build triggers** and status polling still use the existing `/services/{id}/...` paths unchanged.
> 
> Scope is **scripts only**—no application or runtime code.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b8a68b74668f4572f6d4f2732b36279310151e6d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->