### PR TITLE
chore(northflank): configure services in deploy-live

### DIFF
--- a/scripts/northflank/deploy-live.ts
+++ b/scripts/northflank/deploy-live.ts
@@ -89,6 +89,10 @@ async function main() {
   }
 
   const { execSync } = await import('node:child_process');
+  execSync('pnpm exec tsx scripts/northflank/configure-services.ts --execute', {
+    stdio: 'inherit',
+    cwd: process.cwd(),
+  });
   execSync('pnpm exec tsx scripts/northflank/ensure-build-cache.ts --execute', {
     stdio: 'inherit',
     cwd: process.cwd(),


### PR DESCRIPTION
Ensures every manual deploy-live run applies build plan, probes, and 32GB build disk before triggering builds.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches the production deploy entrypoint and pushes live Northflank service configuration before every build; a configure failure blocks the entire deploy.
> 
> **Overview**
> **Live deploys** now run `configure-services.ts --execute` at the start of the `--execute` path in `deploy-live.ts`, **before** `ensure-build-cache`. Each manual production deploy reapplies Northflank service settings (Dockerfile paths, BuildKit cache, runtime env, readiness probes, build disk sizing) via the existing configure script, then continues with branch updates and builds as before.
> 
> A non-zero exit from `configure-services` stops the deploy immediately (same `execSync` behavior as the build-cache step).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6aec87da12c0b1bc2b20d38f57f8b8ae9419d00b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Run `configure-services.ts` before build cache check in `deploy-live`
> Adds a synchronous call to `scripts/northflank/configure-services.ts --execute` at the start of [deploy-live.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/255/files#diff-c69e95a9066a4a1532e68facafdb33e441e2b6d2cfea0a81a15985ab2b73d595), before the existing `ensure-build-cache` step. Risk: if `configure-services.ts` exits with a non-zero code, the deploy script terminates early.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6aec87d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->