### PR TITLE
fix(admin): fix Northflank build — supabase-config route stack overflow

### DIFF
--- a/app/api/public/supabase-config/route.ts
+++ b/app/api/public/supabase-config/route.ts
@@ -1,25 +1,9 @@
 // PUBLIC ROUTE: Supabase anon key is intended for browser use (RLS-protected).
 
-import { NextResponse } from 'next/server';
-import { getServerPublicSupabaseConfig } from '@/lib/supabase/public-config';
+import { getSupabasePublicConfigResponse } from '@/lib/api/public/supabase-config';
 
 export const dynamic = 'force-dynamic';
 
 export async function GET() {
-  const config = getServerPublicSupabaseConfig();
-  if (!config) {
-    return NextResponse.json(
-      { error: 'Authentication service is not configured on this deployment.' },
-      { status: 503 },
-    );
-  }
-
-  return NextResponse.json(
-    { url: config.url, anonKey: config.anonKey },
-    {
-      headers: {
-        'Cache-Control': 'private, no-store',
-      },
-    },
-  );
+  return getSupabasePublicConfigResponse();
 }

--- a/apps/admin/app/api/public/supabase-config/route.ts
+++ b/apps/admin/app/api/public/supabase-config/route.ts
@@ -1,3 +1,9 @@
 // PUBLIC ROUTE: Supabase anon key is intended for browser use (RLS-protected).
 
-export { dynamic, GET } from '@/app/api/public/supabase-config/route';
+import { getSupabasePublicConfigResponse } from '@/lib/api/public/supabase-config';
+
+export const dynamic = 'force-dynamic';
+
+export async function GET() {
+  return getSupabasePublicConfigResponse();
+}

--- a/lib/api/public/supabase-config.ts
+++ b/lib/api/public/supabase-config.ts
@@ -1,0 +1,23 @@
+// PUBLIC ROUTE helper: Supabase anon key is intended for browser use (RLS-protected).
+
+import { NextResponse } from 'next/server';
+import { getServerPublicSupabaseConfig } from '@/lib/supabase/public-config';
+
+export function getSupabasePublicConfigResponse() {
+  const config = getServerPublicSupabaseConfig();
+  if (!config) {
+    return NextResponse.json(
+      { error: 'Authentication service is not configured on this deployment.' },
+      { status: 503 },
+    );
+  }
+
+  return NextResponse.json(
+    { url: config.url, anonKey: config.anonKey },
+    {
+      headers: {
+        'Cache-Control': 'private, no-store',
+      },
+    },
+  );
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Root cause

`apps/admin/app/api/public/supabase-config/route.ts` re-exported from `@/app/api/public/supabase-config/route`. In the admin app, `@` → repo root, but Next bundled the admin route against itself → **Maximum call stack size exceeded** during `next build`.

## Fix

- Shared handler: `lib/api/public/supabase-config.ts`
- Thin route files in LMS + admin (literal `export const dynamic = 'force-dynamic'`)

Verified locally: `cd apps/admin && pnpm exec next build` completes successfully.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

