### PR TITLE
ci(northflank): 60min deploy wait timeout

### DIFF
--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -80,7 +80,7 @@ jobs:
         run: pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_LMS_SERVICE_ID"
 
       - name: Wait for LMS deployment
-        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --timeout-ms 1200000
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --timeout-ms 3600000
 
       - name: Smoke LMS
         run: |


### PR DESCRIPTION
LMS builds ~43min; 20min workflow wait caused false failures while deploy succeeded.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single workflow timeout tweak with no runtime, auth, or data-path impact.
> 
> **Overview**
> The **Deploy LMS** GitHub Actions workflow now allows up to **60 minutes** (was 20) for the Northflank `wait-service` step after triggering an LMS build, so long builds (~43 min) are less likely to fail the job while the deploy still completes successfully.
> 
> No application or infrastructure logic changes—only the CI wait duration in `.github/workflows/deploy-lms.yml`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 44bebc922356b3e8c964bcf78008c070a2486bca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->