### PR TITLE
fix(admin-docker): correct @napi-rs/canvas export path for Northflank

### DIFF
--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -11,13 +11,19 @@ const root = process.cwd();
 const exportRoot = join(root, 'export', 'pdf-node_modules');
 
 function copyDir(src, destRelative) {
-  const dest = join(exportRoot, destRelative);
+  // destRelative uses slashes e.g. "@napi-rs/canvas" → export/pdf-node_modules/@napi-rs/canvas
+  const dest = join(exportRoot, ...destRelative.split('/'));
   mkdirSync(dirname(dest), { recursive: true });
   cpSync(src, dest, { recursive: true });
   console.log(`[export-pdf] -> ${destRelative}`);
 }
 
 function copyPkg(packageName, destRelative) {
+  const pkgJson = require.resolve(`${packageName}/package.json`, { paths: [root] });
+  copyDir(dirname(pkgJson), destRelative);
+}
+
+function copyPkgAs(packageName, destRelative) {
   const pkgJson = require.resolve(`${packageName}/package.json`, { paths: [root] });
   copyDir(dirname(pkgJson), destRelative);
 }
@@ -31,13 +37,8 @@ function copyPkgFromDir(srcDir, destRelative) {
 
 mkdirSync(exportRoot, { recursive: true });
 
+// Must match node_modules/@napi-rs/{canvas,canvas-linux-x64-gnu} layout
 copyPkg('@napi-rs/canvas', '@napi-rs/canvas');
-
-try {
-  copyPkg('@napi-rs/canvas-linux-x64-gnu', '@napi-rs/canvas-linux-x64-gnu');
-} catch {
-  console.warn('[export-pdf] @napi-rs/canvas-linux-x64-gnu not found (non-linux build?)');
-}
 
 // pdf-parse does not export package.json subpath; resolve entry then dirname
 const pdfParseEntry = require.resolve('pdf-parse', { paths: [root] });
@@ -64,7 +65,8 @@ if (canvasNative) {
   console.warn('[export-pdf] @napi-rs/canvas-linux-x64-gnu not in pnpm store');
 }
 
-if (!existsSync(join(exportRoot, '@napi-rs/canvas/package.json'))) {
+const canvasPkg = join(exportRoot, '@napi-rs', 'canvas', 'package.json');
+if (!existsSync(canvasPkg)) {
   console.error('[export-pdf] @napi-rs/canvas export failed');
   process.exit(1);
 }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem
Admin Northflank builds fail at Docker step:
`test -f /export/pdf-node_modules/@napi-rs/canvas/package.json`

`copyDir` used `join(exportRoot, '@napi-rs/canvas')` as a **single** path segment instead of nested `@napi-rs/canvas`.

## Fix
Split `destRelative` on `/` when joining under `export/pdf-node_modules`.

## Deploy
After merge, run **Deploy production (both services)** so LMS + Admin catch up to `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `@napi-rs/canvas` export path construction in admin PDF deps script for Northflank
> - Fixes [export-admin-pdf-deps.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/263/files#diff-6008e504749ec4e549578b5971e34032f88e4e8b024a078fb3f215409361abbe) to correctly resolve the `@napi-rs/canvas` package path by splitting slash-separated path segments before passing them to `path.join`.
> - Adds a `copyPkgAs` helper that locates a package's `package.json` and copies its directory to a caller-specified destination.
> - Removes the previous attempt to copy `@napi-rs/canvas-linux-x64-gnu` from `node_modules`, which was producing spurious warnings when the package was not found.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f652126.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->