### PR TITLE
fix(docker): Northflank admin build OOM (4GB heap)

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -30,7 +30,8 @@ COPY . .
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV NODE_OPTIONS=--max-old-space-size=8192
+# Northflank nf-compute-400 builders are ~4GB RAM; 8192 heap OOM-kills `next build` in ~1m
+ENV NODE_OPTIONS=--max-old-space-size=4096
 ENV BUILD_SCOPE=1
 # Required at `next build` (overridden by Northflank secret group / build args when set)
 ENV NEXT_PUBLIC_ADMIN_URL=https://admin.elevateforhumanity.org


### PR DESCRIPTION
Admin `next build` passes on main locally (~3min) but Northflank fails in ~1m with no compile log — typical OOM on nf-compute-400 when NODE_OPTIONS requests 8192MB heap.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time Docker env only; no runtime app, auth, or data-path changes.
> 
> **Overview**
> Fixes **Northflank admin image builds** failing early (~1 minute) with little compile output by aligning Node’s heap with the builder’s RAM.
> 
> In `Dockerfile.northflank-admin`, **`NODE_OPTIONS`** is changed from **`--max-old-space-size=8192`** to **`4096`**, with a comment that **nf-compute-400** builders have about **4GB** memory and an **8GB** heap can **OOM-kill** `next build`. Local builds on larger machines are unchanged; only the Northflank Docker build path is affected.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7b5f3eae7ee514d1b1134f892a7449251da47dac. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->