### PR TITLE
chore(northflank): verify health probes in deploy CI; document no-AWS path

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -66,6 +66,9 @@ jobs:
       - name: Configure Northflank services
         run: pnpm tsx scripts/northflank/configure-services.ts --execute
 
+      - name: Verify health probes on /api/ping
+        run: pnpm tsx scripts/northflank/verify-health-checks.ts
+
       - name: Point admin service at main
         run: pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_ADMIN_SERVICE_ID" "$DEPLOY_BRANCH"
 

--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -73,6 +73,9 @@ jobs:
       - name: Configure Northflank services
         run: pnpm tsx scripts/northflank/configure-services.ts --execute
 
+      - name: Verify health probes on /api/ping
+        run: pnpm tsx scripts/northflank/verify-health-checks.ts
+
       - name: Point LMS service at main
         run: pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_LMS_SERVICE_ID" "$DEPLOY_BRANCH"
 

--- a/.github/workflows/deploy-production-dispatch.yml
+++ b/.github/workflows/deploy-production-dispatch.yml
@@ -44,6 +44,9 @@ jobs:
       - name: Configure Northflank
         run: pnpm tsx scripts/northflank/configure-services.ts --execute
 
+      - name: Verify health probes on /api/ping
+        run: pnpm tsx scripts/northflank/verify-health-checks.ts
+
       - name: Set branches to main
         run: |
           pnpm tsx scripts/northflank/set-service-branch.ts "$NORTHFLANK_LMS_SERVICE_ID" main

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -869,7 +869,7 @@ Durable cannot CNAME-flatten apex to Northflank. **Do not** use apex **A** → N
 | Dashboard UI (`app/admin/*`, WIOA ETPL) | None | N/A — API → Supabase only |
 
 Full audit: `docs/audits/ADMIN_DASHBOARD_STORAGE_AUDIT.md` §6. LMS video jobs: `POST /api/videos/generate` uses the same Supabase upload path (no `public/generated/`).
-- **Admin (AWS ECS, legacy):** `elevate-admin-service` on `elevate-cluster`, `Dockerfile.admin`, CodeBuild `elevate-admin-build`. Deploy: `.github/workflows/deploy-admin.yml` on `main`.
+- **Admin (Northflank):** `elevate-admin` combined service, `Dockerfile.northflank-admin`. Deploy: `.github/workflows/deploy-admin.yml` on `main` (not AWS ECS).
 - `apps/admin/server.js` must load `.next/required-server-files.json` at startup.
 - **BuildKit cache:** `pnpm tsx scripts/northflank/ensure-build-cache.ts --execute` (10GB `useCache` on both services)
 - **Deploy both:** `DEPLOY_BRANCH=main pnpm tsx scripts/northflank/deploy-live.ts --execute`

--- a/scripts/northflank/inspect-services.ts
+++ b/scripts/northflank/inspect-services.ts
@@ -58,15 +58,10 @@ async function main() {
   if (!pid) process.exit(1);
   for (const sid of ['elevate-admin', 'elevate-lms']) {
     const s = await nfFetch<NorthflankService>(projectApiPath(pid, `/services/${sid}`));
+    // Combined service health probes are only returned on PATCH (GET returns 405).
+    // Run configure-services --execute or verify-health-checks.ts to confirm probes.
     let combinedHealth: CombinedService['healthChecks'];
-    try {
-      const combined = await nfFetch<CombinedService>(combinedServicePatchPath(pid, sid), {
-        method: 'GET',
-      });
-      combinedHealth = combined.healthChecks;
-    } catch {
-      combinedHealth = undefined;
-    }
+    combinedHealth = undefined;
     const dockerfile =
       s.vcsData?.dockerFilePath ??
       s.buildSettings?.dockerfile?.dockerFilePath ??

--- a/scripts/verify-no-aws-deploy.mjs
+++ b/scripts/verify-no-aws-deploy.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+/**
+ * CI guard: production deploy must be Northflank-only (no AWS ECS workflows).
+ */
+import { existsSync, readdirSync, readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+const workflowDir = '.github/workflows';
+const forbidden = [
+  /deploy-aws\.yml$/,
+  /amazon-ecs/,
+  /aws-actions\/configure-aws-credentials/,
+  /elevate-cluster/,
+  /AWS_ACCESS_KEY_ID.*deploy/i,
+];
+
+let failed = false;
+for (const file of readdirSync(workflowDir)) {
+  if (!file.endsWith('.yml') && !file.endsWith('.yaml')) continue;
+  const text = readFileSync(join(workflowDir, file), 'utf8');
+  for (const pattern of forbidden) {
+    if (pattern.test(file) || pattern.test(text)) {
+      console.error(`❌ ${file}: matches forbidden AWS deploy pattern ${pattern}`);
+      failed = true;
+    }
+  }
+}
+
+const required = [
+  '.github/workflows/deploy-lms.yml',
+  '.github/workflows/deploy-admin.yml',
+  'Dockerfile.northflank-lms',
+  'Dockerfile.northflank-admin',
+];
+for (const path of required) {
+  if (!existsSync(path)) {
+    console.error(`❌ missing required Northflank artifact: ${path}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  process.exit(1);
+}
+console.log('✅ No AWS ECS deploy workflows; Northflank deploy artifacts present.');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Audit follow-up

- Run `verify-health-checks.ts` after `configure-services` in all three deploy workflows
- Add `scripts/verify-no-aws-deploy.mjs` (no ECS workflows in repo)
- Fix stale AGENTS.md line claiming admin deploys via AWS ECS
- Document Northflank vs AWS in Cursor Cloud instructions

No runtime behavior change beyond CI running health verification before builds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add health probe verification step to Northflank deploy CI workflows
> - Adds a 'Verify health probes on /api/ping' step to [deploy-admin.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-daf7602af3bf35582d4429f9815881f05a27a4b370b68700ab937b3b34834ee2), [deploy-lms.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-0c0c3d5abea19ae2d1f33f2b07e80b448a988a020b644b4d1606e681926887b4), and [deploy-production-dispatch.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-99418284a8fa23fe088a60aa547b9607ac956feb3bc90157d689443b2e4ee482), running before branch switching and build triggers.
> - Adds [verify-no-aws-deploy.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-0518a64b8092cf983c0857fb7c14d523cf681ee43e32ffb0e8d4012b93b2322a), a CI guard that fails if any AWS/ECS deploy patterns are found in workflows or if required Northflank artifacts are missing.
> - Updates [AGENTS.md](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) to document the Admin service as Northflank-based, removing legacy AWS ECS references.
> - Removes the combined service health-check fetch from [inspect-services.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/264/files#diff-be391904145a7bfbdba39b3511cdd32417ee3c2ecc1cf2d208f0588a2c4d1f40); `combinedHealth` is now always `undefined`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c67a76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->