### PR TITLE
fix(account): unblock Next.js build for Northflank deploys

### DIFF
--- a/app/account/invoices/page.tsx
+++ b/app/account/invoices/page.tsx
@@ -1,12 +1,5 @@
 'use client';
 
-import type { Metadata } from 'next';
-
-export const metadata = {
-  title: 'Invoices | Account',
-  robots: { index: false, follow: false },
-};
-
 import { useState } from 'react';
 import { AccountBillingShell } from '@/components/billing/AccountBillingShell';
 import { Loader2 } from 'lucide-react';


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Northflank **LMS** and **Admin** deploys after merge #246 failed at `BUILDING → FAILURE`. Compliance Gate on PRs shows the same root cause:

`app/account/invoices/page.tsx` exports `metadata` from a `'use client'` page (disallowed in Next.js 15).

Metadata is already defined in `app/account/invoices/layout.tsx`.

## Fix

Remove duplicate `metadata` export from the client page.

## Deploy impact

After merge to `main`, re-run:
- **Actions → Deploy LMS → Run workflow**
- **Actions → Deploy Admin → Run workflow**

Or push will auto-trigger deploy workflows when `app/**` changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

