### PR TITLE
fix(admin): Supabase slide cache and runtime disk cleanup

### DIFF
--- a/apps/admin/app/api/devstudio/devcontainer/route.ts
+++ b/apps/admin/app/api/devstudio/devcontainer/route.ts
@@ -322,18 +322,20 @@ export async function PUT(request: NextRequest) {
     }
 
     if (!hasGitHubToken()) {
-      try {
-        const result = await writeLocalDevcontainer(content, sha);
-        if (result.conflict) return safeError('sha mismatch; reload before saving', 409);
-
-        return NextResponse.json({
-          ok: true,
-          sha: result.sha,
-          commit: 'local write (GITHUB_TOKEN not configured)',
-        });
-      } catch {
-        return safeError('Save requires GITHUB_TOKEN in production environments', 503);
+      if (mode !== 'local-only') {
+        return safeError(
+          'Save requires GITHUB_TOKEN. Production admin must use DEVSTUDIO_DEVCONTAINER_MODE=github-only.',
+          503,
+        );
       }
+      const result = await writeLocalDevcontainer(content, sha);
+      if (result.conflict) return safeError('sha mismatch; reload before saving', 409);
+
+      return NextResponse.json({
+        ok: true,
+        sha: result.sha,
+        commit: 'local write (dev only — local-only mode)',
+      });
     }
 
     const encoded = Buffer.from(content, 'utf-8').toString('base64');

--- a/docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md
+++ b/docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md
@@ -1,6 +1,6 @@
 # Admin dashboard — storage & memory audit (line-by-line)
 
-**Date:** 2026-05-30  
+**Date:** 2026-05-30 (updated after PR #233 / follow-up)  
 **Scope:** `apps/admin` (421 API routes, 362 admin pages), Northflank `Dockerfile.northflank-admin`, shared `@/*` monorepo imports.  
 **Goal:** Confirm nothing duplicates heavy deps or fills disk/memory unexpectedly.
 
@@ -10,13 +10,13 @@
 
 | Area | Status | Notes |
 |------|--------|--------|
-| Build / standalone image | **Improved (PR #233)** | `outputFileTracingExcludes` + `prune-admin-standalone.mjs`; playwright/puppeteer not in trace |
-| Runtime container disk | **Risk — video routes** | Writes under `public/generated/`, `public/videos/slide-image-cache/`, `os.tmpdir()` |
-| Docker image `public/` | **~190 MB** | Full repo `public/` copied into admin image (mostly `public/images` 165 MB) |
+| Build / standalone image | **Fixed (PR #233)** | `outputFileTracingExcludes` + `prune-admin-standalone.mjs`; playwright/puppeteer not in trace |
+| Runtime container disk | **Fixed** | Lesson/slide media → Supabase `course-videos`; temps under `os.tmpdir()` only |
+| Docker image `public/` | **Slimmed (PR #233)** | Selective `public/` subtrees in `Dockerfile.northflank-admin` (not full ~190 MB tree) |
 | Dashboard UI pages | **OK** | No server imports of Remotion/ffmpeg; data via Supabase APIs |
-| WIOA compliance UI | **OK** | JSON to Supabase only; no local file cache |
-| Dev Studio | **Caution** | Shell/autofix/stabilize can spike CPU/RAM; devcontainer can write `.devcontainer/` in `local-only` mode |
-| Missing upload caps | **Fix pending** | `/api/admin/videos/upload`, `/api/admin/import` had no size limits |
+| WIOA compliance UI | **OK** | RSC: `requireRole` only; data via `/api/admin/compliance/wioa-etpl/*` |
+| Dev Studio | **Caution** | CPU/RAM spikes on stabilize/autofix; prod uses `DEVSTUDIO_DEVCONTAINER_MODE=github-only` |
+| Upload caps | **Fixed (PR #233)** | Video 200 MB; CSV import 10 MB / 25k rows |
 
 **Not a duplicate-deps problem:** Admin does not import puppeteer/playwright in any route (only `scripts/`). The earlier bloat was **file tracing + missing post-build prune**, not duplicate WIOA/compliance code.
 
@@ -52,7 +52,7 @@
 | 52–54 | `NODE_OPTIONS=4096`, `DISABLE_WEBPACK_FILESYSTEM_CACHE=1` | RAM/disk tradeoff for build |
 | 70–75 | `next build` + `prune-admin-standalone.mjs` | Drops playwright/puppeteer/three/etc. from standalone |
 | 77–95 | Export `ws`, `sharp`, `@img/*` | Explicit runtime copies (sharp excluded from trace globs) |
-| 115–122 | Runtime: standalone + `.next/server` + `.next/static` + **`public/`** | **~190 MB** `public/` in every admin pod |
+| 115–122 | Runtime: standalone + `.next/server` + `.next/static` + **selective `public/`** | Slim copy (images subset + remotion assets); not full repo `public/` |
 | 137 | Healthcheck `/api/ping` | No storage |
 
 **Gap:** `remotion-src/` must exist at runtime for Remotion `bundle({ entryPoint })` — ensure it is included in standalone trace (do not add `remotion-src/**` to admin excludes).
@@ -105,13 +105,13 @@ These are the **only** routes that grow filesystem inside the container (ephemer
 
 | Route | Writes to | Cleaned? | Risk |
 |-------|-----------|----------|------|
-| `POST /api/admin/generate-lesson-videos` | `public/generated/lessons/*.mp3`, Remotion `*.mp4` | **No** — persists until redeploy | **High** if batch-run |
-| `POST /api/admin/courses/[courseId]/generate-videos` | `os.tmpdir()/vid-gen-*` | **Yes** — `rmSync` in `finally` block | Medium if crash mid-batch |
-| `POST /api/admin/preview-slide` | `public/videos/slide-image-cache/` (via `lesson-video-renderer`) | **No** — cache grows | Medium |
-| `POST /api/admin/wioa/pirl-export` | `os.tmpdir()/pirl-{jobId}/` | After upload to storage | Low if cleanup runs |
-| `POST /api/devstudio/devcontainer` | `.devcontainer/devcontainer.json` | N/A | **Only if `DEVSTUDIO_DEVCONTAINER_MODE=local-only`** — use `github-only` in prod |
+| `POST /api/admin/generate-lesson-videos` | `os.tmpdir()` + Supabase `course-videos/generated-lessons/` | Temp deleted after upload | Low |
+| `POST /api/admin/courses/[courseId]/generate-videos` | `os.tmpdir()/vid-gen-*` | **Yes** — `rmSync` in `finally` | Medium if crash mid-batch |
+| `POST /api/admin/preview-slide` | `os.tmpdir()/elevate-slide-cache/` + Supabase `course-videos/slide-cache/` | Temp cleaned per request | Low |
+| `POST /api/admin/wioa/pirl-export` | `os.tmpdir()/pirl-{jobId}/` | After upload to storage | Low |
+| `PUT /api/devstudio/devcontainer` | `.devcontainer/` **blocked** unless `local-only` + no `GITHUB_TOKEN` | N/A in prod (`github-only`) | Low in prod |
 
-**Recommendation:** Point video outputs to Supabase Storage/R2 only; treat container `public/` as read-only in production.
+**Production:** Treat container `public/` as read-only; all durable media in Supabase Storage.
 
 ---
 
@@ -137,8 +137,8 @@ These are the **only** routes that grow filesystem inside the container (ephemer
 | `/api/admin/contracts/upload` | 50 MB | OK |
 | `/api/admin/courses/parse-file` | 10 MB | OK |
 | `/api/admin/validate-coi` | 10 MB | OK |
-| `/api/admin/videos/upload` | **None** | **Fixed in branch** — add cap |
-| `/api/admin/import` | **None** | **Fixed in branch** — add CSV cap |
+| `/api/admin/videos/upload` | 200 MB | OK (PR #233) |
+| `/api/admin/import` | 10 MB / 25k rows | OK (PR #233) |
 
 ---
 
@@ -176,11 +176,13 @@ Command: `pnpm audit:admin-standalone` (after `cd apps/admin && pnpm exec next b
 ## 12. Action checklist
 
 - [x] Shared trace excludes + admin prune (PR #233)
-- [ ] Merge PR #233 and verify Northflank admin build size
-- [ ] Set `DEVSTUDIO_DEVCONTAINER_MODE=github-only` on production admin
-- [ ] Add upload caps on videos/import (this audit branch)
-- [ ] Move `public/generated` video output to Supabase Storage (follow-up)
-- [ ] Optional: slim Docker `public/` copy to admin-needed assets only (follow-up)
+- [x] Merge PR #233; Northflank env dedupe + `NEXT_PUBLIC_SUPABASE_ANON_KEY` fix (PR #234)
+- [x] `DEVSTUDIO_DEVCONTAINER_MODE=github-only` in Northflank sync (`canonical-env.mjs`)
+- [x] Upload caps on videos/import
+- [x] Lesson/slide media → Supabase (`lib/video/upload-lesson-media.ts`, `lib/video/slide-image-cache.ts`)
+- [x] Slim Docker `public/` copy in `Dockerfile.northflank-admin`
+- [x] GitHub Actions: single `NORTHFLANK_API_TOKEN` (no duplicate secret names)
+- [ ] Verify latest `elevate-admin` Northflank build after each merge to `main`
 
 ---
 

--- a/lib/video/slide-image-cache.ts
+++ b/lib/video/slide-image-cache.ts
@@ -1,0 +1,120 @@
+/**
+ * Slide preview images — Supabase course-videos/slide-cache + os.tmpdir for canvas reads.
+ * Never writes under public/videos/slide-image-cache.
+ */
+
+import crypto from 'crypto';
+import { createWriteStream } from 'fs';
+import { mkdir, unlink } from 'fs/promises';
+import { existsSync } from 'fs';
+import os from 'os';
+import path from 'path';
+import { pipeline } from 'stream/promises';
+import { lessonMediaPublicUrl, uploadCourseVideosObject } from './upload-lesson-media';
+
+function slideCacheStoragePath(cacheKey: string): string {
+  return `slide-cache/${cacheKey}.jpg`;
+}
+
+function slideCacheTempPath(cacheKey: string): string {
+  return path.join(os.tmpdir(), 'elevate-slide-cache', `${cacheKey}.jpg`);
+}
+
+async function downloadToTemp(url: string, dest: string): Promise<void> {
+  await mkdir(path.dirname(dest), { recursive: true });
+  const res = await fetch(url);
+  if (!res.ok || !res.body) throw new Error(`Failed to download slide image (${res.status})`);
+  await pipeline(res.body as unknown as NodeJS.ReadableStream, createWriteStream(dest));
+}
+
+/**
+ * Returns a local path suitable for canvas loadImage, or null if no image could be fetched.
+ */
+export async function getSlideImageLocalPath(prompt: string | undefined): Promise<string | null> {
+  if (!prompt?.trim()) return null;
+
+  const cacheKey = crypto.createHash('md5').update(prompt).digest('hex');
+  const storagePath = slideCacheStoragePath(cacheKey);
+  const publicUrl = lessonMediaPublicUrl(storagePath);
+  const tmpPath = slideCacheTempPath(cacheKey);
+
+  try {
+    const head = await fetch(publicUrl, { method: 'HEAD' });
+    if (head.ok) {
+      await downloadToTemp(publicUrl, tmpPath);
+      return tmpPath;
+    }
+  } catch {
+    /* fetch fresh */
+  }
+
+  const buffer = await fetchSlideImageBytes(prompt);
+  if (!buffer) return null;
+
+  await mkdir(path.dirname(tmpPath), { recursive: true });
+  await uploadCourseVideosObject(buffer, storagePath, 'image/jpeg');
+  const { writeFile } = await import('fs/promises');
+  await writeFile(tmpPath, buffer);
+
+  return tmpPath;
+}
+
+async function fetchSlideImageBytes(prompt: string): Promise<Buffer | null> {
+  const pexelsKey = process.env.PEXELS_API_KEY;
+  if (pexelsKey) {
+    try {
+      const res = await fetch(
+        `https://api.pexels.com/v1/search?query=${encodeURIComponent(prompt)}&per_page=1&orientation=landscape`,
+        { headers: { Authorization: pexelsKey } },
+      );
+      if (res.ok) {
+        const data = (await res.json()) as { photos: { src: { large: string } }[] };
+        const url = data.photos?.[0]?.src?.large;
+        if (url) {
+          const img = await fetch(url);
+          if (img.ok) return Buffer.from(await img.arrayBuffer());
+        }
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  const openaiKey = process.env.OPENAI_API_KEY;
+  if (openaiKey) {
+    try {
+      const res = await fetch('https://api.openai.com/v1/images/generations', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${openaiKey}` },
+        body: JSON.stringify({
+          model: 'dall-e-3',
+          prompt: `Photorealistic professional training photo: ${prompt}. Clean, well-lit, no text overlays.`,
+          n: 1,
+          size: '1792x1024',
+          quality: 'standard',
+          style: 'natural',
+        }),
+      });
+      if (res.ok) {
+        const data = (await res.json()) as { data: { url: string }[] };
+        const url = data.data?.[0]?.url;
+        if (url) {
+          const img = await fetch(url);
+          if (img.ok) return Buffer.from(await img.arrayBuffer());
+        }
+      }
+    } catch {
+      /* fall through */
+    }
+  }
+
+  return null;
+}
+
+/** Remove temp slide file after render (Supabase copy remains for reuse). */
+export async function cleanupSlideImageTemp(localPath: string | null): Promise<void> {
+  if (!localPath) return;
+  if (!localPath.startsWith(os.tmpdir())) return;
+  if (!existsSync(localPath)) return;
+  await unlink(localPath).catch(() => {});
+}

--- a/lib/video/upload-lesson-media.ts
+++ b/lib/video/upload-lesson-media.ts
@@ -20,13 +20,11 @@ export function lessonMediaPublicUrl(storagePath: string): string {
   return `${base}/storage/v1/object/public/${BUCKET}/${storagePath}`;
 }
 
-export async function uploadLessonMediaBuffer(
+export async function uploadCourseVideosObject(
   buffer: Buffer,
-  lessonId: string,
-  ext: 'mp3' | 'mp4',
+  storagePath: string,
+  contentType: string,
 ): Promise<string> {
-  const storagePath = lessonMediaStoragePath(lessonId, ext);
-  const contentType = ext === 'mp3' ? 'audio/mpeg' : 'video/mp4';
   const supaUrl = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '');
   const svc = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!supaUrl || !svc) {
@@ -45,10 +43,20 @@ export async function uploadLessonMediaBuffer(
 
   if (!res.ok) {
     const text = await res.text();
-    throw new Error(`Lesson media upload failed: ${text.slice(0, 200)}`);
+    throw new Error(`Storage upload failed (${storagePath}): ${text.slice(0, 200)}`);
   }
 
   return lessonMediaPublicUrl(storagePath);
+}
+
+export async function uploadLessonMediaBuffer(
+  buffer: Buffer,
+  lessonId: string,
+  ext: 'mp3' | 'mp4',
+): Promise<string> {
+  const storagePath = lessonMediaStoragePath(lessonId, ext);
+  const contentType = ext === 'mp3' ? 'audio/mpeg' : 'video/mp4';
+  return uploadCourseVideosObject(buffer, storagePath, contentType);
 }
 
 /** Temp paths for Remotion/ffmpeg — always under os.tmpdir(), never public/. */

--- a/server/lesson-video-renderer.ts
+++ b/server/lesson-video-renderer.ts
@@ -7,76 +7,14 @@
  */
 
 import fs from 'fs/promises';
-import fssync from 'fs';
 import path from 'path';
-import crypto from 'crypto';
 import { execSync } from 'child_process';
 import type { LessonSlide } from '../lib/autopilot/lesson-script-generator';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
-
-const IMAGE_CACHE_DIR = path.join(process.cwd(), 'public', 'videos', 'slide-image-cache');
+import { cleanupSlideImageTemp, getSlideImageLocalPath } from '@/lib/video/slide-image-cache';
 
 async function fetchSlideImage(prompt: string | undefined): Promise<string | null> {
-  if (!prompt) return null;
-  const cacheKey = crypto.createHash('md5').update(prompt).digest('hex');
-  const cachePath = path.join(IMAGE_CACHE_DIR, `${cacheKey}.jpg`);
-  if (fssync.existsSync(cachePath)) return cachePath;
-  await fs.mkdir(IMAGE_CACHE_DIR, { recursive: true });
-
-  const pexelsKey = process.env.PEXELS_API_KEY;
-  if (pexelsKey) {
-    try {
-      const res = await fetch(
-        `https://api.pexels.com/v1/search?query=${encodeURIComponent(prompt)}&per_page=1&orientation=landscape`,
-        { headers: { Authorization: pexelsKey } },
-      );
-      if (res.ok) {
-        const data = (await res.json()) as { photos: { src: { large: string } }[] };
-        const url = data.photos?.[0]?.src?.large;
-        if (url) {
-          const img = await fetch(url);
-          if (img.ok) {
-            await fs.writeFile(cachePath, Buffer.from(await img.arrayBuffer()));
-            return cachePath;
-          }
-        }
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-
-  const openaiKey = process.env.OPENAI_API_KEY;
-  if (openaiKey) {
-    try {
-      const res = await fetch('https://api.openai.com/v1/images/generations', {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json', Authorization: `Bearer ${openaiKey}` },
-        body: JSON.stringify({
-          model: 'dall-e-3',
-          prompt: `Photorealistic professional training photo: ${prompt}. Clean, well-lit, no text overlays.`,
-          n: 1,
-          size: '1792x1024',
-          quality: 'standard',
-          style: 'natural',
-        }),
-      });
-      if (res.ok) {
-        const data = (await res.json()) as { data: { url: string }[] };
-        const url = data.data?.[0]?.url;
-        if (url) {
-          const img = await fetch(url);
-          if (img.ok) {
-            await fs.writeFile(cachePath, Buffer.from(await img.arrayBuffer()));
-            return cachePath;
-          }
-        }
-      }
-    } catch {
-      /* fall through */
-    }
-  }
-  return null;
+  return getSlideImageLocalPath(prompt);
 }
 
 let _createCanvas: any;
@@ -408,7 +346,11 @@ export async function renderSlideFrameForPreview(
   opts: RenderOptions,
 ): Promise<Buffer> {
   const imagePath = await fetchSlideImage(slide.imagePrompt).catch(() => null);
-  return renderSlideFrame(slide, slideIndex, totalSlides, opts, imagePath, 0);
+  try {
+    return await renderSlideFrame(slide, slideIndex, totalSlides, opts, imagePath, 0);
+  } finally {
+    await cleanupSlideImageTemp(imagePath);
+  }
 }
 
 async function getFFmpeg() {
@@ -580,6 +522,11 @@ export async function renderLessonVideo(
     );
   });
 
+  await Promise.all(
+    [...new Set(slideImages.filter((p): p is string => Boolean(p)))].map((p) =>
+      cleanupSlideImageTemp(p),
+    ),
+  );
   await fs.rm(tempDir, { recursive: true, force: true });
   return { duration: finalDuration, fileSize: fileStat.size };
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Completes the admin storage audit follow-ups from PR #233.

## Changes
- **`lib/video/slide-image-cache.ts`**: Slide preview images persist in Supabase `course-videos/slide-cache/`; canvas reads use `os.tmpdir()` only (no `public/videos/slide-image-cache/`).
- **`lib/video/upload-lesson-media.ts`**: Shared `uploadCourseVideosObject()` for slide cache + lesson media.
- **`server/lesson-video-renderer.ts`**: Uses slide cache module; cleans temp slide files after preview and full video render.
- **`apps/admin/app/api/devstudio/devcontainer/route.ts`**: Blocks local `.devcontainer` writes unless `DEVSTUDIO_DEVCONTAINER_MODE=local-only` without `GITHUB_TOKEN` (production uses `github-only`).
- **`docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md`**: Updated executive summary and runtime disk table to reflect fixed state.

## Verification
- Pre-push: redirect guards, TypeScript baseline, ESLint on changed files — all passed.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

