### PR TITLE
feat(store): SaaS plans, add-on marketplace, beauty dashboard entry

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -895,6 +895,8 @@ Precedence at runtime: `platform_secrets > app_secrets > process.env`
 
 - **14-day app trials:** `/apps/{website-builder|sam-gov|grants}/start-trial` → `lib/trial/start-app-trial.ts` (admin insert into `user_app_subscriptions`).
 - **Individual paid plans:** `lib/apps/individual-app-plans.ts` + `IndividualAppPlansSection` on store pages; checkout via `POST /api/apps/upgrade`.
+- **Org SaaS plans (Solo/Business/Professional):** `lib/store/platform-pricing.ts`, `/store/plans`, checkout `POST /api/store/platform-checkout`, entitlements `lib/platform/entitlements.ts`, blueprint `docs/platform-saas-blueprint.md`.
+- **Beauty vertical store:** `/store/beauty-programs` → `/store/plans?vertical=beauty`.
 - **Import website:** `/import` → `POST /api/ai/import-site` (auth required). Builder: `/apps/website-builder`.
 - **DB:** Apply `supabase/migrations/20260702000015_individual_app_subscriptions.sql` if trials or “New Website” fail (missing `app_slug` / RLS).
 

--- a/app/api/store/platform-checkout/route.ts
+++ b/app/api/store/platform-checkout/route.ts
@@ -1,0 +1,139 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { getStripe } from '@/lib/stripe/client';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { logger } from '@/lib/logger';
+import {
+  ADD_ON_MARKETPLACE,
+  BASE_PLANS,
+  addonPriceCents,
+  getAddOn,
+  licenseTierForPlan,
+  priceCents,
+  type BasePlanId,
+  type BillingInterval,
+} from '@/lib/store/platform-pricing';
+
+async function _POST(request: NextRequest) {
+  try {
+    const rateLimited = await applyRateLimit(request, 'payment');
+    if (rateLimited) return rateLimited;
+
+    const supabase = await createClient();
+    const {
+      data: { user },
+    } = await supabase.auth.getUser();
+    if (!user) {
+      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const planId = body.planId as BasePlanId;
+    const interval = (body.interval || 'monthly') as BillingInterval;
+    const addonSlugs: string[] = Array.isArray(body.addonSlugs) ? body.addonSlugs : [];
+
+    const plan = BASE_PLANS[planId];
+    if (!plan) {
+      return NextResponse.json({ error: 'Invalid plan' }, { status: 400 });
+    }
+    if (interval !== 'monthly' && interval !== 'annual') {
+      return NextResponse.json({ error: 'Invalid billing interval' }, { status: 400 });
+    }
+
+    for (const slug of addonSlugs) {
+      if (!getAddOn(slug)) {
+        return NextResponse.json({ error: `Unknown add-on: ${slug}` }, { status: 400 });
+      }
+    }
+
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('stripe_customer_id, tenant_id')
+      .eq('id', user.id)
+      .maybeSingle();
+
+    const stripe = getStripe();
+    if (!stripe) {
+      return NextResponse.json({ error: 'Payment processing not configured' }, { status: 503 });
+    }
+
+    let customerId = profile?.stripe_customer_id as string | undefined;
+    if (!customerId) {
+      const customer = await stripe.customers.create({
+        email: user.email,
+        metadata: { user_id: user.id },
+      });
+      customerId = customer.id;
+      await supabase.from('profiles').update({ stripe_customer_id: customerId }).eq('id', user.id);
+    }
+
+    const lineItems: { price_data: object; quantity: number }[] = [
+      {
+        price_data: {
+          currency: 'usd',
+          product_data: {
+            name: `Elevate ${plan.name} (${interval})`,
+            description: plan.featureBullets.slice(0, 3).join(' · '),
+          },
+          unit_amount: priceCents(plan, interval),
+          recurring: {
+            interval: interval === 'annual' ? 'year' : 'month',
+          },
+        },
+        quantity: 1,
+      },
+    ];
+
+    for (const slug of addonSlugs) {
+      const addon = ADD_ON_MARKETPLACE.find((a) => a.slug === slug);
+      if (!addon) continue;
+      lineItems.push({
+        price_data: {
+          currency: 'usd',
+          product_data: {
+            name: `Add-on: ${addon.name}`,
+            description: addon.description,
+          },
+          unit_amount: addonPriceCents(addon),
+          recurring: { interval: 'month' },
+        },
+        quantity: 1,
+      });
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org';
+
+    const session = await stripe.checkout.sessions.create({
+      customer: customerId,
+      payment_method_types: ['card'],
+      line_items: lineItems,
+      mode: 'subscription',
+      success_url: `${siteUrl}/store/plans?success=1`,
+      cancel_url: `${siteUrl}/store/plans?canceled=1`,
+      metadata: {
+        checkout_type: 'platform_saas',
+        user_id: user.id,
+        tenant_id: profile?.tenant_id || '',
+        plan_id: planId,
+        billing_interval: interval,
+        addon_slugs: addonSlugs.join(','),
+        license_tier: licenseTierForPlan(planId, interval),
+      },
+      subscription_data: {
+        metadata: {
+          checkout_type: 'platform_saas',
+          plan_id: planId,
+          tenant_id: profile?.tenant_id || '',
+        },
+      },
+    });
+
+    return NextResponse.json({ checkoutUrl: session.url, sessionId: session.id });
+  } catch (error) {
+    logger.error('platform-checkout error', error as Error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}
+
+export const POST = withApiAudit('/api/store/platform-checkout', _POST);

--- a/app/api/webhooks/store/route.ts
+++ b/app/api/webhooks/store/route.ts
@@ -254,6 +254,25 @@ async function _POST(req: NextRequest) {
     if (metadata.delivery === 'digital' && userId && productId) {
       await unlockDownload(userId, productId, stripePaymentId);
     }
+
+    // ── Platform SaaS (Solo / Business / Professional + add-ons) ─────────
+    if (metadata.checkout_type === 'platform_saas' && metadata.tenant_id) {
+      const adminDb = await requireAdminClient();
+      if (adminDb) {
+        const { fulfillPlatformSaasSubscription } = await import('@/lib/platform/fulfillment');
+        const result = await fulfillPlatformSaasSubscription(adminDb, {
+          user_id: metadata.user_id || userId || '',
+          tenant_id: metadata.tenant_id,
+          plan_id: metadata.plan_id as 'solo' | 'business' | 'professional',
+          billing_interval: (metadata.billing_interval || 'monthly') as 'monthly' | 'annual',
+          addon_slugs: metadata.addon_slugs,
+          stripe_subscription_id:
+            typeof session.subscription === 'string' ? session.subscription : undefined,
+          stripe_customer_id: typeof session.customer === 'string' ? session.customer : undefined,
+        });
+        logger.info('platform_saas fulfillment', { result, tenantId: metadata.tenant_id });
+      }
+    }
   }
 
   // Handle invoice.payment_succeeded (for enterprise invoices)

--- a/app/store/beauty-programs/page.tsx
+++ b/app/store/beauty-programs/page.tsx
@@ -1,0 +1,134 @@
+export const dynamic = 'force-static';
+
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { BeautyDashboardCloneSection } from '@/components/store/BeautyDashboardCloneSection';
+import { BEAUTY_DASHBOARD_CLONE_META } from '@/lib/store/beauty-dashboard-clone';
+import { ArrowRight, LayoutDashboard, Users, Scissors } from 'lucide-react';
+
+export const metadata: Metadata = {
+  title: BEAUTY_DASHBOARD_CLONE_META.title,
+  description: BEAUTY_DASHBOARD_CLONE_META.description,
+  alternates: { canonical: BEAUTY_DASHBOARD_CLONE_META.canonical },
+  openGraph: {
+    title: BEAUTY_DASHBOARD_CLONE_META.title,
+    description: BEAUTY_DASHBOARD_CLONE_META.description,
+    images: ['/images/pages/barber-gallery-1.webp'],
+  },
+};
+
+export default function BeautyProgramsStorePage() {
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-7xl mx-auto px-4 py-4">
+        <Breadcrumbs
+          items={[
+            { label: 'Store', href: '/store' },
+            { label: 'Beauty Programs', href: '/store/beauty-programs' },
+          ]}
+        />
+      </div>
+
+      <section className="py-16 px-4">
+        <div className="max-w-6xl mx-auto grid lg:grid-cols-2 gap-12 items-center">
+          <div>
+            <span className="inline-flex items-center gap-2 bg-brand-red-100 text-brand-red-800 text-xs font-bold px-3 py-1 rounded-full mb-4">
+              <Scissors className="w-3.5 h-3.5" />
+              For outside organizations
+            </span>
+            <h1 className="text-4xl md:text-5xl font-bold text-slate-900 mb-6">
+              Beauty program dashboard clone
+            </h1>
+            <p className="text-xl text-slate-600 mb-8">
+              License a white-label admin dashboard for barber, cosmetology, esthetician, and nail
+              schools. Run enrollments, OJT hours, host shops, and compliance from your own branded
+              tenant — without building software from scratch.
+            </p>
+            <div className="flex flex-wrap gap-4">
+              <Link
+                href="/store/trial?vertical=beauty"
+                className="inline-flex items-center gap-2 bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold text-lg"
+              >
+                Start 14-day org trial
+                <ArrowRight className="w-5 h-5" />
+              </Link>
+              <Link
+                href="/store/demo/admin"
+                className="inline-flex items-center gap-2 border border-slate-300 hover:bg-slate-50 text-slate-900 px-8 py-4 rounded-lg font-bold text-lg"
+              >
+                <LayoutDashboard className="w-5 h-5" />
+                Open dashboard demo
+              </Link>
+            </div>
+          </div>
+          <div className="relative aspect-[4/3] rounded-2xl overflow-hidden shadow-xl border border-slate-200">
+            <Image
+              src="/images/pages/barber-gallery-1.webp"
+              alt="Beauty school training environment"
+              fill
+              className="object-cover"
+              sizes="(max-width: 1024px) 100vw, 50vw"
+              priority
+            />
+          </div>
+        </div>
+      </section>
+
+      <section className="py-12 px-4 bg-slate-900 text-white">
+        <div className="max-w-6xl mx-auto grid sm:grid-cols-3 gap-8 text-center">
+          {[
+            {
+              icon: LayoutDashboard,
+              title: 'Admin dashboard clone',
+              desc: 'Same operational shell as Elevate — enrollment, reporting, instructors, credentials.',
+            },
+            {
+              icon: Users,
+              title: 'Your brand & subdomain',
+              desc: 'Students and partners see your school name, not ours.',
+            },
+            {
+              icon: Scissors,
+              title: 'Beauty program templates',
+              desc: 'Barber, cosmo, esthetician, nail, and educator tracks ready to configure.',
+            },
+          ].map((item) => (
+            <div key={item.title}>
+              <item.icon className="w-10 h-10 text-brand-red-400 mx-auto mb-3" />
+              <h2 className="font-bold text-lg mb-2">{item.title}</h2>
+              <p className="text-slate-400 text-sm">{item.desc}</p>
+            </div>
+          ))}
+        </div>
+      </section>
+
+      <BeautyDashboardCloneSection />
+
+      <section className="py-14 px-4 border-t border-slate-200">
+        <div className="max-w-3xl mx-auto text-center">
+          <h2 className="text-2xl font-bold text-slate-900 mb-4">Need source code instead?</h2>
+          <p className="text-slate-600 mb-6">
+            Self-host the full platform with a clone license, or stay on managed hosting with the
+            dashboard clone above.
+          </p>
+          <div className="flex flex-wrap gap-4 justify-center">
+            <Link
+              href="/store/licenses#clone"
+              className="text-brand-blue-600 font-semibold hover:underline"
+            >
+              View clone licenses
+            </Link>
+            <Link
+              href="/store/licenses/managed-platform"
+              className="text-brand-blue-600 font-semibold hover:underline"
+            >
+              Managed platform overview
+            </Link>
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/app/store/demo/admin/page.tsx
+++ b/app/store/demo/admin/page.tsx
@@ -21,6 +21,12 @@ export default function AdminDemoPage() {
             </div>
           </div>
           <Link
+            href="/store/beauty-programs"
+            className="bg-slate-700 text-white px-4 py-2 rounded-lg font-bold hover:bg-slate-800 transition text-sm"
+          >
+            Beauty schools
+          </Link>
+          <Link
             href="/store/licenses"
             className="bg-blue-600 text-white px-6 py-2 rounded-lg font-bold hover:bg-blue-700 transition"
           >

--- a/app/store/page.tsx
+++ b/app/store/page.tsx
@@ -35,7 +35,8 @@ export default function StorePage() {
         belowHeroHeadline={hero.belowHeroHeadline}
         belowHeroSubheadline={hero.belowHeroSubheadline}
         ctas={[
-          { label: 'Start 14-Day Free Trial', href: '/store/trial' },
+          { label: 'View Plans from $29/mo', href: '/store/plans' },
+          { label: 'Start 14-Day Free Trial', href: '/store/trial', variant: 'secondary' },
           { label: 'Try Full Demo - No Signup', href: '/store/demo/admin', variant: 'secondary' },
         ]}
         trustIndicators={hero.trustIndicators}
@@ -111,6 +112,45 @@ export default function StorePage() {
             ))}
           </div>
           <p className="text-slate-500 text-xs text-center">Demo uses sample data. Nothing affects real systems.</p>
+        </div>
+      </section>
+
+      {/* ============ BEAUTY DASHBOARD CLONE ============ */}
+      <section className="py-14 sm:py-20 bg-brand-red-50 border-y border-brand-red-100">
+        <div className="max-w-5xl mx-auto px-6 flex flex-col md:flex-row gap-8 items-center">
+          <div className="flex-1">
+            <p className="text-brand-red-700 font-bold text-xs uppercase tracking-widest mb-2">Store · Beauty vertical</p>
+            <h2 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-3">
+              Dashboard clone for outside beauty organizations
+            </h2>
+            <p className="text-slate-600 mb-6">
+              Barber, cosmetology, esthetician, and nail schools can license your admin dashboard experience —
+              branded tenant, 14-day trial, and program templates ready to configure.
+            </p>
+            <div className="flex flex-wrap gap-3">
+              <Link
+                href="/store/plans?vertical=beauty"
+                className="inline-flex items-center gap-2 bg-brand-red-600 text-white px-6 py-3 rounded-lg font-bold hover:bg-brand-red-700"
+              >
+                Beauty plans from $29/mo <ArrowRight className="w-4 h-4" />
+              </Link>
+              <Link
+                href="/store/beauty-programs"
+                className="inline-flex items-center gap-2 border border-slate-300 bg-white px-6 py-3 rounded-lg font-bold text-slate-900 hover:bg-slate-50"
+              >
+                Program overview
+              </Link>
+            </div>
+          </div>
+          <div className="relative w-full md:w-72 aspect-square rounded-xl overflow-hidden shadow-lg flex-shrink-0">
+            <Image
+              src="/images/pages/barber-gallery-1.webp"
+              alt="Beauty school training"
+              fill
+              className="object-cover"
+              sizes="288px"
+            />
+          </div>
         </div>
       </section>
 

--- a/app/store/plans/PlansPageClient.tsx
+++ b/app/store/plans/PlansPageClient.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { PlatformBasePlansSection } from '@/components/store/PlatformBasePlansSection';
+import { AddOnMarketplaceSection } from '@/components/store/AddOnMarketplaceSection';
+
+interface Props {
+  vertical?: string;
+}
+
+const BEAUTY_DEFAULT_ADDONS = ['student-management', 'apprenticeship-management'];
+
+export function PlansPageClient({ vertical }: Props) {
+  const initialAddons = vertical === 'beauty' ? BEAUTY_DEFAULT_ADDONS : [];
+  const [selectedAddons, setSelectedAddons] = useState<string[]>(initialAddons);
+
+  const toggleAddon = (slug: string) => {
+    setSelectedAddons((prev) =>
+      prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug],
+    );
+  };
+
+  return (
+    <>
+      <PlatformBasePlansSection
+        selectedAddonSlugs={selectedAddons}
+        headline={vertical === 'beauty' ? 'Plans for beauty schools & salons' : 'Base plans'}
+        subheadline={
+          vertical === 'beauty'
+            ? 'Start as a solo barber or spa at $29/month. Add student management, apprenticeship, and workforce modules as you grow.'
+            : 'Start simple. Add workforce, LMS, and apprenticeship modules when you are ready.'
+        }
+      />
+      <AddOnMarketplaceSection selectedSlugs={selectedAddons} onToggle={toggleAddon} />
+      <section className="py-12 px-4 border-t border-slate-200">
+        <div className="max-w-3xl mx-auto text-center text-sm text-slate-600">
+          <p className="mb-4">
+            Need a full platform license or source-code clone?{' '}
+            <Link href="/store/licenses" className="text-brand-blue-600 font-semibold hover:underline">
+              Enterprise licensing
+            </Link>
+            {' · '}
+            <Link href="/store/beauty-programs" className="text-brand-blue-600 font-semibold hover:underline">
+              Beauty program overview
+            </Link>
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/app/store/plans/page.tsx
+++ b/app/store/plans/page.tsx
@@ -1,0 +1,51 @@
+export const dynamic = 'force-static';
+
+import { Metadata } from 'next';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import Link from 'next/link';
+import { PlansPageClient } from './PlansPageClient';
+
+export const metadata: Metadata = {
+  title: 'Plans & Add-Ons | Elevate Store',
+  description:
+    'Solo, Business, and Professional plans from $29/month. Add LMS, workforce, apprenticeship, and AI modules à la carte.',
+  alternates: { canonical: 'https://www.elevateforhumanity.org/store/plans' },
+};
+
+export default async function StorePlansPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ vertical?: string }>;
+}) {
+  const params = await searchParams;
+  const vertical = params.vertical;
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="max-w-7xl mx-auto px-4 py-4">
+        <Breadcrumbs
+          items={[
+            { label: 'Store', href: '/store' },
+            { label: 'Plans & Add-Ons' },
+          ]}
+        />
+      </div>
+
+      <section className="py-12 px-4 text-center border-b border-slate-200">
+        <h1 className="text-4xl font-bold text-slate-900 mb-4">Simple plans. Powerful add-ons.</h1>
+        <p className="text-lg text-slate-600 max-w-2xl mx-auto mb-6">
+          One entry point for barbers, spas, and training providers. Subscribe to a base plan, then
+          turn on only the modules you need.
+        </p>
+        <Link
+          href="/store/trial"
+          className="text-brand-blue-600 font-semibold hover:underline"
+        >
+          Prefer a 14-day org trial first? Start here →
+        </Link>
+      </section>
+
+      <PlansPageClient vertical={vertical} />
+    </div>
+  );
+}

--- a/app/store/trial/page.tsx
+++ b/app/store/trial/page.tsx
@@ -1,7 +1,9 @@
 'use client';
 
-import { useState } from 'react';
+import { useState, useEffect, Suspense } from 'react';
+import { useSearchParams } from 'next/navigation';
 import Link from 'next/link';
+import { BEAUTY_TRIAL_PROGRAMS_PREFILL } from '@/lib/store/beauty-dashboard-clone';
 import Image from 'next/image';
 import {
   ArrowRight, Clock, Shield, Loader2, AlertCircle,
@@ -40,7 +42,8 @@ const CHECKLIST_EXISTING = [
   { label: 'Launch', desc: 'Go live — trial data carries over' },
 ];
 
-export default function TrialPage() {
+function TrialPageContent() {
+  const searchParams = useSearchParams();
   const [orgName, setOrgName] = useState('');
   const [adminName, setAdminName] = useState('');
   const [adminEmail, setAdminEmail] = useState('');
@@ -48,6 +51,12 @@ export default function TrialPage() {
   const [existingUrl, setExistingUrl] = useState('');
   const [programs, setPrograms] = useState('');
   const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (searchParams.get('vertical') === 'beauty') {
+      setPrograms((prev) => (prev.trim() ? prev : BEAUTY_TRIAL_PROGRAMS_PREFILL));
+    }
+  }, [searchParams]);
   const [error, setError] = useState<string | null>(null);
   const [correlationId, setCorrelationId] = useState<string | null>(null);
   const [result, setResult] = useState<TrialResult | null>(null);
@@ -325,11 +334,26 @@ export default function TrialPage() {
                 <p className="text-sm text-slate-500">Want to see the platform first?{' '}
                   <Link href="/store/demos" className="text-brand-red-600 font-medium hover:underline">Open full demo →</Link>
                 </p>
+                <p className="text-sm text-slate-500">Beauty schools & salons?{' '}
+                  <Link href="/store/beauty-programs" className="text-brand-red-600 font-medium hover:underline">Dashboard clone for beauty programs →</Link>
+                </p>
               </div>
             </div>
           </div>
         </div>
       </section>
     </div>
+  );
+}
+
+export default function TrialPage() {
+  return (
+    <Suspense
+      fallback={
+        <div className="min-h-screen flex items-center justify-center text-slate-600">Loading trial…</div>
+      }
+    >
+      <TrialPageContent />
+    </Suspense>
   );
 }

--- a/components/store/AddOnMarketplaceSection.tsx
+++ b/components/store/AddOnMarketplaceSection.tsx
@@ -1,0 +1,89 @@
+'use client';
+
+import { useState } from 'react';
+import { Check, Plus } from 'lucide-react';
+import { ADD_ON_MARKETPLACE } from '@/lib/store/platform-pricing';
+
+interface Props {
+  selectedSlugs: string[];
+  onToggle: (slug: string) => void;
+}
+
+export function AddOnMarketplaceSection({ selectedSlugs, onToggle }: Props) {
+  return (
+    <section className="py-16 px-4 bg-slate-50" id="addons">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl font-bold text-center text-slate-900 mb-2">Add-on marketplace</h2>
+        <p className="text-slate-600 text-center mb-10 max-w-2xl mx-auto">
+          A barber can start at $29/month. A workforce training provider can grow to $250–500/month
+          by adding LMS, workforce, apprenticeship, employer portal, and AI modules.
+        </p>
+        <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {ADD_ON_MARKETPLACE.map((addon) => {
+            const selected = selectedSlugs.includes(addon.slug);
+            return (
+              <div
+                key={addon.slug}
+                className={`rounded-xl border p-6 flex flex-col bg-white ${
+                  selected ? 'border-brand-blue-500 ring-2 ring-brand-blue-200' : 'border-slate-200'
+                }`}
+              >
+                <div className="flex justify-between items-start gap-2 mb-2">
+                  <h3 className="font-bold text-slate-900">{addon.name}</h3>
+                  <span className="text-lg font-bold text-brand-blue-600 whitespace-nowrap">
+                    ${addon.priceMonthly}/mo
+                  </span>
+                </div>
+                <p className="text-sm text-slate-600 mb-4">{addon.description}</p>
+                {addon.usageNote && (
+                  <p className="text-xs text-slate-500 mb-3">{addon.usageNote}</p>
+                )}
+                <ul className="space-y-2 mb-6 flex-1">
+                  {addon.bullets.map((b) => (
+                    <li key={b} className="flex items-start gap-2 text-sm text-slate-700">
+                      <Check className="w-4 h-4 text-brand-green-600 flex-shrink-0 mt-0.5" />
+                      {b}
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  type="button"
+                  onClick={() => onToggle(addon.slug)}
+                  className={`w-full py-2.5 rounded-lg text-sm font-semibold flex items-center justify-center gap-2 ${
+                    selected
+                      ? 'bg-brand-blue-600 text-white'
+                      : 'border border-slate-300 text-slate-800 hover:bg-slate-50'
+                  }`}
+                >
+                  <Plus className="w-4 h-4" />
+                  {selected ? 'Included at checkout' : 'Add to checkout'}
+                </button>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+    </section>
+  );
+}
+
+/** Self-contained marketplace with local selection state */
+export function AddOnMarketplaceStandalone({
+  initialSlugs = [],
+  onSelectionChange,
+}: {
+  initialSlugs?: string[];
+  onSelectionChange?: (slugs: string[]) => void;
+}) {
+  const [selected, setSelected] = useState<string[]>(initialSlugs);
+
+  const toggle = (slug: string) => {
+    setSelected((prev) => {
+      const next = prev.includes(slug) ? prev.filter((s) => s !== slug) : [...prev, slug];
+      onSelectionChange?.(next);
+      return next;
+    });
+  };
+
+  return <AddOnMarketplaceSection selectedSlugs={selected} onToggle={toggle} />;
+}

--- a/components/store/BeautyDashboardCloneSection.tsx
+++ b/components/store/BeautyDashboardCloneSection.tsx
@@ -1,0 +1,74 @@
+'use client';
+
+import Link from 'next/link';
+import { ArrowRight, LayoutDashboard } from 'lucide-react';
+import { BEAUTY_PROGRAM_CARDS, BEAUTY_TRIAL_PROGRAMS_PREFILL } from '@/lib/store/beauty-dashboard-clone';
+
+/**
+ * Beauty vertical landing — programs list + CTA to canonical /store/plans pricing.
+ */
+export function BeautyDashboardCloneSection() {
+  return (
+    <>
+      <section className="py-14 px-4 bg-white border-b border-slate-200">
+        <div className="max-w-6xl mx-auto">
+          <h2 className="text-3xl font-bold text-slate-900 text-center mb-3">
+            Programs included in your dashboard clone
+          </h2>
+          <p className="text-slate-600 text-center mb-10 max-w-2xl mx-auto">
+            Outside organizations get the same admin dashboard experience as Elevate — pre-wired for
+            beauty and personal-services training, not a generic empty LMS.
+          </p>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {BEAUTY_PROGRAM_CARDS.map((p) => (
+              <Link
+                key={p.slug}
+                href={p.href}
+                className="rounded-xl border border-slate-200 p-5 hover:border-brand-blue-300 hover:shadow-md transition"
+              >
+                <h3 className="font-bold text-slate-900 mb-1">{p.name}</h3>
+                <p className="text-sm text-slate-600">{p.summary}</p>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="py-16 px-4 bg-slate-50">
+        <div className="max-w-3xl mx-auto text-center">
+          <LayoutDashboard className="w-12 h-12 text-brand-blue-600 mx-auto mb-4" />
+          <h2 className="text-3xl font-bold text-slate-900 mb-3">Pricing: start at $29/month</h2>
+          <p className="text-slate-600 mb-8">
+            Use Solo for a single chair or spa, Business for a small team, Professional when you need
+            LMS and certificates. Add student management, apprenticeship, and workforce modules only
+            when you need them.
+          </p>
+          <div className="flex flex-wrap gap-4 justify-center">
+            <Link
+              href="/store/plans?vertical=beauty"
+              className="inline-flex items-center gap-2 bg-brand-red-600 text-white px-8 py-4 rounded-lg font-bold hover:bg-brand-red-700"
+            >
+              View plans & add-ons
+              <ArrowRight className="w-5 h-5" />
+            </Link>
+            <Link
+              href="/store/trial?vertical=beauty"
+              className="inline-flex items-center gap-2 border border-slate-300 bg-white px-8 py-4 rounded-lg font-bold text-slate-900 hover:bg-slate-50"
+            >
+              14-day org trial
+            </Link>
+            <Link
+              href="/store/demo/admin"
+              className="inline-flex items-center gap-2 text-brand-blue-600 font-semibold hover:underline py-4"
+            >
+              Preview dashboard demo
+            </Link>
+          </div>
+          <p className="text-xs text-slate-500 mt-6">
+            Trial prefill programs: {BEAUTY_TRIAL_PROGRAMS_PREFILL}
+          </p>
+        </div>
+      </section>
+    </>
+  );
+}

--- a/components/store/PlatformBasePlansSection.tsx
+++ b/components/store/PlatformBasePlansSection.tsx
@@ -1,0 +1,175 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Check, Loader2, ShoppingCart } from 'lucide-react';
+import {
+  BASE_PLANS,
+  type BasePlanId,
+  type BillingInterval,
+} from '@/lib/store/platform-pricing';
+
+interface Props {
+  selectedAddonSlugs?: string[];
+  headline?: string;
+  subheadline?: string;
+}
+
+export function PlatformBasePlansSection({
+  selectedAddonSlugs = [],
+  headline = 'Base plans',
+  subheadline = 'Start simple. Add workforce, LMS, and apprenticeship modules when you are ready.',
+}: Props) {
+  const [interval, setInterval] = useState<BillingInterval>('monthly');
+  const [loadingPlan, setLoadingPlan] = useState<string | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  const plans = Object.values(BASE_PLANS);
+
+  const subscribe = async (planId: BasePlanId) => {
+    setError(null);
+    setLoadingPlan(planId);
+    try {
+      const res = await fetch('/api/store/platform-checkout', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          planId,
+          interval,
+          addonSlugs: selectedAddonSlugs,
+        }),
+      });
+      const data = await res.json();
+      if (!res.ok) {
+        if (res.status === 401) {
+          window.location.href = `/login?redirect=${encodeURIComponent('/store/plans')}`;
+          return;
+        }
+        throw new Error(data.error || 'Checkout failed');
+      }
+      if (data.checkoutUrl) {
+        window.location.href = data.checkoutUrl;
+        return;
+      }
+      throw new Error('No checkout URL returned');
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Could not start checkout');
+    } finally {
+      setLoadingPlan(null);
+    }
+  };
+
+  return (
+    <section className="py-16 px-4 bg-white" id="base-plans">
+      <div className="max-w-6xl mx-auto">
+        <h2 className="text-3xl font-bold text-center text-slate-900 mb-2">{headline}</h2>
+        <p className="text-slate-600 text-center mb-8 max-w-2xl mx-auto">{subheadline}</p>
+
+        <div className="flex justify-center mb-10">
+          <div className="inline-flex rounded-lg border border-slate-200 p-1 bg-slate-50">
+            <button
+              type="button"
+              onClick={() => setInterval('monthly')}
+              className={`px-5 py-2 rounded-md text-sm font-semibold ${
+                interval === 'monthly' ? 'bg-white shadow text-slate-900' : 'text-slate-600'
+              }`}
+            >
+              Monthly
+            </button>
+            <button
+              type="button"
+              onClick={() => setInterval('annual')}
+              className={`px-5 py-2 rounded-md text-sm font-semibold ${
+                interval === 'annual' ? 'bg-white shadow text-slate-900' : 'text-slate-600'
+              }`}
+            >
+              Annual <span className="text-brand-green-600 text-xs ml-1">save ~17%</span>
+            </button>
+          </div>
+        </div>
+
+        {error && (
+          <p className="mb-6 text-center text-sm text-brand-red-600 bg-brand-red-50 border border-brand-red-200 rounded-lg py-2 px-4 max-w-lg mx-auto">
+            {error}
+          </p>
+        )}
+
+        <div className="grid md:grid-cols-3 gap-8">
+          {plans.map((plan) => {
+            const popular = plan.popular;
+            const price = interval === 'annual' ? plan.priceAnnual : plan.priceMonthly;
+            const priceLabel = interval === 'annual' ? '/yr' : '/mo';
+            return (
+              <div
+                key={plan.id}
+                className={`rounded-2xl p-8 flex flex-col ${
+                  popular
+                    ? 'bg-brand-blue-600 text-white ring-4 ring-brand-blue-300 shadow-xl'
+                    : 'bg-slate-50 border border-slate-200'
+                }`}
+              >
+                {popular && (
+                  <span className="self-start bg-brand-red-600 text-white text-xs font-bold px-3 py-1 rounded-full mb-3">
+                    MOST POPULAR
+                  </span>
+                )}
+                <h3 className={`text-2xl font-bold ${popular ? 'text-white' : 'text-slate-900'}`}>
+                  {plan.name}
+                </h3>
+                <div className="mt-4 mb-6">
+                  <span className="text-4xl font-bold">${price}</span>
+                  <span className={popular ? 'text-brand-blue-100' : 'text-slate-600'}>
+                    {priceLabel}
+                  </span>
+                </div>
+                <ul className="space-y-3 mb-8 flex-1">
+                  {plan.featureBullets.map((f) => (
+                    <li key={f} className="flex items-start gap-2 text-sm">
+                      <Check
+                        className={`w-5 h-5 flex-shrink-0 ${popular ? 'text-white' : 'text-brand-green-600'}`}
+                      />
+                      <span className={popular ? 'text-white' : 'text-slate-700'}>{f}</span>
+                    </li>
+                  ))}
+                </ul>
+                <button
+                  type="button"
+                  disabled={loadingPlan !== null}
+                  onClick={() => subscribe(plan.id)}
+                  className={`w-full py-3 rounded-lg font-bold flex items-center justify-center gap-2 disabled:opacity-60 ${
+                    popular
+                      ? 'bg-white text-brand-blue-700 hover:bg-brand-blue-50'
+                      : 'bg-brand-blue-600 text-white hover:bg-brand-blue-700'
+                  }`}
+                >
+                  {loadingPlan === plan.id ? (
+                    <Loader2 className="w-5 h-5 animate-spin" />
+                  ) : (
+                    <ShoppingCart className="w-4 h-4" />
+                  )}
+                  Subscribe
+                </button>
+                <Link
+                  href="/store/trial"
+                  className={`block w-full text-center py-2.5 mt-2 rounded-lg text-sm font-semibold border ${
+                    popular
+                      ? 'border-white/40 text-white hover:bg-white/10'
+                      : 'border-slate-300 text-slate-700 hover:bg-white'
+                  }`}
+                >
+                  Or start 14-day org trial
+                </Link>
+              </div>
+            );
+          })}
+        </div>
+
+        {selectedAddonSlugs.length > 0 && (
+          <p className="text-center text-xs text-slate-500 mt-6">
+            Checkout includes selected add-ons: {selectedAddonSlugs.join(', ')}
+          </p>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/docs/platform-saas-blueprint.md
+++ b/docs/platform-saas-blueprint.md
@@ -1,0 +1,80 @@
+# Platform SaaS Blueprint (Elevate)
+
+Elevate already implements most of the “full code” scope as a production LMS + workforce platform (~516 Supabase tables, multi-tenant `tenants`, `licenses.features`, provisioning, Stripe). This document maps the **simplified go-to-market pricing** onto that architecture.
+
+## Pricing (canonical)
+
+Source: `lib/store/platform-pricing.ts`
+
+| Plan | Monthly | Annual |
+|------|--------:|-------:|
+| Solo | $29 | $290 |
+| Business | $59 | $590 |
+| Professional | $99 | $990 |
+
+Add-ons are sold separately via the marketplace on `/store/plans#addons`.
+
+## Feature flags
+
+Canonical keys: `lib/platform/features.ts` (`PlatformFeature`).
+
+Runtime check (tenant license):
+
+```typescript
+import { hasFeature } from '@/lib/middleware/withLicense';
+const allowed = await hasFeature(tenantId, 'lms');
+```
+
+Resolve entitlements from plan + add-ons:
+
+```typescript
+import { resolveEntitlements } from '@/lib/platform/entitlements';
+const { features, maxUsers } = resolveEntitlements('business', ['workforce-development']);
+```
+
+After Stripe checkout, fulfillment writes `licenses.features` and `organization_addons` rows: `lib/platform/fulfillment.ts`.
+
+## Database mapping (existing + new)
+
+| Concept | Elevate table / mechanism |
+|---------|---------------------------|
+| Organizations | `tenants` |
+| Users | `auth.users` + `profiles` (`tenant_id`) |
+| Plans / subscriptions | `licenses` (`tier`, `stripe_subscription_id`, `features[]`) |
+| Add-ons | `organization_addons` (migration `20260702000016`) |
+| CRM, courses, WIOA, apprenticeship | Existing domain tables (contacts, `courses`, `program_enrollments`, `progress_entries`, etc.) |
+
+Recommended future tables (optional, not required for v1 pricing UI):
+
+- `saas_plans` — mirror catalog in DB for admin editing
+- `usage_meters` — SMS/storage overage
+
+## Checkout flow
+
+1. Customer selects plan + add-ons on `/store/plans`
+2. `POST /api/store/platform-checkout` → Stripe Checkout (subscription)
+3. `checkout.session.completed` → `app/api/webhooks/store` → `fulfillPlatformSaasSubscription`
+
+**Requirement:** User’s `profiles.tenant_id` must be set (create org via `/store/trial` first if needed).
+
+## Comparison to Marblism
+
+| Marblism | Elevate |
+|----------|---------|
+| Prompt-to-app SaaS builder | Operational workforce + beauty/trades LMS |
+| Next.js + Supabase + Stripe greenfield | Same stack, domain-specific modules already built |
+| AI employees / app generation | AI tutor, Dev Studio, content tools (different product lane) |
+
+Elevate is closer to **GoHighLevel + TalentLMS + apprenticeship compliance** than a generic app generator.
+
+## Module delivery order (recommended)
+
+1. ✅ Pricing catalog + store UI + checkout API  
+2. Apply migrations `20260702000015`, `20260702000016` in Supabase SQL Editor  
+3. Gate routes with `hasFeature` / `withLicense` per module  
+4. Metered SMS/storage (Stripe usage records)  
+5. Admin UI to view/edit `organization_addons` per tenant  
+
+## Migrations (manual)
+
+- `supabase/migrations/20260702000016_organization_addons.sql`

--- a/lib/licensing/billing-authority.ts
+++ b/lib/licensing/billing-authority.ts
@@ -33,6 +33,11 @@ const SUBSCRIPTION_TIERS = new Set([
   'org_annual',
   'team_monthly',
   'team_annual',
+  // SaaS base plans (store/plans)
+  'solo_monthly',
+  'solo_annual',
+  'business_monthly',
+  'business_annual',
 ]);
 
 // DB tiers that MUST have expires_at (time-boxed)

--- a/lib/platform/entitlements.ts
+++ b/lib/platform/entitlements.ts
@@ -1,0 +1,62 @@
+import type { BasePlanId } from '@/lib/store/platform-pricing';
+import { BASE_PLANS, getAddOn } from '@/lib/store/platform-pricing';
+import type { PlatformFeatureKey } from '@/lib/platform/features';
+
+export interface ResolvedEntitlements {
+  planId: BasePlanId;
+  features: PlatformFeatureKey[];
+  maxUsers: number;
+  maxLocations: number;
+  maxContacts: number | null;
+  addonSlugs: string[];
+  additionalUsers: number;
+  additionalLocations: number;
+  additionalStorageGb: number;
+}
+
+/**
+ * Merge base plan features with add-on feature keys (deduped).
+ */
+export function resolveEntitlements(
+  planId: BasePlanId,
+  addonSlugs: string[] = [],
+): ResolvedEntitlements {
+  const plan = BASE_PLANS[planId];
+  const featureSet = new Set<PlatformFeatureKey>(plan.features);
+
+  let additionalUsers = 0;
+  let additionalLocations = 0;
+  let additionalStorageGb = 0;
+
+  for (const slug of addonSlugs) {
+    const addon = getAddOn(slug);
+    if (!addon) continue;
+    for (const f of addon.features) featureSet.add(f);
+    if (slug === 'additional-user') additionalUsers += 1;
+    if (slug === 'additional-location') additionalLocations += 1;
+    if (slug === 'additional-storage') additionalStorageGb += 100;
+  }
+
+  return {
+    planId,
+    features: [...featureSet],
+    maxUsers: plan.maxUsers + additionalUsers,
+    maxLocations: plan.maxLocations + additionalLocations,
+    maxContacts: plan.maxContacts,
+    addonSlugs: [...addonSlugs],
+    additionalUsers,
+    additionalLocations,
+    additionalStorageGb,
+  };
+}
+
+/**
+ * Check feature access for a tenant license feature list.
+ */
+export function hasPlatformFeature(
+  licenseFeatures: string[] | null | undefined,
+  feature: PlatformFeatureKey,
+): boolean {
+  if (!licenseFeatures?.length) return false;
+  return licenseFeatures.includes(feature);
+}

--- a/lib/platform/features.ts
+++ b/lib/platform/features.ts
@@ -1,0 +1,36 @@
+/**
+ * Platform feature keys for plan + add-on entitlements.
+ * Stored on licenses.features (text[]) and checked via hasPlatformFeature().
+ */
+
+export const PlatformFeature = {
+  CRM: 'crm',
+  WEBSITE: 'website',
+  BOOKING: 'booking',
+  FORMS: 'forms',
+  EMAIL_MARKETING: 'email_marketing',
+  AI_BASIC: 'ai_basic',
+  AI_ADVANCED: 'ai_advanced',
+  AI_CONTENT: 'ai_content',
+  AI_CHAT_WIDGET: 'ai_chat_widget',
+  SMS: 'sms',
+  AUTOMATIONS: 'automations',
+  INVOICING: 'invoicing',
+  LEAD_FUNNELS: 'lead_funnels',
+  CLIENT_PORTAL: 'client_portal',
+  LMS: 'lms',
+  CERTIFICATES: 'certificates',
+  WORKFLOW_AUTOMATION: 'workflow_automation',
+  REPORTING: 'reporting',
+  CUSTOM_BRANDING: 'custom_branding',
+  STUDENT_MANAGEMENT: 'student_management',
+  WORKFORCE: 'workforce',
+  APPRENTICESHIP: 'apprenticeship',
+  EMPLOYER_PORTAL: 'employer_portal',
+  TESTING_CENTER: 'testing_center',
+  WHITE_LABEL_MOBILE: 'white_label_mobile',
+} as const;
+
+export type PlatformFeatureKey = (typeof PlatformFeature)[keyof typeof PlatformFeature];
+
+export const ALL_PLATFORM_FEATURE_KEYS: PlatformFeatureKey[] = Object.values(PlatformFeature);

--- a/lib/platform/fulfillment.ts
+++ b/lib/platform/fulfillment.ts
@@ -1,0 +1,100 @@
+import { logger } from '@/lib/logger';
+import type { SupabaseClient } from '@/lib/supabase';
+import type { BasePlanId, BillingInterval } from '@/lib/store/platform-pricing';
+import { licenseTierForPlan } from '@/lib/store/platform-pricing';
+import { resolveEntitlements } from '@/lib/platform/entitlements';
+
+export interface PlatformSaasCheckoutMetadata {
+  user_id: string;
+  tenant_id?: string;
+  plan_id: BasePlanId;
+  billing_interval: BillingInterval;
+  addon_slugs?: string;
+  stripe_subscription_id?: string;
+  stripe_customer_id?: string;
+}
+
+/**
+ * Apply plan + add-ons to tenant license after Stripe checkout.
+ */
+export async function fulfillPlatformSaasSubscription(
+  adminSupabase: SupabaseClient,
+  meta: PlatformSaasCheckoutMetadata,
+): Promise<{ ok: boolean; error?: string }> {
+  const { user_id, tenant_id, plan_id, billing_interval } = meta;
+  const addonSlugs = (meta.addon_slugs || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter(Boolean);
+
+  if (!tenant_id) {
+    logger.warn('platform_saas fulfillment: no tenant_id on profile', { user_id });
+    return { ok: false, error: 'No organization linked to this account' };
+  }
+
+  const entitlements = resolveEntitlements(plan_id, addonSlugs);
+  const tier = licenseTierForPlan(plan_id, billing_interval);
+
+  const { data: license, error: fetchErr } = await adminSupabase
+    .from('licenses')
+    .select('id, features')
+    .eq('tenant_id', tenant_id)
+    .maybeSingle();
+
+  if (fetchErr) {
+    logger.error('platform_saas: license fetch failed', fetchErr);
+    return { ok: false, error: fetchErr.message };
+  }
+
+  const licensePayload = {
+    tier,
+    status: 'active',
+    features: entitlements.features,
+    max_users: entitlements.maxUsers,
+    stripe_subscription_id: meta.stripe_subscription_id ?? null,
+    stripe_customer_id: meta.stripe_customer_id ?? null,
+    metadata: {
+      saas_plan_id: plan_id,
+      billing_interval,
+      addon_slugs: addonSlugs,
+      max_locations: entitlements.maxLocations,
+      max_contacts: entitlements.maxContacts,
+      additional_storage_gb: entitlements.additionalStorageGb,
+    },
+    updated_at: new Date().toISOString(),
+  };
+
+  if (license?.id) {
+    const { error: updateErr } = await adminSupabase
+      .from('licenses')
+      .update(licensePayload)
+      .eq('id', license.id);
+    if (updateErr) return { ok: false, error: updateErr.message };
+  } else {
+    const { error: insertErr } = await adminSupabase.from('licenses').insert({
+      tenant_id,
+      domain: 'pending-setup',
+      customer_email: null,
+      license_key: `saas-${tenant_id.slice(0, 8)}`,
+      ...licensePayload,
+    });
+    if (insertErr) return { ok: false, error: insertErr.message };
+  }
+
+  for (const slug of addonSlugs) {
+    const { error: addonErr } = await adminSupabase.from('organization_addons').upsert(
+      {
+        tenant_id,
+        addon_slug: slug,
+        status: 'active',
+        activated_at: new Date().toISOString(),
+      },
+      { onConflict: 'tenant_id,addon_slug' },
+    );
+    if (addonErr) {
+      logger.warn('organization_addons upsert failed', { slug, addonErr });
+    }
+  }
+
+  return { ok: true };
+}

--- a/lib/store/beauty-dashboard-clone.ts
+++ b/lib/store/beauty-dashboard-clone.ts
@@ -1,0 +1,142 @@
+/**
+ * Beauty & personal-services vertical — org dashboard clone (managed white-label).
+ * Checkout reuses platform license slugs; trial uses /api/trial/start-managed.
+ */
+
+export const BEAUTY_PROGRAM_SLUGS = [
+  'barber-apprenticeship',
+  'cosmetology-apprenticeship',
+  'esthetician-apprenticeship',
+  'esthetician',
+  'nail-technician-apprenticeship',
+  'beauty-career-educator',
+] as const;
+
+export type BeautyProgramSlug = (typeof BEAUTY_PROGRAM_SLUGS)[number];
+
+export interface BeautyProgramCard {
+  slug: BeautyProgramSlug;
+  name: string;
+  href: string;
+  summary: string;
+}
+
+export const BEAUTY_PROGRAM_CARDS: BeautyProgramCard[] = [
+  {
+    slug: 'barber-apprenticeship',
+    name: 'Barber Apprenticeship',
+    href: '/programs/barber-apprenticeship',
+    summary: 'OJT hours, host shops, state board prep, and WIOA-ready enrollment.',
+  },
+  {
+    slug: 'cosmetology-apprenticeship',
+    name: 'Cosmetology Apprenticeship',
+    href: '/programs/cosmetology-apprenticeship',
+    summary: 'Apprenticeship tracking, curriculum modules, and compliance reporting.',
+  },
+  {
+    slug: 'esthetician-apprenticeship',
+    name: 'Esthetician Apprenticeship',
+    href: '/programs/esthetician-apprenticeship',
+    summary: 'Clinical hours, instructor sign-off, and learner progress dashboards.',
+  },
+  {
+    slug: 'esthetician',
+    name: 'Esthetician Program',
+    href: '/programs/esthetician',
+    summary: 'Short-form esthetician pathway with enrollment and credential tracking.',
+  },
+  {
+    slug: 'nail-technician-apprenticeship',
+    name: 'Nail Technician Apprenticeship',
+    href: '/programs/nail-technician-apprenticeship',
+    summary: 'Salon partners, hour logs, and board-aligned lesson structure.',
+  },
+  {
+    slug: 'beauty-career-educator',
+    name: 'Beauty Career Educator',
+    href: '/programs/beauty-career-educator',
+    summary: 'Train-the-trainer track for schools expanding instructor capacity.',
+  },
+];
+
+/** Prefill value for managed trial form */
+export const BEAUTY_TRIAL_PROGRAMS_PREFILL = BEAUTY_PROGRAM_SLUGS.join(', ');
+
+export interface BeautyDashboardClonePlan {
+  id: string;
+  name: string;
+  description: string;
+  monthlyPrice: number;
+  setupFee: number;
+  features: string[];
+  checkoutHref: string;
+  trialQuery: string;
+  popular?: boolean;
+}
+
+export const BEAUTY_DASHBOARD_CLONE_PLANS: BeautyDashboardClonePlan[] = [
+  {
+    id: 'beauty-growth',
+    name: 'Beauty School Starter',
+    description: 'Single-location schools and boutique academies',
+    monthlyPrice: 1500,
+    setupFee: 7500,
+    features: [
+      'White-label admin dashboard (your brand)',
+      'Up to 500 active learners',
+      'Barber, cosmetology, esthetician program templates',
+      'Enrollment & document intake',
+      'OJT / apprenticeship hour tracking',
+      'Instructor & student portals',
+      'Certificate and progress reporting',
+    ],
+    checkoutHref: '/store/licenses/checkout/efh-core-platform',
+    trialQuery: '?vertical=beauty',
+    popular: false,
+  },
+  {
+    id: 'beauty-professional',
+    name: 'Beauty Provider Pro',
+    description: 'Multi-program schools and workforce partners',
+    monthlyPrice: 2500,
+    setupFee: 10000,
+    features: [
+      'Everything in Starter',
+      'Up to 2,000 active learners',
+      'Partner & employer dashboards',
+      'Host shop / salon partner management',
+      'WIOA & grant compliance exports',
+      'BNPL and payment plan checkout',
+      'Priority onboarding',
+    ],
+    checkoutHref: '/store/licenses/checkout/school-license',
+    trialQuery: '?vertical=beauty',
+    popular: true,
+  },
+  {
+    id: 'beauty-enterprise',
+    name: 'Beauty Enterprise',
+    description: 'State boards, chains, and multi-site networks',
+    monthlyPrice: 3500,
+    setupFee: 15000,
+    features: [
+      'Unlimited learners',
+      'Multi-location admin clone',
+      'Custom domain & API access',
+      'Dedicated success manager',
+      'Advanced analytics & audit logs',
+      'Optional source-code clone license',
+    ],
+    checkoutHref: '/contact?subject=Beauty%20Enterprise%20Dashboard%20Clone',
+    trialQuery: '?vertical=beauty',
+    popular: false,
+  },
+];
+
+export const BEAUTY_DASHBOARD_CLONE_META = {
+  title: 'Beauty Program Dashboard Clone | Elevate Store',
+  description:
+    'License a white-label admin dashboard for outside beauty schools and training organizations. Barber, cosmetology, esthetician, and nail programs with 14-day managed trial.',
+  canonical: 'https://www.elevateforhumanity.org/store/beauty-programs',
+};

--- a/lib/store/cards.ts
+++ b/lib/store/cards.ts
@@ -87,9 +87,9 @@ export const primaryCards: StoreCard[] = [
   {
     id: 'subscriptions',
     title: 'Plans & Pricing',
-    subtitle: 'Subscriptions & Checkout',
-    description: 'View pricing plans, manage subscriptions, and complete purchases.',
-    href: '/store/subscriptions',
+    subtitle: 'Solo · Business · Professional',
+    description: 'Base plans from $29/mo plus add-on marketplace for LMS, workforce, and apprenticeship.',
+    href: '/store/plans',
     image: '/images/pages/store-recommendations.webp',
     icon: 'credit-card',
     tourId: 'store-card-pricing',
@@ -116,6 +116,21 @@ export const secondaryCards: StoreCard[] = [
     tourDescription: 'Access WIOA, FERPA, and WCAG compliance tools for workforce programs.',
   },
   {
+    id: 'beauty-dashboard',
+    title: 'Beauty Dashboard Clone',
+    subtitle: 'For Outside Schools',
+    description:
+      'White-label admin dashboard for barber, cosmetology, esthetician, and nail programs. 14-day org trial.',
+    href: '/store/beauty-programs',
+    image: '/images/pages/barber-gallery-1.webp',
+    icon: 'server',
+    tourId: 'store-card-beauty-dashboard',
+    tier: 'secondary',
+    order: 7,
+    tourDescription:
+      'License a branded admin dashboard clone for beauty schools and training providers outside your network.',
+  },
+  {
     id: 'programs',
     title: 'Training Programs',
     subtitle: 'WIOA-Funded Training',
@@ -125,7 +140,7 @@ export const secondaryCards: StoreCard[] = [
     icon: 'users',
     tourId: 'store-card-programs',
     tier: 'secondary',
-    order: 7,
+    order: 8,
     tourDescription: 'Browse career training programs including Barber, CNA, HVAC, and CDL.',
   },
   {
@@ -138,7 +153,7 @@ export const secondaryCards: StoreCard[] = [
     icon: 'users',
     tourId: 'store-card-demo',
     tier: 'secondary',
-    order: 8,
+    order: 9,
     tourDescription:
       'Schedule a demo to see how our platform can transform your training operations.',
   },
@@ -152,7 +167,7 @@ export const secondaryCards: StoreCard[] = [
     icon: 'users',
     tourId: 'store-card-contact',
     tier: 'secondary',
-    order: 9,
+    order: 10,
     tourDescription: 'Connect with our sales team for enterprise pricing and custom solutions.',
   },
 ];

--- a/lib/store/platform-pricing.ts
+++ b/lib/store/platform-pricing.ts
@@ -1,0 +1,256 @@
+/**
+ * Simplified market entry: base plans + add-on marketplace.
+ * Stripe checkout: POST /api/store/platform-checkout
+ */
+
+import type { PlatformFeatureKey } from '@/lib/platform/features';
+import { PlatformFeature } from '@/lib/platform/features';
+
+export type BasePlanId = 'solo' | 'business' | 'professional';
+export type BillingInterval = 'monthly' | 'annual';
+
+export interface BasePlanDefinition {
+  id: BasePlanId;
+  name: string;
+  priceMonthly: number;
+  priceAnnual: number;
+  maxUsers: number;
+  maxLocations: number;
+  maxContacts: number | null;
+  features: PlatformFeatureKey[];
+  featureBullets: string[];
+  popular?: boolean;
+}
+
+export interface AddOnDefinition {
+  slug: string;
+  name: string;
+  priceMonthly: number;
+  description: string;
+  features: PlatformFeatureKey[];
+  bullets: string[];
+  /** Usage-based note shown in UI */
+  usageNote?: string;
+}
+
+export const BASE_PLANS: Record<BasePlanId, BasePlanDefinition> = {
+  solo: {
+    id: 'solo',
+    name: 'Solo',
+    priceMonthly: 29,
+    priceAnnual: 290,
+    maxUsers: 1,
+    maxLocations: 1,
+    maxContacts: 100,
+    features: [
+      PlatformFeature.CRM,
+      PlatformFeature.WEBSITE,
+      PlatformFeature.BOOKING,
+      PlatformFeature.FORMS,
+      PlatformFeature.EMAIL_MARKETING,
+      PlatformFeature.AI_BASIC,
+    ],
+    featureBullets: [
+      '1 user',
+      'Website',
+      'Booking calendar',
+      'CRM',
+      '100 contacts',
+      'Forms',
+      'Email marketing',
+      'Basic AI content generation',
+      '1 business location',
+    ],
+  },
+  business: {
+    id: 'business',
+    name: 'Business',
+    priceMonthly: 59,
+    priceAnnual: 590,
+    maxUsers: 3,
+    maxLocations: 1,
+    maxContacts: null,
+    features: [
+      PlatformFeature.CRM,
+      PlatformFeature.WEBSITE,
+      PlatformFeature.BOOKING,
+      PlatformFeature.FORMS,
+      PlatformFeature.EMAIL_MARKETING,
+      PlatformFeature.AI_BASIC,
+      PlatformFeature.AUTOMATIONS,
+      PlatformFeature.INVOICING,
+      PlatformFeature.LEAD_FUNNELS,
+      PlatformFeature.CLIENT_PORTAL,
+      PlatformFeature.SMS,
+    ],
+    featureBullets: [
+      'Up to 3 users',
+      'Everything in Solo',
+      'Unlimited contacts',
+      'Automations',
+      'Invoicing',
+      'Lead funnels',
+      'Client portal',
+      'SMS messaging',
+    ],
+    popular: true,
+  },
+  professional: {
+    id: 'professional',
+    name: 'Professional',
+    priceMonthly: 99,
+    priceAnnual: 990,
+    maxUsers: 10,
+    maxLocations: 1,
+    maxContacts: null,
+    features: [
+      PlatformFeature.CRM,
+      PlatformFeature.WEBSITE,
+      PlatformFeature.BOOKING,
+      PlatformFeature.FORMS,
+      PlatformFeature.EMAIL_MARKETING,
+      PlatformFeature.AI_BASIC,
+      PlatformFeature.AUTOMATIONS,
+      PlatformFeature.INVOICING,
+      PlatformFeature.LEAD_FUNNELS,
+      PlatformFeature.CLIENT_PORTAL,
+      PlatformFeature.SMS,
+      PlatformFeature.LMS,
+      PlatformFeature.CERTIFICATES,
+      PlatformFeature.WORKFLOW_AUTOMATION,
+      PlatformFeature.REPORTING,
+      PlatformFeature.CUSTOM_BRANDING,
+    ],
+    featureBullets: [
+      'Up to 10 users',
+      'Everything in Business',
+      'LMS access',
+      'Certificates',
+      'Workflow automation',
+      'Reporting dashboard',
+      'Custom branding',
+    ],
+  },
+};
+
+export const ADD_ON_MARKETPLACE: AddOnDefinition[] = [
+  {
+    slug: 'ai-addon',
+    name: 'AI Add-On',
+    priceMonthly: 19,
+    description: 'Advanced AI assistant, content, and chat widget.',
+    features: [PlatformFeature.AI_ADVANCED, PlatformFeature.AI_CONTENT, PlatformFeature.AI_CHAT_WIDGET],
+    bullets: ['Advanced AI assistant', 'AI content generation', 'AI chat widget'],
+  },
+  {
+    slug: 'text-messaging',
+    name: 'Text Messaging',
+    priceMonthly: 15,
+    description: 'SMS outreach with included bundle.',
+    features: [PlatformFeature.SMS],
+    bullets: ['500 SMS included', 'Additional usage billed separately'],
+    usageNote: '500 SMS/mo included',
+  },
+  {
+    slug: 'online-courses-lms',
+    name: 'Online Courses / LMS',
+    priceMonthly: 29,
+    description: 'Courses, certificates, and student tracking.',
+    features: [PlatformFeature.LMS, PlatformFeature.CERTIFICATES],
+    bullets: ['Unlimited courses', 'Certificates', 'Student tracking'],
+  },
+  {
+    slug: 'student-management',
+    name: 'Student Management',
+    priceMonthly: 49,
+    description: 'Enrollment, attendance, and transcripts.',
+    features: [PlatformFeature.STUDENT_MANAGEMENT],
+    bullets: ['Enrollment management', 'Attendance', 'Progress tracking', 'Transcript records'],
+  },
+  {
+    slug: 'workforce-development',
+    name: 'Workforce Development',
+    priceMonthly: 99,
+    description: 'WIOA, SNAP E&T, case notes, and outcomes.',
+    features: [PlatformFeature.WORKFORCE],
+    bullets: ['WIOA tracking', 'SNAP E&T tracking', 'Case notes', 'Outcome reporting'],
+  },
+  {
+    slug: 'apprenticeship-management',
+    name: 'Apprenticeship Management',
+    priceMonthly: 99,
+    description: 'RAPIDS, OJT, employers, and hour verification.',
+    features: [PlatformFeature.APPRENTICESHIP],
+    bullets: ['RAPIDS tracking', 'OJT tracking', 'Employer management', 'Hours verification'],
+  },
+  {
+    slug: 'employer-portal',
+    name: 'Employer Portal',
+    priceMonthly: 49,
+    description: 'Jobs, applicants, and workforce requests.',
+    features: [PlatformFeature.EMPLOYER_PORTAL],
+    bullets: ['Job postings', 'Applicant tracking', 'Workforce requests'],
+  },
+  {
+    slug: 'credential-testing-center',
+    name: 'Credential Testing Center',
+    priceMonthly: 49,
+    description: 'Exam scheduling and credential tracking.',
+    features: [PlatformFeature.TESTING_CENTER],
+    bullets: ['Exam scheduling', 'Testing management', 'Credential tracking'],
+  },
+  {
+    slug: 'white-label-mobile',
+    name: 'White Label Mobile App',
+    priceMonthly: 199,
+    description: 'Branded mobile experience for learners and clients.',
+    features: [PlatformFeature.WHITE_LABEL_MOBILE],
+    bullets: ['Branded iOS/Android PWA', 'Push-ready architecture', 'Your logo and colors'],
+  },
+  {
+    slug: 'additional-user',
+    name: 'Additional User',
+    priceMonthly: 10,
+    description: 'Per-seat expansion beyond plan limits.',
+    features: [],
+    bullets: ['$10/month each', 'Adds one licensed seat'],
+  },
+  {
+    slug: 'additional-location',
+    name: 'Additional Location',
+    priceMonthly: 25,
+    description: 'Extra business location on your account.',
+    features: [],
+    bullets: ['$25/month each', 'Separate location settings'],
+  },
+  {
+    slug: 'additional-storage',
+    name: 'Additional Storage',
+    priceMonthly: 10,
+    description: 'Extra document and media storage.',
+    features: [],
+    bullets: ['$10/month per 100 GB', 'Documents and media'],
+  },
+];
+
+export function getBasePlan(id: string): BasePlanDefinition | null {
+  if (id in BASE_PLANS) return BASE_PLANS[id as BasePlanId];
+  return null;
+}
+
+export function getAddOn(slug: string): AddOnDefinition | undefined {
+  return ADD_ON_MARKETPLACE.find((a) => a.slug === slug);
+}
+
+export function priceCents(plan: BasePlanDefinition, interval: BillingInterval): number {
+  const dollars = interval === 'annual' ? plan.priceAnnual : plan.priceMonthly;
+  return Math.round(dollars * 100);
+}
+
+export function addonPriceCents(addon: AddOnDefinition): number {
+  return Math.round(addon.priceMonthly * 100);
+}
+
+export function licenseTierForPlan(planId: BasePlanId, interval: BillingInterval): string {
+  return `${planId}_${interval}`;
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -262,6 +262,11 @@ const nextConfig = {
       // OLD URL ALIASES → CORRECT EXISTING PAGES
       // ============================================
       // /for-students has a dedicated public page — no redirect
+      {
+        source: '/store/codebase-clone',
+        destination: '/store/licenses#clone',
+        permanent: false,
+      },
       { source: '/forgotpassword', destination: '/reset-password', permanent: true },
       { source: '/resetpassword', destination: '/reset-password', permanent: true },
       { source: '/verifyemail', destination: '/verify-email', permanent: true },

--- a/supabase/migrations/20260702000016_organization_addons.sql
+++ b/supabase/migrations/20260702000016_organization_addons.sql
@@ -1,0 +1,37 @@
+-- SaaS add-on subscriptions per organization (tenant).
+-- Base plans update licenses.features via platform checkout fulfillment.
+
+CREATE TABLE IF NOT EXISTS public.organization_addons (
+  id uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id uuid NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  addon_slug text NOT NULL,
+  status text NOT NULL DEFAULT 'active' CHECK (status IN ('active', 'canceled', 'past_due')),
+  stripe_subscription_item_id text,
+  activated_at timestamptz NOT NULL DEFAULT now(),
+  canceled_at timestamptz,
+  metadata jsonb DEFAULT '{}'::jsonb,
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, addon_slug)
+);
+
+CREATE INDEX IF NOT EXISTS organization_addons_tenant_id_idx
+  ON public.organization_addons (tenant_id);
+
+ALTER TABLE public.organization_addons ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS organization_addons_tenant_admin ON public.organization_addons;
+CREATE POLICY organization_addons_tenant_admin ON public.organization_addons
+  FOR ALL TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT p.tenant_id FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.tenant_id IS NOT NULL
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT p.tenant_id FROM public.profiles p
+      WHERE p.id = auth.uid() AND p.tenant_id IS NOT NULL
+    )
+  );

--- a/tests/unit/platform/entitlements.test.ts
+++ b/tests/unit/platform/entitlements.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, it } from 'vitest';
+import { resolveEntitlements, hasPlatformFeature } from '@/lib/platform/entitlements';
+import { PlatformFeature } from '@/lib/platform/features';
+
+describe('resolveEntitlements', () => {
+  it('solo plan includes CRM and not LMS', () => {
+    const e = resolveEntitlements('solo', []);
+    expect(e.features).toContain(PlatformFeature.CRM);
+    expect(e.features).not.toContain(PlatformFeature.LMS);
+    expect(e.maxUsers).toBe(1);
+  });
+
+  it('professional includes LMS', () => {
+    const e = resolveEntitlements('professional', []);
+    expect(e.features).toContain(PlatformFeature.LMS);
+    expect(e.maxUsers).toBe(10);
+  });
+
+  it('merges add-on features', () => {
+    const e = resolveEntitlements('solo', ['workforce-development', 'ai-addon']);
+    expect(e.features).toContain(PlatformFeature.WORKFORCE);
+    expect(e.features).toContain(PlatformFeature.AI_ADVANCED);
+  });
+
+  it('additional-user increases seat count', () => {
+    const e = resolveEntitlements('business', ['additional-user', 'additional-user']);
+    expect(e.maxUsers).toBe(5);
+  });
+});
+
+describe('hasPlatformFeature', () => {
+  it('returns true when feature present', () => {
+    expect(hasPlatformFeature(['crm', 'website'], PlatformFeature.CRM)).toBe(true);
+  });
+  it('returns false when missing', () => {
+    expect(hasPlatformFeature(['crm'], PlatformFeature.LMS)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the simplified **Solo / Business / Professional** pricing model with a separate **add-on marketplace**, wired to Elevate's existing `tenants` + `licenses.features` entitlement system.

## Store

- **`/store/plans`** — base plans (monthly/annual) + add-on selection
- **`/store/beauty-programs`** — beauty vertical overview → links to `/store/plans?vertical=beauty`
- Store home + cards updated to point at new plans entry

## Technical

- `lib/store/platform-pricing.ts` — canonical catalog
- `lib/platform/features.ts` + `entitlements.ts` + `fulfillment.ts`
- `POST /api/store/platform-checkout` — Stripe subscription checkout
- Store webhook fulfills `checkout_type=platform_saas` → updates `licenses` + `organization_addons`
- Migration: `20260702000016_organization_addons.sql`
- Blueprint: `docs/platform-saas-blueprint.md`
- Unit tests: `tests/unit/platform/entitlements.test.ts`

## After merge

1. Run migrations in Supabase SQL Editor: `20260702000015` (if not applied), `20260702000016`
2. Users need `profiles.tenant_id` before SaaS checkout (use `/store/trial` first)

## Deploy

LMS deploy via standard GitHub Actions workflow on merge to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

