### PR TITLE
fix(northflank): remove unsupported Docker cache mounts from Northflank builds

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -34,16 +34,16 @@ COPY packages/ui/package.json packages/ui/package.json
 
 # Store on /app so pnpm can hardlink into node_modules (same filesystem as /app).
 # Do NOT use --package-import-method=copy — it duplicates every package and causes ENOSPC.
-RUN --mount=type=cache,id=pnpm-store-admin,target=/app/.pnpm-store \
-    pnpm config set store-dir /app/.pnpm-store \
+# No RUN --mount=type=cache here — Northflank BuildKit does not always bind external
+# cache mounts; rely on /app/.pnpm-store on the build volume + internal BuildKit cache.
+RUN pnpm config set store-dir /app/.pnpm-store \
     && pnpm fetch --frozen-lockfile
 
 COPY . .
 
 ENV HUSKY=0
 ENV CI=true
-RUN --mount=type=cache,id=pnpm-store-admin,target=/app/.pnpm-store \
-    pnpm config set store-dir /app/.pnpm-store \
+RUN pnpm config set store-dir /app/.pnpm-store \
     && pnpm install --frozen-lockfile --offline --prefer-offline
 
 ENV NODE_ENV=production

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -32,16 +32,14 @@ COPY packages/db/package.json packages/db/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
-RUN --mount=type=cache,id=pnpm-store-lms,target=/app/.pnpm-store \
-    pnpm config set store-dir /app/.pnpm-store \
+RUN pnpm config set store-dir /app/.pnpm-store \
     && pnpm fetch --frozen-lockfile
 
 COPY . .
 
 ENV HUSKY=0
 ENV CI=true
-RUN --mount=type=cache,id=pnpm-store-lms,target=/app/.pnpm-store \
-    pnpm config set store-dir /app/.pnpm-store \
+RUN pnpm config set store-dir /app/.pnpm-store \
     && pnpm install --frozen-lockfile --offline --prefer-offline
 
 ENV NODE_ENV=production


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Admin and LMS Northflank builds were failing in ~3 minutes during BUILDING (before `next build` completes). Local `next build` succeeds.

This removes `RUN --mount=type=cache` from `Dockerfile.northflank-admin` and `Dockerfile.northflank-lms`. Northflank uses internal BuildKit cache (`useInternalCache`); external cache mounts may not bind on their builders. pnpm still uses `/app/.pnpm-store` on the build volume with hardlinks (no `--package-import-method=copy`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

