### PR TITLE
fix(northflank): bundle sharp from builder (no runtime npm install)

### DIFF
--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -28,9 +28,9 @@ ENV COMMIT_REF=$COMMIT_REF
 
 WORKDIR /app
 
-# Install sharp for Next.js image optimization (must match runtime arch)
-RUN npm install --os=linux --cpu=x64 sharp@0.33.5 --no-save 2>/dev/null || \
-    npm install sharp@0.33.5 --no-save
+# Install sharp for Next.js image optimization (ECS host-built image; Northflank uses Dockerfile.northflank-admin)
+RUN npm install --os=linux --cpu=x64 sharp@0.34.5 --no-save 2>/dev/null || \
+    npm install sharp@0.34.5 --no-save
 
 # Copy standalone server output produced by `next build` in apps/admin/
 COPY apps/admin/.next/standalone ./

--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -49,6 +49,19 @@ RUN set -eux; \
   cp -a "${WS_DIR}/." /export/ws/; \
   test -f /export/ws/package.json
 
+# Bundle sharp + linux x64 @img bindings (runtime npm install fails in slim CI images)
+RUN set -eux; \
+  mkdir -p /export/sharp-node_modules/@img; \
+  SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")"; \
+  cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/; \
+  for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
+    node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
+    name="$(basename "$pkg")"; \
+    cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
+  done; \
+  test -f /export/sharp-node_modules/sharp/package.json; \
+  test -d /export/sharp-node_modules/@img/sharp-linux-x64
+
 # --- runtime (same as Dockerfile.admin) ---
 FROM public.ecr.aws/docker/library/node:20-bookworm-slim
 
@@ -67,10 +80,10 @@ ENV COMMIT_REF=$COMMIT_REF
 
 WORKDIR /app
 
-RUN npm install --os=linux --cpu=x64 sharp@0.33.5 --no-save 2>/dev/null || \
-    npm install sharp@0.33.5 --no-save
-
 COPY --from=builder /app/apps/admin/.next/standalone ./
+RUN mkdir -p node_modules
+COPY --from=builder /export/sharp-node_modules/sharp ./node_modules/sharp
+COPY --from=builder /export/sharp-node_modules/@img ./node_modules/@img
 COPY --from=builder /app/apps/admin/.next/server ./apps/admin/.next/server
 COPY --from=builder /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=builder /app/apps/admin/.next/required-server-files.json ./apps/admin/.next/required-server-files.json

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -41,6 +41,19 @@ ENV SKIP_ENV_VALIDATION=true
 
 RUN pnpm exec next build
 
+# Bundle sharp + linux x64 @img bindings (runtime npm install fails in slim CI images)
+RUN set -eux; \
+  mkdir -p /export/sharp-node_modules/@img; \
+  SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")"; \
+  cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/; \
+  for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
+    node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
+    name="$(basename "$pkg")"; \
+    cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
+  done; \
+  test -f /export/sharp-node_modules/sharp/package.json; \
+  test -d /export/sharp-node_modules/@img/sharp-linux-x64
+
 # --- runtime (Dockerfile.package layout) ---
 FROM public.ecr.aws/docker/library/node:20-bookworm-slim
 
@@ -59,10 +72,10 @@ ENV COMMIT_REF=$COMMIT_REF
 
 WORKDIR /app
 
-RUN npm install --os=linux --cpu=x64 sharp@0.33.5 --no-save 2>/dev/null || \
-    npm install sharp@0.33.5 --no-save
-
 COPY --from=builder /app/.next/standalone ./
+RUN mkdir -p node_modules
+COPY --from=builder /export/sharp-node_modules/sharp ./node_modules/sharp
+COPY --from=builder /export/sharp-node_modules/@img ./node_modules/@img
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/server ./.next/server
 COPY --from=builder /app/public ./public

--- a/scripts/northflank/deploy-live.ts
+++ b/scripts/northflank/deploy-live.ts
@@ -6,10 +6,10 @@
  *   DEPLOY_BRANCH=cursor/fix-header-mobile-desktop-c4c6 pnpm tsx scripts/northflank/deploy-live.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function setBranch(projectId: string, serviceId: string, branch: string) {
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({ vcsData: { projectBranch: branch } }),
   });

--- a/scripts/northflank/ensure-build-cache.ts
+++ b/scripts/northflank/ensure-build-cache.ts
@@ -6,7 +6,7 @@
  *   pnpm tsx scripts/northflank/ensure-build-cache.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, resolveProjectId } from './lib';
 
 const SERVICES = [
   {
@@ -45,7 +45,7 @@ async function main() {
     };
     console.log(`${dryRun ? '[dry-run]' : '[patch]'} ${id} → ${dockerfile} cache ${BUILDKIT.cacheStorageSize}MB`);
     if (!dryRun) {
-      await nfFetch(projectApiPath(projectId, `/services/${id}`), {
+      await nfFetch(combinedServicePath(projectId, id), {
         method: 'PATCH',
         body: JSON.stringify(patch),
       });

--- a/scripts/northflank/lib.ts
+++ b/scripts/northflank/lib.ts
@@ -74,3 +74,8 @@ export function projectApiPath(projectId: string, suffix: string): string {
   }
   return `/projects/${projectId}${suffix}`;
 }
+
+/** PATCH/GET combined CI/CD service (elevate-lms, elevate-admin). */
+export function combinedServicePath(projectId: string, serviceId: string): string {
+  return projectApiPath(projectId, `/services/combined/${serviceId}`);
+}

--- a/scripts/northflank/set-service-branch.ts
+++ b/scripts/northflank/set-service-branch.ts
@@ -5,7 +5,7 @@
  *   pnpm tsx scripts/northflank/set-service-branch.ts elevate-lms cursor/northflank-setup-c4c6 --build
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function main() {
   const serviceId = process.argv[2];
@@ -23,7 +23,7 @@ async function main() {
     process.exit(1);
   }
 
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({
       vcsData: {


### PR DESCRIPTION
Removes failing runtime step:

```
RUN npm install --os=linux --cpu=x64 sharp@0.33.5 --no-save ...
```

Same pattern as #218 (ws): copy sharp + @img linux-x64 from pnpm builder. Pins align with lockfile (0.34.5).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Container build and deploy-script path changes only; no application auth or business logic.
> 
> **Overview**
> **Northflank LMS and admin images** no longer run `npm install sharp` in the slim runtime stage (that step was failing in CI). The builder now copies **sharp 0.34.5** and the Linux x64 `@img` native bindings from the pnpm tree into the image, matching the existing **ws** bundling approach. **ECS `Dockerfile.admin`** still installs sharp at runtime but bumps the pin to **0.34.5** and notes that Northflank uses the northflank Dockerfiles.
> 
> **Northflank deploy scripts** PATCH combined CI/CD services via **`/services/combined/{id}`** through a new **`combinedServicePath`** helper (`deploy-live`, `ensure-build-cache`, `set-service-branch`); build triggers still use the existing build endpoint.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1be536b284ef7e735d045d76be47bee3ff1a2e23. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->