### PR TITLE
fix(supabase): prefer SUPABASE_* runtime env over build-inlined NEXT_PUBLIC_*

### DIFF
--- a/lib/supabase/public-config.ts
+++ b/lib/supabase/public-config.ts
@@ -30,14 +30,23 @@ export function isPlaceholderSupabaseConfig(
   return false;
 }
 
-/** Read from process.env (build-time inline and/or Node runtime on ECS). */
-export function getServerPublicSupabaseConfig(): SupabasePublicConfig | null {
+/**
+ * Server-side env resolution. Prefer SUPABASE_* (runtime injection) over NEXT_PUBLIC_*
+ * because Next inlines NEXT_PUBLIC_* at build time (Docker build-placeholder leaks otherwise).
+ */
+export function resolveServerSupabaseRawEnv(): { url?: string; anonKey?: string } {
   const url = normalizeSupabaseProjectUrl(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
+    process.env.SUPABASE_URL || process.env.NEXT_PUBLIC_SUPABASE_URL,
   );
   const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
-    process.env.SUPABASE_ANON_KEY?.trim();
+    process.env.SUPABASE_ANON_KEY?.trim() ||
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim();
+  return { url, anonKey };
+}
+
+/** Read from process.env (runtime ECS/Northflank + optional build-time NEXT_PUBLIC_*). */
+export function getServerPublicSupabaseConfig(): SupabasePublicConfig | null {
+  const { url, anonKey } = resolveServerSupabaseRawEnv();
   if (isPlaceholderSupabaseConfig(url, anonKey)) return null;
   return { url: url!, anonKey: anonKey! };
 }

--- a/lib/supabase/server-env.ts
+++ b/lib/supabase/server-env.ts
@@ -1,5 +1,7 @@
-import { isPlaceholderSupabaseConfig } from '@/lib/supabase/public-config';
-import { normalizeSupabaseProjectUrl } from '@/lib/supabase/normalize-url';
+import {
+  isPlaceholderSupabaseConfig,
+  resolveServerSupabaseRawEnv,
+} from '@/lib/supabase/public-config';
 
 export type ServerSupabaseEnv = {
   url: string;
@@ -8,24 +10,13 @@ export type ServerSupabaseEnv = {
 
 /** Resolved Supabase URL + anon key for server auth (runtime process.env). */
 export function resolveServerSupabaseEnv(): ServerSupabaseEnv | null {
-  const url = normalizeSupabaseProjectUrl(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
-  );
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
-    process.env.SUPABASE_ANON_KEY?.trim();
-
+  const { url, anonKey } = resolveServerSupabaseRawEnv();
   if (isPlaceholderSupabaseConfig(url, anonKey)) return null;
   return { url: url!, anonKey: anonKey! };
 }
 
 export function getServerSupabaseEnvMisconfigurationReason(): string | null {
-  const url = normalizeSupabaseProjectUrl(
-    process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL,
-  );
-  const anonKey =
-    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY?.trim() ||
-    process.env.SUPABASE_ANON_KEY?.trim();
+  const { url, anonKey } = resolveServerSupabaseRawEnv();
 
   if (!url?.trim()) return 'NEXT_PUBLIC_SUPABASE_URL (or SUPABASE_URL) is missing';
   if (!anonKey?.trim()) return 'NEXT_PUBLIC_SUPABASE_ANON_KEY (or SUPABASE_ANON_KEY) is missing';

--- a/tests/unit/supabase-public-config.test.ts
+++ b/tests/unit/supabase-public-config.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it } from 'vitest';
 import {
   getServerPublicSupabaseConfig,
   isPlaceholderSupabaseConfig,
+  resolveServerSupabaseRawEnv,
 } from '@/lib/supabase/public-config';
 
 describe('supabase public-config', () => {
@@ -32,6 +33,20 @@ describe('supabase public-config', () => {
     process.env.NEXT_PUBLIC_SUPABASE_URL = prevUrl;
     process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = prevKey;
     process.env.SUPABASE_URL = prevSupabaseUrl;
+  });
+
+  it('prefers SUPABASE_ANON_KEY over inlined NEXT_PUBLIC build placeholder', () => {
+    const prevAnon = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+    const prevRuntime = process.env.SUPABASE_ANON_KEY;
+    const prevUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = 'build-placeholder';
+    process.env.SUPABASE_ANON_KEY = 'eyJhbGciOiJIUzI1NiJ9.runtime';
+    process.env.NEXT_PUBLIC_SUPABASE_URL = 'https://cuxzzpsyufcewtmicszk.supabase.co';
+    const cfg = getServerPublicSupabaseConfig();
+    expect(cfg?.anonKey).toBe('eyJhbGciOiJIUzI1NiJ9.runtime');
+    process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY = prevAnon;
+    process.env.SUPABASE_ANON_KEY = prevRuntime;
+    process.env.NEXT_PUBLIC_SUPABASE_URL = prevUrl;
   });
 
   it('getServerPublicSupabaseConfig falls back to SUPABASE_URL', () => {


### PR DESCRIPTION
Northflank admin builds with build-placeholder in NEXT_PUBLIC_*; Next inlines that into the server bundle. Runtime keys must use SUPABASE_ANON_KEY / SUPABASE_URL from Northflank secret group.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how server auth and public config endpoints resolve credentials; mis-ordering could break login in production, but scope is narrow and covered by a new unit test.
> 
> **Overview**
> Server-side Supabase config resolution now **prefers runtime `SUPABASE_URL` / `SUPABASE_ANON_KEY`** over build-inlined `NEXT_PUBLIC_*`, so Docker/Northflank images built with `build-placeholder` in `NEXT_PUBLIC_*` still pick up real credentials from the secret group at runtime.
> 
> A shared **`resolveServerSupabaseRawEnv`** helper centralizes that ordering; **`getServerPublicSupabaseConfig`** and **`resolveServerSupabaseEnv`** / misconfiguration checks in `server-env.ts` delegate to it instead of duplicating env reads. Browser resolution is unchanged.
> 
> A unit test asserts **`SUPABASE_ANON_KEY` wins** when `NEXT_PUBLIC_SUPABASE_ANON_KEY` is still a build placeholder.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bcc303446fbbd9cd1755ea3a5cdee575436540b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->