### PR TITLE
fix(northflank): correct wait-service status parsing for deploy workflows

### DIFF
--- a/scripts/northflank/deploy-live.ts
+++ b/scripts/northflank/deploy-live.ts
@@ -27,17 +27,30 @@ async function triggerBuild(projectId: string, serviceId: string) {
 async function waitForRunning(projectId: string, serviceId: string, maxMs = 900_000) {
   const start = Date.now();
   while (Date.now() - start < maxMs) {
-    const s = await nfFetch<{ deploymentStatus?: { status?: string }; buildStatus?: string }>(
-      projectApiPath(projectId, `/services/${serviceId}`),
-    );
-    const st = s.deploymentStatus?.status ?? s.buildStatus ?? 'unknown';
+    const s = await nfFetch<{
+      deploymentStatus?: { status?: string };
+      buildStatus?: string;
+      status?: { build?: { status?: string }; deployment?: { status?: string } };
+    }>(projectApiPath(projectId, `/services/${serviceId}`));
+    const build = s.status?.build?.status ?? s.buildStatus;
+    const deploy = s.status?.deployment?.status ?? s.deploymentStatus?.status;
+    const st =
+      build && !['SUCCESS', 'COMPLETED'].includes(build)
+        ? build
+        : (deploy ?? build ?? 'unknown');
     process.stdout.write(`\r  ${serviceId}: ${st}   `);
-    if (st === 'COMPLETED' || st === 'RUNNING' || st === 'SUCCESS') {
+    if (build === 'FAILURE' || build === 'FAILED' || build === 'ERROR') {
+      console.log('\n  BUILD FAILED');
+      return false;
+    }
+    const deployReady = deploy && ['COMPLETED', 'RUNNING', 'SUCCESS'].includes(deploy);
+    const buildDone = !build || ['SUCCESS', 'COMPLETED', 'SKIPPED'].includes(build);
+    if (buildDone && deployReady) {
       console.log('');
       return true;
     }
-    if (st === 'FAILED' || st === 'ERROR') {
-      console.log('\n  FAILED');
+    if (deploy === 'FAILED' || deploy === 'ERROR') {
+      console.log('\n  DEPLOY FAILED');
       return false;
     }
     await new Promise((r) => setTimeout(r, 15_000));

--- a/scripts/northflank/dump-build-storage.ts
+++ b/scripts/northflank/dump-build-storage.ts
@@ -1,12 +1,12 @@
 #!/usr/bin/env tsx
 /** Print Northflank build storage + billing from the combined-service API (source of truth for PATCH). */
-import { combinedServicePatchPath, nfFetch, resolveProjectId } from './lib';
+import { nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function main() {
   const pid = resolveProjectId();
   if (!pid) process.exit(1);
   for (const sid of ['elevate-lms', 'elevate-admin']) {
-    const s = await nfFetch<Record<string, unknown>>(combinedServicePatchPath(pid, sid));
+    const s = await nfFetch<Record<string, unknown>>(projectApiPath(pid, `/services/${sid}`));
     const buildSettings = s.buildSettings as Record<string, unknown> | undefined;
     const buildConfiguration = s.buildConfiguration as Record<string, unknown> | undefined;
     const billing = s.billing as Record<string, unknown> | undefined;

--- a/scripts/northflank/wait-service.ts
+++ b/scripts/northflank/wait-service.ts
@@ -12,7 +12,22 @@ import { nfFetch, projectApiPath, resolveProjectId } from './lib';
 type ServiceStatus = {
   deploymentStatus?: { status?: string };
   buildStatus?: string;
+  status?: {
+    build?: { status?: string };
+    deployment?: { status?: string; reason?: string };
+  };
 };
+
+function resolveServicePhase(service: ServiceStatus): string {
+  const build = service.status?.build?.status ?? service.buildStatus;
+  const deploy = service.status?.deployment?.status ?? service.deploymentStatus?.status;
+
+  if (build && !['SUCCESS', 'COMPLETED'].includes(build)) {
+    return build;
+  }
+  if (deploy) return deploy;
+  return build ?? deploy ?? 'unknown';
+}
 
 function argValue(name: string): string | undefined {
   const index = process.argv.indexOf(name);
@@ -38,18 +53,33 @@ async function main() {
 
   while (Date.now() - start < timeoutMs) {
     const service = await nfFetch<ServiceStatus>(projectApiPath(projectId, `/services/${serviceId}`));
-    const status = service.deploymentStatus?.status ?? service.buildStatus ?? 'unknown';
+    const build = service.status?.build?.status ?? service.buildStatus;
+    const deploy = service.status?.deployment?.status ?? service.deploymentStatus?.status;
+    const phase = resolveServicePhase(service);
+    const label =
+      build && deploy && build !== deploy ? `${build} (deploy: ${deploy})` : phase;
 
-    if (status !== last) {
-      console.log(`${serviceId}: ${status}`);
-      last = status;
+    if (label !== last) {
+      console.log(`${serviceId}: ${label}`);
+      last = label;
     }
 
-    if (['COMPLETED', 'RUNNING', 'SUCCESS'].includes(status)) {
+    if (build === 'FAILURE' || build === 'ERROR' || build === 'FAILED') {
+      console.error(`${serviceId} build failed (${build})`);
+      process.exit(1);
+    }
+
+    const deployReady =
+      deploy && ['COMPLETED', 'RUNNING', 'SUCCESS'].includes(deploy);
+    const buildDone =
+      !build || ['SUCCESS', 'COMPLETED', 'SKIPPED'].includes(build);
+
+    if (buildDone && deployReady) {
       return;
     }
-    if (['FAILED', 'ERROR'].includes(status)) {
-      console.error(`${serviceId} failed with status ${status}`);
+
+    if (['FAILED', 'ERROR'].includes(deploy ?? '')) {
+      console.error(`${serviceId} deployment failed (${deploy})`);
       process.exit(1);
     }
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
GitHub deploy workflows waited 20m reporting `unknown` because Northflank returns `status.build` / `status.deployment`, not legacy `buildStatus` fields. Fails fast on `build: FAILURE` instead of timing out.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

