### PR TITLE
fix(barber): host shop partner display, dedupe, and enroll CTA

### DIFF
--- a/app/programs/barber-apprenticeship/host-shops/page.tsx
+++ b/app/programs/barber-apprenticeship/host-shops/page.tsx
@@ -3,10 +3,11 @@ export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
 import Link from 'next/link';
 import Image from 'next/image';
-import { Shield, Users, Award, Building2 } from 'lucide-react';
+import { Shield, Users, Award, Building2, MapPin } from 'lucide-react';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import HostShopSyllabusRequirement from '@/components/programs/beauty/HostShopSyllabusRequirement';
+import { getApprovedShops, PROGRAM_LABELS } from '@/lib/programs/host-shops';
 
 export const metadata: Metadata = {
   title: 'Become a Host Barbershop | Barber Apprenticeship',
@@ -16,7 +17,8 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HostShopsPage() {
+export default async function HostShopsPage() {
+  const approvedShops = await getApprovedShops('barber');
 
   return (
     <main className="bg-white">
@@ -226,6 +228,54 @@ export default function HostShopsPage() {
 
       <HostShopSyllabusRequirement programSlug="barber-apprenticeship" />
 
+      {/* Approved host shops */}
+      <section className="py-16 px-6 bg-slate-50 border-y border-slate-200">
+        <div className="max-w-5xl mx-auto">
+          <h2 className="text-3xl font-bold text-center mb-3 text-slate-900">Approved Host Shops</h2>
+          <p className="text-center text-slate-700 mb-10 max-w-2xl mx-auto">
+            These partner barbershops are approved to host DOL-registered barber apprentices in the
+            Indianapolis metro area. Apprentices may be placed based on availability.
+          </p>
+          {approvedShops.length === 0 ? (
+            <p className="text-center text-slate-600">
+              Approved host shop list is loading. Contact us for current placement partners.
+            </p>
+          ) : (
+            <ul className="grid gap-4 sm:grid-cols-2">
+              {approvedShops.map((shop) => (
+                <li
+                  key={shop.id}
+                  className="rounded-xl border border-slate-200 bg-white p-6 shadow-sm"
+                >
+                  <div className="flex items-start gap-3">
+                    <MapPin className="mt-1 h-5 w-5 shrink-0 text-brand-red-600" aria-hidden />
+                    <div>
+                      <h3 className="text-lg font-bold text-slate-900">{shop.name}</h3>
+                      <p className="mt-1 text-sm text-slate-700">
+                        {[shop.address, shop.city, shop.state, shop.zip].filter(Boolean).join(', ')}
+                      </p>
+                      {shop.supervisor ? (
+                        <p className="mt-2 text-sm text-slate-600">
+                          Supervisor: {shop.supervisor}
+                        </p>
+                      ) : null}
+                      <p className="mt-3 text-xs font-semibold uppercase tracking-wide text-brand-green-700">
+                        Approved host shop
+                      </p>
+                      <p className="mt-1 text-sm text-slate-600">
+                        {shop.programs
+                          .map((slug) => PROGRAM_LABELS[slug] ?? slug)
+                          .join(' · ')}
+                      </p>
+                    </div>
+                  </div>
+                </li>
+              ))}
+            </ul>
+          )}
+        </div>
+      </section>
+
       {/* Approval Process */}
       <section className="py-16 px-6">
         <div className="max-w-4xl mx-auto">
@@ -272,7 +322,7 @@ export default function HostShopsPage() {
               General Inquiry
             </Link>
             <Link
-              href="/programs/barber-apprenticeship/host-shops"
+              href="/partners/barber-host-shop/apply"
               className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold transition"
             >
               Enroll as a Host Shop

--- a/data/programs/barber-apprenticeship.ts
+++ b/data/programs/barber-apprenticeship.ts
@@ -246,7 +246,8 @@ export const BARBER_APPRENTICESHIP: ProgramSchema = {
   facilityInfo: 'Host barbershops across Indianapolis metro area',
   bilingualSupport: 'Bilingual (English/Spanish) instruction available.',
   employerPartners: [
-    'Partner barbershops in Indianapolis (host shops)',
+    'Elevate Prestige Barber and Beauty Institute',
+    'Kountry Kutz Barbershop',
     'Indiana Barber Association',
   ],
   pricingIncludes: [

--- a/lib/barber/apprentice-stripe-billing.ts
+++ b/lib/barber/apprentice-stripe-billing.ts
@@ -132,6 +132,7 @@ async function ensureWeeklySubscription(
     proration_behavior: 'none',
     metadata: {
       program: 'barber-apprenticeship',
+      program_holder: 'Elevate Prestige Barber and Beauty Institute',
       enrollment_id: meta.enrollmentId,
       apprentice_name: meta.name,
     },

--- a/lib/beauty-apprenticeship/host-partners.ts
+++ b/lib/beauty-apprenticeship/host-partners.ts
@@ -13,7 +13,7 @@ export type FeaturedHostPartner = {
 
 export const FEATURED_BEAUTY_HOST_PARTNERS: FeaturedHostPartner[] = [
   {
-    name: 'Prestige Elevation Barber and Beauty Institute LLC',
+    name: 'Elevate Prestige Barber and Beauty Institute',
     dba: 'Prestige Kountry Kuts',
     city: 'Indianapolis',
     state: 'IN',

--- a/lib/programs/host-shops.ts
+++ b/lib/programs/host-shops.ts
@@ -88,7 +88,7 @@ function parseAddress(raw: string): { address: string; city: string; state: stri
 
 /** Normalize shop names for deduplication (not for display). */
 export function normalizeShopKey(name: string): string {
-  let key = name
+  const key = name
     .toLowerCase()
     .trim()
     .replace(/\s+/g, ' ')

--- a/lib/programs/host-shops.ts
+++ b/lib/programs/host-shops.ts
@@ -35,8 +35,47 @@ export const PROGRAM_SLUGS = {
 
 export type ProgramKey = keyof typeof PROGRAM_SLUGS;
 
+/** Human-readable labels for program slugs on marketing pages */
+export const PROGRAM_LABELS: Record<string, string> = {
+  [PROGRAM_SLUGS.barber]: 'Barber Apprenticeship',
+  [PROGRAM_SLUGS.cosmetology]: 'Cosmetology Apprenticeship',
+  'nail-technician-apprenticeship': 'Nail Technician Apprenticeship',
+  'esthetician-apprenticeship': 'Esthetician Apprenticeship',
+};
+
+export const ELEVATE_PRESTIGE_BARBER_INSTITUTE = 'Elevate Prestige Barber and Beauty Institute';
+export const KOUNTRY_KUTZ_BARBERSHOP = 'Kountry Kutz Barbershop';
+
+const BARBER_FALLBACK_SHOPS: HostShop[] = [
+  {
+    id: 'fallback-elevate-prestige',
+    name: ELEVATE_PRESTIGE_BARBER_INSTITUTE,
+    address: '6331 N Keystone Ave',
+    city: 'Indianapolis',
+    state: 'IN',
+    zip: '46220',
+    phone: '(317) 760-7908',
+    email: 'elevate4humanityedu@gmail.com',
+    supervisor: '',
+    programs: [PROGRAM_SLUGS.barber, PROGRAM_SLUGS.cosmetology],
+    badge: 'partner',
+  },
+  {
+    id: 'fallback-kountry-kutz',
+    name: KOUNTRY_KUTZ_BARBERSHOP,
+    address: 'New Palestine area',
+    city: 'New Palestine',
+    state: 'IN',
+    zip: '46163',
+    phone: '',
+    email: '',
+    supervisor: '',
+    programs: [PROGRAM_SLUGS.barber],
+    badge: 'partner',
+  },
+];
+
 function parseAddress(raw: string): { address: string; city: string; state: string; zip: string } {
-  // Expected format: "123 Main St, City, ST 12345"
   const parts = raw.split(',').map((p) => p.trim());
   const stateZip = (parts[2] ?? '').split(' ').filter(Boolean);
   return {
@@ -47,17 +86,121 @@ function parseAddress(raw: string): { address: string; city: string; state: stri
   };
 }
 
+/** Normalize shop names for deduplication (not for display). */
+export function normalizeShopKey(name: string): string {
+  let key = name
+    .toLowerCase()
+    .trim()
+    .replace(/\s+/g, ' ')
+    .replace(/\b(l\.?l\.?c\.?|llc|inc|corp|co)\b/g, '')
+    .replace(/[.,']/g, '')
+    .trim();
+
+  if (
+    key.includes('prestige elevation') ||
+    key.includes('prestige kountry') ||
+    key.includes('elevate prestige')
+  ) {
+    return 'elevate prestige barber and beauty institute';
+  }
+  if (key.includes('kountry kutz')) {
+    return 'kountry kutz barbershop';
+  }
+  if (key.includes("cal's kutz") || key.includes('cals kutz')) {
+    return 'cals kutz studio';
+  }
+  if (key.includes('b-52') || key.includes('b52')) {
+    return 'b-52s barber shop';
+  }
+  if (key.includes('style and scissor')) {
+    return 'style and scissor salon';
+  }
+
+  return key;
+}
+
+function canonicalDisplayName(key: string, fallbackName: string): string {
+  if (key === 'elevate prestige barber and beauty institute') {
+    return ELEVATE_PRESTIGE_BARBER_INSTITUTE;
+  }
+  if (key === 'kountry kutz barbershop') {
+    return KOUNTRY_KUTZ_BARBERSHOP;
+  }
+  return fallbackName.trim();
+}
+
+function pickRicherField(current: string, next: string): string {
+  return next.trim().length > current.trim().length ? next : current;
+}
+
+function mergeShops(existing: HostShop, incoming: HostShop): HostShop {
+  return {
+    id: existing.id.startsWith('fallback-') ? incoming.id : existing.id,
+    name: canonicalDisplayName(
+      normalizeShopKey(existing.name),
+      pickRicherField(existing.name, incoming.name),
+    ),
+    address: pickRicherField(existing.address, incoming.address),
+    city: pickRicherField(existing.city, incoming.city),
+    state: pickRicherField(existing.state || 'IN', incoming.state || 'IN'),
+    zip: pickRicherField(existing.zip, incoming.zip),
+    phone: pickRicherField(existing.phone, incoming.phone),
+    email: pickRicherField(existing.email, incoming.email),
+    supervisor: pickRicherField(existing.supervisor, incoming.supervisor),
+    programs: [...new Set([...existing.programs, ...incoming.programs])],
+    badge: existing.badge || incoming.badge,
+  };
+}
+
+function dedupeShops(shops: HostShop[]): HostShop[] {
+  const byKey = new Map<string, HostShop>();
+  for (const shop of shops) {
+    const key = normalizeShopKey(shop.name);
+    const existing = byKey.get(key);
+    if (existing) {
+      byKey.set(key, mergeShops(existing, shop));
+    } else {
+      byKey.set(key, { ...shop, name: canonicalDisplayName(key, shop.name) });
+    }
+  }
+  return [...byKey.values()].sort((a, b) => a.name.localeCompare(b.name));
+}
+
+function ensureBarberFallbacks(shops: HostShop[]): HostShop[] {
+  const merged = dedupeShops(shops);
+  const byKey = new Map(merged.map((s) => [normalizeShopKey(s.name), s]));
+
+  for (const fallback of BARBER_FALLBACK_SHOPS) {
+    const key = normalizeShopKey(fallback.name);
+    const existing = byKey.get(key);
+    if (existing) {
+      byKey.set(key, mergeShops(existing, fallback));
+    } else {
+      byKey.set(key, { ...fallback });
+    }
+  }
+
+  return [...byKey.values()]
+    .filter((s) => s.programs.includes(PROGRAM_SLUGS.barber))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
 export async function getApprovedShops(program?: ProgramKey): Promise<HostShop[]> {
-  // Admin client requires SUPABASE_SERVICE_ROLE_KEY from runtime env/secrets.
-  // build time. Return empty list so static generation succeeds; ISR will
-  // populate real data at runtime.
   let db: Awaited<ReturnType<typeof requireAdminClient>>;
   try {
     db = await requireAdminClient();
   } catch {
+    if (program === 'barber') {
+      return ensureBarberFallbacks(BARBER_FALLBACK_SHOPS);
+    }
     return [];
   }
-  if (!db) return [];
+  if (!db) {
+    if (program === 'barber') {
+      return ensureBarberFallbacks(BARBER_FALLBACK_SHOPS);
+    }
+    return [];
+  }
 
   const [{ data: barberRows }, { data: hostRows }] = await Promise.all([
     db
@@ -74,10 +217,9 @@ export async function getApprovedShops(program?: ProgramKey): Promise<HostShop[]
       .order('shop_name'),
   ]);
 
-  // Normalise barber rows
   const barberShops: HostShop[] = (barberRows ?? []).map((s) => ({
     id: s.id,
-    name: s.shop_dba_name || s.shop_legal_name,
+    name: (s.shop_dba_name || s.shop_legal_name || '').trim(),
     address: s.shop_address_line1 ?? '',
     city: s.shop_city ?? '',
     state: s.shop_state ?? 'IN',
@@ -89,38 +231,34 @@ export async function getApprovedShops(program?: ProgramKey): Promise<HostShop[]
     badge: 'partner',
   }));
 
-  // Normalise host rows
   const hostShops: HostShop[] = (hostRows ?? []).map((s) => {
     const parsed = parseAddress(s.address ?? '');
+    const intakePrograms = (s.intake?.programs as string[] | undefined) ?? [];
     return {
       id: s.id,
-      name: s.shop_name,
+      name: (s.shop_name ?? '').trim(),
       ...parsed,
       phone: s.phone ?? '',
       email: s.email ?? '',
       supervisor: '',
-      programs: (s.intake?.programs as string[]) ?? [PROGRAM_SLUGS.cosmetology],
+      programs:
+        intakePrograms.length > 0 ? intakePrograms : [PROGRAM_SLUGS.cosmetology],
       badge: 'partner',
     };
   });
 
-  // Merge programs for shops present in both tables (matched by name)
-  const barberNameMap = new Map(barberShops.map((s) => [s.name.toLowerCase(), s]));
-  barberShops.forEach((bs) => {
-    const match = hostShops.find((hs) => hs.name.toLowerCase() === bs.name.toLowerCase());
-    if (match) bs.programs = [...new Set([...bs.programs, ...match.programs])];
-  });
+  const merged = dedupeShops([...barberShops, ...hostShops]);
 
-  // Host-only shops (not already in barber table)
-  const hostOnly = hostShops.filter((s) => !barberNameMap.has(s.name.toLowerCase()));
-
-  const all = [...barberShops, ...hostOnly];
-
-  // Filter by exact program slug if requested
-  if (program) {
-    const slug = PROGRAM_SLUGS[program];
-    return all.filter((s) => s.programs.includes(slug));
+  if (program === 'barber') {
+    const slug = PROGRAM_SLUGS.barber;
+    const barberFromDb = merged.filter((s) => s.programs.includes(slug));
+    return ensureBarberFallbacks(barberFromDb);
   }
 
-  return all;
+  if (program) {
+    const slug = PROGRAM_SLUGS[program];
+    return merged.filter((s) => s.programs.includes(slug));
+  }
+
+  return merged;
 }


### PR DESCRIPTION
## Summary
- Deduplicate barber host shops (Elevate Prestige always included; Kountry Kutz listed once)
- Add Approved Host Shops section on `/programs/barber-apprenticeship/host-shops`
- Fix Enroll as a Host Shop CTA → `/partners/barber-host-shop/apply`
- Update public employer partners and apprentice Stripe billing metadata to Elevate Prestige Barber and Beauty Institute

## Testing
- ESLint + prettier on touched files
- `getApprovedShops('barber')` smoke (Elevate Prestige + single Kountry Kutz)
- quality-gates.sh

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes public partner listings and barber host-shop merge/fallback behavior (including hardcoded fallbacks when admin DB fails), plus Stripe subscription metadata for billing traceability.
> 
> **Overview**
> The barber host-shops marketing page is now **async** and loads **`getApprovedShops('barber')`** to render a new **Approved Host Shops** grid (address, supervisor, program labels via **`PROGRAM_LABELS`**), with a fallback message when the list is empty. The **Enroll as a Host Shop** CTA now points to **`/partners/barber-host-shop/apply`** instead of the same page.
> 
> **`lib/programs/host-shops`** gains canonical partner names, barber **fallback** shop records when Supabase is unavailable, and **deduplication/merge** logic (normalized keys, richer fields, guaranteed Elevate Prestige + Kountry Kutz for barber). Public copy and featured partners rename **Prestige Elevation** to **Elevate Prestige Barber and Beauty Institute**; program data **`employerPartners`** lists the two named shops. New apprentice Stripe subscriptions include **`program_holder`** metadata for that institute.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 442658f181c9d8ff266149b5c46aff8f905d8be1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->