### PR TITLE
fix(beauty): barber weekly billing, header programs, funded apply

### DIFF
--- a/app/api/barber/webhook/route.ts
+++ b/app/api/barber/webhook/route.ts
@@ -16,6 +16,7 @@ import {
 
 import { withRuntime } from '@/lib/api/withRuntime';
 import { BARBER_PROGRAM_ID, BARBER_COURSE_ID } from '@/lib/barber/pricing';
+import { createBarberWeeklySubscriptionAfterCheckout } from '@/lib/barber/create-weekly-subscription';
 import { STRIPE_BNPL_PAYMENT_METHODS } from '@/lib/bnpl-config';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
@@ -491,6 +492,33 @@ ${!fullyPaid ? `<p><strong>Payment plan:</strong> Weekly invoices will arrive ev
           }).select('id').maybeSingle();
           if (subRecordError) {
             logger.error('barber_subscriptions insert error:', new Error(subRecordError.message));
+          }
+
+          // Payment plan: create weekly Stripe subscription (same as barber_full_tuition path)
+          if (!fullyPaid && weeklyPaymentCents > 0 && weeksRemaining > 0) {
+            const billing = await createBarberWeeklySubscriptionAfterCheckout({
+              stripe,
+              supabase,
+              session,
+              customerId,
+              customerEmail,
+              applicationId,
+              weeklyPaymentCents,
+              invoiceWeeks: weeksRemaining,
+              fullyPaid,
+            });
+            if (billing.error) {
+              try {
+                const { sendEmail } = await import('@/lib/email/sendgrid');
+                await sendEmail({
+                  to: 'elevate4humanityedu@gmail.com',
+                  subject: '⚠️ Weekly billing setup failed — manual action required',
+                  html: `<p>Student: ${customerEmail}<br>Customer ID: ${customerId}<br>Weekly: $${(weeklyPaymentCents / 100).toFixed(2)}<br>Weeks: ${weeksRemaining}</p><p>Error: ${billing.error}</p>`,
+                });
+              } catch {
+                /* non-fatal */
+              }
+            }
           }
 
           // Update applications.payment_status so the admin approval gate passes

--- a/app/programs/cosmetology-apprenticeship/apply/page.tsx
+++ b/app/programs/cosmetology-apprenticeship/apply/page.tsx
@@ -61,6 +61,7 @@ export default function CosmetologyApplyIndexPage() {
             description="I want to enroll in the cosmetology apprenticeship program as a student."
             enrollHref="/programs/cosmetology-apprenticeship/apply/apprentice"
             inquiryHref="/programs/cosmetology-apprenticeship/request-info"
+            routeFundedToEnrollment
             accentColor="brand-red"
           />
 

--- a/app/programs/nail-technician-apprenticeship/apply/page.tsx
+++ b/app/programs/nail-technician-apprenticeship/apply/page.tsx
@@ -58,8 +58,9 @@ export default function NailApplyIndexPage() {
             icon={<Sparkles className="w-6 h-6 text-purple-600" />}
             title="I'm an Apprentice"
             description="I want to enroll in the nail technician apprenticeship program as a student."
-            enrollHref="/apply?program=nail-technician-apprenticeship&type=enrollment"
+            enrollHref="/programs/nail-technician-apprenticeship/apply/apprentice"
             inquiryHref="/contact?program=nail-technician-apprenticeship"
+            routeFundedToEnrollment
             accentColor="brand-red"
           />
 

--- a/components/programs/FundingGateCard.tsx
+++ b/components/programs/FundingGateCard.tsx
@@ -41,6 +41,8 @@ interface Props {
   description: string;
   enrollHref: string;
   inquiryHref: string;
+  /** When true, funded paths go to enrollHref with ?funding= instead of inquiry only */
+  routeFundedToEnrollment?: boolean;
   /** Tailwind color prefix, e.g. 'brand-red' */
   accentColor?: string;
 }
@@ -65,8 +67,10 @@ export default function FundingGateCard({
     }
     if (SELF_PAY_VALUES.has(funding)) {
       router.push(enrollHref);
+    } else if (routeFundedToEnrollment) {
+      const join = enrollHref.includes('?') ? '&' : '?';
+      router.push(`${enrollHref}${join}funding=${encodeURIComponent(funding)}`);
     } else {
-      // Pass funding type so the inquiry form can pre-fill it
       router.push(`${inquiryHref}?funding=${encodeURIComponent(funding)}`);
     }
   };

--- a/lib/barber/create-weekly-subscription.ts
+++ b/lib/barber/create-weekly-subscription.ts
@@ -1,0 +1,108 @@
+import type Stripe from 'stripe';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getBillingCycleAnchor } from '@/lib/programs/pricing';
+import { logger } from '@/lib/logger';
+
+/**
+ * After barber checkout (payment plan), attach PM and create weekly Stripe subscription.
+ * Used by /api/barber/webhook for checkout_type barber_enrollment (public apply flow).
+ */
+export async function createBarberWeeklySubscriptionAfterCheckout(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient;
+  session: Stripe.Checkout.Session;
+  customerId: string;
+  customerEmail: string;
+  applicationId?: string;
+  weeklyPaymentCents: number;
+  invoiceWeeks: number;
+  fullyPaid: boolean;
+  bnplProvider?: string | null;
+}): Promise<{ subscriptionId?: string; error?: string }> {
+  const {
+    stripe,
+    supabase,
+    session,
+    customerId,
+    customerEmail,
+    applicationId,
+    weeklyPaymentCents,
+    invoiceWeeks,
+    fullyPaid,
+    bnplProvider,
+  } = params;
+
+  if (fullyPaid || bnplProvider || weeklyPaymentCents <= 0 || invoiceWeeks <= 0) {
+    return {};
+  }
+
+  try {
+    const checkoutSession = await stripe.checkout.sessions.retrieve(session.id, {
+      expand: ['payment_intent.payment_method'],
+    });
+    const pi = checkoutSession.payment_intent as Stripe.PaymentIntent | null;
+    const pmId =
+      typeof pi?.payment_method === 'string'
+        ? pi.payment_method
+        : (pi?.payment_method as Stripe.PaymentMethod | null)?.id;
+
+    if (!pmId) {
+      logger.warn('[barber/billing] No payment method — weekly subscription not created', {
+        customerId,
+      });
+      return { error: 'no_payment_method' };
+    }
+
+    await stripe.paymentMethods.attach(pmId, { customer: customerId }).catch(() => {});
+    await stripe.customers.update(customerId, {
+      invoice_settings: { default_payment_method: pmId },
+    });
+
+    const weeklyPrice = await stripe.prices.create({
+      currency: 'usd',
+      unit_amount: weeklyPaymentCents,
+      recurring: { interval: 'week', interval_count: 1 },
+      product_data: { name: 'Barber Apprenticeship — Weekly Tuition' },
+    });
+
+    const billingAnchor = getBillingCycleAnchor();
+
+    const subscription = await stripe.subscriptions.create({
+      customer: customerId,
+      items: [{ price: weeklyPrice.id }],
+      billing_cycle_anchor: billingAnchor,
+      proration_behavior: 'none',
+      metadata: {
+        program: 'barber-apprenticeship',
+        weeks_remaining: invoiceWeeks.toString(),
+        application_id: applicationId || '',
+        customer_email: customerEmail,
+      },
+      cancel_at: billingAnchor + invoiceWeeks * 7 * 24 * 60 * 60,
+    });
+
+    await supabase
+      .from('barber_subscriptions')
+      .update({ stripe_subscription_id: subscription.id })
+      .eq('stripe_customer_id', customerId)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    logger.info('[barber/billing] Weekly subscription created', {
+      customerId,
+      subscriptionId: subscription.id,
+      weeklyPaymentCents,
+      weeks: invoiceWeeks,
+    });
+
+    return { subscriptionId: subscription.id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      '[barber/billing] Failed to create weekly subscription',
+      err instanceof Error ? err : new Error(message),
+      { customerId },
+    );
+    return { error: message };
+  }
+}

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -49,9 +49,14 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'CDL Training', href: '/programs/cdl-training' },
       { name: 'All Trades →', href: '/programs/skilled-trades', isSectionLink: true },
 
-      { name: '— Beauty (overview) —', href: '/programs#cat-beauty', isHeader: true },
-      { name: 'Beauty & Cosmetology Hub', href: '/programs#cat-beauty' },
+      { name: '— Beauty & Apprenticeships —', href: '/programs#cat-beauty', isHeader: true },
+      { name: 'Barber Apprenticeship', href: canonicalRoutes.programs.barberApprenticeship },
+      { name: 'Cosmetology Apprenticeship', href: canonicalRoutes.programs.cosmetologyApprenticeship },
+      { name: 'Nail Technician Apprenticeship', href: '/programs/nail-technician-apprenticeship' },
+      { name: 'Esthetician Apprenticeship', href: canonicalRoutes.programs.estheticianApprenticeship },
+      { name: 'Beauty & Cosmetology Hub', href: '/programs#cat-beauty', isSectionLink: true },
       { name: 'Beauty & Career Educator', href: '/programs/beauty-career-educator' },
+      { name: 'All apprenticeships →', href: '/apprenticeships', isSectionLink: true },
 
       { name: '— Technology —', href: '/programs/technology', isHeader: true },
       { name: 'IT Help Desk', href: '/programs/it-help-desk' },

--- a/lib/program-registry.ts
+++ b/lib/program-registry.ts
@@ -224,6 +224,7 @@ export const PROGRAMS: ProgramEntry[] = [
     category: 'Barber & Beauty',
     formType: 'apply',
     active: true,
+    dedicatedApplyPage: '/programs/nail-technician-apprenticeship/apply',
   },
   {
     slug: 'beauty-career-educator',


### PR DESCRIPTION
Fixes barber payment-plan weekly Stripe subscription on live checkout webhook; adds beauty apprenticeships to Programs header; enables funded routing on cosmetology/nail apply gates.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Creates live Stripe subscriptions and charges from the barber webhook; misconfiguration could bill incorrectly or leave students without recurring billing until manual fix.
> 
> **Overview**
> **Barber payment plans** on the public `barber_enrollment` checkout path now spin up **weekly Stripe subscriptions** after checkout via shared helper `createBarberWeeklySubscriptionAfterCheckout` (attach PM, weekly price, billing anchor, auto-cancel). Failures email ops; this mirrors behavior that already existed for `barber_full_tuition`.
> 
> **Beauty apply routing:** `FundingGateCard` gains optional `routeFundedToEnrollment` so WIOA/FSSA/etc. go to the apprentice enroll URL with `?funding=` instead of inquiry-only. Cosmetology and nail apply index pages enable it; nail also points self-pay enrollment at the dedicated apprentice apply page.
> 
> **Discovery:** Programs nav lists individual beauty apprenticeships plus “All apprenticeships”; nail technician is registered with a `dedicatedApplyPage` in `program-registry`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d6b8e5aa6667250181c35c92f17dfde2d0bb1e28. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add barber weekly billing, funded routing for beauty apply pages, and apprenticeship nav links
> - Creates [`createBarberWeeklySubscriptionAfterCheckout`](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-f15171bb49266cd24d946e10f81d96e15303986f7faface570a3edcf943f2902) to set up a weekly Stripe subscription after checkout for barbers on a payment plan, anchored to the billing cycle and auto-cancelled after the invoice period.
> - Calls this utility in the [barber webhook](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-6658fbdafde532351b1977dcba8df4a85b520fc620ce7d1d8771ce557c49b04e) after subscription insert; on failure, sends an admin notification email.
> - Adds `routeFundedToEnrollment` prop to [`FundingGateCard`](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-d54dc7b1c86174d8232a0631831e10eecd61edaff980ec6db58406a0684c503b): when true, funded selections route to `enrollHref?funding=...` instead of the inquiry page.
> - Enables `routeFundedToEnrollment` on the [cosmetology](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-6a63d240a89967d0f52517f02eebd9a5107fab6764444812308df5e5612dca3e) and [nail technician](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-6d41a0cc874ebcfc451c416b14713c48a7f5560d0f9b0c7e273e8f06255ffffd) apply pages.
> - Adds direct apprenticeship submenu links and an "All apprenticeships" link under Programs in [site navigation](https://github.com/elevate-for-humanity/Elevate-lms/pull/257/files#diff-4a50adcb0dcec63dfc56096cd65044e1ed4a673603fe2b895267d3bd3232f47b).
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d6b8e5a. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->