### PR TITLE
Improve Northflank deploy failure diagnostics

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -70,10 +70,11 @@ jobs:
         run: pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_ADMIN_SERVICE_ID" "$DEPLOY_BRANCH"
 
       - name: Trigger admin build
+        id: trigger_admin_build
         run: pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_ADMIN_SERVICE_ID"
 
       - name: Wait for admin deployment
-        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_ADMIN_SERVICE_ID" --timeout-ms 1200000
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_ADMIN_SERVICE_ID" --build-id "${{ steps.trigger_admin_build.outputs.build_id }}" --timeout-ms 1200000
 
       - name: Smoke admin
         run: |

--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -77,10 +77,11 @@ jobs:
         run: pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_LMS_SERVICE_ID" "$DEPLOY_BRANCH"
 
       - name: Trigger LMS build
+        id: trigger_lms_build
         run: pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_LMS_SERVICE_ID"
 
       - name: Wait for LMS deployment
-        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --timeout-ms 3600000
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --build-id "${{ steps.trigger_lms_build.outputs.build_id }}" --timeout-ms 3600000
 
       - name: Smoke LMS
         run: |

--- a/scripts/northflank/trigger-build.ts
+++ b/scripts/northflank/trigger-build.ts
@@ -6,6 +6,7 @@
  *   pnpm tsx scripts/northflank/trigger-build.ts elevate-admin
  */
 
+import fs from 'node:fs';
 import { nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 async function main() {
@@ -30,6 +31,10 @@ async function main() {
     body: JSON.stringify({}),
   });
   console.log(`Triggered build for ${serviceId}:`, build);
+
+  if (process.env.GITHUB_OUTPUT && build.id) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `build_id=${build.id}\n`, 'utf8');
+  }
 }
 
 main().catch((e) => {

--- a/scripts/northflank/wait-service.ts
+++ b/scripts/northflank/wait-service.ts
@@ -5,6 +5,7 @@
  * Usage:
  *   pnpm tsx scripts/northflank/wait-service.ts elevate-admin
  *   pnpm tsx scripts/northflank/wait-service.ts elevate-lms --timeout-ms 1200000
+ *   pnpm tsx scripts/northflank/wait-service.ts elevate-admin --build-id <id>
  */
 
 import { nfFetch, projectApiPath, resolveProjectId } from './lib';
@@ -13,16 +14,50 @@ type ServiceStatus = {
   deploymentStatus?: { status?: string };
   buildStatus?: string;
   status?: {
-    build?: { status?: string };
-    deployment?: { status?: string; reason?: string };
+    build?: { status?: string; lastTransitionTime?: string };
+    deployment?: { status?: string; reason?: string; lastTransitionTime?: string };
   };
 };
+
+type ServiceBuild = {
+  id: string;
+  branch?: string;
+  status?: string;
+  sha?: string;
+  concluded?: boolean;
+  success?: boolean;
+  message?: string | null;
+  createdAt?: string;
+  buildConcludedAt?: number;
+};
+
+type ServiceBuildList = {
+  builds?: ServiceBuild[];
+};
+
+type BuildLogLine = {
+  containerId?: string;
+  log?: string;
+  ts?: string;
+};
+
+const BUILD_FAILURE_STATUSES = new Set([
+  'ABORTED',
+  'CRASHED',
+  'ERROR',
+  'FAILED',
+  'FAILURE',
+  'SUBMISSION_FAILURE',
+]);
+const BUILD_DONE_STATUSES = new Set(['SUCCESS', 'COMPLETED', 'SKIPPED']);
+const DEPLOY_READY_STATUSES = new Set(['COMPLETED', 'RUNNING', 'SUCCESS']);
+const DEPLOY_FAILURE_STATUSES = new Set(['FAILED', 'ERROR']);
 
 function resolveServicePhase(service: ServiceStatus): string {
   const build = service.status?.build?.status ?? service.buildStatus;
   const deploy = service.status?.deployment?.status ?? service.deploymentStatus?.status;
 
-  if (build && !['SUCCESS', 'COMPLETED'].includes(build)) {
+  if (build && !BUILD_DONE_STATUSES.has(build)) {
     return build;
   }
   if (deploy) return deploy;
@@ -34,10 +69,135 @@ function argValue(name: string): string | undefined {
   return index >= 0 ? process.argv[index + 1] : undefined;
 }
 
+function redactText(value: string): string {
+  return value
+    .replace(/Bearer\s+[A-Za-z0-9._~+/=-]+/gi, 'Bearer [redacted]')
+    .replace(
+      /((?:token|secret|password|authorization|api[_-]?key|private[_-]?key)[\w-]*\s*[:=]\s*)[^\s,;]+/gi,
+      '$1[redacted]',
+    );
+}
+
+function redactValue(value: unknown): unknown {
+  if (typeof value === 'string') return redactText(value);
+  if (Array.isArray(value)) return value.map((item) => redactValue(item));
+  if (!value || typeof value !== 'object') return value;
+
+  return Object.fromEntries(
+    Object.entries(value as Record<string, unknown>).map(([key, nested]) => {
+      if (/token|secret|password|authorization|api[_-]?key|private[_-]?key/i.test(key)) {
+        return [key, '[redacted]'];
+      }
+      return [key, redactValue(nested)];
+    }),
+  );
+}
+
+function formatError(error: unknown): string {
+  return error instanceof Error ? error.message : String(error);
+}
+
+async function resolveBuildId(
+  projectId: string,
+  serviceId: string,
+  preferredBuildId?: string,
+): Promise<string | undefined> {
+  const normalized = preferredBuildId?.trim();
+  if (normalized) return normalized;
+
+  try {
+    const list = await nfFetch<ServiceBuildList>(
+      projectApiPath(projectId, `/services/${serviceId}/build?per_page=1`),
+    );
+    return list.builds?.[0]?.id;
+  } catch (error) {
+    console.error(`Could not resolve latest Northflank build id: ${formatError(error)}`);
+    return undefined;
+  }
+}
+
+async function fetchBuildDetails(
+  projectId: string,
+  serviceId: string,
+  buildId: string,
+): Promise<ServiceBuild | undefined> {
+  try {
+    return await nfFetch<ServiceBuild>(
+      projectApiPath(projectId, `/services/${serviceId}/build/${buildId}`),
+    );
+  } catch (error) {
+    console.error(`Could not fetch Northflank build ${buildId}: ${formatError(error)}`);
+    return undefined;
+  }
+}
+
+async function printBuildLogs(
+  projectId: string,
+  serviceId: string,
+  buildId: string,
+): Promise<void> {
+  const params = new URLSearchParams({
+    buildId,
+    queryType: 'range',
+    endTime: new Date().toISOString(),
+    duration: '3600',
+    lineLimit: '200',
+    direction: 'backward',
+  });
+
+  try {
+    const logs = await nfFetch<BuildLogLine[]>(
+      projectApiPath(projectId, `/services/${serviceId}/build-logs?${params.toString()}`),
+    );
+
+    if (!Array.isArray(logs) || logs.length === 0) {
+      console.error(`No Northflank build logs returned for ${serviceId} build ${buildId}.`);
+      return;
+    }
+
+    console.error(`Last ${logs.length} Northflank build log lines for ${serviceId} build ${buildId}:`);
+    for (const entry of logs) {
+      const timestamp = entry.ts ? `${entry.ts} ` : '';
+      console.error(redactText(`${timestamp}${entry.log ?? ''}`));
+    }
+  } catch (error) {
+    console.error(`Could not fetch Northflank build logs for ${buildId}: ${formatError(error)}`);
+  }
+}
+
+async function printFailureDiagnostics(
+  projectId: string,
+  serviceId: string,
+  buildId: string | undefined,
+  service: ServiceStatus,
+): Promise<void> {
+  const resolvedBuildId = await resolveBuildId(projectId, serviceId, buildId);
+  const build = resolvedBuildId
+    ? await fetchBuildDetails(projectId, serviceId, resolvedBuildId)
+    : undefined;
+
+  console.error(`${serviceId} failure diagnostics:`);
+  console.error(
+    JSON.stringify(
+      redactValue({
+        buildId: resolvedBuildId,
+        build,
+        serviceStatus: service,
+      }),
+      null,
+      2,
+    ),
+  );
+
+  if (resolvedBuildId) {
+    await printBuildLogs(projectId, serviceId, resolvedBuildId);
+  }
+}
+
 async function main() {
   const serviceId = process.argv[2];
   if (!serviceId || serviceId.startsWith('--')) {
-    console.error('Usage: pnpm tsx scripts/northflank/wait-service.ts <service-id> [--timeout-ms 900000]');
+    console.error('Usage: pnpm tsx scripts/northflank/wait-service.ts <service-id> [--timeout-ms 900000] [--build-id <id>]');
     process.exit(1);
   }
 
@@ -48,11 +208,14 @@ async function main() {
   }
 
   const timeoutMs = Number(argValue('--timeout-ms') || 900_000);
+  const buildId = argValue('--build-id');
   const start = Date.now();
   let last = '';
+  let lastService: ServiceStatus | undefined;
 
   while (Date.now() - start < timeoutMs) {
     const service = await nfFetch<ServiceStatus>(projectApiPath(projectId, `/services/${serviceId}`));
+    lastService = service;
     const build = service.status?.build?.status ?? service.buildStatus;
     const deploy = service.status?.deployment?.status ?? service.deploymentStatus?.status;
     const phase = resolveServicePhase(service);
@@ -64,22 +227,22 @@ async function main() {
       last = label;
     }
 
-    if (build === 'FAILURE' || build === 'ERROR' || build === 'FAILED') {
+    if (BUILD_FAILURE_STATUSES.has(build ?? '')) {
       console.error(`${serviceId} build failed (${build})`);
+      await printFailureDiagnostics(projectId, serviceId, buildId, service);
       process.exit(1);
     }
 
-    const deployReady =
-      deploy && ['COMPLETED', 'RUNNING', 'SUCCESS'].includes(deploy);
-    const buildDone =
-      !build || ['SUCCESS', 'COMPLETED', 'SKIPPED'].includes(build);
+    const deployReady = deploy && DEPLOY_READY_STATUSES.has(deploy);
+    const buildDone = !build || BUILD_DONE_STATUSES.has(build);
 
     if (buildDone && deployReady) {
       return;
     }
 
-    if (['FAILED', 'ERROR'].includes(deploy ?? '')) {
+    if (DEPLOY_FAILURE_STATUSES.has(deploy ?? '')) {
       console.error(`${serviceId} deployment failed (${deploy})`);
+      await printFailureDiagnostics(projectId, serviceId, buildId, service);
       process.exit(1);
     }
 
@@ -87,6 +250,9 @@ async function main() {
   }
 
   console.error(`${serviceId} did not settle within ${timeoutMs}ms`);
+  if (lastService) {
+    await printFailureDiagnostics(projectId, serviceId, buildId, lastService);
+  }
   process.exit(1);
 }
 

--- a/tests/e2e/full-enrollment-journey.spec.ts
+++ b/tests/e2e/full-enrollment-journey.spec.ts
@@ -58,7 +58,7 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
     await expect(page).toHaveURL(/\/apply/);
 
     // Step 2.2: Verify apply landing page content
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Check Your Eligibility', level: 1 })).toBeVisible();
 
     // Step 2.3: Verify the canonical intake form and program path are presented
     const formSection = page.locator('#application, form, [id*="form"]');
@@ -110,8 +110,9 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
    * Phase 4: Authentication - User creates account or logs in
    */
   test('Phase 4: Authentication Flow', async ({ page }) => {
-    // Step 4.1: Navigate to registration page
-    await page.goto('/register');
+    // Step 4.1: Navigate to canonical signup page
+    await page.goto('/signup');
+    await expect(page.getByRole('heading', { name: 'Create Your Account', level: 1 })).toBeVisible();
 
     // Step 4.2: Verify registration form exists
     const emailInput = page.locator('input[type="email"]');
@@ -216,7 +217,7 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
 
     // Application Landing
     await page.goto('/apply');
-    await expect(page.locator('h1')).toBeVisible();
+    await expect(page.getByRole('heading', { name: 'Check Your Eligibility', level: 1 })).toBeVisible();
     journeySteps.push('✓ Apply landing page displayed');
 
     // Intake Form
@@ -229,7 +230,8 @@ test.describe('Full Enrollment Journey: Apply → Auth → Checkout → Enrollme
     await expect(page.locator('input[type="email"]').first()).toBeVisible();
     journeySteps.push('✓ Login page accessible');
 
-    await page.goto('/register');
+    await page.goto('/signup');
+    await expect(page.getByRole('heading', { name: 'Create Your Account', level: 1 })).toBeVisible();
     await expect(page.locator('input[type="email"]').first()).toBeVisible();
     journeySteps.push('✓ Registration page accessible');
 
@@ -412,7 +414,7 @@ test.describe('Enrollment Journey Mobile Experience', () => {
   });
 
   test('no horizontal scroll on enrollment pages', async ({ page }) => {
-    const pages = ['/apply', '/login', '/register', '/funding'];
+    const pages = ['/apply', '/login', '/signup', '/funding'];
 
     for (const url of pages) {
       await page.goto(url);


### PR DESCRIPTION
## Summary
- Emit the Northflank build ID from `trigger-build.ts` as a GitHub Actions output.
- Pass that build ID into Admin and LMS deploy wait steps.
- Print redacted service/build diagnostics plus the latest Northflank build log lines when a build, deploy, or timeout fails.
- Carry the enrollment E2E route repairs into this branch so deploy diagnostics are not blocked by stale `/apply` and `/register` assertions.

## Why
The current Admin and LMS deploy failures only report one-line Northflank build failures in GitHub Actions, with no remote build output. The Northflank API supports fetching service build logs with `buildId`, so this wires the workflow to surface the actual failed build logs in the next run.

## Validation
- Current PR head: `33f23149b59a9c31ea54fc2a6e40fff6b73f1a4d`.
- Passing so far: Survival Guard, Integrity Gate.
- Still running: Lint, Pre-deploy Check, CI/CD Pipeline, Compliance Gate, Autopilot.
- No production deploy or merge performed.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to deploy scripts/workflows and test selectors; no runtime app or auth logic is modified.
> 
> **Overview**
> **Northflank deploy workflows** now capture the build ID from `trigger-build.ts` (via `GITHUB_OUTPUT`) and pass it into `wait-service.ts` so failures are tied to the build that was just triggered, not whatever happens to be “latest” on the service.
> 
> **`wait-service.ts`** gains optional `--build-id`, broader build/deploy status handling, and **failure diagnostics**: redacted JSON for build/service state plus up to ~200 lines of Northflank build logs on build failure, deploy failure, or timeout.
> 
> **Enrollment E2E** (`full-enrollment-journey.spec.ts`) is updated to match canonical routes and copy: `/apply` expects **Check Your Eligibility**, registration flows use **`/signup`** with **Create Your Account** instead of `/register` and generic `h1` checks.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 33f23149b59a9c31ea54fc2a6e40fff6b73f1a4d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->