### PR TITLE
fix(admin): restore SitePreviewPanelWrapper (Northflank build)

### DIFF
--- a/components/admin/dashboard/SitePreviewPanelWrapper.tsx
+++ b/components/admin/dashboard/SitePreviewPanelWrapper.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+import { ColoredLivePreviewFrame } from './ColoredLivePreviewFrame';
+import type { SitePreviewTarget } from './types';
+
+/** Admin dashboard column — live iframe previews + optional site health strip. */
+export default function SitePreviewPanelWrapper({ sites }: { sites: SitePreviewTarget[] }) {
+  const targets = sites.map((s) => ({
+    label: s.label || s.url,
+    url: s.url,
+  }));
+
+  return (
+    <div className="overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm">
+      <div className="border-b border-slate-100 px-4 py-3">
+        <h2 className="text-sm font-bold text-slate-900">Live sites</h2>
+        <p className="text-xs text-slate-500">Quick preview of production URLs</p>
+      </div>
+      <ColoredLivePreviewFrame
+        targets={targets}
+        className="rounded-none border-0"
+        minHeight={280}
+        workspaceMinHeight={300}
+        showSiteHealth
+      />
+    </div>
+  );
+}

--- a/scripts/northflank/deploy-live.ts
+++ b/scripts/northflank/deploy-live.ts
@@ -6,10 +6,10 @@
  *   DEPLOY_BRANCH=cursor/fix-header-mobile-desktop-c4c6 pnpm tsx scripts/northflank/deploy-live.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function setBranch(projectId: string, serviceId: string, branch: string) {
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({ vcsData: { projectBranch: branch } }),
   });

--- a/scripts/northflank/ensure-build-cache.ts
+++ b/scripts/northflank/ensure-build-cache.ts
@@ -6,7 +6,7 @@
  *   pnpm tsx scripts/northflank/ensure-build-cache.ts --execute
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, resolveProjectId } from './lib';
 
 const SERVICES = [
   {
@@ -45,7 +45,7 @@ async function main() {
     };
     console.log(`${dryRun ? '[dry-run]' : '[patch]'} ${id} → ${dockerfile} cache ${BUILDKIT.cacheStorageSize}MB`);
     if (!dryRun) {
-      await nfFetch(projectApiPath(projectId, `/services/${id}`), {
+      await nfFetch(combinedServicePath(projectId, id), {
         method: 'PATCH',
         body: JSON.stringify(patch),
       });

--- a/scripts/northflank/lib.ts
+++ b/scripts/northflank/lib.ts
@@ -74,3 +74,8 @@ export function projectApiPath(projectId: string, suffix: string): string {
   }
   return `/projects/${projectId}${suffix}`;
 }
+
+/** PATCH/GET combined CI/CD service (elevate-lms, elevate-admin). */
+export function combinedServicePath(projectId: string, serviceId: string): string {
+  return projectApiPath(projectId, `/services/combined/${serviceId}`);
+}

--- a/scripts/northflank/set-service-branch.ts
+++ b/scripts/northflank/set-service-branch.ts
@@ -5,7 +5,7 @@
  *   pnpm tsx scripts/northflank/set-service-branch.ts elevate-lms cursor/northflank-setup-c4c6 --build
  */
 
-import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+import { combinedServicePath, nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function main() {
   const serviceId = process.argv[2];
@@ -23,7 +23,7 @@ async function main() {
     process.exit(1);
   }
 
-  await nfFetch(projectApiPath(projectId, `/services/${serviceId}`), {
+  await nfFetch(combinedServicePath(projectId, serviceId), {
     method: 'PATCH',
     body: JSON.stringify({
       vcsData: {


### PR DESCRIPTION
Fixes Northflank `pnpm exec next build` failure:

```
Module not found: Can't resolve './SitePreviewPanelWrapper'
```

Adds thin wrapper around `ColoredLivePreviewFrame` for the admin dashboard grid.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> UI wrapper re-export and deploy-script URL fixes; no auth or data-model changes, though wrong API paths could affect deploy automation if misconfigured.
> 
> **Overview**
> Restores the missing **`SitePreviewPanelWrapper`** module so the admin dashboard can build again: a client column that maps `sites` into **`ColoredLivePreviewFrame`** with a “Live sites” header and **`showSiteHealth`**.
> 
> Northflank deploy helpers now PATCH **combined** CI/CD services via a shared **`combinedServicePath`** (`/services/combined/{serviceId}`) in **`deploy-live`**, **`ensure-build-cache`**, and **`set-service-branch`** instead of the old `/services/{id}` path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9cac25eac003f0f6a7eeb65c2e3e10cdae540615. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->