### PR TITLE
Fix store 14-day trial website provisioning

### DIFF
--- a/app/api/trial/start-managed/route.ts
+++ b/app/api/trial/start-managed/route.ts
@@ -9,6 +9,8 @@ import { withApiAudit } from '@/lib/audit/withApiAudit';
 
 import { withRuntime } from '@/lib/api/withRuntime';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { provisionTrialWebsite } from '@/lib/tenant/provision-trial-website';
+import { tenantAdminUrl } from '@/lib/tenant/public-site-url';
 
 const TRIAL_DURATION_DAYS = 14;
 
@@ -56,30 +58,30 @@ function slugify(name: string): string {
     .slice(0, 30);
 }
 
-
 async function sendTrialWelcomeEmail(
   email: string,
   orgName: string,
   subdomain: string,
   dashboardUrl: string,
+  publicSiteUrl: string,
   correlationId: string,
 ) {
   const sendgridKey = process.env.SENDGRID_API_KEY;
   if (!sendgridKey) {
     logger.warn(
-      `[trial] ${correlationId} — SENDGRID_API_KEY not configured, skipping welcome email`,
+      `[trial] ${correlationId} - SENDGRID_API_KEY not configured, skipping welcome email`,
     );
     return;
   }
 
   await resend.emails.send({
-    from: 'Elevate LMS <${PLATFORM_DEFAULTS.emailFromAddress}>',
+    from: `${PLATFORM_DEFAULTS.emailFromName} <${PLATFORM_DEFAULTS.emailFromAddress}>`,
     to: email,
-    subject: `Your 14-day trial is ready — ${orgName}`,
-    headers: { 'X-Correlation-ID': correlationId },
+    subject: `Your 14-day trial is ready - ${orgName}`,
     html: `
       <h1>Your trial is live.</h1>
       <p>Organization: <strong>${orgName}</strong></p>
+      <p>Workspace: <strong>${subdomain}</strong></p>
       <p><a href="${dashboardUrl}" style="display:inline-block;padding:12px 24px;background:#dc2626;color:#fff;font-weight:bold;text-decoration:none;border-radius:6px;">Open Your Dashboard</a></p>
       <p>Your public site: <a href="${publicSiteUrl}">${publicSiteUrl}</a></p>
       <h2>What to do now:</h2>
@@ -99,15 +101,15 @@ async function sendTrialWelcomeEmail(
  * POST /api/trial/start-managed
  *
  * Public self-service endpoint. Creates a 14-day managed platform trial.
- * No auth required — rate-limited by email.
+ * No auth required - rate-limited by email.
  *
- * Body: { orgName, adminName, adminEmail }
- * Returns: { ok, tenantUrl, subdomain, trialEndsAt, correlationId }
+ * Body: { orgName, adminName, adminEmail, websiteMode, existingUrl, programs }
+ * Returns: { ok, tenantUrl, publicPreviewUrl, websiteId, subdomain, trialEndsAt, correlationId }
  */
 async function _POST(request: NextRequest) {
   await hydrateProcessEnv();
 
-  // Correlation ID for tracing failures across client ↔ server
+  // Correlation ID for tracing failures across client/server.
   const correlationId = `trial_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 
   try {
@@ -141,6 +143,9 @@ async function _POST(request: NextRequest) {
       return NextResponse.json({ error: 'Invalid email address', correlationId }, { status: 400 });
     }
 
+    const connectionMode: 'new_site' | 'existing_site' | 'api_embed' =
+      websiteMode === 'existing' ? 'existing_site' : 'new_site';
+
     // Rate limit (Upstash Redis if available, in-memory fallback)
     if (!(await checkTrialRateLimit(email))) {
       return NextResponse.json(
@@ -151,7 +156,7 @@ async function _POST(request: NextRequest) {
 
     const supabase = await getSupabaseAdmin();
     if (!supabase) {
-      logger.error(`[trial] ${correlationId} — Supabase not configured`);
+      logger.error(`[trial] ${correlationId} - Supabase not configured`);
       return NextResponse.json({ error: 'Service unavailable', correlationId }, { status: 503 });
     }
 
@@ -163,10 +168,12 @@ async function _POST(request: NextRequest) {
       .maybeSingle();
 
     if (existingOrg) {
+      const tenantUrl = tenantAdminUrl(existingOrg.slug, '/admin');
       return NextResponse.json(
         {
           error: 'A trial already exists for this email address',
-          tenantUrl: `https://${existingOrg.slug}.app.elevateforhumanity.org/admin`,
+          tenantUrl,
+          publicPreviewUrl: `https://${existingOrg.slug}.app.elevateforhumanity.org`,
           subdomain: existingOrg.slug,
         },
         { status: 409 },
@@ -221,7 +228,7 @@ async function _POST(request: NextRequest) {
       const detail = orgError
         ? (orgError as { message?: string }).message ?? JSON.stringify(orgError)
         : 'insert returned no row (RLS or trigger blocked read-back)';
-      logger.error(`[trial] ${correlationId} — Org creation error: ${detail}`, orgError instanceof Error ? orgError : new Error(detail));
+      logger.error(`[trial] ${correlationId} - Org creation error: ${detail}`, orgError instanceof Error ? orgError : new Error(detail));
       return NextResponse.json(
         { error: 'Failed to create organization', correlationId },
         { status: 500 },
@@ -250,7 +257,7 @@ async function _POST(request: NextRequest) {
       const detail = licenseError
         ? (licenseError as { message?: string }).message ?? JSON.stringify(licenseError)
         : 'insert returned no row (RLS or trigger blocked read-back)';
-      logger.error(`[trial] ${correlationId} — License creation error: ${detail}`, licenseError instanceof Error ? licenseError : new Error(detail));
+      logger.error(`[trial] ${correlationId} - License creation error: ${detail}`, licenseError instanceof Error ? licenseError : new Error(detail));
       // Rollback org
       await supabase.from('organizations').delete().eq('id', org.id);
       return NextResponse.json(
@@ -259,9 +266,28 @@ async function _POST(request: NextRequest) {
       );
     }
 
-    // Resolve connection mode from websiteMode field
-    const connectionMode: 'new_site' | 'existing_site' | 'api_embed' =
-      websiteMode === 'existing' ? 'existing_site' : 'new_site';
+    const website = await provisionTrialWebsite({
+      organizationId: org.id,
+      organizationName: orgName.trim(),
+      subdomain,
+      trialEndsAt: trialEndsAt.toISOString(),
+      contactEmail: email,
+      industry: typeof programs === 'string' && programs.trim() ? programs.trim() : 'Training Provider',
+      websiteMode: connectionMode,
+    });
+
+    if (!website.ok) {
+      logger.error(
+        `[trial] ${correlationId} - Website provisioning error: ${website.error}`,
+        new Error(website.error),
+      );
+      await supabase.from('managed_licenses').delete().eq('id', license.id).then(() => {}, () => {});
+      await supabase.from('organizations').delete().eq('id', org.id).then(() => {}, () => {});
+      return NextResponse.json(
+        { error: 'Failed to provision trial website', correlationId },
+        { status: 500 },
+      );
+    }
 
     // Log provisioning event
     await supabase
@@ -279,9 +305,11 @@ async function _POST(request: NextRequest) {
           connection_mode: connectionMode,
           existing_url: existingUrl || null,
           programs: programs || null,
+          website_id: website.websiteId,
+          public_preview_url: website.publicUrl,
         },
       })
-      .then(()=>{}, ()=>{}); // Non-critical
+      .then(() => {}, () => {}); // Non-critical
 
     // Store extra intake fields on the org record if columns exist (best-effort)
     if (existingUrl || programs) {
@@ -292,24 +320,25 @@ async function _POST(request: NextRequest) {
           ...(programs ? { notes: `Programs: ${programs}` } : {}),
         })
         .eq('id', org.id)
-        .then(()=>{}, ()=>{});
+        .then(() => {}, () => {});
     }
 
-    const dashboardUrl = `https://${subdomain}.app.elevateforhumanity.org/admin`;
-    const publicPreviewUrl = `https://${subdomain}.app.elevateforhumanity.org`;
+    const dashboardUrl = tenantAdminUrl(subdomain, '/admin');
+    const publicPreviewUrl = website.publicUrl;
 
     // Send welcome email
     try {
-      await sendTrialWelcomeEmail(email, orgName.trim(), subdomain, dashboardUrl, correlationId);
+      await sendTrialWelcomeEmail(email, orgName.trim(), subdomain, dashboardUrl, publicPreviewUrl, correlationId);
     } catch (emailError) {
-      logger.error(`[trial] ${correlationId} — Failed to send welcome email:`, emailError);
-      // Don't fail — trial is created
+      logger.error(`[trial] ${correlationId} - Failed to send welcome email:`, emailError);
+      // Don't fail - trial is created
     }
 
     return NextResponse.json({
       ok: true,
       tenantUrl: dashboardUrl,
       publicPreviewUrl,
+      websiteId: website.websiteId,
       subdomain,
       trialEndsAt: trialEndsAt.toISOString(),
       correlationId,
@@ -319,7 +348,7 @@ async function _POST(request: NextRequest) {
   } catch (error) {
     const errMsg = error instanceof Error ? error.message : JSON.stringify(error);
     logger.error(
-      `[trial] ${correlationId} — Unexpected error: ${errMsg}`,
+      `[trial] ${correlationId} - Unexpected error: ${errMsg}`,
       error instanceof Error ? error : new Error(errMsg),
     );
     return NextResponse.json({ error: 'Internal server error', correlationId }, { status: 500 });

--- a/app/store/apps/website-builder/page.tsx
+++ b/app/store/apps/website-builder/page.tsx
@@ -73,16 +73,16 @@ export default function WebsiteBuilderAppPage() {
               </p>
               <div className="flex flex-wrap gap-4">
                 <Link
-                  href="/apps/website-builder/start-trial"
+                  href="/store/trial?app=website-builder&mode=new"
                   className="inline-flex items-center gap-2 bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold text-lg transition-colors"
                 >
                   Start 14-day free trial
                 </Link>
                 <Link
-                  href="/import"
+                  href="/store/trial?app=website-builder&mode=existing"
                   className="inline-flex items-center gap-2 border border-slate-300 hover:bg-slate-50 text-slate-900 px-8 py-4 rounded-lg font-bold text-lg transition-colors"
                 >
-                  Import existing site
+                  Connect existing site
                 </Link>
               </div>
             </div>
@@ -159,7 +159,7 @@ export default function WebsiteBuilderAppPage() {
           </p>
           <div className="flex flex-wrap gap-4 justify-center">
             <Link
-              href="/apps/website-builder/start-trial"
+              href="/store/trial?app=website-builder&mode=new"
               className="bg-brand-red-600 hover:bg-brand-red-700 text-white px-8 py-4 rounded-lg font-bold"
             >
               Start Free Trial

--- a/app/store/trial/page.tsx
+++ b/app/store/trial/page.tsx
@@ -56,6 +56,11 @@ function TrialPageContent() {
     if (searchParams.get('vertical') === 'beauty') {
       setPrograms((prev) => (prev.trim() ? prev : BEAUTY_TRIAL_PROGRAMS_PREFILL));
     }
+
+    const mode = searchParams.get('mode');
+    if (mode === 'existing' || mode === 'new') {
+      setWebsiteMode(mode);
+    }
   }, [searchParams]);
   const [error, setError] = useState<string | null>(null);
   const [correlationId, setCorrelationId] = useState<string | null>(null);
@@ -213,7 +218,7 @@ function TrialPageContent() {
     );
   }
 
-  // ── Form state ─────────────────────────────────────────────────────────────
+  // ── Form state ────────────────────────────────────────────────────────────
   return (
     <div className="min-h-screen bg-white">
       <div className="bg-white border-b">

--- a/tests/e2e/full-enrollment-journey.spec.ts
+++ b/tests/e2e/full-enrollment-journey.spec.ts
@@ -58,7 +58,7 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
     await expect(page).toHaveURL(/\/apply/);
 
     // Step 2.2: Verify apply landing page content
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Check Your Eligibility', level: 1 })).toBeVisible();
 
     // Step 2.3: Verify the canonical intake form and program path are presented
     const formSection = page.locator('#application, form, [id*="form"]');
@@ -216,7 +216,7 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
 
     // Application Landing
     await page.goto('/apply');
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Check Your Eligibility', level: 1 })).toBeVisible();
     journeySteps.push('✓ Apply landing page displayed');
 
     // Intake Form

--- a/tests/e2e/full-enrollment-journey.spec.ts
+++ b/tests/e2e/full-enrollment-journey.spec.ts
@@ -110,8 +110,9 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
    * Phase 4: Authentication - User creates account or logs in
    */
   test('Phase 4: Authentication Flow', async ({ page }) => {
-    // Step 4.1: Navigate to registration page
-    await page.goto('/register');
+    // Step 4.1: Navigate to canonical signup page
+    await page.goto('/signup');
+    await expect(page.getByRole('heading', { name: 'Create Your Account', level: 1 })).toBeVisible();
 
     // Step 4.2: Verify registration form exists
     const emailInput = page.locator('input[type="email"]');
@@ -229,7 +230,8 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
     await expect(page.locator('input[type="email"]').first()).toBeVisible();
     journeySteps.push('✓ Login page accessible');
 
-    await page.goto('/register');
+    await page.goto('/signup');
+    await expect(page.getByRole('heading', { name: 'Create Your Account', level: 1 })).toBeVisible();
     await expect(page.locator('input[type="email"]').first()).toBeVisible();
     journeySteps.push('✓ Registration page accessible');
 
@@ -412,7 +414,7 @@ test.describe('Enrollment Journey Mobile Experience', () => {
   });
 
   test('no horizontal scroll on enrollment pages', async ({ page }) => {
-    const pages = ['/apply', '/login', '/register', '/funding'];
+    const pages = ['/apply', '/login', '/signup', '/funding'];
 
     for (const url of pages) {
       await page.goto(url);


### PR DESCRIPTION
## Summary
- Route Website Builder store CTAs to the public `/store/trial` application instead of the authenticated app subscription redirect.
- Preselect `Build a new site` or `Connect existing site` from the store CTA query string.
- Provision a `user_websites` record during `/api/trial/start-managed` before returning success, and return `websiteId` plus the real public preview URL.
- Fix the welcome email bug where `publicSiteUrl` was referenced without being passed and the sender string was not interpolated.
- Stabilize enrollment E2E assertions for `/apply` and the canonical `/signup` route.

## Validation
- Did not submit a live trial form because that would create production Supabase records.
- Current PR head: `1dbfcaba11c281ad2b2c8d552a9700e1e32b47a8`.
- Passing on latest head so far: Design Policy Enforcement, Survival Guard, Integrity Gate, Lint, Pre-deploy Check.
- Still running on latest head: CI/CD Pipeline, Compliance Gate, Autopilot.

## Production safety
No deploy or merge performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes the public trial API to create and roll back database records (org, license, website) on each signup, which affects production tenant provisioning if provisioning or rollback fails.
> 
> **Overview**
> **Managed trial start** now provisions a `user_websites` record via `provisionTrialWebsite` before success, rolls back org/license on failure, and returns `websiteId` plus the real `publicPreviewUrl`. Dashboard/preview URLs use `tenantAdminUrl`; duplicate-email **409** responses include the same URL helpers. Welcome email fixes the sender name, passes `publicSiteUrl`, and adds workspace context in the body.
> 
> **Store funnel:** Website Builder CTAs point at `/store/trial` with `app` and `mode` query params; the trial form preselects **new** vs **existing** site from `mode`.
> 
> **E2E:** Enrollment journey tests target canonical `/apply` and `/signup` headings instead of generic `h1` or `/register`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbfcaba11c281ad2b2c8d552a9700e1e32b47a8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->