### PR TITLE
docs(admin): correct runtime disk writers table; fix LMS video generate path

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -855,6 +855,19 @@ Durable cannot CNAME-flatten apex to Northflank. **Do not** use apex **A** → N
 - **Build context:** `.dockerignore` excludes `node_modules`, `.next`, `supabase/`, `tests/`, `docs/`, etc. Verify with `tar -cf - --exclude-from=.dockerignore . | wc -c` (expect well under 1 GB).
 - **LMS:** service `elevate-lms`, Dockerfile `Dockerfile.northflank-lms`, branch `main`, readiness path `/api/ping`
 - **Admin (Northflank):** service `elevate-admin`, Dockerfile `Dockerfile.northflank-admin`, branch `main`, readiness path `/api/ping`. Same pnpm fetch/offline flow as LMS (no `--package-import-method=copy`). After `next build`, **`node scripts/prune-admin-standalone.mjs`**. Lesson video/TTS output → **Supabase `course-videos`** (`lib/video/upload-lesson-media.ts`), not `public/generated/`. Runtime image copies slim `public/` subtrees + `remotion-src/` only. Northflank secret group `elevate-production-env`: canonical **`NORTHFLANK_API_TOKEN`** only (no `NORTHFLANK_API_KEY` / `NF_API_TOKEN` duplicates); set **`DEVSTUDIO_DEVCONTAINER_MODE=github-only`**. Sync: `pnpm tsx scripts/northflank/sync-env.ts --execute`.
+
+**Admin runtime disk (line-by-line — do not write under `public/` in production):**
+
+| Route | Writes | Cleaned? |
+|-------|--------|----------|
+| `POST /api/admin/generate-lesson-videos` | `os.tmpdir()` during Remotion/TTS; durable → Supabase `course-videos/generated-lessons/` | Yes — temp removed after upload (`lib/video/remotion-render.ts`, `upload-lesson-media.ts`) |
+| `POST /api/admin/courses/[id]/generate-videos` | `os.tmpdir()/vid-gen-*` | Yes — `rmSync` in `finally` |
+| `POST /api/admin/preview-slide` | `os.tmpdir()/elevate-slide-cache/`; durable cache → Supabase `course-videos/slide-cache/` | Yes — temp per request (`lib/video/slide-image-cache.ts`) |
+| `POST /api/admin/wioa/pirl-export` | `os.tmpdir()/pirl-*` | Yes — after upload |
+| `PUT /api/devstudio/devcontainer` | `.devcontainer/` only in `local-only` without `GITHUB_TOKEN` | Blocked in prod (`github-only`) |
+| Dashboard UI (`app/admin/*`, WIOA ETPL) | None | N/A — API → Supabase only |
+
+Full audit: `docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md` §6. LMS video jobs: `POST /api/videos/generate` uses the same Supabase upload path (no `public/generated/`).
 - **Admin (AWS ECS, legacy):** `elevate-admin-service` on `elevate-cluster`, `Dockerfile.admin`, CodeBuild `elevate-admin-build`. Deploy: `.github/workflows/deploy-admin.yml` on `main`.
 - `apps/admin/server.js` must load `.next/required-server-files.json` at startup.
 - **BuildKit cache:** `pnpm tsx scripts/northflank/ensure-build-cache.ts --execute` (10GB `useCache` on both services)

--- a/app/api/videos/generate/route.ts
+++ b/app/api/videos/generate/route.ts
@@ -19,15 +19,12 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
 import { apiRequireAdmin } from '@/lib/admin/guards';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
 import { createJob, markRendering, markComplete, markFailed } from '@/lib/video/job-queue';
 import { renderLessonVideo, inferDomainKey } from '@/lib/video/remotion-render';
-import { readFile, unlink } from 'fs/promises';
-import path from 'path';
 
 export const runtime = 'nodejs';
 export const maxDuration = 600;
@@ -49,9 +46,6 @@ export async function POST(request: NextRequest) {
   }
 
   const supabase = await createClient();
-  const adminDb = await requireAdminClient();
-  if (!adminDb) return safeError('Service unavailable', 503);
-
   // Fetch lesson + course
   const { data: lesson, error: lessonErr } = await supabase
     .from('course_lessons')
@@ -87,7 +81,6 @@ export async function POST(request: NextRequest) {
     script: lesson.script ?? lesson.title,
     bulletPoints: Array.isArray(lesson.bullet_points) ? lesson.bullet_points : [],
     durationSecs: lesson.duration_seconds ?? undefined,
-    adminDb,
   }).catch((err) => {
     // audit-safe: err goes to logger only, not HTTP response
     logger.error('[VideoGenerate] Background render threw', err);
@@ -115,9 +108,8 @@ async function runRender(opts: {
   script: string;
   bulletPoints: string[];
   durationSecs?: number;
-  adminDb: NonNullable<Awaited<ReturnType<typeof requireAdminClient>>>;
 }) {
-  const { jobId, lessonId, courseTitle, lessonTitle, script, bulletPoints, adminDb } = opts;
+  const { jobId, lessonId, courseTitle, lessonTitle, script, bulletPoints } = opts;
 
   await markRendering(jobId);
 
@@ -144,37 +136,9 @@ async function runRender(opts: {
       return;
     }
 
-    // Upload MP4 from public/generated to Supabase Storage
-    const localPath = path.join(process.cwd(), 'public', result.videoUrl);
-    let storageUrl = result.videoUrl; // fallback to local public path
-
-    try {
-      const buffer = await readFile(localPath);
-      const storagePath = `lessons/${lessonId}/lesson-video.mp4`;
-
-      const { error: uploadErr } = await adminDb.storage
-        .from('course-videos')
-        .upload(storagePath, buffer, { contentType: 'video/mp4', upsert: true });
-
-      if (!uploadErr) {
-        const { data: urlData } = adminDb.storage.from('course-videos').getPublicUrl(storagePath);
-        storageUrl = urlData.publicUrl;
-        // Clean up local file after successful upload
-        await unlink(localPath).catch(() => {});
-      } else {
-        logger.warn(
-          '[VideoGenerate] Storage upload failed, keeping local URL: ' + uploadErr.message,
-        );
-      }
-    } catch (readErr) {
-      logger.warn(
-        '[VideoGenerate] Could not read local MP4 for upload: ' +
-          (readErr instanceof Error ? readErr.message : readErr),
-      );
-    }
-
+    // renderLessonVideo uploads to Supabase course-videos and removes os.tmpdir() temps
     await markComplete(jobId, {
-      video_url: storageUrl,
+      video_url: result.videoUrl,
       audio_url: result.audioUrl ?? undefined,
       duration_seconds: result.duration,
       scene_count: undefined,

--- a/docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md
+++ b/docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md
@@ -99,9 +99,11 @@
 
 ---
 
-## 6. Runtime disk writers (admin API routes)
+## 6. Line-by-line: what can fill disk at runtime (admin API routes)
 
-These are the **only** routes that grow filesystem inside the container (ephemeral disk on Northflank):
+**Do not use the pre–PR #233 table** (`public/generated/`, `public/videos/slide-image-cache/` growing until redeploy). Current behavior:
+
+These are the **only** routes that touch the container filesystem (ephemeral disk on Northflank). Durable media belongs in **Supabase Storage**, not `public/`:
 
 | Route | Writes to | Cleaned? | Risk |
 |-------|-----------|----------|------|


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Replaces the outdated audit table that listed `public/generated/` and `public/videos/slide-image-cache/` as growing until redeploy.

- **AGENTS.md** — authoritative line-by-line runtime disk table (current behavior after #233/#235)
- **docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md** — §6 retitled and warns against the old table
- **app/api/videos/generate/route.ts** — remove stale re-upload from `public/`; `renderLessonVideo` already uploads to Supabase and cleans temps
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

