### PR TITLE
docs: pdfjs fix options vs Elevate

### DIFF
--- a/docs/audits/pdfjs-canvas-production.md
+++ b/docs/audits/pdfjs-canvas-production.md
@@ -53,3 +53,29 @@ node -e "require('@napi-rs/canvas'); console.log('canvas ok')"
 - Confirm admin build ran **after** prune-list change.
 - Run `pnpm install` so lockfile includes `@napi-rs/canvas`.
 - Do not add `pdfjs-dist` back to `SHARED_STANDALONE_PRUNE_PACKAGES`.
+
+## Options matrix (generic Next.js advice vs Elevate)
+
+| Approach | Generic advice | Elevate decision |
+|----------|----------------|------------------|
+| **1. Install `@napi-rs/canvas`** | Recommended | **Done** — direct dep + lockfile; admin standalone no longer prunes canvas/pdfjs |
+| **2. Browser-only `pdfjs-dist`** | Good for in-app PDF viewers | **N/A today** — no `import "pdfjs-dist"` in app code; only `pdf-parse` on **server** API routes |
+| **3. Global DOM polyfill shim** | Works in some setups | **Skipped** — native canvas is cleaner when we already ship the binary |
+| **4. Pin `pdfjs-dist@4.10.38`** | Fixes many deploys | **Not used** — `pdf-parse@2.4.5` requires `pdfjs-dist@5.4.296`; downgrading breaks pdf-parse |
+| **Docker `pnpm install --frozen-lockfile`** | Required | **Already** in `Dockerfile.northflank-*`; avoid `--prod` that strips optionals |
+
+### PDF stacks on Elevate (do not conflate)
+
+| Library | Use | Canvas needed? |
+|---------|-----|----------------|
+| `pdf-parse` + `pdfjs-dist` | Admin text extract from uploads | **Yes** (admin container) |
+| `pdf-lib` / `pdfkit` | Generate MOUs, certs, grants | No pdfjs |
+| `@react-pdf/renderer` | Listed in package.json; **no app imports found** | Separate from pdfjs-dist warnings |
+
+### If we add a client PDF viewer later
+
+Use `next/dynamic` with `{ ssr: false }` — do not import `pdfjs-dist` in Server Components or root layout.
+
+### Northflank / ECS
+
+Redeploy **elevate-admin** after merges **#258** and **#259**. LMS may still log warnings only if something calls `pdf-parse` on www (unlikely; LMS prunes PDF stack).


### PR DESCRIPTION
Documents which generic PDF.js deployment options apply after #258/#259.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change with no runtime, auth, or dependency changes.
> 
> **Overview**
> Extends **`docs/audits/pdfjs-canvas-production.md`** so reviewers can tell generic Next.js/pdfjs guidance apart from what Elevate actually did after **#258** / **#259**.
> 
> Adds an **options matrix** (install `@napi-rs/canvas`, browser-only pdfjs, polyfills, pinning `pdfjs-dist@4`, Docker install flags) with an **Elevate decision** column. Adds a **PDF stacks** table separating `pdf-parse`/`pdfjs-dist`, `pdf-lib`/`pdfkit`, and `@react-pdf/renderer`. Notes a future **client viewer** should use `next/dynamic` with `{ ssr: false }`, and that **Northflank** should redeploy **elevate-admin** after those merges.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b0d2748dde55aaf7e23c12903f348d5302679474. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Clarify pdfjs canvas options for generic Next.js vs Elevate in docs
> Adds several sections to [pdfjs-canvas-production.md](https://github.com/elevate-for-humanity/Elevate-lms/pull/260/files#diff-f7850e1ebf34c2d38ca7b3ceee41d5b460676e5abdec30a71745332f8cc42df8) to reduce confusion between generic Next.js canvas/pdfjs advice and Elevate-specific behavior.
>
> - Adds an options matrix table comparing approaches (e.g. install behavior, canvas handling) for generic Next.js vs Elevate
> - Adds a 'PDF stacks on Elevate' table listing relevant libraries and whether native canvas is required for each
> - Documents how to add a client-side PDF viewer using `next/dynamic` with SSR disabled
> - Adds a Northflank/ECS note to redeploy `elevate-admin` after specific merges
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b0d2748.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->