### PR TITLE
fix(ui): chat assistant stuck open — restore close controls

### DIFF
--- a/components/AIAssistantBubble.tsx
+++ b/components/AIAssistantBubble.tsx
@@ -49,7 +49,22 @@ export function AIAssistantBubble() {
 
   const handleClose = () => {
     setIsOpen(false);
+    setShowWelcome(false);
   };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
 
   const handleSend = async () => {
     if (!input.trim() || isLoading) return;
@@ -139,11 +154,13 @@ export function AIAssistantBubble() {
   return (
     <>
       {showWelcome && !isOpen && (
-        <div className="fixed bottom-24 right-6 z-50 animate-fade-in">
+        <div className="fixed bottom-24 right-6 z-[60] animate-fade-in">
           <div className="bg-white rounded-lg shadow-2xl p-4 max-w-xs border border-slate-200 relative">
             <button
+              type="button"
               onClick={() => setShowWelcome(false)}
               className="absolute top-2 right-2 text-slate-700 hover:text-black"
+              aria-label="Dismiss chat prompt"
             >
               <X className="h-4 w-4" />
             </button>
@@ -154,6 +171,7 @@ export function AIAssistantBubble() {
               I can help you explore training options and check your eligibility!
             </p>
             <button
+              type="button"
               onClick={handleOpen}
               className="text-xs bg-brand-orange-600 text-white px-3 py-2.5 rounded-md hover:bg-brand-orange-700 transition-colors font-medium"
             >
@@ -165,8 +183,10 @@ export function AIAssistantBubble() {
 
       {!isOpen && (
         <button
+          type="button"
           onClick={handleOpen}
-          className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-40 flex bg-brand-orange-600 text-white rounded-full p-4 shadow-2xl hover:bg-brand-orange-700 transition-all hover:scale-110"
+          className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-[60] flex bg-brand-orange-600 text-white rounded-full p-4 shadow-2xl hover:bg-brand-orange-700 transition-all hover:scale-110"
+          aria-label="Open AI assistant"
         >
           <MessageCircle className="h-10 w-10" />
           <span className="absolute -top-1 -right-1 bg-brand-green-500 w-4 h-4 rounded-full border-2 border-white" />
@@ -174,7 +194,19 @@ export function AIAssistantBubble() {
       )}
 
       {isOpen && (
-        <div className="fixed inset-0 md:inset-auto md:bottom-6 md:right-6 z-50 w-full md:w-96 h-full md:h-[600px] bg-white md:rounded-2xl shadow-2xl flex flex-col border border-slate-200">
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-[60] bg-black/40 md:hidden"
+            aria-label="Close chat"
+            onClick={handleClose}
+          />
+          <div
+            className="fixed inset-0 md:inset-auto md:bottom-6 md:right-6 z-[61] w-full md:w-96 h-full md:h-[600px] bg-white md:rounded-2xl shadow-2xl flex flex-col border border-slate-200"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Elevate AI Assistant"
+          >
           <div className="bg-gradient-to-r from-brand-orange-600 to-brand-orange-500 text-white p-4 md:rounded-t-2xl flex items-center justify-between flex-shrink-0">
             <div className="flex items-center gap-3">
               <div className="bg-white/20 rounded-full p-2">
@@ -189,11 +221,12 @@ export function AIAssistantBubble() {
               </div>
             </div>
             <button
+              type="button"
               onClick={handleClose}
               aria-label="Close chat"
-              className="text-slate-900 hover:bg-white/20 rounded-full p-2 transition-colors"
+              className="text-white hover:bg-white/20 rounded-full p-2 transition-colors"
             >
-              <X className="h-6 w-6" />
+              <X className="h-6 w-6" aria-hidden />
             </button>
           </div>
 
@@ -254,9 +287,11 @@ export function AIAssistantBubble() {
                 className="flex-1 px-4 py-2 border border-slate-300 rounded-full focus:outline-none focus:ring-2 focus:ring-brand-orange-500 text-sm"
               />
               <button
+                type="button"
                 onClick={handleSend}
                 disabled={!input.trim() || isLoading}
                 className="bg-brand-orange-600 text-white rounded-full p-2 hover:bg-brand-orange-700 disabled:opacity-50"
+                aria-label="Send message"
               >
                 {isLoading ? (
                   <Loader2 className="h-5 w-5 animate-spin" />
@@ -274,6 +309,7 @@ export function AIAssistantBubble() {
             </p>
           </div>
         </div>
+        </>
       )}
     </>
   );

--- a/components/ChatAssistant.tsx
+++ b/components/ChatAssistant.tsx
@@ -52,6 +52,20 @@ export default function ChatAssistant({
 
   useEffect(scrollToBottom, [messages]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
+
   // Initialize with welcome message
   useEffect(() => {
     if (isOpen && messages.length === 0) {
@@ -178,10 +192,10 @@ export default function ChatAssistant({
     }
   };
 
-  if (!isOpen) return null;
-  {
+  if (!isOpen) {
     return (
       <button
+        type="button"
         onClick={() => setIsOpen(true)}
         className="chat-assistant-button"
         style={{
@@ -258,6 +272,7 @@ export default function ChatAssistant({
         </div>
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
+            type="button"
             onClick={() => setIsMinimized(!isMinimized)}
             style={{
               background: 'transparent',
@@ -273,6 +288,7 @@ export default function ChatAssistant({
             {isMinimized ? <Maximize2 size={20} /> : <Minimize2 size={20} />}
           </button>
           <button
+            type="button"
             onClick={() => setIsOpen(false)}
             style={{
               background: 'transparent',

--- a/components/ElevateChatWidget.tsx
+++ b/components/ElevateChatWidget.tsx
@@ -39,6 +39,20 @@ export function ElevateChatWidget() {
     localStorage.setItem('elevate-chat-interacted', 'true');
   };
 
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
   return (
     <>
       {/* Proactive chat prompt */}
@@ -117,8 +131,22 @@ export function ElevateChatWidget() {
 
       {/* Modal overlay */}
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="bg-white rounded-3xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden animate-scale-in">
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Elevate AI Helper"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setOpen(false);
+          }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close chat"
+            onClick={() => setOpen(false)}
+          />
+          <div className="relative bg-white rounded-3xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden animate-scale-in">
             <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between bg-gradient-to-r from-emerald-500 to-teal-600 text-white">
               <div className="flex items-center gap-3">
                 <MessageCircle size={24} />
@@ -130,10 +158,10 @@ export function ElevateChatWidget() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="text-slate-900 hover:bg-white/20 rounded-full p-2 transition-colors"
+                className="relative z-10 text-white hover:bg-white/20 rounded-full p-2 transition-colors"
                 aria-label="Close chat"
               >
-                <X size={20} />
+                <X size={20} aria-hidden />
               </button>
             </div>
             <iframe src="/ai-chat" className="flex-1 w-full border-0" title="Elevate AI Chat" />


### PR DESCRIPTION
## Problem
Site chat assist could appear stuck open with no obvious way to dismiss it.

## Root cause
`ChatAssistant.tsx` had inverted open/close logic: when `isOpen` was true it returned only the launcher button and never rendered the panel (with the X close control).

## Fix
- **ChatAssistant**: correct FAB vs panel branches; Escape closes; lock body scroll while open
- **AIAssistantBubble** (site-wide widget): white close icon on orange header; Escape; tap backdrop on mobile; higher z-index
- **ElevateChatWidget**: backdrop click + Escape + visible close button

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Front-end-only UX and accessibility tweaks in three chat components; no API, auth, or data changes.
> 
> **Overview**
> Fixes chat UIs that could feel **stuck open** by correcting broken open/close rendering and adding consistent dismiss paths across three widgets.
> 
> **`ChatAssistant`** had inverted branching: when `isOpen` was true it only rendered the floating launcher, so the panel (and **X**) never appeared. The PR swaps the branches so closed shows the FAB and open shows the full panel, and adds **Escape** plus **body scroll lock** while open.
> 
> **`AIAssistantBubble`** and **`ElevateChatWidget`** gain the same **Escape** / scroll-lock behavior, higher **z-index**, a **mobile backdrop** (and clickable overlay on the modal widget) to close, **dialog** semantics, and **visible** header close controls (white icon on colored headers). Closing also clears the welcome prompt on the bubble; buttons get `type="button"` and basic **aria** labels.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6af4af1f08a0401bc207d28032e51d632f11f165. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->