### PR TITLE
fix(northflank): repair sync-env URL fallback

### DIFF
--- a/scripts/northflank/canonical-env.mjs
+++ b/scripts/northflank/canonical-env.mjs
@@ -46,9 +46,8 @@ export function dedupeSecretVariables(variables) {
     }
   }
 
-  const defaultUrl = defaultSupabaseUrl();
-  if (!out[SUPABASE_CANONICAL_PUBLIC]?.trim() && defaultUrl) {
-    out[SUPABASE_CANONICAL_PUBLIC] = defaultUrl;
+  if (!out[SUPABASE_CANONICAL_PUBLIC]?.trim()) {
+    out[SUPABASE_CANONICAL_PUBLIC] = SUPABASE_URL_FALLBACK;
   }
 
   if (!out.SUPABASE_URL?.trim() && out.SUPABASE_SERVICE_ROLE_KEY) {


### PR DESCRIPTION
Fixes ReferenceError in dedupeSecretVariables after #233 merge.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small change to Northflank env deduplication defaults; no auth or runtime app logic beyond ensuring sync scripts do not crash.
> 
> **Overview**
> **Northflank env sync** no longer calls the removed `defaultSupabaseUrl()` helper inside `dedupeSecretVariables`, which was causing a **ReferenceError** after the prior merge.
> 
> When `NEXT_PUBLIC_SUPABASE_URL` is missing or blank after deduplication, the script now always sets it to the exported **`SUPABASE_URL_FALLBACK`** constant instead of only filling it when a dynamic default URL was available.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 266b5fcfe647100e5de791c3a771d49b521eee50. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->