### PR TITLE
fix(admin): remove /admin/dashboard self-redirect loop

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -41,8 +41,7 @@ const adminConfig = {
   async redirects() {
     return [
       // ── Lizzy control plane (retired dev-studio / ai-console admin routes) ──
-      { source: '/admin/dashboard', destination: '/admin/dashboard', permanent: true },
-      { source: '/admin/dashboard/:path*', destination: '/admin/dashboard', permanent: true },
+      // Do NOT redirect /admin/dashboard → itself (infinite loop).
       { source: '/admin/ai-console', destination: '/admin/dashboard', permanent: true },
       { source: '/admin/ai-console/:path*', destination: '/admin/dashboard', permanent: true },
       { source: '/admin/ai-studio', destination: '/admin/dashboard', permanent: true },


### PR DESCRIPTION
Removes no-op redirects that sent  to itself, which could prevent the dashboard from ever rendering.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small routing-config fix with no auth, data, or API changes; only removes broken redirects and adds a guard comment.
> 
> **Overview**
> Removes **identity redirects** in `apps/admin/next.config.mjs` that mapped `/admin/dashboard` and `/admin/dashboard/*` to the same path, which could trap requests in an infinite redirect loop and block the dashboard from loading.
> 
> A comment documents that `/admin/dashboard` must not redirect to itself. **Legacy routes** (`/admin/ai-console`, `/admin/ai-studio`, etc.) still permanently forward to `/admin/dashboard` unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 538adfd6e2303982ff206e5d4af3289f9137b89c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->