### PR TITLE
fix(admin-docker): ship pdf-parse + canvas in image; eliminate stale PDF runtime

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -94,6 +94,10 @@ RUN set -eux; \
   test -f /export/sharp-node_modules/sharp/package.json; \
   test -d /export/sharp-node_modules/@img/sharp-linux-x64
 
+# pdf-parse → pdfjs-dist → @napi-rs/canvas (must survive standalone + prune)
+RUN node scripts/export-admin-pdf-deps.mjs \
+  && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+
 # --- runtime (same as Dockerfile.admin) ---
 FROM node:20-bookworm-slim
 
@@ -116,6 +120,9 @@ COPY --from=builder /app/apps/admin/.next/standalone ./
 RUN mkdir -p node_modules
 COPY --from=builder /export/sharp-node_modules/sharp ./node_modules/sharp
 COPY --from=builder /export/sharp-node_modules/@img ./node_modules/@img
+COPY --from=builder /export/pdf-node_modules/@napi-rs ./node_modules/@napi-rs
+COPY --from=builder /export/pdf-node_modules/pdfjs-dist ./node_modules/pdfjs-dist
+COPY --from=builder /export/pdf-node_modules/pdf-parse ./node_modules/pdf-parse
 COPY --from=builder /app/apps/admin/.next/server ./apps/admin/.next/server
 COPY --from=builder /app/apps/admin/.next/static ./apps/admin/.next/static
 COPY --from=builder /app/apps/admin/.next/required-server-files.json ./apps/admin/.next/required-server-files.json
@@ -132,6 +139,9 @@ COPY --from=builder /app/apps/admin/server.js ./apps/admin/server.js
 RUN mkdir -p apps/admin/node_modules
 COPY --from=builder /export/ws ./apps/admin/node_modules/ws
 RUN test -f apps/admin/node_modules/ws/package.json
+
+# Fail image build if PDF stack is missing (prevents silent canvas warnings in prod)
+RUN node -e "require('@napi-rs/canvas'); require('pdf-parse'); console.log('[admin] pdf runtime ok')"
 
 RUN addgroup --gid 1001 nodejs && \
     adduser --uid 1001 --ingroup nodejs --disabled-password --gecos "" nextjs && \

--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -1,0 +1,72 @@
+/**
+ * Copy pdf-parse → pdfjs-dist → @napi-rs/canvas into /export/pdf-node_modules
+ * for admin Docker runtime (same pattern as sharp/ws).
+ */
+import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { createRequire } from 'node:module';
+
+const require = createRequire(import.meta.url);
+const root = process.cwd();
+const exportRoot = join(root, 'export', 'pdf-node_modules');
+
+function copyDir(src, destRelative) {
+  const dest = join(exportRoot, destRelative);
+  mkdirSync(dirname(dest), { recursive: true });
+  cpSync(src, dest, { recursive: true });
+  console.log(`[export-pdf] -> ${destRelative}`);
+}
+
+function copyPkg(packageName, destRelative) {
+  const pkgJson = require.resolve(`${packageName}/package.json`, { paths: [root] });
+  copyDir(dirname(pkgJson), destRelative);
+}
+
+function copyPkgFromDir(srcDir, destRelative) {
+  if (!existsSync(srcDir)) {
+    throw new Error(`missing ${srcDir}`);
+  }
+  copyDir(srcDir, destRelative);
+}
+
+mkdirSync(exportRoot, { recursive: true });
+
+copyPkg('@napi-rs/canvas', '@napi-rs/canvas');
+
+try {
+  copyPkg('@napi-rs/canvas-linux-x64-gnu', '@napi-rs/canvas-linux-x64-gnu');
+} catch {
+  console.warn('[export-pdf] @napi-rs/canvas-linux-x64-gnu not found (non-linux build?)');
+}
+
+// pdf-parse does not export package.json subpath; resolve entry then dirname
+const pdfParseEntry = require.resolve('pdf-parse', { paths: [root] });
+copyDir(dirname(pdfParseEntry), 'pdf-parse');
+
+// pdfjs-dist lives in pnpm store (not always hoisted to workspace root)
+const pnpmDir = join(root, 'node_modules', '.pnpm');
+const pdfjsStore = readdirSync(pnpmDir).find((e) => e.startsWith('pdfjs-dist@'));
+if (!pdfjsStore) {
+  throw new Error('pdfjs-dist not found under node_modules/.pnpm');
+}
+copyDir(join(pnpmDir, pdfjsStore, 'node_modules', 'pdfjs-dist'), 'pdfjs-dist');
+
+// Native binding for linux x64 (bookworm admin image)
+const canvasNative = readdirSync(pnpmDir).find((e) =>
+  e.startsWith('@napi-rs+canvas-linux-x64-gnu@'),
+);
+if (canvasNative) {
+  copyDir(
+    join(pnpmDir, canvasNative, 'node_modules', '@napi-rs', 'canvas-linux-x64-gnu'),
+    '@napi-rs/canvas-linux-x64-gnu',
+  );
+} else {
+  console.warn('[export-pdf] @napi-rs/canvas-linux-x64-gnu not in pnpm store');
+}
+
+if (!existsSync(join(exportRoot, '@napi-rs/canvas/package.json'))) {
+  console.error('[export-pdf] @napi-rs/canvas export failed');
+  process.exit(1);
+}
+
+console.log('[export-pdf] done');


### PR DESCRIPTION
Bundles @napi-rs/canvas, pdfjs-dist, pdf-parse into admin Docker image like sharp. Build fails if canvas missing.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to admin Docker build/packaging; build may fail hard if PDF deps are missing, which is intentional and reduces silent prod breakage.
> 
> **Overview**
> The admin Northflank image now **bundles the full PDF stack** (`pdf-parse`, `pdfjs-dist`, `@napi-rs/canvas`, and the linux x64 native binding when present) so it survives Next standalone output and `prune-admin-standalone`, matching how **sharp** and **ws** are already exported.
> 
> A new build script copies those packages from the pnpm store into `export/pdf-node_modules`. The Dockerfile runs it in the builder stage, **COPY**s the result into runtime `node_modules`, and adds a **`require` smoke check** so the image build fails if canvas or pdf-parse is missing instead of shipping a broken PDF runtime in prod.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit fe989f549f22815e42ec9ca564c11f6ede780d24. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Ship `pdf-parse` and `@napi-rs/canvas` into the admin Docker image and remove stale PDF runtime
> - Adds [scripts/export-admin-pdf-deps.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/262/files#diff-6008e504749ec4e549578b5971e34032f88e4e8b024a078fb3f215409361abbe), a build-time script that copies `pdf-parse`, `pdfjs-dist`, and `@napi-rs/canvas` (plus the linux-x64-gnu native binding if present) from the pnpm store into `export/pdf-node_modules`.
> - Updates [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/262/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) to run this script during the build and COPY the exported modules into `node_modules` in the final image.
> - A build-time `require` check for `@napi-rs/canvas` and `pdf-parse` causes the image build to fail fast if the PDF stack is missing.
> - Risk: the build will now fail if `@napi-rs/canvas` cannot be resolved, which is a hard gate where previously a broken PDF runtime may have shipped silently.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fe989f5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->