### PR TITLE
fix(northflank): full LMS Docker build without BUILD_SCOPE

### DIFF
--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -44,9 +44,9 @@ RUN pnpm config set store-dir /app/.pnpm-store \
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
-# nf-compute-800-32 builder; leave headroom for native compile + BuildKit
-ENV NODE_OPTIONS=--max-old-space-size=6144
-ENV BUILD_SCOPE=1
+# nf-compute-800-32 builder — full LMS graph (do not set BUILD_SCOPE=1 here;
+# scoped builds pull server-only json-cache into client chunks and fail webpack).
+ENV NODE_OPTIONS=--max-old-space-size=8192
 ENV DISABLE_WEBPACK_FILESYSTEM_CACHE=1
 # Required at `next build` because NEXT_PUBLIC_* values are inlined into the
 # client bundle. Northflank must provide the real anon key as a build arg or

--- a/lib/data/json-cache.ts
+++ b/lib/data/json-cache.ts
@@ -19,8 +19,8 @@ export function loadJsonOnce<T = unknown>(filename: string): T {
   }
 
   try {
-    const { readFileSync } = require('node:fs') as typeof import('node:fs');
-    const { join } = require('node:path') as typeof import('node:path');
+    const { readFileSync } = require('fs') as typeof import('fs');
+    const { join } = require('path') as typeof import('path');
     const raw = readFileSync(join(process.cwd(), 'public/data', filename), 'utf8');
     const parsed = JSON.parse(raw) as T;
     _cache.set(filename, parsed);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Northflank LMS builds failed with `BUILD_SCOPE=1` because `heroBanners` → `json-cache` is pulled into client webpack (`node:path` error).

- Drop `BUILD_SCOPE=1` from `Dockerfile.northflank-lms` (use full `next build` on nf-compute-800-32)
- Restore 8192MB heap for full graph
- Use `fs`/`path` requires in json-cache for webpack compatibility
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

