### PR TITLE
fix(marketing): program card photos, hero compliance, site visual audit

### DIFF
--- a/app/programs/building-services-technician/page.tsx
+++ b/app/programs/building-services-technician/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import FundingInfoBlock from '@/components/programs/FundingInfoBlock';
+import { CleanPageHero } from '@/components/programs/CleanPageHero';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const metadata: Metadata = {
@@ -28,27 +28,13 @@ const FAQS = [
 export default function BuildingServicesTechnicianPage() {
   return (
     <main className="min-h-screen bg-white">
-      {/* Hero Banner */}
-      <section className="relative w-full" style={{ height: 'clamp(300px, 45vw, 520px)' }}>
-        <Image
-          src="/images/programs/efh-building-tech-hero.jpg"
-          alt="Building Services Technician working on facility maintenance"
-          fill
-          priority
-          className="object-cover"
-          sizes="100vw"
-          placeholder="empty"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 via-brand-blue-800/40 to-transparent" />
-        <div className="absolute bottom-8 left-6 sm:left-10 max-w-2xl">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2">
-            Building Services Technician
-          </h1>
-          <p className="text-white/90 text-base sm:text-lg leading-relaxed">
-            DOL Registered Apprenticeship. Earn while you learn with paid on-the-job training.
-          </p>
-        </div>
-      </section>
+      <CleanPageHero
+        src="/images/programs/efh-building-tech-hero.jpg"
+        alt="Building Services Technician working on facility maintenance"
+        title="Building Services Technician"
+        subtitle="DOL Registered Apprenticeship. Earn while you learn with paid on-the-job training."
+        priority
+      />
 
       {/* Stats Strip */}
       <section className="bg-slate-900 py-6 px-6">

--- a/app/programs/direct-support-professional/page.tsx
+++ b/app/programs/direct-support-professional/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import FundingInfoBlock from '@/components/programs/FundingInfoBlock';
+import { CleanPageHero } from '@/components/programs/CleanPageHero';
 
 export const metadata: Metadata = {
   title: 'Direct Support Professional Training | Free DSP Program Indiana',
@@ -27,27 +27,13 @@ const FAQS = [
 export default function DirectSupportProfessionalPage() {
   return (
     <main className="min-h-screen bg-white">
-      {/* Hero Banner */}
-      <section className="relative w-full" style={{ height: 'clamp(300px, 45vw, 520px)' }}>
-        <Image
-          src="/images/gallery/image2.webp"
-          alt="Direct Support Professional training session"
-          fill
-          priority
-          className="object-cover"
-          sizes="100vw"
-          placeholder="empty"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 via-brand-blue-800/40 to-transparent" />
-        <div className="absolute bottom-8 left-6 sm:left-10 max-w-2xl">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2">
-            Direct Support Professional
-          </h1>
-          <p className="text-white/90 text-base sm:text-lg leading-relaxed">
-            Help individuals with disabilities live independently. Free training with job placement included.
-          </p>
-        </div>
-      </section>
+      <CleanPageHero
+        src="/images/gallery/image2.webp"
+        alt="Direct Support Professional training session"
+        title="Direct Support Professional"
+        subtitle="Help individuals with disabilities live independently. Free training with job placement included."
+        priority
+      />
 
       {/* Stats Strip */}
       <section className="bg-slate-900 py-6 px-6">

--- a/app/programs/drug-alcohol-specimen-collector/page.tsx
+++ b/app/programs/drug-alcohol-specimen-collector/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import FundingInfoBlock from '@/components/programs/FundingInfoBlock';
+import { CleanPageHero } from '@/components/programs/CleanPageHero';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const metadata: Metadata = {
@@ -29,27 +29,13 @@ const FAQS = [
 export default function DrugAlcoholSpecimenCollectorPage() {
   return (
     <main className="min-h-screen bg-white">
-      {/* Hero Banner */}
-      <section className="relative w-full" style={{ height: 'clamp(300px, 45vw, 520px)' }}>
-        <Image
-          src="/images/healthcare/healthcare-professional-portrait-1.jpg"
-          alt="Healthcare professional in specimen collection lab"
-          fill
-          priority
-          className="object-cover"
-          sizes="100vw"
-          placeholder="empty"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 via-brand-blue-800/40 to-transparent" />
-        <div className="absolute bottom-8 left-6 sm:left-10 max-w-2xl">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2">
-            Drug &amp; Alcohol Specimen Collector
-          </h1>
-          <p className="text-white/90 text-base sm:text-lg leading-relaxed">
-            DOT-certified training. High demand across transportation, healthcare, and corporate sectors.
-          </p>
-        </div>
-      </section>
+      <CleanPageHero
+        src="/images/healthcare/healthcare-professional-portrait-1.jpg"
+        alt="Healthcare professional in specimen collection lab"
+        title="Drug & Alcohol Specimen Collector"
+        subtitle="DOT-certified training. High demand across transportation, healthcare, and corporate sectors."
+        priority
+      />
 
       {/* Stats Strip */}
       <section className="bg-slate-900 py-6 px-6">

--- a/app/programs/finance-bookkeeping-accounting/page.tsx
+++ b/app/programs/finance-bookkeeping-accounting/page.tsx
@@ -1,8 +1,8 @@
 export const dynamic = 'force-dynamic';
 import type { Metadata } from 'next';
 import Link from 'next/link';
-import Image from 'next/image';
 import FundingInfoBlock from '@/components/programs/FundingInfoBlock';
+import { CleanPageHero } from '@/components/programs/CleanPageHero';
 
 export const metadata: Metadata = {
   title: 'Finance, Bookkeeping & Accounting Credential Pathway | ETPL Approved | Indianapolis',
@@ -31,27 +31,13 @@ const FAQS = [
 export default function FinanceBookkeepingAccountingPage() {
   return (
     <main className="min-h-screen bg-white">
-      {/* Hero Banner */}
-      <section className="relative w-full" style={{ height: 'clamp(300px, 45vw, 520px)' }}>
-        <Image
-          src="/images/pages/finance-accounting.webp"
-          alt="Finance and accounting credential pathway"
-          fill
-          priority
-          className="object-cover object-center"
-          sizes="100vw"
-          placeholder="empty"
-        />
-        <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 via-brand-blue-800/40 to-transparent" />
-        <div className="absolute bottom-8 left-6 sm:left-10 max-w-2xl">
-          <h1 className="text-3xl sm:text-4xl md:text-5xl font-bold text-white mb-2">
-            Finance, Bookkeeping &amp; Accounting
-          </h1>
-          <p className="text-white/90 text-base sm:text-lg leading-relaxed">
-            Tiered credential pathway. Tax preparation, bookkeeping, payroll, and accounting. ETPL approved.
-          </p>
-        </div>
-      </section>
+      <CleanPageHero
+        src="/images/pages/finance-accounting.webp"
+        alt="Finance and accounting credential pathway"
+        title="Finance, Bookkeeping & Accounting"
+        subtitle="Tiered credential pathway. Tax preparation, bookkeeping, payroll, and accounting. ETPL approved."
+        priority
+      />
 
       {/* Stats Strip */}
       <section className="bg-slate-900 py-6 px-6">

--- a/components/home/HomeCareerPathways.tsx
+++ b/components/home/HomeCareerPathways.tsx
@@ -11,7 +11,7 @@ import Image from 'next/image';
 import { ArrowRight } from 'lucide-react';
 import { ALL_PROGRAMS } from '@/data/programs/catalog';
 import type { ProgramSchema } from '@/lib/programs/program-schema';
-import { card, layout } from '@/lib/page-design-tokens';
+import { card, grid, layout } from '@/lib/page-design-tokens';
 
 // Featured programs shown on homepage - ordered by demand/visibility
 const FEATURED_SLUGS = [
@@ -53,7 +53,7 @@ function PathwayCard({ prog }: { prog: ProgramSchema }) {
   return (
     <article className="group flex flex-col rounded-2xl overflow-hidden bg-white border border-slate-200 hover:border-brand-red-300 hover:shadow-lg transition-all hover:-translate-y-0.5">
       {/* Image */}
-      <div className={card.image16x9Desktop}>
+      <div className={card.programImage}>
         <Image
           src={prog.heroImage}
           alt={prog.heroImageAlt || prog.title}
@@ -169,7 +169,7 @@ export function HomeCareerPathways() {
           </div>
         </div>
 
-        <div className="grid grid-cols-1 xs:grid-cols-2 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4 gap-4">
+        <div className={grid.homePrograms}>
           {featured.map((prog) => (
             <PathwayCard key={prog.slug} prog={prog} />
           ))}

--- a/components/home/HomeHowItWorks.tsx
+++ b/components/home/HomeHowItWorks.tsx
@@ -91,8 +91,8 @@ export function HomeHowItWorks() {
           </p>
         </div>
 
-        {/* Step grid — 1 col mobile, 2 col sm, 3 col md, 6 col lg */}
-        <div className="grid grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-3 xl:grid-cols-6 gap-3 mb-10">
+        {/* Step grid — 2×3 on desktop so photos stay readable */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 mb-10">
           {STEPS.map((step, i) => (
             <Link
               key={step.n}
@@ -100,13 +100,13 @@ export function HomeHowItWorks() {
               className={`group relative flex flex-col rounded-2xl overflow-hidden bg-slate-900 border-t-4 ${step.accent} hover:ring-1 hover:ring-slate-600 transition-all hover:-translate-y-0.5`}
             >
               {/* Photo */}
-              <div className={`${card.image16x9Desktop} sm:aspect-[3/2] lg:h-32`}>
+              <div className={card.programImage}>
                 <Image
                   src={step.img}
                   alt={step.imgAlt}
                   fill
                   className="object-cover object-top transition-transform duration-500 group-hover:scale-105"
-                  sizes="(max-width: 640px) 100vw, (max-width: 768px) 50vw, (max-width: 1024px) 33vw, 16vw"
+                  sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
                   loading={i < 2 ? 'eager' : 'lazy'}
                   placeholder="empty"
                 />
@@ -126,14 +126,6 @@ export function HomeHowItWorks() {
               </div>
 
               {/* Connector arrow (desktop only) */}
-              {i < STEPS.length - 1 && (
-                <span
-                  className="hidden lg:flex absolute -right-2 top-1/3 z-10 w-4 h-4 items-center justify-center rounded-full bg-slate-800 border border-slate-700"
-                  aria-hidden="true"
-                >
-                  <ArrowRight className="w-2.5 h-2.5 text-slate-500" />
-                </span>
-              )}
             </Link>
           ))}
         </div>

--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -61,6 +61,8 @@ export interface HeroVideoProps {
    * Default false — metadata preload avoids blocking LCP on inner pages.
    */
   eagerVideoLoad?: boolean;
+  /** Tighter below-hero typography and spacing (home page). */
+  compactBelowHero?: boolean;
 }
 
 /* ------------------------------------------------------------------ */
@@ -82,6 +84,7 @@ export default function HeroVideo({
   className = '',
   children,
   eagerVideoLoad = false,
+  compactBelowHero = false,
 }: HeroVideoProps) {
   const wrapperRef = useRef<HTMLDivElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
@@ -275,32 +278,60 @@ export default function HeroVideo({
       {/* BELOW-HERO CONTENT */}
       {/* All primary messaging lives here — never on the video */}
       {(belowHeroHeadline || belowHeroSubheadline || ctas || trustIndicators || children) && (
-        <section className={heroTokens.belowPanel}>
-          <div className="max-w-4xl mx-auto px-4 sm:px-6">
+        <section
+          className={
+            compactBelowHero
+              ? 'border-b border-slate-100 py-4 sm:py-5'
+              : heroTokens.belowPanel
+          }
+        >
+          <div className="max-w-3xl mx-auto px-4 sm:px-6">
             {children ? (
               children
             ) : (
               <>
                 {belowHeroHeadline && (
-                  <h1 className={heroTokens.belowHeadline}>
+                  <h1
+                    className={
+                      compactBelowHero
+                        ? 'text-lg sm:text-xl lg:text-2xl font-bold text-slate-900 leading-snug mb-2'
+                        : heroTokens.belowHeadline
+                    }
+                  >
                     {belowHeroHeadline}
                   </h1>
                 )}
                 {belowHeroSubheadline && (
-                  <p className="text-slate-700 text-base sm:text-lg leading-relaxed mb-6 sm:mb-8 max-w-2xl">
+                  <p
+                    className={
+                      compactBelowHero
+                        ? 'text-slate-600 text-sm sm:text-[0.9375rem] leading-relaxed mb-4 max-w-xl'
+                        : 'text-slate-700 text-base sm:text-lg leading-relaxed mb-6 sm:mb-8 max-w-2xl'
+                    }
+                  >
                     {belowHeroSubheadline}
                   </p>
                 )}
                 {ctas && ctas.length > 0 && (
-                  <div className="flex flex-col sm:flex-row gap-3 mb-6">
+                  <div
+                    className={
+                      compactBelowHero
+                        ? 'flex flex-col sm:flex-row gap-2 mb-2'
+                        : 'flex flex-col sm:flex-row gap-3 mb-6'
+                    }
+                  >
                     {ctas.map((cta) => (
                       <a
                         key={cta.href}
                         href={cta.href}
                         className={
                           cta.variant === 'secondary'
-                            ? 'text-center border border-slate-300 text-slate-700 font-bold px-7 py-3.5 rounded-lg hover:bg-slate-50 transition-colors text-sm'
-                            : 'text-center bg-brand-red-600 hover:bg-brand-red-700 text-white font-bold px-7 py-3.5 rounded-lg transition-colors text-sm'
+                            ? compactBelowHero
+                              ? 'text-center border border-slate-300 text-slate-700 font-semibold px-5 py-2 rounded-lg hover:bg-slate-50 transition-colors text-sm'
+                              : 'text-center border border-slate-300 text-slate-700 font-bold px-7 py-3.5 rounded-lg hover:bg-slate-50 transition-colors text-sm'
+                            : compactBelowHero
+                              ? 'text-center bg-brand-red-600 hover:bg-brand-red-700 text-white font-semibold px-5 py-2 rounded-lg transition-colors text-sm'
+                              : 'text-center bg-brand-red-600 hover:bg-brand-red-700 text-white font-bold px-7 py-3.5 rounded-lg transition-colors text-sm'
                         }
                       >
                         {cta.label}

--- a/components/programs/CleanPageHero.tsx
+++ b/components/programs/CleanPageHero.tsx
@@ -1,0 +1,38 @@
+import Image from 'next/image';
+import { hero, layout, type } from '@/lib/page-design-tokens';
+
+interface CleanPageHeroProps {
+  src: string;
+  alt: string;
+  title: string;
+  subtitle?: string;
+  priority?: boolean;
+}
+
+/**
+ * Marketing hero — image band only, copy in white panel below.
+ * No gradient overlays or text on the image (page-design-standard).
+ */
+export function CleanPageHero({ src, alt, title, subtitle, priority }: CleanPageHeroProps) {
+  return (
+    <>
+      <div className={hero.imageWrap}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          priority={priority}
+          className="object-cover object-center"
+          sizes={hero.imageSizes}
+          placeholder="empty"
+        />
+      </div>
+      <section className={hero.contentPanel}>
+        <div className={`${layout.containerNarrow} py-6 sm:py-8`}>
+          <h1 className={type.h1}>{title}</h1>
+          {subtitle ? <p className={`${type.body} mt-3 max-w-2xl`}>{subtitle}</p> : null}
+        </div>
+      </section>
+    </>
+  );
+}

--- a/components/programs/ProgramCard.tsx
+++ b/components/programs/ProgramCard.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import type { Program } from '@/lib/programs/programs.data';
 import { getProgramCardImage } from '@/lib/images/programImages';
 import { resolveSiteImagePath } from '@/lib/images/site-image-paths';
+import { card } from '@/lib/page-design-tokens';
 
 /**
  * Standard program card — system-locked structure.
@@ -13,7 +14,7 @@ export default function ProgramCard({ program }: { program: Program }) {
   return (
     <div className="bg-white border border-slate-200 rounded-2xl overflow-hidden hover:shadow-md hover:-translate-y-0.5 transition-all">
       {/* Flush top image — 16:9 */}
-      <div className="relative aspect-[16/9] overflow-hidden">
+      <div className={card.programImage}>
         {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
         <Image
           src={resolveSiteImagePath(

--- a/components/programs/ProgramMediaCard.tsx
+++ b/components/programs/ProgramMediaCard.tsx
@@ -1,0 +1,54 @@
+import Image from 'next/image';
+import { card } from '@/lib/page-design-tokens';
+
+interface ProgramMediaCardProps {
+  src: string;
+  alt: string;
+  title: string;
+  subtitle?: string;
+  step?: number;
+  className?: string;
+}
+
+/**
+ * Image card with caption below — no gradient overlay, no text on image.
+ */
+export function ProgramMediaCard({
+  src,
+  alt,
+  title,
+  subtitle,
+  step,
+  className = '',
+}: ProgramMediaCardProps) {
+  return (
+    <div
+      className={`flex flex-col overflow-hidden rounded-2xl border border-slate-200 bg-white shadow-sm ${className}`}
+    >
+      <div className={card.programImage}>
+        <Image
+          src={src}
+          alt={alt}
+          fill
+          sizes="(max-width: 640px) 100vw, (max-width: 1024px) 50vw, 33vw"
+          className="object-cover object-center"
+          placeholder="empty"
+        />
+        {step != null ? (
+          <span
+            className="absolute top-3 left-3 flex h-8 w-8 items-center justify-center rounded-full bg-brand-red-600 text-sm font-extrabold text-white shadow"
+            aria-hidden="true"
+          >
+            {step}
+          </span>
+        ) : null}
+      </div>
+      <div className="p-3 sm:p-4">
+        <p className="text-sm font-bold leading-snug text-slate-900">{title}</p>
+        {subtitle ? (
+          <p className="mt-1 text-xs leading-snug text-slate-600">{subtitle}</p>
+        ) : null}
+      </div>
+    </div>
+  );
+}

--- a/components/programs/VisualProgramTemplate.tsx
+++ b/components/programs/VisualProgramTemplate.tsx
@@ -7,6 +7,7 @@ import type { Program } from '@/lib/types/program';
 import { ProgramTutorCTA } from '@/components/ProgramTutorCTA';
 import { PROGRAMS } from '@/lib/ai/programRegistry';
 import HeroVideo from '@/components/marketing/HeroVideo';
+import { ProgramMediaCard } from '@/components/programs/ProgramMediaCard';
 import { Check, Clock, Award, DollarSign, MapPin, ArrowRight } from 'lucide-react';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
@@ -189,26 +190,14 @@ export function VisualProgramTemplate({ program, slug }: VisualProgramTemplatePr
                 sub: 'Job placement included',
               },
             ].map((card, i) => (
-              <div
+              <ProgramMediaCard
                 key={i}
-                className="group rounded-2xl overflow-hidden shadow-md hover:shadow-xl transition-shadow"
-              >
-                <div className="relative aspect-[4/3]">
-        {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
-                  <Image
-                    src={card.img}
-                    alt={card.label}
-                    fill
-                    sizes="(max-width: 640px) 50vw, 25vw"
-                    className="object-cover group-hover:scale-105 transition-transform duration-300" placeholder="empty"
-                  />
-                  <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 to-transparent" />
-                  <div className="absolute bottom-0 left-0 right-0 p-3">
-                    <p className="text-white font-bold text-sm leading-tight">{card.label}</p>
-                    <p className="text-slate-300 text-xs mt-0.5 leading-tight">{card.sub}</p>
-                  </div>
-                </div>
-              </div>
+                src={card.img}
+                alt={card.label}
+                title={card.label}
+                subtitle={card.sub}
+                className="hover:shadow-md transition-shadow"
+              />
             ))}
           </div>
         </div>
@@ -226,19 +215,12 @@ export function VisualProgramTemplate({ program, slug }: VisualProgramTemplatePr
             </p>
             <div className="grid grid-cols-2 md:grid-cols-3 gap-3 sm:gap-4">
               {program.whatYouLearn.slice(0, 6).map((item: string, i: number) => (
-                <div key={i} className="relative aspect-[4/3] rounded-2xl overflow-hidden group">
-                  <Image
+                <div key={i} className="flex flex-col gap-2">
+                  <ProgramMediaCard
                     src={images.tiles[i % images.tiles.length]}
                     alt={item}
-                    fill
-                    sizes="(max-width: 640px) 50vw, 33vw"
-                    className="object-cover group-hover:scale-105 transition-transform duration-300" placeholder="empty"
+                    title={item}
                   />
-                  <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 via-brand-blue-800/40 to-transparent" />
-                  <div className="absolute bottom-0 left-0 right-0 p-4 flex items-start gap-2">
-                    <Check className="w-4 h-4 text-brand-green-400 flex-shrink-0 mt-0.5" />
-                    <p className="text-white text-sm font-semibold leading-snug">{item}</p>
-                  </div>
                 </div>
               ))}
             </div>
@@ -384,26 +366,14 @@ export function VisualProgramTemplate({ program, slug }: VisualProgramTemplatePr
                 desc: 'Career services connects you with employers',
               },
             ].map((s) => (
-              <div
+              <ProgramMediaCard
                 key={s.step}
-                className="relative aspect-square rounded-2xl overflow-hidden shadow-md"
-              >
-                <Image
-                  src={s.img}
-                  alt={s.label}
-                  fill
-                  sizes="(max-width: 640px) 50vw, 25vw"
-                  className="object-cover" placeholder="empty"
-                />
-                <div className="absolute inset-0 bg-gradient-to-t from-brand-blue-900/80 to-transparent" />
-                <div className="absolute top-3 left-3 w-8 h-8 bg-brand-red-600 rounded-full flex items-center justify-center text-white font-extrabold text-sm shadow">
-                  {s.step}
-                </div>
-                <div className="absolute bottom-0 left-0 right-0 p-3">
-                  <p className="text-white font-bold text-sm">{s.label}</p>
-                  <p className="text-slate-300 text-xs mt-0.5 leading-tight">{s.desc}</p>
-                </div>
-              </div>
+                src={s.img}
+                alt={s.label}
+                title={s.label}
+                subtitle={s.desc}
+                step={s.step}
+              />
             ))}
           </div>
         </div>

--- a/components/shared/ProgramGrid.tsx
+++ b/components/shared/ProgramGrid.tsx
@@ -15,7 +15,7 @@ interface ProgramGridProps {
 const GRID: Record<number, string> = {
   2: 'grid grid-cols-1 sm:grid-cols-2 gap-5',
   3: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5',
-  4: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5',
+  4: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4 gap-4 max-w-6xl mx-auto',
 };
 
 export default function ProgramGrid({ programs, cols = 3 }: ProgramGridProps) {

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -20,6 +20,7 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
         videoSrcDesktop={banner.videoSrcDesktop!}
         videoSrcMobile={banner.videoSrcMobile}
         eagerVideoLoad
+        compactBelowHero
         voiceoverSrc={banner.voiceoverSrc}
         microLabel={banner.microLabel}
         belowHeroHeadline={banner.belowHeroHeadline}

--- a/docs/audits/marketing-visual-compliance-audit.md
+++ b/docs/audits/marketing-visual-compliance-audit.md
@@ -1,0 +1,102 @@
+# Marketing visual compliance audit
+
+**Date:** 2026-05-30  
+**Standards:** `docs/page-design-standard.md`, `docs/hero-video-standard.md`, `lib/page-design-tokens.ts`
+
+## Rules (non-negotiable)
+
+| Rule | Requirement |
+|------|-------------|
+| Hero / video frame | No gradient wash, no headlines or CTAs on the image |
+| Hero height | `hero.imageWrap` — `h-[clamp(190px,32vw,360px)]` |
+| Program cards | Photo on top, copy below; no text-on-image gradients |
+| Card grid | Prefer `lg:grid-cols-3` — avoid 4+ columns that stretch cards too wide |
+| Card image | `card.programImage` — `aspect-[16/10]` / `16/9`, `max-h-48` |
+
+## Fixed in this pass
+
+| Area | Change |
+|------|--------|
+| Homepage — How it works | 3-column grid; taller `card.programImage`; removed 6-column strip |
+| Homepage — Career pathways | 3-column grid; `card.programImage` instead of squashed `lg:h-32` |
+| `ProgramCard` / `ProgramGrid` | Shared `programImage` token; 3-col default |
+| `VisualProgramTemplate` | Replaced gradient image cards with `ProgramMediaCard` |
+| Legacy program pages (4) | `CleanPageHero` — image band + white copy panel |
+| Design tokens | `grid.homePrograms`, `grid.programs` (3 col), `card.programImage` |
+
+## Reusable components
+
+- `components/programs/CleanPageHero.tsx` — static page heroes
+- `components/programs/ProgramMediaCard.tsx` — image + caption below (no overlay)
+- `components/marketing/HeroVideo.tsx` — video heroes (`compactBelowHero` for home)
+
+## Remaining violations (prioritize by traffic)
+
+Run to refresh counts:
+
+```bash
+rg "absolute inset-0 bg-gradient|bg-gradient-to-t from-(brand|slate|black)" app components --glob "*.tsx" -l
+```
+
+### P0 — Public marketing / program surfaces
+
+| File | Issue |
+|------|--------|
+| `app/scholarships/page.tsx` | Hero gradient + text on image |
+| `app/check-eligibility/page.tsx` | Hero gradient overlay |
+| `app/partners/training-sites/page.tsx` | Hero gradient |
+| `app/apprenticeships/ipla-exam/page.tsx` | Hero gradient |
+| `app/help/page.tsx` | Hero gradient sections |
+| `app/lms/(app)/courses/[courseId]/page.tsx` | Course hero gradient (learner-facing) |
+| `components/templates/PageHero.tsx` | Full gradient header (legacy) |
+| `components/templates/ContentPageTemplate.tsx` | Gradient header |
+
+### P1 — Portals / secondary marketing
+
+| Pattern | Examples |
+|---------|----------|
+| `program-holder/dashboard` | Hero gradient |
+| `app/funding/jri/page.tsx` | Hero gradient |
+| `app/store/licenses/page.tsx` | Hero gradient |
+| `app/impact/page.tsx`, `app/donate/page.tsx` | Marketing gradient heroes |
+| `components/portal/PortalPageLayout.tsx` | Default gradient props on heroes |
+
+### P2 — Acceptable / out of scope
+
+- UI chrome (progress bars, chat widget headers, achievement badges)
+- Email HTML / API templates
+- Admin dashboard decorative gradients
+- Solid `bg-gradient-to-br` section backgrounds **without** image overlays (review case-by-case)
+
+## Hero sizing gaps
+
+| Pattern | Fix |
+|---------|-----|
+| `style={{ height: 'clamp(300px, 45vw, 520px)' }}` on heroes | Migrate to `hero.imageWrap` + below panel |
+| `h-[45vh] min-h-[280px]` on old program pages | Use `hero.imageWrap` per design standard |
+| Home below-hero block too tall | `HeroVideo` `compactBelowHero` on `HomeHeroVideo` |
+
+## Program card grids
+
+| Location | Grid |
+|----------|------|
+| `/` featured pathways | `grid.homePrograms` (3 col) |
+| `/programs` catalog sections | `lg:grid-cols-3` (existing) |
+| `ProgramGrid` | Default 3; max 4 with `max-w-6xl` |
+| `/programs/catalog` DB cards | `xl:grid-cols-3` (OK) |
+
+## CI recommendation
+
+Add a lint script (future):
+
+```bash
+# Fail on image-frame gradient overlays (allowlist file for exceptions)
+rg "absolute inset-0 bg-gradient-to-t" app components --glob "*.tsx"
+```
+
+## Sign-off checklist for new pages
+
+- [ ] Hero uses `HeroVideo`, `HeroPicture`, or `CleanPageHero`
+- [ ] Program cards use `ProgramCard` or `ProgramMediaCard`
+- [ ] No `absolute` text on hero images
+- [ ] Card grid ≤ 3 columns on desktop unless documented exception

--- a/lib/page-design-tokens.ts
+++ b/lib/page-design-tokens.ts
@@ -77,9 +77,12 @@ export const card = {
   base: 'bg-white border border-slate-200 rounded-2xl overflow-hidden hover:shadow-md hover:-translate-y-0.5 transition-all',
   /** Card image container — 16:9 */
   image16x9: 'relative aspect-[16/9] overflow-hidden',
-  /** Homepage / pathway cards — shorter image band on desktop */
+  /** Homepage / pathway cards — visible photo band without squashing on wide grids */
   image16x9Desktop:
-    'relative aspect-[2/1] max-h-36 lg:aspect-auto lg:h-32 overflow-hidden bg-slate-100',
+    'relative aspect-[16/10] sm:aspect-[16/9] max-h-44 overflow-hidden bg-slate-100',
+  /** Standard program card image (catalog, grids) */
+  programImage:
+    'relative aspect-[16/10] sm:aspect-[16/9] max-h-48 overflow-hidden bg-slate-100',
   /** Card image container — 4:3 */
   image4x3: 'relative aspect-[4/3] overflow-hidden',
   /** Card body padding */
@@ -146,8 +149,10 @@ export const ICC_INSTRUCTION =
 // ─── Responsive grid presets ─────────────────────────────────────────────────
 
 export const grid = {
-  /** 1 → 2 → 4 program cards */
-  programs: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-5',
+  /** 1 → 2 → 3 program cards (avoids overly wide cards on desktop) */
+  programs: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4 max-w-5xl mx-auto',
+  /** Homepage featured pathways — 2–3 columns */
+  homePrograms: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-4',
   /** 1 → 2 → 3 content cards */
   cards3: 'grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-5',
   /** 1 → 2 content cards */


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses homepage program cards that were too wide / had squashed photos, and starts a site-wide compliance pass for hero and card imagery per `docs/page-design-standard.md`.

## Changes

- **Program cards:** New `card.programImage` token (`16/10`–`16/9`, `max-h-48`). Homepage pathways use a **3-column** grid instead of 4. How-it-works steps use **3×2** layout with readable photo bands (no more `lg:h-32` strip).
- **No gradient on cards:** `ProgramMediaCard` for image + caption below. `VisualProgramTemplate` career tiles, learn tiles, and step cards migrated off `bg-gradient-to-t` overlays.
- **Hero compliance:** `CleanPageHero` for static heroes (image band + white copy panel). Applied to DSP, Building Services, Finance/Accounting, and Specimen Collector program pages.
- **Home hero copy block:** `compactBelowHero` on `HomeHeroVideo` (smaller headline/CTAs under video).
- **Audit doc:** `docs/audits/marketing-visual-compliance-audit.md` lists ~24 remaining gradient-on-image hits (scholarships, check-eligibility, LMS course hero, legacy templates, etc.) with P0/P1 priority.

## How to verify

1. Open `/` — pathway cards should show clear photos, 3 per row on desktop.
2. Scroll to “One system. End-to-end.” — six steps with visible images, not thin slivers.
3. Open any program using `VisualProgramTemplate` (e.g. HVAC) — no dark gradient wash on tile images.
4. Open `/programs/direct-support-professional` — title/subtitle below hero image, not on top.

## Follow-up (documented in audit)

- Migrate P0 pages (scholarships, check-eligibility, LMS course landing) to `CleanPageHero` / `HeroVideo`.
- Optional CI grep for `absolute inset-0 bg-gradient-to-t` on marketing routes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Replace gradient hero overlays with `CleanPageHero` and standardize program card images across marketing pages
> - Adds [`CleanPageHero`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-2f3e324160520af32b0d3f3cde29a3422398b276b6e2065c996ddea2f84ed489), a reusable hero component that renders an image band with a separate white content panel, replacing custom gradient overlays with on-image text in four program pages.
> - Adds [`ProgramMediaCard`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-6bae97a70fd2174527d0e09d0eb97903f412c1b5bce26eba593ed9d7fe57b591) and integrates it into [`VisualProgramTemplate`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-1b48ec71fa22a4a428594701e1a0f7f22857f26794fae67aed8086509235cbdb), moving captions below images and removing gradient overlays from snapshot cards, learning tiles, and step cards.
> - Standardizes card image tokens in [`lib/page-design-tokens.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-d4631cc032db79e18f0f45467e8fe2ff0e12e5498360f9616255506075cce1b2) by adding a `programImage` token (aspect `[16/10]/[16/9]`, `max-h-48`) used across [`ProgramCard`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-329a831beac39c567e840226ea22529c99d402654a77d8ecdec1b806b4714bb3), [`HomeCareerPathways`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-33ee0d1af68440561e1b53b3a6b52c07509cd207e56e153d342ec900943d24f6), and [`HomeHowItWorks`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-5e126b7d6fabf3ced0b2715965a9fd84ae7fa6021bb373deba4216b290185716).
> - Adds a `compactBelowHero` prop to [`HeroVideo`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-09bbffe6e45d3d6235aee606d0825338e90c31ab4910cb0742664fbdcdbb60cb) and activates it on the home page via [`HomeHeroVideo`](https://github.com/elevate-for-humanity/Elevate-lms/pull/247/files#diff-dbf377d6ffab2d32492c71ee711d7709b99700531992ade49e322c11003b98ff), reducing below-hero padding, typography size, and CTA button size.
> - Behavioral Change: card image aspect ratios and max heights change site-wide; step connector arrows are removed from `HomeHowItWorks`; the programs grid caps at 3 columns on `lg` screens instead of 4.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5586ca8.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->