### PR TITLE
fix(runtime): pdfjs-dist + @napi-rs/canvas for admin PDF APIs

### DIFF
--- a/docs/audits/pdfjs-canvas-production.md
+++ b/docs/audits/pdfjs-canvas-production.md
@@ -1,0 +1,55 @@
+# pdfjs-dist / @napi-rs/canvas production warnings
+
+**Symptom (admin/LMS container logs):**
+
+```text
+Warning: Cannot load "@napi-rs/canvas" package: Error: Cannot find module '@napi-rs/canvas'
+Warning: Cannot polyfill `DOMMatrix` / `ImageData` / `Path2D`
+Require stack: ... pdfjs-dist/legacy/build/pdf.mjs
+```
+
+## Cause
+
+`pdf-parse@2.x` depends on `pdfjs-dist@5.x`, which uses native canvas on Node for server-side PDF parsing.
+
+Our **admin** standalone image ran `scripts/prune-admin-standalone.mjs`, which previously deleted:
+
+- `pdfjs-dist`
+- entire `@napi-rs` scope (including `@napi-rs/canvas`)
+
+So routes that `import('pdf-parse')` still executed, but pdfjs could not load canvas.
+
+## Not a deploy failure
+
+These are **stderr warnings** at runtime when a code path loads pdfjs. They do **not** stop `next build` or Northflank health checks unless the process crashes afterward (uncommon).
+
+Failed deploys were separate: ENOSPC, LMS build timeout, probe timing.
+
+## Fix (2026-06)
+
+1. **`@napi-rs/canvas`** added as a direct dependency in `package.json`.
+2. **Prune lists:** removed `pdfjs-dist` and `@napi-rs` from shared prune; LMS-only prune still drops PDF stack on **www** container (no admin document APIs).
+3. **`serverExternalPackages`:** `pdf-parse`, `pdfjs-dist`, `@napi-rs/canvas` externalized so standalone retains them for admin.
+4. **`lib/insurance/scan-approve-strict.ts`:** dynamic `import('pdf-parse')` (no top-level load at boot).
+
+## Affected routes (admin)
+
+- `/api/admin/courses/parse-file`
+- `/api/admin/documents/extract`
+- `/api/admin/contracts/extract`
+- `/api/admin/courses/generate/parse`
+- `/api/ocr/extract` (LMS — pdf-parse pruned on LMS; OCR falls back)
+
+## Verify after deploy
+
+```bash
+pnpm tsx scripts/northflank/verify-health-checks.ts
+# In admin container (if shell available):
+node -e "require('@napi-rs/canvas'); console.log('canvas ok')"
+```
+
+## If warnings persist
+
+- Confirm admin build ran **after** prune-list change.
+- Run `pnpm install` so lockfile includes `@napi-rs/canvas`.
+- Do not add `pdfjs-dist` back to `SHARED_STANDALONE_PRUNE_PACKAGES`.

--- a/lib/insurance/scan-approve-strict.ts
+++ b/lib/insurance/scan-approve-strict.ts
@@ -1,4 +1,3 @@
-import pdf from 'pdf-parse';
 import { ocrPdfFirstPages } from './ocr';
 import { validateCoiText, type CoiTextValidationResult } from './validate-coi-text';
 
@@ -35,9 +34,10 @@ export async function scanApproveStrict(args: {
   let method: StrictInsuranceDecision['method'] = 'PDF_TEXT';
   let ocrConfidence: number | undefined;
 
-  // 1) Try native PDF text extraction
+  // 1) Try native PDF text extraction (pdf-parse → pdfjs-dist; needs @napi-rs/canvas in admin runtime)
   try {
-    const parsed = await pdf(args.pdfBuffer);
+    const pdfParse = (await import('pdf-parse')).default;
+    const parsed = await pdfParse(args.pdfBuffer);
     extractedText = parsed.text || '';
   } catch {
     extractedText = '';

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -16,6 +16,8 @@ const nextConfig = {
     'tesseract.js-core',
     'sharp',
     'pdf-parse',
+    'pdfjs-dist',
+    '@napi-rs/canvas',
     'pdfkit',
     'pdf-lib',
     'jspdf',

--- a/package.json
+++ b/package.json
@@ -117,6 +117,7 @@
     "oauth-1.0a": "^2.2.6",
     "openai": "6.9.1",
     "passport-google-oauth20": "2.0.0",
+    "@napi-rs/canvas": "0.1.80",
     "pdf-parse": "^2.4.5",
     "pdfkit": "^0.18.0",
     "playwright": "^1.57.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -65,6 +65,9 @@ importers:
       '@monaco-editor/react':
         specifier: 4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.1(react@19.2.1))(react@19.2.1)
+      '@napi-rs/canvas':
+        specifier: 0.1.80
+        version: 0.1.80
       '@node-saml/passport-saml':
         specifier: 5.1.0
         version: 5.1.0

--- a/scripts/prune-standalone-packages.mjs
+++ b/scripts/prune-standalone-packages.mjs
@@ -35,9 +35,8 @@ export const SHARED_STANDALONE_PRUNE_PACKAGES = [
   'html2canvas',
   'node-pty',
   'canvas',
-  '@napi-rs',
+  // Do NOT prune @napi-rs or pdfjs-dist globally — admin document APIs need them (pdf-parse → pdfjs-dist).
   'jspdf',
-  'pdfjs-dist',
   'fontkit',
   'hyphen',
   'mediabunny',
@@ -71,6 +70,8 @@ export const LMS_ONLY_STANDALONE_PRUNE_PACKAGES = [
   '@rspack',
   'pdf-parse',
   'pdfkit',
+  'pdfjs-dist',
+  '@napi-rs/canvas',
 ];
 
 /** Admin-only extras (Remotion kept for lesson video API). */


### PR DESCRIPTION
Fixes production warnings when admin routes load pdf-parse. Stops pruning canvas/pdfjs from admin standalone; adds direct @napi-rs/canvas dep. See docs/audits/pdfjs-canvas-production.md.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production container contents and server PDF parsing for admin document/insurance routes; mis-pruning or missing native canvas could break extraction until redeploy.
> 
> **Overview**
> Restores the **pdf-parse → pdfjs-dist → @napi-rs/canvas** stack in **admin** standalone deploys so server-side PDF text extraction stops logging missing-module warnings.
> 
> **Packaging:** `@napi-rs/canvas` is a direct dependency; `pdfjs-dist` and `@napi-rs/canvas` are added to `serverExternalPackages`. Shared standalone prune no longer strips `@napi-rs` / `pdfjs-dist`; the LMS image still prunes the PDF stack via `LMS_ONLY_STANDALONE_PRUNE_PACKAGES`.
> 
> **Runtime:** `scanApproveStrict` loads `pdf-parse` with a **dynamic import** only when extracting text, avoiding boot-time pdfjs initialization.
> 
> New audit note: `docs/audits/pdfjs-canvas-production.md`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 557c0eb6e4318b30394a079d1cb8dcc9c539ef8a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pdfjs-dist and @napi-rs/canvas runtime errors in admin PDF APIs
> - Adds `@napi-rs/canvas` as a direct dependency and marks both `pdfjs-dist` and `@napi-rs/canvas` as `serverExternalPackages` in [next.config.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/258/files#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2) so they are not bundled by Next.js.
> - Converts the static `pdf-parse` import in [lib/insurance/scan-approve-strict.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/258/files#diff-b5ea04760718709b27c171250c1bca3015e07ae6732db479c716158568290157) to a dynamic import inside the call site to avoid load-time initialization errors.
> - Moves `pdfjs-dist` and `@napi-rs/canvas` out of the shared standalone prune list in [scripts/prune-standalone-packages.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/258/files#diff-d3bed54d59e320cb5926beee85849a52a061aa843bbdff2dae93afcbeee000ff) so they are retained in admin images but still pruned from LMS-only images.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 557c0eb. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->