### PR TITLE
fix(northflank): LMS Docker build memory and standalone prune

### DIFF
--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -44,7 +44,8 @@ RUN pnpm config set store-dir /app/.pnpm-store \
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-ENV NODE_OPTIONS=--max-old-space-size=8192
+# nf-compute-800-32 builder; leave headroom for native compile + BuildKit
+ENV NODE_OPTIONS=--max-old-space-size=6144
 ENV BUILD_SCOPE=1
 ENV DISABLE_WEBPACK_FILESYSTEM_CACHE=1
 # Required at `next build` because NEXT_PUBLIC_* values are inlined into the
@@ -62,7 +63,8 @@ ENV SKIP_ENV_VALIDATION=true
 
 RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && pnpm exec next build
+    && pnpm exec next build \
+    && node scripts/prune-standalone.mjs
 
 # Bundle sharp + linux x64 @img bindings (runtime npm install fails in slim CI images)
 RUN set -eux; \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Northflank LMS builds failed ~6min while admin succeeded at ~16min on the same commit.

- Reduce `NODE_OPTIONS` heap to 6144MB (headroom on nf-compute-800-32)
- Run `scripts/prune-standalone.mjs` after `next build` (matches admin prune pattern)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

