### PR TITLE
fix(admin): externalize pdfjs + canvas

### DIFF
--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -126,6 +126,8 @@ const adminConfig = {
     'tesseract.js',
     'tesseract.js-core',
     'pdf-parse',
+    'pdfjs-dist',
+    '@napi-rs/canvas',
     'pdfkit',
     'pdf-lib',
     '@aws-sdk/client-s3',


### PR DESCRIPTION
Admin standalone uses apps/admin/next.config — mirror root serverExternalPackages for pdf-parse stack.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time Next.js config only; no application logic, auth, or data-path changes.
> 
> **Overview**
> Adds **`pdfjs-dist`** and **`@napi-rs/canvas`** to **`serverExternalPackages`** in `apps/admin/next.config.mjs`, directly under the existing document OCR / extract entries (`tesseract.js`, `pdf-parse`).
> 
> That keeps Next from webpack-bundling the native/heavy pieces that **`pdf-parse`** pulls in at runtime, so the **admin standalone** build matches the root app’s externalization for the same PDF stack.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 96b79850e81825fe9d67750b82cb059549a90ae0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Externalize `pdfjs-dist` and `@napi-rs/canvas` in admin Next.js config
> Adds `pdfjs-dist` and `@napi-rs/canvas` to the externalized packages list in [next.config.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/259/files#diff-e828c07fa656d38e17175d7af2758d0f906bfdd02a3005a99fefd6469eff345f), alongside existing entries like `tesseract.js` and `pdf-parse`. This prevents Next.js from bundling these native/heavy packages and lets Node resolve them at runtime instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 96b7985.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->