### PR TITLE
fix(video): Remotion bundle ref-count and empty batch onProgress

### DIFF
--- a/lib/video/remotion-bundle-cache.ts
+++ b/lib/video/remotion-bundle-cache.ts
@@ -1,21 +1,19 @@
 /**
  * Remotion webpack bundle cache — lazy, on-demand only.
- * Release after renders to avoid holding hundreds of MB on idle admin pods.
+ * Reference-counted release so concurrent renders do not delete a shared bundle.
  */
 
 import path from 'node:path';
-import os from 'node:os';
-import { readdir, rm } from 'node:fs/promises';
+import { rm } from 'node:fs/promises';
 import { bundle } from '@remotion/bundler';
 import { logger } from '@/lib/logger';
 
 let _bundleUrl: string | null = null;
+let _bundleRefCount = 0;
 
 const DEFAULT_ENTRY = path.join(process.cwd(), 'remotion-src', 'index.ts');
 
-export async function getRemotionBundleUrl(
-  entryPoint: string = DEFAULT_ENTRY,
-): Promise<string> {
+async function ensureRemotionBundle(entryPoint: string = DEFAULT_ENTRY): Promise<string> {
   if (_bundleUrl) return _bundleUrl;
 
   logger.info('[RemotionBundle] Bundling composition (first use this process)...');
@@ -33,28 +31,64 @@ export async function getRemotionBundleUrl(
   return _bundleUrl;
 }
 
-/** Drop in-memory bundle reference and best-effort webpack temp dirs under os.tmpdir(). */
+/**
+ * Hold the shared bundle for one render job. Call once per concurrent render (or once per batch).
+ */
+export async function retainRemotionBundle(
+  entryPoint: string = DEFAULT_ENTRY,
+): Promise<string> {
+  _bundleRefCount++;
+  return ensureRemotionBundle(entryPoint);
+}
+
+/** @deprecated Prefer retainRemotionBundle — does not increment ref count. */
+export async function getRemotionBundleUrl(
+  entryPoint: string = DEFAULT_ENTRY,
+): Promise<string> {
+  return ensureRemotionBundle(entryPoint);
+}
+
+/**
+ * Release one hold on the bundle. Deletes only this process's bundle directory when the last hold ends.
+ */
 export async function releaseRemotionBundle(): Promise<void> {
+  if (_bundleRefCount > 0) {
+    _bundleRefCount--;
+  }
+
+  if (_bundleRefCount > 0) {
+    return;
+  }
+
+  const bundlePath = _bundleUrl;
   _bundleUrl = null;
-  const tmp = os.tmpdir();
-  const entries = await readdir(tmp).catch(() => [] as string[]);
-  let removed = 0;
-  for (const name of entries) {
-    if (
-      name.startsWith('remotion-webpack-bundle-') ||
-      name.startsWith('esbuild-') ||
-      name.startsWith('remotion-')
-    ) {
-      await rm(path.join(tmp, name), { recursive: true, force: true }).catch(() => {});
-      removed++;
-    }
+
+  if (!bundlePath) {
+    return;
   }
-  if (removed > 0) {
-    logger.info('[RemotionBundle] Released bundle cache', { removedDirs: removed });
-  }
+
+  await rm(bundlePath, { recursive: true, force: true }).catch((err) => {
+    logger.warn('[RemotionBundle] Failed to remove bundle directory', {
+      bundlePath,
+      error: err instanceof Error ? err.message : String(err),
+    });
+  });
+
+  logger.info('[RemotionBundle] Released bundle cache', { bundlePath });
 }
 
 /** Default: release after each render/batch unless explicitly disabled. */
 export function shouldReleaseRemotionBundleAfterJob(): boolean {
   return process.env.REMOTION_RELEASE_BUNDLE_AFTER_RENDER !== 'false';
+}
+
+/** @internal Test-only reset */
+export function _resetRemotionBundleCacheForTests(): void {
+  _bundleUrl = null;
+  _bundleRefCount = 0;
+}
+
+/** @internal Test-only introspection */
+export function _getRemotionBundleRefCountForTests(): number {
+  return _bundleRefCount;
 }

--- a/lib/video/remotion-render.ts
+++ b/lib/video/remotion-render.ts
@@ -23,6 +23,7 @@ import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import {
   getRemotionBundleUrl,
   releaseRemotionBundle,
+  retainRemotionBundle,
   shouldReleaseRemotionBundleAfterJob,
 } from './remotion-bundle-cache';
 import {
@@ -168,16 +169,31 @@ function estimateDuration(script: string): number {
 
 // ── Main render function ──────────────────────────────────────────────────────
 
+export interface RenderLessonVideoOptions {
+  /** Batch already called retainRemotionBundle — skip per-lesson retain/release. */
+  sharedBundleSession?: boolean;
+}
+
 /**
  * Render a lesson MP4 using the free pipeline:
  *   edge-tts → Pexels/Pollinations → Remotion
  *
  * Renders to a temp dir, uploads MP4 (+ MP3) to Supabase course-videos, then deletes temp files.
  */
-export async function renderLessonVideo(input: RemotionLessonInput): Promise<RemotionRenderResult> {
+export async function renderLessonVideo(
+  input: RemotionLessonInput,
+  options?: RenderLessonVideoOptions,
+): Promise<RemotionRenderResult> {
   const { lessonId, domainKey = 'default', instructorId } = input;
   const instructor = getInstructor(instructorId);
   const paths = lessonRenderTempPaths(lessonId);
+
+  const releaseAfterJob = shouldReleaseRemotionBundleAfterJob();
+  const ownsBundle = releaseAfterJob && !options?.sharedBundleSession;
+
+  if (ownsBundle) {
+    await retainRemotionBundle();
+  }
 
   try {
     await mkdir(paths.dir, { recursive: true });
@@ -276,10 +292,6 @@ export async function renderLessonVideo(input: RemotionLessonInput): Promise<Rem
     const videoUrl = await uploadLessonFileFromDisk(paths.videoPath, lessonId, 'mp4');
     await rm(paths.dir, { recursive: true, force: true }).catch(() => {});
 
-    if (shouldReleaseRemotionBundleAfterJob()) {
-      await releaseRemotionBundle();
-    }
-
     return {
       success: true,
       videoUrl,
@@ -294,15 +306,15 @@ export async function renderLessonVideo(input: RemotionLessonInput): Promise<Rem
     await unlink(paths.videoPath).catch(() => {});
     await rm(paths.dir, { recursive: true, force: true }).catch(() => {});
 
-    if (shouldReleaseRemotionBundleAfterJob()) {
-      await releaseRemotionBundle();
-    }
-
     return {
       success: false,
       error: msg,
       method: 'remotion-free',
     };
+  } finally {
+    if (ownsBundle) {
+      await releaseRemotionBundle();
+    }
   }
 }
 
@@ -323,24 +335,35 @@ export async function renderLessonVideoBatch(
   onProgress?: (done: number, total: number, current: RemotionLessonInput) => void,
 ): Promise<BatchRenderResult[]> {
   const results: BatchRenderResult[] = [];
+  const releaseAfterJob = shouldReleaseRemotionBundleAfterJob();
 
-  for (let i = 0; i < lessons.length; i++) {
-    const lesson = lessons[i];
-    onProgress?.(i, lessons.length, lesson);
-
-    const result = await renderLessonVideo(lesson);
-    results.push({ lessonId: lesson.lessonId, title: lesson.title, result });
-
-    // Brief pause between renders to let GC run
-    if (i < lessons.length - 1) {
-      await new Promise((r) => setTimeout(r, 500));
-    }
+  if (releaseAfterJob) {
+    await retainRemotionBundle();
   }
 
-  onProgress?.(lessons.length, lessons.length, lessons[lessons.length - 1]);
+  try {
+    for (let i = 0; i < lessons.length; i++) {
+      const lesson = lessons[i];
+      onProgress?.(i, lessons.length, lesson);
 
-  if (shouldReleaseRemotionBundleAfterJob()) {
-    await releaseRemotionBundle();
+      const result = await renderLessonVideo(lesson, {
+        sharedBundleSession: releaseAfterJob,
+      });
+      results.push({ lessonId: lesson.lessonId, title: lesson.title, result });
+
+      // Brief pause between renders to let GC run
+      if (i < lessons.length - 1) {
+        await new Promise((r) => setTimeout(r, 500));
+      }
+    }
+
+    if (lessons.length > 0) {
+      onProgress?.(lessons.length, lessons.length, lessons[lessons.length - 1]!);
+    }
+  } finally {
+    if (releaseAfterJob) {
+      await releaseRemotionBundle();
+    }
   }
 
   return results;

--- a/tests/unit/remotion-bundle-cache.test.ts
+++ b/tests/unit/remotion-bundle-cache.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+
+vi.mock('@remotion/bundler', () => ({
+  bundle: vi.fn(async () => '/tmp/remotion-test-bundle'),
+}));
+
+import {
+  _getRemotionBundleRefCountForTests,
+  _resetRemotionBundleCacheForTests,
+  releaseRemotionBundle,
+  retainRemotionBundle,
+} from '@/lib/video/remotion-bundle-cache';
+
+describe('remotion-bundle-cache', () => {
+  beforeEach(() => {
+    _resetRemotionBundleCacheForTests();
+    vi.clearAllMocks();
+  });
+
+  it('keeps bundle until all holders release', async () => {
+    await retainRemotionBundle();
+    await retainRemotionBundle();
+    expect(_getRemotionBundleRefCountForTests()).toBe(2);
+
+    await releaseRemotionBundle();
+    expect(_getRemotionBundleRefCountForTests()).toBe(1);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Addresses code review on Remotion bundle lifecycle.

## Low — empty batch `onProgress`
`renderLessonVideoBatch` no longer calls `onProgress(0, 0, undefined)` when `lessons` is empty.

## Medium — concurrent bundle deletion
- `retainRemotionBundle()` / `releaseRemotionBundle()` use a **reference count**
- Only the **owned bundle directory** is removed when the last holder releases (no blanket `remotion-*` sweep under `os.tmpdir()`)
- **Batch** renders retain once and pass `sharedBundleSession` to per-lesson renders so the bundle is not released between lessons
- **Single** renders use `try/finally` for one retain/release pair

## Tests
`tests/unit/remotion-bundle-cache.test.ts` — ref count stays elevated until all holders release.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Remotion bundle ref-counting and skip empty-batch `onProgress` callback
> - Introduces a reference counter in [remotion-bundle-cache.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/269/files#diff-b3d4ff7fbc5d8ccdaa503fd21013384999b60440c00f3b729d9afa7335ae9b12) so multiple callers can share one bundle; the bundle directory is deleted only when the last holder calls `releaseRemotionBundle`.
> - Adds `retainRemotionBundle` to explicitly acquire a hold, and rewrites `releaseRemotionBundle` to decrement the counter and skip deletion while holders remain.
> - `renderLessonVideoBatch` in [remotion-render.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/269/files#diff-2945b22acf26cdf1bd6a571635b959a49586dee4cd92619863d2c0aceaf11efc) now retains the bundle once for the entire batch and passes `sharedBundleSession` to each per-lesson call, preventing redundant retain/release cycles.
> - Guards the batch `onProgress` callback so it is not called when the lesson list is empty.
> - Behavioral Change: `releaseRemotionBundle` no longer sweeps the entire tmpdir; it removes only the specific bundle directory, and only when the ref count reaches zero.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 519f0da.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->