### PR TITLE
chore(deploy): detect and prevent stale production images

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Wait for admin deployment
         run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_ADMIN_SERVICE_ID" --timeout-ms 1200000
 
+      - name: Verify deployed SHA matches main
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: pnpm tsx scripts/northflank/verify-deployed-sha.ts elevate-admin
+
       - name: Smoke admin
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -82,6 +82,11 @@ jobs:
       - name: Wait for LMS deployment
         run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --timeout-ms 3600000
 
+      - name: Verify deployed SHA matches main
+        env:
+          EXPECTED_SHA: ${{ github.sha }}
+        run: pnpm tsx scripts/northflank/verify-deployed-sha.ts elevate-lms
+
       - name: Smoke LMS
         run: |
           set -euo pipefail

--- a/.github/workflows/deploy-production-dispatch.yml
+++ b/.github/workflows/deploy-production-dispatch.yml
@@ -1,0 +1,64 @@
+name: Deploy production (both services)
+
+# Manual full-platform deploy when production SHAs lag behind main.
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: northflank-production-full
+  cancel-in-progress: false
+
+jobs:
+  deploy-both:
+    name: Configure, build, and verify LMS + Admin
+    runs-on: ubuntu-latest
+    env:
+      NORTHFLANK_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
+      NORTHFLANK_TEAM_ID: ${{ secrets.NORTHFLANK_TEAM_ID || 'elevates-team' }}
+      NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID || 'elevate-platform' }}
+      NORTHFLANK_LMS_SERVICE_ID: ${{ secrets.NORTHFLANK_LMS_SERVICE_ID || 'elevate-lms' }}
+      NORTHFLANK_ADMIN_SERVICE_ID: ${{ secrets.NORTHFLANK_ADMIN_SERVICE_ID || 'elevate-admin' }}
+      DEPLOY_BRANCH: main
+      NORTHFLANK_EPHEMERAL_STORAGE_MB: "32768"
+      EXPECTED_SHA: ${{ github.sha }}
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: main
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Configure Northflank
+        run: pnpm tsx scripts/northflank/configure-services.ts --execute
+
+      - name: Set branches to main
+        run: |
+          pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_LMS_SERVICE_ID" main
+          pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_ADMIN_SERVICE_ID" main
+
+      - name: Trigger builds
+        run: |
+          pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_LMS_SERVICE_ID"
+          pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_ADMIN_SERVICE_ID"
+
+      - name: Wait for admin
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_ADMIN_SERVICE_ID" --timeout-ms 1200000
+
+      - name: Wait for LMS
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --timeout-ms 3600000
+
+      - name: Verify both SHAs match main
+        run: pnpm tsx scripts/northflank/verify-deployed-sha.ts

--- a/scripts/northflank/verify-deployed-sha.ts
+++ b/scripts/northflank/verify-deployed-sha.ts
@@ -1,0 +1,101 @@
+#!/usr/bin/env tsx
+/**
+ * Compare Northflank deployed SHA vs expected main commit.
+ * Fails CI when production is still on an old image after a deploy workflow.
+ *
+ *   EXPECTED_SHA=$(git rev-parse origin/main) pnpm tsx scripts/northflank/verify-deployed-sha.ts
+ *   pnpm tsx scripts/northflank/verify-deployed-sha.ts --trigger  # rebuild stale services
+ */
+
+import { execSync } from 'node:child_process';
+import { nfFetch, projectApiPath, resolveProjectId } from './lib';
+
+type ServiceStatus = {
+  vcsData?: { projectBranch?: string };
+  deployment?: { internal?: { deployedSHA?: string; branch?: string } };
+  status?: { build?: { status?: string }; deployment?: { status?: string } };
+};
+
+const ALL_SERVICES = ['elevate-lms', 'elevate-admin'] as const;
+
+function resolveExpectedSha(): string {
+  if (process.env.EXPECTED_SHA || process.env.GITHUB_SHA) {
+    return (process.env.EXPECTED_SHA || process.env.GITHUB_SHA || '').trim();
+  }
+  try {
+    return execSync('git rev-parse origin/main', { encoding: 'utf8' }).trim();
+  } catch {
+    return execSync('git rev-parse HEAD', { encoding: 'utf8' }).trim();
+  }
+}
+
+function shaMatches(deployed: string | undefined, expected: string): boolean {
+  if (!deployed || !expected) return false;
+  const d = deployed.toLowerCase();
+  const e = expected.toLowerCase();
+  return d === e || d.startsWith(e.slice(0, 7)) || e.startsWith(d.slice(0, 7));
+}
+
+async function triggerBuild(projectId: string, serviceId: string) {
+  await nfFetch(projectApiPath(projectId, `/services/${serviceId}/build`), {
+    method: 'POST',
+    body: JSON.stringify({}),
+  });
+  console.log(`[trigger] ${serviceId}`);
+}
+
+async function main() {
+  const projectId = resolveProjectId();
+  if (!projectId) process.exit(1);
+
+  const expected = resolveExpectedSha();
+  const trigger = process.argv.includes('--trigger');
+  const onlyArg = process.argv.find((a) => a.startsWith('elevate-'));
+  const services = onlyArg
+    ? ([onlyArg] as readonly string[])
+    : process.env.NORTHFLANK_VERIFY_SERVICE
+      ? [process.env.NORTHFLANK_VERIFY_SERVICE]
+      : ALL_SERVICES;
+  let stale = false;
+
+  console.log(`Expected production SHA (main): ${expected.slice(0, 12)}…\n`);
+
+  for (const serviceId of services) {
+    const s = await nfFetch<ServiceStatus>(projectApiPath(projectId, `/services/${serviceId}`));
+    const deployed =
+      s.deployment?.internal?.deployedSHA ??
+      (s as { deployedSHA?: string }).deployedSHA;
+    const branch = s.vcsData?.projectBranch ?? s.deployment?.internal?.branch ?? '?';
+    const build = s.status?.build?.status ?? '?';
+    const deploy = s.status?.deployment?.status ?? '?';
+    const ok = shaMatches(deployed, expected);
+
+    console.log(
+      `${serviceId}: branch=${branch} build=${build} deploy=${deploy}\n  deployed=${deployed?.slice(0, 12) ?? 'unknown'}…  ${ok ? '✅ current' : '❌ STALE'}`,
+    );
+
+    if (!ok) {
+      stale = true;
+      if (trigger) await triggerBuild(projectId, serviceId);
+    }
+  }
+
+  if (stale && !trigger) {
+    console.error(
+      '\nProduction is behind main. Wait for in-flight builds or run:\n  pnpm tsx scripts/northflank/verify-deployed-sha.ts --trigger',
+    );
+    process.exit(1);
+  }
+
+  if (stale && trigger) {
+    console.log('\nTriggered rebuild for stale service(s). Monitor Northflank UI or wait-service.ts');
+    process.exit(0);
+  }
+
+  console.log('\nAll services match main.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
Adds SHA verification after Northflank deploy waits and a manual deploy-both workflow.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Deploy jobs can fail when Northflank’s reported SHA lags the triggering commit even if health checks pass, which may block releases until staleness is resolved.
> 
> **Overview**
> Adds **post-deploy SHA checks** so CI fails when Northflank is still serving an old commit after `wait-service` completes, instead of only relying on smoke tests.
> 
> New **`verify-deployed-sha.ts`** reads each service’s `deployedSHA` from the Northflank API, compares it to `EXPECTED_SHA` / `GITHUB_SHA` (with short-SHA tolerance), and exits non-zero when production is stale. Per-service workflows pass a single service id (`elevate-admin` / `elevate-lms`); **`--trigger`** can kick off rebuilds for stale services locally.
> 
> **`deploy-admin`** and **`deploy-lms`** now run verification immediately after the wait step, before existing smoke checks. A new **`deploy-production-dispatch`** workflow can be run manually to configure Northflank, build both LMS and Admin from `main`, wait on both, and verify both SHAs in one job.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7a489d21ef22de78b09ffb1ac2dac470056485f0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Detect and prevent stale production images in deploy workflows
> - Adds [verify-deployed-sha.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/261/files#diff-cbc0dad9a4d4909546ad8c5be817694fe25ac14851bd66bd6a6a12b565542d3d), a CLI that fetches the deployed SHA from the Northflank service status API and compares it against the expected commit (from `EXPECTED_SHA`, `GITHUB_SHA`, or `git rev-parse origin/main`).
> - Integrates SHA verification as a post-deploy step in the [deploy-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/261/files#diff-daf7602af3bf35582d4429f9815881f05a27a4b370b68700ab937b3b34834ee2) and [deploy-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/261/files#diff-0c0c3d5abea19ae2d1f33f2b07e80b448a988a020b644b4d1606e681926887b4) workflows, failing the job if production is behind.
> - Adds [deploy-production-dispatch.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/261/files#diff-99418284a8fa23fe088a60aa547b9607ac956feb3bc90157d689443b2e4ee482), a manually triggered workflow that configures, builds, and verifies both LMS and Admin services against the current `main` commit.
> - The CLI also supports a `--trigger` flag to initiate a rebuild for stale services instead of just failing.
> - Risk: deploy workflows will now fail if the deployed SHA does not match the expected commit, which may surface previously silent staleness.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 7a489d2. 4 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->