### PR TITLE
feat(store): individual subscription plans and 14-day app trials

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -891,6 +891,13 @@ Precedence at runtime: `platform_secrets > app_secrets > process.env`
 
 **Dev Studio AI Chat** (`/api/devstudio/chat`) uses Groq/Gemini with tool calling for platform operations. This is separate from `lib/ai/ai-service.ts` (`aiChat()`) which is for course content generation.
 
+### Store apps — individual trials & plans
+
+- **14-day app trials:** `/apps/{website-builder|sam-gov|grants}/start-trial` → `lib/trial/start-app-trial.ts` (admin insert into `user_app_subscriptions`).
+- **Individual paid plans:** `lib/apps/individual-app-plans.ts` + `IndividualAppPlansSection` on store pages; checkout via `POST /api/apps/upgrade`.
+- **Import website:** `/import` → `POST /api/ai/import-site` (auth required). Builder: `/apps/website-builder`.
+- **DB:** Apply `supabase/migrations/20260702000015_individual_app_subscriptions.sql` if trials or “New Website” fail (missing `app_slug` / RLS).
+
 ### Stripe webhooks (production)
 
 - **Canonical URL:** `https://www.elevateforhumanity.org/api/webhooks/stripe` — register in Stripe Dashboard (live), then set signing secret in the Northflank production secret group for the **LMS** service.

--- a/app/api/apps/trial/start/route.ts
+++ b/app/api/apps/trial/start/route.ts
@@ -1,6 +1,7 @@
 import { logger } from '@/lib/logger';
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 
@@ -60,23 +61,29 @@ async function _POST(request: NextRequest) {
     const trialEndsAt = new Date();
     trialEndsAt.setDate(trialEndsAt.getDate() + TRIAL_DURATION_DAYS);
 
-    const { data: subscription, error } = await supabase
+    const row = {
+      user_id: user.id,
+      app_slug: appSlug,
+      plan: plan,
+      status: 'trial',
+      trial_ends_at: trialEndsAt.toISOString(),
+      current_period_start: new Date().toISOString(),
+      current_period_end: trialEndsAt.toISOString(),
+    };
+
+    const admin = await getAdminClient();
+    const { data: subscription, error } = await admin
       .from('user_app_subscriptions')
-      .insert({
-        user_id: user.id,
-        app_slug: appSlug,
-        plan: plan,
-        status: 'trial',
-        trial_ends_at: trialEndsAt.toISOString(),
-        current_period_start: new Date().toISOString(),
-        current_period_end: trialEndsAt.toISOString(),
-      })
+      .insert(row)
       .select()
       .maybeSingle();
 
     if (error) {
       logger.error('Error creating trial:', error);
-      return NextResponse.json({ error: 'Failed to create trial' }, { status: 500 });
+      return NextResponse.json(
+        { error: 'Failed to create trial', detail: error.message },
+        { status: 500 },
+      );
     }
 
     return NextResponse.json({

--- a/app/apps/website-builder/WebsiteBuilderApp.tsx
+++ b/app/apps/website-builder/WebsiteBuilderApp.tsx
@@ -42,11 +42,13 @@ export function WebsiteBuilderApp({
   const [showNewModal, setShowNewModal] = useState(false);
   const [selectedTemplate, setSelectedTemplate] = useState('');
   const [loading, setLoading] = useState(false);
+  const [createError, setCreateError] = useState<string | null>(null);
   const supabase = createClient();
 
   const createWebsite = async (name: string, templateId: string) => {
     if (!supabase) return;
     setLoading(true);
+    setCreateError(null);
 
     const { data, error } = await supabase
       .from('user_websites')
@@ -59,13 +61,28 @@ export function WebsiteBuilderApp({
       .select()
       .single();
 
-    if (!error && data) {
-      // Create default pages
-      await supabase.from('website_pages').insert([
+    if (error) {
+      setCreateError(
+        error.message.includes('column')
+          ? 'Database not fully configured. Apply migration 20260702000015_individual_app_subscriptions.sql in Supabase.'
+          : error.message,
+      );
+      setLoading(false);
+      return;
+    }
+
+    if (data) {
+      const { error: pagesError } = await supabase.from('website_pages').insert([
         { website_id: data.id, name: 'Home', slug: 'home', is_home: true, blocks: [] },
         { website_id: data.id, name: 'About', slug: 'about', blocks: [] },
         { website_id: data.id, name: 'Contact', slug: 'contact', blocks: [] },
       ]);
+
+      if (pagesError) {
+        setCreateError(pagesError.message);
+        setLoading(false);
+        return;
+      }
 
       setWebsites((prev) => [data, ...prev]);
       setShowNewModal(false);
@@ -118,13 +135,28 @@ export function WebsiteBuilderApp({
               {websites.length} website{websites.length !== 1 ? 's' : ''}
             </p>
           </div>
-          <button
-            onClick={() => setShowNewModal(true)}
-            className="px-4 py-2 bg-brand-blue-600 text-white rounded-lg font-medium flex items-center gap-2"
-          >
-            <Plus className="w-5 h-5" /> New Website
-          </button>
+          <div className="flex flex-wrap items-center gap-2">
+            <Link
+              href="/import"
+              className="px-4 py-2 border border-slate-300 rounded-lg font-medium text-slate-700 hover:bg-slate-50"
+            >
+              Import website
+            </Link>
+            <button
+              type="button"
+              onClick={() => setShowNewModal(true)}
+              className="px-4 py-2 bg-brand-blue-600 text-white rounded-lg font-medium flex items-center gap-2"
+            >
+              <Plus className="w-5 h-5" /> New Website
+            </button>
+          </div>
         </div>
+
+        {createError && (
+          <p className="mb-6 text-sm text-brand-red-700 bg-brand-red-50 border border-brand-red-200 rounded-lg px-4 py-3">
+            {createError}
+          </p>
+        )}
 
         {/* Website Grid */}
         {websites.length === 0 ? (

--- a/app/apps/website-builder/start-trial/page.tsx
+++ b/app/apps/website-builder/start-trial/page.tsx
@@ -25,7 +25,12 @@ async function startTrial() {
   redirect('/apps/website-builder?welcome=true');
 }
 
-export default async function StartTrialPage() {
+export default async function StartTrialPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ error?: string }>;
+}) {
+  const { error: errorParam } = await searchParams;
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
   if (!user) redirect('/login?redirect=/apps/website-builder/start-trial');
@@ -68,6 +73,14 @@ export default async function StartTrialPage() {
             <h2 className="text-2xl font-bold text-slate-900">Start Your Free Trial</h2>
             <p className="text-slate-600 mt-2">No credit card required.</p>
           </div>
+
+          {errorParam === 'failed' && (
+            <div className="mb-6 rounded-lg border border-brand-red-200 bg-brand-red-50 px-4 py-3 text-sm text-brand-red-800">
+              We could not start your trial. An admin may need to run migration{' '}
+              <code className="text-xs">20260702000015_individual_app_subscriptions.sql</code> in Supabase,
+              then try again.
+            </div>
+          )}
 
           <ul className="space-y-3 mb-8">
             {features.map((feature, i) => (

--- a/app/import/page.tsx
+++ b/app/import/page.tsx
@@ -72,8 +72,13 @@ export default function ImportSitePage() {
 
       const data = await res.json();
 
+      if (res.status === 401) {
+        window.location.href = '/login?redirect=/import';
+        return;
+      }
+
       if (!res.ok) {
-        throw new Error(data.error || 'Import failed');
+        throw new Error(data.error || data.detail || 'Import failed');
       }
 
       setExtracted(data.extracted);
@@ -81,7 +86,7 @@ export default function ImportSitePage() {
       localStorage.setItem('sitePreviewConfig', JSON.stringify(data.config));
       setStep('review');
     } catch (err) {
-      setError('An error occurred');
+      setError(err instanceof Error ? err.message : 'Import failed. Sign in and ensure AI keys are configured.');
       setStep('url');
     } finally {
       setAnalyzing(false);
@@ -112,9 +117,14 @@ export default function ImportSitePage() {
             <Globe className="w-6 h-6 text-brand-green-400" />
             <span className="font-bold text-lg">Import Your Website</span>
           </div>
-          <Link href="/programs" className="text-slate-400 hover:text-white text-sm">
-            Or build from scratch →
-          </Link>
+          <div className="flex flex-col items-end gap-1 text-sm">
+            <Link href="/apps/website-builder/start-trial" className="text-brand-blue-600 font-semibold hover:underline">
+              Start Website Builder trial →
+            </Link>
+            <Link href="/programs" className="text-slate-500 hover:text-slate-800">
+              Or browse programs
+            </Link>
+          </div>
         </div>
       </header>
 

--- a/app/store/apps/grants/page.tsx
+++ b/app/store/apps/grants/page.tsx
@@ -5,7 +5,9 @@ import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
 import CanonicalVideo from '@/components/video/CanonicalVideo';
-import { Check, Play, ShoppingCart, Star, Search, Bell, FileText, DollarSign, Calendar, Users } from 'lucide-react';
+import { Play, Star, Search, Bell, FileText, DollarSign, Calendar, Users } from 'lucide-react';
+import { IndividualAppPlansSection } from '@/components/store/IndividualAppPlansSection';
+import { INDIVIDUAL_APP_CATALOG } from '@/lib/apps/individual-app-plans';
 
 export const metadata: Metadata = {
   title: 'Grants Discovery & Management App | Elevate Store',
@@ -40,13 +42,8 @@ const grantSources = [
   'Workforce Development Funding',
 ];
 
-const pricing = [
-  { name: 'Nonprofit', price: 79, period: '/month', features: ['50 Grant Searches/month', 'Basic AI Matching', 'Deadline Alerts', 'Email Support', '3 Team Members'] },
-  { name: 'Organization', price: 199, period: '/month', features: ['Unlimited Searches', 'Advanced AI Matching', 'Application Tracking', 'Budget Management', 'Priority Support', '10 Team Members', 'Custom Reports'], popular: true },
-  { name: 'Agency', price: 499, period: '/month', features: ['Everything in Organization', 'Multi-department Access', 'API Integration', 'Dedicated Success Manager', 'Unlimited Team Members', 'White-label Reports', 'Compliance Automation'] },
-];
-
 export default function GrantsAppPage() {
+  const catalog = INDIVIDUAL_APP_CATALOG.grants;
 
   return (
     <div className="min-h-screen bg-white">
@@ -68,16 +65,15 @@ export default function GrantsAppPage() {
               <h1 className="text-4xl md:text-5xl font-bold mb-6">
                 Grants Discovery & Management App
               </h1>
-              <p className="text-xl text-white mb-8">
+              <p className="text-xl text-slate-600 mb-8">
                 Find the right grants faster with AI-powered matching. Track applications, manage deadlines, and streamline compliance reporting.
               </p>
               <div className="flex flex-wrap gap-4">
                 <Link
-                  href="/store/cart?add=grants-org"
+                  href="/apps/grants/start-trial"
                   className="inline-flex items-center gap-2 bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold text-lg transition-colors"
                 >
-                  <ShoppingCart className="w-5 h-5" />
-                  Add to Cart - $199/mo
+                  Start 14-day free trial
                 </Link>
                 <button className="inline-flex items-center gap-2 border border-slate-300 hover:bg-white text-slate-900 px-8 py-4 rounded-lg font-bold text-lg transition-colors">
                   <Play className="w-5 h-5" />
@@ -147,52 +143,15 @@ export default function GrantsAppPage() {
         </div>
       </section>
 
-      {/* Pricing */}
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">Pricing Plans</h2>
-          <p className="text-slate-700 text-center mb-12">Flexible plans for organizations of all sizes</p>
-          <div className="grid md:grid-cols-3 gap-8">
-            {pricing.map((plan, i) => (
-              <div key={i} className={`rounded-2xl p-8 ${plan.popular ? 'bg-brand-green-600 text-white ring-4 ring-brand-green-300' : 'bg-white border border-slate-200'}`}>
-                {plan.popular && <span className="bg-brand-red-600 text-white text-xs font-bold px-3 py-1 rounded-full">MOST POPULAR</span>}
-                <h3 className={`text-2xl font-bold mt-4 ${plan.popular ? 'text-slate-900' : 'text-slate-900'}`}>{plan.name}</h3>
-                <div className="mt-4 mb-6">
-                  <span className="text-4xl font-bold">${plan.price}</span>
-                  <span className={plan.popular ? 'text-white' : 'text-slate-700'}>{plan.period}</span>
-                </div>
-                <ul className="space-y-3 mb-8">
-                  {plan.features.map((f, j) => (
-                    <li key={j} className="flex items-center gap-2">
-                      <Check className={`w-5 h-5 ${plan.popular ? 'text-white' : 'text-brand-green-500'}`} />
-                      <span className={plan.popular ? 'text-white' : 'text-slate-700'}>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href={`/store/cart?add=grants-${plan.name.toLowerCase()}`}
-                  className={`block w-full text-center py-3 rounded-lg font-bold transition-colors ${
-                    plan.popular 
-                      ? 'bg-white text-brand-green-600 hover:bg-white' 
-                      : 'bg-brand-green-600 text-white hover:bg-brand-green-700'
-                  }`}
-                >
-                  <ShoppingCart className="w-4 h-4 inline mr-2" />
-                  Add to Cart
-                </Link>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      <IndividualAppPlansSection catalog={catalog} />
 
       {/* CTA */}
       <section className="py-16 px-4 text-slate-900">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Start Finding Grants Today</h2>
-          <p className="text-slate-700 mb-8">14-day free trial. Card required, not charged until trial ends.</p>
+          <p className="text-slate-700 mb-8">14-day individual free trial — no credit card. Subscribe monthly when you are ready.</p>
           <div className="flex flex-wrap gap-4 justify-center">
-            <Link href="/store/cart?add=grants-org" className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold">
+            <Link href="/apps/grants/start-trial" className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold">
               Start Free Trial
             </Link>
             <Link href="/contact" className="border border-slate-300 hover:bg-white text-slate-900 px-8 py-4 rounded-lg font-bold">

--- a/app/store/apps/sam-gov/page.tsx
+++ b/app/store/apps/sam-gov/page.tsx
@@ -3,6 +3,8 @@ export const dynamic = 'force-static';
 
 import { Metadata } from 'next';
 import { ProductPage } from '@/components/store/ProductPage';
+import { IndividualAppPlansSection } from '@/components/store/IndividualAppPlansSection';
+import { INDIVIDUAL_APP_CATALOG } from '@/lib/apps/individual-app-plans';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const metadata: Metadata = {
@@ -247,6 +249,12 @@ const productData = {
 };
 
 export default function SamGovProductPage() {
+  const catalog = INDIVIDUAL_APP_CATALOG['sam-gov'];
 
-  return <ProductPage product={productData} />;
+  return (
+    <>
+      <ProductPage product={productData} />
+      <IndividualAppPlansSection catalog={catalog} />
+    </>
+  );
 }

--- a/app/store/apps/website-builder/page.tsx
+++ b/app/store/apps/website-builder/page.tsx
@@ -5,7 +5,9 @@ import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
 import CanonicalVideo from '@/components/video/CanonicalVideo';
-import { Check, Play, ShoppingCart, Star, Layout, Palette, Globe, Zap, Shield, BarChart } from 'lucide-react';
+import { Play, Star, Layout, Palette, Globe, Zap, Shield, BarChart } from 'lucide-react';
+import { IndividualAppPlansSection } from '@/components/store/IndividualAppPlansSection';
+import { INDIVIDUAL_APP_CATALOG } from '@/lib/apps/individual-app-plans';
 
 export const metadata: Metadata = {
   title: 'Website Builder for Training Providers | Elevate Store',
@@ -42,13 +44,8 @@ const templates = [
   'Career Services Center',
 ];
 
-const pricing = [
-  { name: 'Starter', price: 29, period: '/month', features: ['1 Website', '5 Pages', 'Basic Templates', 'Elevate Subdomain', 'Email Support', 'Basic Analytics'] },
-  { name: 'Professional', price: 79, period: '/month', features: ['3 Websites', 'Unlimited Pages', 'All Templates', 'Custom Domain', 'LMS Integration', 'Priority Support', 'Advanced Analytics', 'Form Builder'], popular: true },
-  { name: 'Agency', price: 199, period: '/month', features: ['Unlimited Websites', 'White-label Builder', 'Client Management', 'API Access', 'Custom Templates', 'Dedicated Support', 'Multi-user Access', 'Revenue Sharing'] },
-];
-
 export default function WebsiteBuilderAppPage() {
+  const catalog = INDIVIDUAL_APP_CATALOG['website-builder'];
 
   return (
     <div className="min-h-screen bg-white">
@@ -70,21 +67,23 @@ export default function WebsiteBuilderAppPage() {
               <h1 className="text-4xl md:text-5xl font-bold mb-6">
                 Website Builder for Training Providers
               </h1>
-              <p className="text-xl text-white mb-8">
-                Launch a professional training website in minutes. Pre-built templates, LMS integration, enrollment forms, and SEO tools included.
+              <p className="text-xl text-slate-600 mb-8">
+                Launch a professional training website in minutes. Pre-built templates, LMS integration,
+                enrollment forms, and SEO tools included.
               </p>
               <div className="flex flex-wrap gap-4">
                 <Link
-                  href="/store/cart?add=website-pro"
+                  href="/apps/website-builder/start-trial"
                   className="inline-flex items-center gap-2 bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold text-lg transition-colors"
                 >
-                  <ShoppingCart className="w-5 h-5" />
-                  Add to Cart - $79/mo
+                  Start 14-day free trial
                 </Link>
-                <button className="inline-flex items-center gap-2 border border-slate-300 hover:bg-white text-slate-900 px-8 py-4 rounded-lg font-bold text-lg transition-colors">
-                  <Play className="w-5 h-5" />
-                  Watch Demo
-                </button>
+                <Link
+                  href="/import"
+                  className="inline-flex items-center gap-2 border border-slate-300 hover:bg-slate-50 text-slate-900 px-8 py-4 rounded-lg font-bold text-lg transition-colors"
+                >
+                  Import existing site
+                </Link>
               </div>
             </div>
             <div className="relative">
@@ -149,56 +148,24 @@ export default function WebsiteBuilderAppPage() {
         </div>
       </section>
 
-      {/* Pricing */}
-      <section className="py-16 px-4">
-        <div className="max-w-6xl mx-auto">
-          <h2 className="text-3xl font-bold text-center mb-4">Simple Pricing</h2>
-          <p className="text-slate-700 text-center mb-12">Start free, upgrade as you grow</p>
-          <div className="grid md:grid-cols-3 gap-8">
-            {pricing.map((plan, i) => (
-              <div key={i} className={`rounded-2xl p-8 ${plan.popular ? 'bg-brand-blue-600 text-white ring-4 ring-brand-blue-300' : 'bg-white border border-slate-200'}`}>
-                {plan.popular && <span className="bg-brand-red-600 text-white text-xs font-bold px-3 py-1 rounded-full">MOST POPULAR</span>}
-                <h3 className={`text-2xl font-bold mt-4 ${plan.popular ? 'text-slate-900' : 'text-slate-900'}`}>{plan.name}</h3>
-                <div className="mt-4 mb-6">
-                  <span className="text-4xl font-bold">${plan.price}</span>
-                  <span className={plan.popular ? 'text-white' : 'text-slate-700'}>{plan.period}</span>
-                </div>
-                <ul className="space-y-3 mb-8">
-                  {plan.features.map((f, j) => (
-                    <li key={j} className="flex items-center gap-2">
-                      <Check className={`w-5 h-5 ${plan.popular ? 'text-white' : 'text-brand-green-500'}`} />
-                      <span className={plan.popular ? 'text-white' : 'text-slate-700'}>{f}</span>
-                    </li>
-                  ))}
-                </ul>
-                <Link
-                  href={`/store/cart?add=website-${plan.name.toLowerCase()}`}
-                  className={`block w-full text-center py-3 rounded-lg font-bold transition-colors ${
-                    plan.popular 
-                      ? 'bg-white text-brand-blue-600 hover:bg-white' 
-                      : 'bg-brand-blue-600 text-white hover:bg-brand-blue-700'
-                  }`}
-                >
-                  <ShoppingCart className="w-4 h-4 inline mr-2" />
-                  Add to Cart
-                </Link>
-              </div>
-            ))}
-          </div>
-        </div>
-      </section>
+      <IndividualAppPlansSection catalog={catalog} />
 
       {/* CTA */}
       <section className="py-16 px-4 text-slate-900">
         <div className="max-w-4xl mx-auto text-center">
           <h2 className="text-3xl font-bold mb-4">Launch Your Training Website Today</h2>
-          <p className="text-slate-700 mb-8">14-day free trial. Card required, not charged until trial ends.</p>
+          <p className="text-slate-700 mb-8">
+            14-day individual free trial — no credit card. Subscribe monthly when you are ready.
+          </p>
           <div className="flex flex-wrap gap-4 justify-center">
-            <Link href="/store/cart?add=website-pro" className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold">
+            <Link
+              href="/apps/website-builder/start-trial"
+              className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold"
+            >
               Start Free Trial
             </Link>
-            <Link href="/contact" className="border border-slate-300 hover:bg-white text-slate-900 px-8 py-4 rounded-lg font-bold">
-              Request Demo
+            <Link href="/apps/website-builder" className="border border-slate-300 hover:bg-slate-50 text-slate-900 px-8 py-4 rounded-lg font-bold">
+              Open Website Builder
             </Link>
           </div>
         </div>

--- a/components/AIAssistantBubble.tsx
+++ b/components/AIAssistantBubble.tsx
@@ -49,7 +49,22 @@ export function AIAssistantBubble() {
 
   const handleClose = () => {
     setIsOpen(false);
+    setShowWelcome(false);
   };
+
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
 
   const handleSend = async () => {
     if (!input.trim() || isLoading) return;
@@ -139,11 +154,13 @@ export function AIAssistantBubble() {
   return (
     <>
       {showWelcome && !isOpen && (
-        <div className="fixed bottom-24 right-6 z-50 animate-fade-in">
+        <div className="fixed bottom-24 right-6 z-[60] animate-fade-in">
           <div className="bg-white rounded-lg shadow-2xl p-4 max-w-xs border border-slate-200 relative">
             <button
+              type="button"
               onClick={() => setShowWelcome(false)}
               className="absolute top-2 right-2 text-slate-700 hover:text-black"
+              aria-label="Dismiss chat prompt"
             >
               <X className="h-4 w-4" />
             </button>
@@ -154,6 +171,7 @@ export function AIAssistantBubble() {
               I can help you explore training options and check your eligibility!
             </p>
             <button
+              type="button"
               onClick={handleOpen}
               className="text-xs bg-brand-orange-600 text-white px-3 py-2.5 rounded-md hover:bg-brand-orange-700 transition-colors font-medium"
             >
@@ -165,8 +183,10 @@ export function AIAssistantBubble() {
 
       {!isOpen && (
         <button
+          type="button"
           onClick={handleOpen}
-          className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-40 flex bg-brand-orange-600 text-white rounded-full p-4 shadow-2xl hover:bg-brand-orange-700 transition-all hover:scale-110"
+          className="fixed bottom-20 right-4 md:bottom-6 md:right-6 z-[60] flex bg-brand-orange-600 text-white rounded-full p-4 shadow-2xl hover:bg-brand-orange-700 transition-all hover:scale-110"
+          aria-label="Open AI assistant"
         >
           <MessageCircle className="h-10 w-10" />
           <span className="absolute -top-1 -right-1 bg-brand-green-500 w-4 h-4 rounded-full border-2 border-white" />
@@ -174,7 +194,19 @@ export function AIAssistantBubble() {
       )}
 
       {isOpen && (
-        <div className="fixed inset-0 md:inset-auto md:bottom-6 md:right-6 z-50 w-full md:w-96 h-full md:h-[600px] bg-white md:rounded-2xl shadow-2xl flex flex-col border border-slate-200">
+        <>
+          <button
+            type="button"
+            className="fixed inset-0 z-[60] bg-black/40 md:hidden"
+            aria-label="Close chat"
+            onClick={handleClose}
+          />
+          <div
+            className="fixed inset-0 md:inset-auto md:bottom-6 md:right-6 z-[61] w-full md:w-96 h-full md:h-[600px] bg-white md:rounded-2xl shadow-2xl flex flex-col border border-slate-200"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Elevate AI Assistant"
+          >
           <div className="bg-gradient-to-r from-brand-orange-600 to-brand-orange-500 text-white p-4 md:rounded-t-2xl flex items-center justify-between flex-shrink-0">
             <div className="flex items-center gap-3">
               <div className="bg-white/20 rounded-full p-2">
@@ -189,11 +221,12 @@ export function AIAssistantBubble() {
               </div>
             </div>
             <button
+              type="button"
               onClick={handleClose}
               aria-label="Close chat"
-              className="text-slate-900 hover:bg-white/20 rounded-full p-2 transition-colors"
+              className="text-white hover:bg-white/20 rounded-full p-2 transition-colors"
             >
-              <X className="h-6 w-6" />
+              <X className="h-6 w-6" aria-hidden />
             </button>
           </div>
 
@@ -254,9 +287,11 @@ export function AIAssistantBubble() {
                 className="flex-1 px-4 py-2 border border-slate-300 rounded-full focus:outline-none focus:ring-2 focus:ring-brand-orange-500 text-sm"
               />
               <button
+                type="button"
                 onClick={handleSend}
                 disabled={!input.trim() || isLoading}
                 className="bg-brand-orange-600 text-white rounded-full p-2 hover:bg-brand-orange-700 disabled:opacity-50"
+                aria-label="Send message"
               >
                 {isLoading ? (
                   <Loader2 className="h-5 w-5 animate-spin" />
@@ -274,6 +309,7 @@ export function AIAssistantBubble() {
             </p>
           </div>
         </div>
+        </>
       )}
     </>
   );

--- a/components/ChatAssistant.tsx
+++ b/components/ChatAssistant.tsx
@@ -52,6 +52,20 @@ export default function ChatAssistant({
 
   useEffect(scrollToBottom, [messages]);
 
+  useEffect(() => {
+    if (!isOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setIsOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [isOpen]);
+
   // Initialize with welcome message
   useEffect(() => {
     if (isOpen && messages.length === 0) {
@@ -178,10 +192,10 @@ export default function ChatAssistant({
     }
   };
 
-  if (!isOpen) return null;
-  {
+  if (!isOpen) {
     return (
       <button
+        type="button"
         onClick={() => setIsOpen(true)}
         className="chat-assistant-button"
         style={{
@@ -258,6 +272,7 @@ export default function ChatAssistant({
         </div>
         <div style={{ display: 'flex', gap: '8px' }}>
           <button
+            type="button"
             onClick={() => setIsMinimized(!isMinimized)}
             style={{
               background: 'transparent',
@@ -273,6 +288,7 @@ export default function ChatAssistant({
             {isMinimized ? <Maximize2 size={20} /> : <Minimize2 size={20} />}
           </button>
           <button
+            type="button"
             onClick={() => setIsOpen(false)}
             style={{
               background: 'transparent',

--- a/components/ElevateChatWidget.tsx
+++ b/components/ElevateChatWidget.tsx
@@ -39,6 +39,20 @@ export function ElevateChatWidget() {
     localStorage.setItem('elevate-chat-interacted', 'true');
   };
 
+  useEffect(() => {
+    if (!open) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') setOpen(false);
+    };
+    document.addEventListener('keydown', onKeyDown);
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    return () => {
+      document.removeEventListener('keydown', onKeyDown);
+      document.body.style.overflow = prevOverflow;
+    };
+  }, [open]);
+
   return (
     <>
       {/* Proactive chat prompt */}
@@ -117,8 +131,22 @@ export function ElevateChatWidget() {
 
       {/* Modal overlay */}
       {open && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/50 backdrop-blur-sm p-4">
-          <div className="bg-white rounded-3xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden animate-scale-in">
+        <div
+          className="fixed inset-0 z-[60] flex items-center justify-center bg-black/50 backdrop-blur-sm p-4"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Elevate AI Helper"
+          onKeyDown={(e) => {
+            if (e.key === 'Escape') setOpen(false);
+          }}
+        >
+          <button
+            type="button"
+            className="absolute inset-0 cursor-default"
+            aria-label="Close chat"
+            onClick={() => setOpen(false)}
+          />
+          <div className="relative bg-white rounded-3xl shadow-2xl w-full max-w-4xl h-[85vh] flex flex-col overflow-hidden animate-scale-in">
             <div className="px-5 py-3 border-b border-slate-200 flex items-center justify-between bg-gradient-to-r from-emerald-500 to-teal-600 text-white">
               <div className="flex items-center gap-3">
                 <MessageCircle size={24} />
@@ -130,10 +158,10 @@ export function ElevateChatWidget() {
               <button
                 type="button"
                 onClick={() => setOpen(false)}
-                className="text-slate-900 hover:bg-white/20 rounded-full p-2 transition-colors"
+                className="relative z-10 text-white hover:bg-white/20 rounded-full p-2 transition-colors"
                 aria-label="Close chat"
               >
-                <X size={20} />
+                <X size={20} aria-hidden />
               </button>
             </div>
             <iframe src="/ai-chat" className="flex-1 w-full border-0" title="Elevate AI Chat" />

--- a/components/store/IndividualAppPlansSection.tsx
+++ b/components/store/IndividualAppPlansSection.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Check, Clock, Loader2, ShoppingCart } from 'lucide-react';
+import type { IndividualAppCatalog } from '@/lib/apps/individual-app-plans';
+
+interface Props {
+  catalog: IndividualAppCatalog;
+}
+
+export function IndividualAppPlansSection({ catalog }: Props) {
+  const [loadingPlan, setLoadingPlan] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const subscribe = async (planId: string) => {
+    setError(null);
+    setLoadingPlan(planId);
+    try {
+      const res = await fetch('/api/apps/upgrade', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ appSlug: catalog.slug, plan: planId }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        if (res.status === 401) {
+          window.location.href = `/login?redirect=${encodeURIComponent(`/store/apps/${catalog.slug}`)}`;
+          return;
+        }
+        throw new Error(data.error || 'Checkout failed');
+      }
+      if (data.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+        return;
+      }
+      throw new Error('No checkout URL returned');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not start checkout');
+    } finally {
+      setLoadingPlan(null);
+    }
+  };
+
+  return (
+    <section className="py-16 px-4 bg-slate-50">
+      <div className="max-w-6xl mx-auto">
+        <div className="text-center mb-4">
+          <span className="inline-flex items-center gap-2 bg-brand-blue-100 text-brand-blue-800 px-4 py-2 rounded-full text-sm font-bold">
+            <Clock className="w-4 h-4" />
+            {catalog.trialDays}-day free trial — individual account
+          </span>
+        </div>
+        <h2 className="text-3xl font-bold text-center text-slate-900 mb-2">Individual plans</h2>
+        <p className="text-slate-600 text-center mb-4 max-w-2xl mx-auto">{catalog.tagline}</p>
+        <p className="text-center mb-10">
+          <Link
+            href={catalog.trialHref}
+            className="text-brand-blue-600 font-semibold hover:underline"
+          >
+            Start free trial (no card)
+          </Link>
+          {catalog.importHref ? (
+            <>
+              {' '}
+              ·{' '}
+              <Link href={catalog.importHref} className="text-brand-blue-600 font-semibold hover:underline">
+                Import an existing website
+              </Link>
+            </>
+          ) : null}
+        </p>
+
+        {error && (
+          <p className="mb-6 text-center text-sm text-brand-red-600 bg-brand-red-50 border border-brand-red-200 rounded-lg py-2 px-4 max-w-lg mx-auto">
+            {error}
+          </p>
+        )}
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {catalog.plans.map((plan) => {
+            const popular = plan.popular;
+            return (
+              <div
+                key={plan.id}
+                className={`rounded-2xl p-8 flex flex-col ${
+                  popular
+                    ? 'bg-brand-blue-600 text-white ring-4 ring-brand-blue-300 shadow-xl'
+                    : 'bg-white border border-slate-200'
+                }`}
+              >
+                {popular && (
+                  <span className="self-start bg-brand-red-600 text-white text-xs font-bold px-3 py-1 rounded-full mb-3">
+                    MOST POPULAR
+                  </span>
+                )}
+                <h3 className={`text-2xl font-bold ${popular ? 'text-white' : 'text-slate-900'}`}>
+                  {plan.name}
+                </h3>
+                <div className="mt-4 mb-6">
+                  <span className="text-4xl font-bold">${plan.priceMonthly}</span>
+                  <span className={popular ? 'text-brand-blue-100' : 'text-slate-600'}>/mo</span>
+                </div>
+                <ul className="space-y-3 mb-8 flex-1">
+                  {plan.features.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm">
+                      <Check
+                        className={`w-5 h-5 flex-shrink-0 ${popular ? 'text-white' : 'text-brand-green-600'}`}
+                      />
+                      <span className={popular ? 'text-white' : 'text-slate-700'}>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <div className="space-y-2">
+                  <button
+                    type="button"
+                    disabled={loadingPlan !== null}
+                    onClick={() => subscribe(plan.id)}
+                    className={`w-full py-3 rounded-lg font-bold flex items-center justify-center gap-2 transition-colors disabled:opacity-60 ${
+                      popular
+                        ? 'bg-white text-brand-blue-700 hover:bg-brand-blue-50'
+                        : 'bg-brand-blue-600 text-white hover:bg-brand-blue-700'
+                    }`}
+                  >
+                    {loadingPlan === plan.id ? (
+                      <Loader2 className="w-5 h-5 animate-spin" />
+                    ) : (
+                      <ShoppingCart className="w-4 h-4" />
+                    )}
+                    Subscribe — {plan.priceLabel}
+                  </button>
+                  <Link
+                    href={catalog.trialHref}
+                    className={`block w-full text-center py-2.5 rounded-lg text-sm font-semibold border ${
+                      popular
+                        ? 'border-white/40 text-white hover:bg-white/10'
+                        : 'border-slate-300 text-slate-700 hover:bg-slate-50'
+                    }`}
+                  >
+                    Try free for {catalog.trialDays} days
+                  </Link>
+                </div>
+              </div>
+            );
+          })}
+        </div>
+
+        <p className="text-center text-xs text-slate-500 mt-8 max-w-xl mx-auto">
+          Individual subscriptions are tied to your login — not an organization license. Need a team or
+          WIOA provider site?{' '}
+          <Link href="/store/trial" className="text-brand-blue-600 hover:underline">
+            Managed platform trial
+          </Link>
+          .
+        </p>
+      </div>
+    </section>
+  );
+}

--- a/docs/store-14-day-trial.md
+++ b/docs/store-14-day-trial.md
@@ -30,6 +30,28 @@
 
 Used by Website Builder, SAM.gov, Grants, etc. Creates `user_app_subscriptions` (`plan: starter`, `status: trial`, 14 days). Does not create an `organizations` subdomain unless the user also starts a managed trial.
 
+### Individual subscription plans (per user)
+
+Canonical catalog: `lib/apps/individual-app-plans.ts`  
+Store UI: `components/store/IndividualAppPlansSection.tsx`
+
+| App | Trial start | Paid checkout |
+|-----|-------------|---------------|
+| Website Builder | `/apps/website-builder/start-trial` | `POST /api/apps/upgrade` → Stripe |
+| SAM.gov | `/apps/sam-gov/start-trial` | same |
+| Grants | `/apps/grants/start-trial` | same |
+
+Plans per app: **Starter**, **Professional**, **Enterprise** (monthly; prices in `app/api/apps/upgrade/route.ts`).
+
+Import existing site: `/import` (requires login; uses `POST /api/ai/import-site`). After trial, save sites in Website Builder.
+
+### Required migration (trials + builder)
+
+Apply in Supabase SQL Editor:
+
+- `supabase/migrations/20260702000015_individual_app_subscriptions.sql` — adds `app_slug`, `plan`, RLS, `user_websites` / `website_pages` columns
+- `supabase/migrations/20260530000001_tenant_website_builder.sql` — tenant site columns (idempotent if 20260702000015 already run)
+
 ## Lifecycle (`GET /api/cron/trial-lifecycle`)
 
 - Day 7: warning email (orgs with `plan=trial` and `trial_started_at` in window)

--- a/lib/apps/individual-app-plans.ts
+++ b/lib/apps/individual-app-plans.ts
@@ -1,0 +1,155 @@
+/**
+ * Individual (per-user) subscription plans for Elevate Store apps.
+ * Billed monthly via Stripe — see app/api/apps/upgrade/route.ts APP_PRICES.
+ */
+
+export type IndividualAppSlug = 'website-builder' | 'sam-gov' | 'grants';
+
+export type IndividualPlanId = 'starter' | 'professional' | 'enterprise';
+
+export interface IndividualPlanDefinition {
+  id: IndividualPlanId;
+  name: string;
+  priceMonthly: number;
+  priceLabel: string;
+  features: string[];
+  popular?: boolean;
+}
+
+export interface IndividualAppCatalog {
+  slug: IndividualAppSlug;
+  displayName: string;
+  tagline: string;
+  trialDays: number;
+  trialHref: string;
+  appHref: string;
+  importHref?: string;
+  plans: IndividualPlanDefinition[];
+}
+
+const WEBSITE_BUILDER_PLANS: IndividualPlanDefinition[] = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceMonthly: 29,
+    priceLabel: '$29/mo',
+    features: ['1 website', '5 pages', 'Basic templates', 'Elevate subdomain', 'Email support'],
+  },
+  {
+    id: 'professional',
+    name: 'Professional',
+    priceMonthly: 79,
+    priceLabel: '$79/mo',
+    popular: true,
+    features: [
+      '3 websites',
+      'Unlimited pages',
+      'All templates',
+      'Custom domain',
+      'LMS enrollment widgets',
+      'Import existing site',
+      'Priority support',
+    ],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    priceMonthly: 199,
+    priceLabel: '$199/mo',
+    features: [
+      'Unlimited websites',
+      'White-label builder',
+      'API access',
+      'Dedicated support',
+      'Multi-user access',
+    ],
+  },
+];
+
+const SAM_GOV_PLANS: IndividualPlanDefinition[] = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceMonthly: 49,
+    priceLabel: '$49/mo',
+    features: ['1 entity', 'Registration wizard', 'Renewal reminders', 'Email support'],
+  },
+  {
+    id: 'professional',
+    name: 'Professional',
+    priceMonthly: 149,
+    priceLabel: '$149/mo',
+    popular: true,
+    features: ['5 entities', 'Compliance dashboard', 'Team members', 'Priority support'],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    priceMonthly: 399,
+    priceLabel: '$399/mo',
+    features: ['Unlimited entities', 'White-label', 'Dedicated manager', 'SLA'],
+  },
+];
+
+const GRANTS_PLANS: IndividualPlanDefinition[] = [
+  {
+    id: 'starter',
+    name: 'Starter',
+    priceMonthly: 79,
+    priceLabel: '$79/mo',
+    features: ['50 grant searches/mo', 'Basic AI matching', 'Deadline alerts', '3 team members'],
+  },
+  {
+    id: 'professional',
+    name: 'Professional',
+    priceMonthly: 199,
+    priceLabel: '$199/mo',
+    popular: true,
+    features: ['Unlimited searches', 'Application tracking', 'Budget tools', '10 team members'],
+  },
+  {
+    id: 'enterprise',
+    name: 'Enterprise',
+    priceMonthly: 499,
+    priceLabel: '$499/mo',
+    features: ['Agency features', 'API', 'Compliance automation', 'Unlimited team'],
+  },
+];
+
+export const INDIVIDUAL_APP_CATALOG: Record<IndividualAppSlug, IndividualAppCatalog> = {
+  'website-builder': {
+    slug: 'website-builder',
+    displayName: 'Website Builder',
+    tagline: 'For individual providers and small training businesses',
+    trialDays: 14,
+    trialHref: '/apps/website-builder/start-trial',
+    appHref: '/apps/website-builder',
+    importHref: '/import',
+    plans: WEBSITE_BUILDER_PLANS,
+  },
+  'sam-gov': {
+    slug: 'sam-gov',
+    displayName: 'SAM.gov Manager',
+    tagline: 'For individual contractors and small businesses',
+    trialDays: 14,
+    trialHref: '/apps/sam-gov/start-trial',
+    appHref: '/apps/sam-gov',
+    plans: SAM_GOV_PLANS,
+  },
+  grants: {
+    slug: 'grants',
+    displayName: 'Grants Discovery',
+    tagline: 'For individual grant writers and small nonprofits',
+    trialDays: 14,
+    trialHref: '/apps/grants/start-trial',
+    appHref: '/apps/grants',
+    plans: GRANTS_PLANS,
+  },
+};
+
+export function getIndividualAppCatalog(slug: string): IndividualAppCatalog | null {
+  if (slug in INDIVIDUAL_APP_CATALOG) {
+    return INDIVIDUAL_APP_CATALOG[slug as IndividualAppSlug];
+  }
+  return null;
+}

--- a/supabase/migrations/20260702000015_individual_app_subscriptions.sql
+++ b/supabase/migrations/20260702000015_individual_app_subscriptions.sql
@@ -1,0 +1,108 @@
+-- Individual per-user app subscriptions (Website Builder, SAM.gov, Grants)
+-- Idempotent — safe to re-run in Supabase SQL Editor.
+
+ALTER TABLE public.user_app_subscriptions
+  ADD COLUMN IF NOT EXISTS app_slug text,
+  ADD COLUMN IF NOT EXISTS plan text DEFAULT 'starter',
+  ADD COLUMN IF NOT EXISTS current_period_start timestamptz,
+  ADD COLUMN IF NOT EXISTS current_period_end timestamptz,
+  ADD COLUMN IF NOT EXISTS stripe_subscription_id text,
+  ADD COLUMN IF NOT EXISTS stripe_customer_id text;
+
+-- Early baseline used column name "gov" instead of app_slug
+DO $$
+BEGIN
+  IF EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public' AND table_name = 'user_app_subscriptions' AND column_name = 'gov'
+  ) THEN
+    UPDATE public.user_app_subscriptions
+    SET app_slug = COALESCE(app_slug, gov)
+    WHERE app_slug IS NULL AND gov IS NOT NULL;
+  END IF;
+END $$;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_app_subscriptions_user_app_unique
+  ON public.user_app_subscriptions (user_id, app_slug)
+  WHERE user_id IS NOT NULL AND app_slug IS NOT NULL;
+
+-- Website builder tables (columns may be missing if 20260530000001 not applied yet)
+ALTER TABLE public.user_websites
+  ADD COLUMN IF NOT EXISTS organization_id uuid,
+  ADD COLUMN IF NOT EXISTS subdomain text,
+  ADD COLUMN IF NOT EXISTS site_name text,
+  ADD COLUMN IF NOT EXISTS template_id text,
+  ADD COLUMN IF NOT EXISTS is_published boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS site_config jsonb DEFAULT '{}'::jsonb;
+
+ALTER TABLE public.website_pages
+  ADD COLUMN IF NOT EXISTS website_id uuid,
+  ADD COLUMN IF NOT EXISTS slug text,
+  ADD COLUMN IF NOT EXISTS is_home boolean DEFAULT false,
+  ADD COLUMN IF NOT EXISTS blocks jsonb DEFAULT '[]'::jsonb;
+
+CREATE UNIQUE INDEX IF NOT EXISTS user_websites_subdomain_unique
+  ON public.user_websites (subdomain)
+  WHERE subdomain IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS website_pages_website_id_idx
+  ON public.website_pages (website_id);
+
+ALTER TABLE public.user_app_subscriptions ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_app_subscriptions_select_own ON public.user_app_subscriptions;
+CREATE POLICY user_app_subscriptions_select_own ON public.user_app_subscriptions
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS user_app_subscriptions_insert_own ON public.user_app_subscriptions;
+CREATE POLICY user_app_subscriptions_insert_own ON public.user_app_subscriptions
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS user_app_subscriptions_update_own ON public.user_app_subscriptions;
+CREATE POLICY user_app_subscriptions_update_own ON public.user_app_subscriptions
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+ALTER TABLE public.user_websites ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_websites_select_own ON public.user_websites;
+CREATE POLICY user_websites_select_own ON public.user_websites
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS user_websites_insert_own ON public.user_websites;
+CREATE POLICY user_websites_insert_own ON public.user_websites
+  FOR INSERT TO authenticated
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS user_websites_update_own ON public.user_websites;
+CREATE POLICY user_websites_update_own ON public.user_websites
+  FOR UPDATE TO authenticated
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+DROP POLICY IF EXISTS user_websites_delete_own ON public.user_websites;
+CREATE POLICY user_websites_delete_own ON public.user_websites
+  FOR DELETE TO authenticated
+  USING (auth.uid() = user_id);
+
+ALTER TABLE public.website_pages ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS website_pages_via_own_website ON public.website_pages;
+CREATE POLICY website_pages_via_own_website ON public.website_pages
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.user_websites w
+      WHERE w.id = website_pages.website_id AND w.user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM public.user_websites w
+      WHERE w.id = website_pages.website_id AND w.user_id = auth.uid()
+    )
+  );


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds **per-individual** subscription plans (Starter / Professional / Enterprise) for Store apps, separate from the managed organization platform trial.

## What's included

- **Catalog:** `lib/apps/individual-app-plans.ts` — Website Builder, SAM.gov, Grants
- **UI:** `IndividualAppPlansSection` on store pages:
  - `/store/apps/website-builder`
  - `/store/apps/sam-gov`
  - `/store/apps/grants`
- **Checkout:** `POST /api/apps/upgrade` (existing Stripe prices aligned to catalog)
- **Trial:** Links to `/apps/{slug}/start-trial`; trial API uses admin client for insert
- **Migration:** `supabase/migrations/20260702000015_individual_app_subscriptions.sql` — `app_slug`, `plan`, Stripe fields, RLS on `user_app_subscriptions` / website tables
- **Website Builder:** Import link, trial error UI, docs in `docs/store-14-day-trial.md`

## Required after merge

1. Run migration **`20260702000015_individual_app_subscriptions.sql`** in Supabase SQL Editor (and `20260530000001` if website tables are not applied yet).
2. Confirm Stripe webhook updates `user_app_subscriptions` on checkout success (metadata: `app_slug`, `plan`).

## Testing

- Visit store app pages → **Individual plans** section → **Try free for 14 days** / **Subscribe**
- Logged-in: `/apps/website-builder/start-trial` should create trial row when migration is live
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

