### PR TITLE
feat: cosmetology weekly billing, R2 migration, audit cap, production follow-ups

### DIFF
--- a/app/api/cosmetology/webhook/route.ts
+++ b/app/api/cosmetology/webhook/route.ts
@@ -6,7 +6,13 @@ import type Stripe from 'stripe';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { runCosmetologyPostPayment } from '@/lib/enrollment/cosmetology-post-payment';
-import { COSMETOLOGY_PROGRAM_ID, COSMETOLOGY_COURSE_ID, TUITION_CENTS } from '@/lib/cosmetology/pricing';
+import {
+  COSMETOLOGY_PROGRAM_ID,
+  COSMETOLOGY_COURSE_ID,
+  TUITION_CENTS,
+  TUITION_DOLLARS,
+} from '@/lib/cosmetology/pricing';
+import { createWeeklySubscriptionAfterCheckout } from '@/lib/enrollment/create-weekly-subscription-after-checkout';
 import { createOrUpdateEnrollment, linkOrphanedEnrollments } from '@/lib/enrollment-service';
 import { withRuntime } from '@/lib/api/withRuntime';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
@@ -106,6 +112,74 @@ async function _POST(request: NextRequest) {
         const remainingBalanceCents = Math.max(0, adjustedPriceCents - amountPaidCents);
 
         if (checkoutType === 'cosmetology_enrollment') {
+          const paymentType = session.metadata?.payment_type;
+          const hoursPerWeek = parseInt(session.metadata?.hours_per_week || '0', 10);
+          const transferredHours = parseInt(session.metadata?.transfer_hours_claimed || '0', 10);
+          const fullyPaidEnrollment =
+            paymentType === 'pay_in_full' || fullyPaid;
+
+          const { error: subRecordError } = await supabase.from('cosmetology_subscriptions').insert({
+            stripe_customer_id: customerId,
+            customer_email: customerEmail,
+            customer_name: customerName,
+            customer_phone: customerPhone,
+            status: 'active',
+            full_tuition_amount: TUITION_DOLLARS,
+            amount_paid_at_checkout: amountPaidCents / 100,
+            remaining_balance: remainingBalanceCents / 100,
+            payment_method: 'card',
+            fully_paid: fullyPaidEnrollment,
+            weekly_payment_cents: fullyPaidEnrollment ? 0 : weeklyPaymentCents,
+            weeks_remaining: fullyPaidEnrollment ? 0 : weeksRemaining,
+            hours_per_week: hoursPerWeek,
+            transferred_hours_verified: transferredHours,
+            payment_model: fullyPaidEnrollment ? 'paid_in_full' : 'invoices',
+            created_at: new Date().toISOString(),
+          });
+          if (subRecordError) {
+            logger.error('[cosmetology/webhook] cosmetology_subscriptions insert error:', subRecordError);
+          }
+
+          if (!fullyPaidEnrollment && weeklyPaymentCents > 0 && weeksRemaining > 0) {
+            const billing = await createWeeklySubscriptionAfterCheckout({
+              stripe,
+              supabase,
+              session,
+              customerId,
+              customerEmail,
+              applicationId,
+              weeklyPaymentCents,
+              invoiceWeeks: weeksRemaining,
+              fullyPaid: fullyPaidEnrollment,
+              subscriptionsTable: 'cosmetology_subscriptions',
+              productName: 'Cosmetology Apprenticeship — Weekly Tuition',
+              programSlug: 'cosmetology-apprenticeship',
+            });
+            if (billing.error) {
+              try {
+                const { sendEmail } = await import('@/lib/email/sendgrid');
+                await sendEmail({
+                  to: 'elevate4humanityedu@gmail.com',
+                  subject: '⚠️ Cosmetology weekly billing setup failed — manual action required',
+                  html: `<p>Student: ${customerEmail}<br>Customer ID: ${customerId}<br>Weekly: $${(weeklyPaymentCents / 100).toFixed(2)}<br>Weeks: ${weeksRemaining}</p><p>Error: ${billing.error}</p>`,
+                });
+              } catch {
+                /* non-fatal */
+              }
+            }
+          }
+
+          if (applicationId) {
+            await supabase
+              .from('applications')
+              .update({
+                payment_status: 'paid',
+                payment_intent_id: (session.payment_intent as string) ?? null,
+                updated_at: new Date().toISOString(),
+              })
+              .eq('id', applicationId);
+          }
+
           // Write program_enrollments row
           const normalizedEmail = customerEmail.toLowerCase().trim();
           const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;

--- a/docs/audits/admin-runtime-idle-and-storage-2026-06-05.md
+++ b/docs/audits/admin-runtime-idle-and-storage-2026-06-05.md
@@ -102,7 +102,16 @@ CLOUDFLARE_R2_SECRET_ACCESS_KEY=...
 
 ---
 
-## 7. Verify in production
+## 7. Migrate existing Supabase MP4s to R2
+
+```bash
+pnpm tsx scripts/migrate-course-videos-to-r2.ts --dry-run
+pnpm tsx scripts/migrate-course-videos-to-r2.ts --execute --prefix=generated-lessons/
+```
+
+Update `course_lessons.video_url` / enrollment rows manually or via a follow-up SQL job if URLs change domain.
+
+## 8. Verify in production
 
 ```bash
 pnpm tsx scripts/northflank/verify-health-checks.ts

--- a/lib/audit.ts
+++ b/lib/audit.ts
@@ -60,11 +60,24 @@ async function onAuditFailure(context: string, error: unknown, event: Record<str
   // On serverless, stderr (channel 1) is the real last resort.
   if (typeof globalThis.process !== 'undefined') {
     try {
-      // Dynamic require: fs is unavailable in edge runtime, so this is
-      // guarded by the process check and wrapped in try/catch.
-      const { appendFileSync } = require('node:fs');
+      const { appendFileSync, statSync, unlinkSync } = require('node:fs') as typeof import('node:fs');
+      const fallbackPath = '/tmp/audit-fallback.jsonl';
+      const maxBytes = Number(process.env.AUDIT_FALLBACK_MAX_BYTES || 2 * 1024 * 1024);
+      try {
+        const size = statSync(fallbackPath).size;
+        if (size > maxBytes) {
+          unlinkSync(fallbackPath);
+        }
+      } catch {
+        /* file may not exist */
+      }
+      const failureRecord = {
+        context,
+        error: errorMessage,
+        timestamp: new Date().toISOString(),
+      };
       const line = JSON.stringify({ ...failureRecord, event }) + '\n';
-      appendFileSync('/tmp/audit-fallback.jsonl', line);
+      appendFileSync(fallbackPath, line);
     } catch {
       // stderr already has it — edge runtime or fs unavailable
     }

--- a/lib/barber/create-weekly-subscription.ts
+++ b/lib/barber/create-weekly-subscription.ts
@@ -1,11 +1,9 @@
 import type Stripe from 'stripe';
 import type { SupabaseClient } from '@supabase/supabase-js';
-import { getBillingCycleAnchor } from '@/lib/programs/pricing';
-import { logger } from '@/lib/logger';
+import { createWeeklySubscriptionAfterCheckout } from '@/lib/enrollment/create-weekly-subscription-after-checkout';
 
 /**
- * After barber checkout (payment plan), attach PM and create weekly Stripe subscription.
- * Used by /api/barber/webhook for checkout_type barber_enrollment (public apply flow).
+ * Barber apprenticeship weekly billing after checkout.
  */
 export async function createBarberWeeklySubscriptionAfterCheckout(params: {
   stripe: Stripe;
@@ -18,91 +16,11 @@ export async function createBarberWeeklySubscriptionAfterCheckout(params: {
   invoiceWeeks: number;
   fullyPaid: boolean;
   bnplProvider?: string | null;
-}): Promise<{ subscriptionId?: string; error?: string }> {
-  const {
-    stripe,
-    supabase,
-    session,
-    customerId,
-    customerEmail,
-    applicationId,
-    weeklyPaymentCents,
-    invoiceWeeks,
-    fullyPaid,
-    bnplProvider,
-  } = params;
-
-  if (fullyPaid || bnplProvider || weeklyPaymentCents <= 0 || invoiceWeeks <= 0) {
-    return {};
-  }
-
-  try {
-    const checkoutSession = await stripe.checkout.sessions.retrieve(session.id, {
-      expand: ['payment_intent.payment_method'],
-    });
-    const pi = checkoutSession.payment_intent as Stripe.PaymentIntent | null;
-    const pmId =
-      typeof pi?.payment_method === 'string'
-        ? pi.payment_method
-        : (pi?.payment_method as Stripe.PaymentMethod | null)?.id;
-
-    if (!pmId) {
-      logger.warn('[barber/billing] No payment method — weekly subscription not created', {
-        customerId,
-      });
-      return { error: 'no_payment_method' };
-    }
-
-    await stripe.paymentMethods.attach(pmId, { customer: customerId }).catch(() => {});
-    await stripe.customers.update(customerId, {
-      invoice_settings: { default_payment_method: pmId },
-    });
-
-    const weeklyPrice = await stripe.prices.create({
-      currency: 'usd',
-      unit_amount: weeklyPaymentCents,
-      recurring: { interval: 'week', interval_count: 1 },
-      product_data: { name: 'Barber Apprenticeship — Weekly Tuition' },
-    });
-
-    const billingAnchor = getBillingCycleAnchor();
-
-    const subscription = await stripe.subscriptions.create({
-      customer: customerId,
-      items: [{ price: weeklyPrice.id }],
-      billing_cycle_anchor: billingAnchor,
-      proration_behavior: 'none',
-      metadata: {
-        program: 'barber-apprenticeship',
-        weeks_remaining: invoiceWeeks.toString(),
-        application_id: applicationId || '',
-        customer_email: customerEmail,
-      },
-      cancel_at: billingAnchor + invoiceWeeks * 7 * 24 * 60 * 60,
-    });
-
-    await supabase
-      .from('barber_subscriptions')
-      .update({ stripe_subscription_id: subscription.id })
-      .eq('stripe_customer_id', customerId)
-      .order('created_at', { ascending: false })
-      .limit(1);
-
-    logger.info('[barber/billing] Weekly subscription created', {
-      customerId,
-      subscriptionId: subscription.id,
-      weeklyPaymentCents,
-      weeks: invoiceWeeks,
-    });
-
-    return { subscriptionId: subscription.id };
-  } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    logger.error(
-      '[barber/billing] Failed to create weekly subscription',
-      err instanceof Error ? err : new Error(message),
-      { customerId },
-    );
-    return { error: message };
-  }
+}) {
+  return createWeeklySubscriptionAfterCheckout({
+    ...params,
+    subscriptionsTable: 'barber_subscriptions',
+    productName: 'Barber Apprenticeship — Weekly Tuition',
+    programSlug: 'barber-apprenticeship',
+  });
 }

--- a/lib/enrollment/create-weekly-subscription-after-checkout.ts
+++ b/lib/enrollment/create-weekly-subscription-after-checkout.ts
@@ -1,0 +1,115 @@
+import type Stripe from 'stripe';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getBillingCycleAnchor } from '@/lib/programs/pricing';
+import { logger } from '@/lib/logger';
+
+export type ApprenticeshipSubscriptionsTable = 'barber_subscriptions' | 'cosmetology_subscriptions';
+
+/**
+ * After apprenticeship checkout (payment plan), attach PM and create weekly Stripe subscription.
+ */
+export async function createWeeklySubscriptionAfterCheckout(params: {
+  stripe: Stripe;
+  supabase: SupabaseClient;
+  session: Stripe.Checkout.Session;
+  customerId: string;
+  customerEmail: string;
+  applicationId?: string;
+  weeklyPaymentCents: number;
+  invoiceWeeks: number;
+  fullyPaid: boolean;
+  bnplProvider?: string | null;
+  subscriptionsTable: ApprenticeshipSubscriptionsTable;
+  productName: string;
+  programSlug: string;
+}): Promise<{ subscriptionId?: string; error?: string }> {
+  const {
+    stripe,
+    supabase,
+    session,
+    customerId,
+    customerEmail,
+    applicationId,
+    weeklyPaymentCents,
+    invoiceWeeks,
+    fullyPaid,
+    bnplProvider,
+    subscriptionsTable,
+    productName,
+    programSlug,
+  } = params;
+
+  if (fullyPaid || bnplProvider || weeklyPaymentCents <= 0 || invoiceWeeks <= 0) {
+    return {};
+  }
+
+  try {
+    const checkoutSession = await stripe.checkout.sessions.retrieve(session.id, {
+      expand: ['payment_intent.payment_method'],
+    });
+    const pi = checkoutSession.payment_intent as Stripe.PaymentIntent | null;
+    const pmId =
+      typeof pi?.payment_method === 'string'
+        ? pi.payment_method
+        : (pi?.payment_method as Stripe.PaymentMethod | null)?.id;
+
+    if (!pmId) {
+      logger.warn(`[${programSlug}/billing] No payment method — weekly subscription not created`, {
+        customerId,
+      });
+      return { error: 'no_payment_method' };
+    }
+
+    await stripe.paymentMethods.attach(pmId, { customer: customerId }).catch(() => {});
+    await stripe.customers.update(customerId, {
+      invoice_settings: { default_payment_method: pmId },
+    });
+
+    const weeklyPrice = await stripe.prices.create({
+      currency: 'usd',
+      unit_amount: weeklyPaymentCents,
+      recurring: { interval: 'week', interval_count: 1 },
+      product_data: { name: productName },
+    });
+
+    const billingAnchor = getBillingCycleAnchor();
+
+    const subscription = await stripe.subscriptions.create({
+      customer: customerId,
+      items: [{ price: weeklyPrice.id }],
+      billing_cycle_anchor: billingAnchor,
+      proration_behavior: 'none',
+      metadata: {
+        program: programSlug,
+        weeks_remaining: invoiceWeeks.toString(),
+        application_id: applicationId || '',
+        customer_email: customerEmail,
+      },
+      cancel_at: billingAnchor + invoiceWeeks * 7 * 24 * 60 * 60,
+    });
+
+    await supabase
+      .from(subscriptionsTable)
+      .update({ stripe_subscription_id: subscription.id })
+      .eq('stripe_customer_id', customerId)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    logger.info(`[${programSlug}/billing] Weekly subscription created`, {
+      customerId,
+      subscriptionId: subscription.id,
+      weeklyPaymentCents,
+      weeks: invoiceWeeks,
+    });
+
+    return { subscriptionId: subscription.id };
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    logger.error(
+      `[${programSlug}/billing] Failed to create weekly subscription`,
+      err instanceof Error ? err : new Error(message),
+      { customerId },
+    );
+    return { error: message };
+  }
+}

--- a/lib/video/pipeline.ts
+++ b/lib/video/pipeline.ts
@@ -208,9 +208,8 @@ async function getOrFetchBroll(brollKey: string, tmpDir: string): Promise<string
   execSync(`curl -sL "${clipUrl}" -o "${tmpPath}"`, { stdio: 'pipe' });
   execSync(`ffmpeg -y -i "${tmpPath}" -t 30 -c copy "${trimPath}" 2>/dev/null`, { stdio: 'pipe' });
 
-  const url = await uploadToSupabase(
+  const url = await uploadCourseVideosObject(
     fs.readFileSync(trimPath),
-    'course-videos',
     storagePath,
     'video/mp4',
   );

--- a/scripts/migrate-course-videos-to-r2.ts
+++ b/scripts/migrate-course-videos-to-r2.ts
@@ -1,0 +1,109 @@
+#!/usr/bin/env tsx
+/**
+ * Copy large objects from Supabase course-videos → Cloudflare R2 (course-videos/ prefix).
+ *
+ * Usage:
+ *   pnpm tsx scripts/migrate-course-videos-to-r2.ts --dry-run
+ *   pnpm tsx scripts/migrate-course-videos-to-r2.ts --execute
+ *   pnpm tsx scripts/migrate-course-videos-to-r2.ts --execute --prefix generated-lessons/
+ *
+ * Requires: NEXT_PUBLIC_SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY, CLOUDFLARE_R2_*
+ */
+
+import { isR2Configured, uploadToR2 } from '../lib/cloudflare-r2';
+import { shouldUploadCourseMediaToR2 } from '../lib/video/upload-lesson-media';
+
+const BUCKET = 'course-videos';
+
+async function listObjects(prefix: string): Promise<{ name: string }[]> {
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '');
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!base || !key) throw new Error('Supabase credentials missing');
+
+  const out: { name: string }[] = [];
+  let offset = 0;
+  const limit = 1000;
+
+  for (;;) {
+    const res = await fetch(
+      `${base}/storage/v1/object/list/${BUCKET}`,
+      {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${key}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ prefix, limit, offset, sortBy: { column: 'name', order: 'asc' } }),
+      },
+    );
+    if (!res.ok) {
+      throw new Error(`List failed: ${await res.text()}`);
+    }
+    const batch = (await res.json()) as { name: string }[];
+    if (!batch?.length) break;
+    for (const item of batch) {
+      if (item.name && !item.name.endsWith('/')) out.push(item);
+    }
+    if (batch.length < limit) break;
+    offset += limit;
+  }
+  return out;
+}
+
+async function downloadObject(storagePath: string): Promise<Buffer> {
+  const base = process.env.NEXT_PUBLIC_SUPABASE_URL?.replace(/\/$/, '');
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY!;
+  const res = await fetch(`${base}/storage/v1/object/${BUCKET}/${storagePath}`, {
+    headers: { Authorization: `Bearer ${key}` },
+  });
+  if (!res.ok) throw new Error(`Download ${storagePath}: ${res.status}`);
+  return Buffer.from(await res.arrayBuffer());
+}
+
+async function main() {
+  const dryRun = !process.argv.includes('--execute');
+  const prefixArg = process.argv.find((a) => a.startsWith('--prefix='));
+  const prefix = prefixArg?.split('=')[1] ?? '';
+
+  if (!isR2Configured()) {
+    console.error('Cloudflare R2 not configured (CLOUDFLARE_ACCOUNT_ID, CLOUDFLARE_R2_ACCESS_KEY_ID, CLOUDFLARE_R2_SECRET_ACCESS_KEY)');
+    process.exit(1);
+  }
+
+  console.log(dryRun ? '=== DRY RUN ===' : '=== EXECUTE ===');
+  const objects = await listObjects(prefix);
+  const videos = objects.filter((o) => o.name.endsWith('.mp4'));
+  console.log(`Found ${videos.length} MP4 objects under ${prefix || '(root)'}`);
+
+  let migrated = 0;
+  let skipped = 0;
+
+  for (const { name: storagePath } of videos) {
+    if (dryRun) {
+      console.log(`  would migrate: ${storagePath}`);
+      migrated++;
+      continue;
+    }
+
+    const buf = await downloadObject(storagePath);
+    if (!shouldUploadCourseMediaToR2(buf, 'video/mp4')) {
+      skipped++;
+      continue;
+    }
+
+    const result = await uploadToR2(buf, `course-videos/${storagePath}`, 'video/mp4');
+    if (!result.success) {
+      console.error(`  failed: ${storagePath} — ${result.error}`);
+      continue;
+    }
+    console.log(`  ok: ${storagePath} → ${result.url?.slice(0, 80)}…`);
+    migrated++;
+  }
+
+  console.log(`\nDone. migrated=${migrated} skipped=${skipped} (update DB video_url separately if needed)`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/tests/unit/lib/create-weekly-subscription.test.ts
+++ b/tests/unit/lib/create-weekly-subscription.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import type { ApprenticeshipSubscriptionsTable } from '@/lib/enrollment/create-weekly-subscription-after-checkout';
+
+describe('create-weekly-subscription-after-checkout', () => {
+  it('accepts both subscription tables', () => {
+    const tables: ApprenticeshipSubscriptionsTable[] = [
+      'barber_subscriptions',
+      'cosmetology_subscriptions',
+    ];
+    expect(tables).toHaveLength(2);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Production follow-ups (do all)

### Cosmetology billing (parity with barber)
- `cosmetology_enrollment` writes `cosmetology_subscriptions` and creates weekly Stripe subscription on payment plans
- Shared `lib/enrollment/create-weekly-subscription-after-checkout.ts`

### Storage
- `scripts/migrate-course-videos-to-r2.ts` — copy MP4s from Supabase `course-videos` to R2
- Pipeline b-roll clips use `uploadCourseVideosObject` (R2 when large)

### Ops
- `/tmp/audit-fallback.jsonl` capped at 2MB (`AUDIT_FALLBACK_MAX_BYTES`)
- Fixed audit fallback JSON (`failureRecord` bug)

After merge: run Northflank deploy + `sync-env --execute` with R2 keys in environment.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cosmetology weekly billing, R2 migration script, and audit log rotation cap
> - Adds cosmetology enrollment support to the Stripe webhook in [app/api/cosmetology/webhook/route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/266/files#diff-bd1881dbc15100f2abaf24a00912b3ee94e0655213977d13412cb230f00ebefd): inserts a `cosmetology_subscriptions` row, optionally creates a weekly Stripe subscription for non-fully-paid enrollments, and marks the related application as paid.
> - Extracts a generic `createWeeklySubscriptionAfterCheckout` util in [lib/enrollment/create-weekly-subscription-after-checkout.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/266/files#diff-87e980b4fdfefb4cb168e22953e05d709b9c7df263592de4c2b29756e0e7a282) shared by both barber and cosmetology programs; the barber implementation now delegates to it.
> - Adds a CLI migration script in [scripts/migrate-course-videos-to-r2.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/266/files#diff-d7e870ba97c7f7c730cdd81ac0f10a3a5f436a935ce850e2df7df0e9be71d8e4) to copy MP4s from the Supabase `course-videos` bucket to Cloudflare R2, with `--dry-run`/`--execute` flags.
> - Switches B-roll uploads in [lib/video/pipeline.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/266/files#diff-5919226c7a2065a732f4c202927222aa799d47bcf98850fa55d405056c5717ec) from `uploadToSupabase` to `uploadCourseVideosObject` (R2-backed helper).
> - Caps the local audit fallback file at `AUDIT_FALLBACK_MAX_BYTES` (default 2 MB) in [lib/audit.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/266/files#diff-d85a6e4c96a13cefe5d82f4c3c7913d30abdddb6400007682af300e549c1c8b2), deleting and recreating the file when the limit is exceeded.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 23d0bf4. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->