### PR TITLE
fix(northflank): ENOSPC v2 — node_modules cache mount + 64GB build disk

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -43,7 +43,7 @@ jobs:
       NORTHFLANK_ADMIN_SERVICE_ID: ${{ secrets.NORTHFLANK_ADMIN_SERVICE_ID || 'elevate-admin' }}
       NORTHFLANK_LMS_SERVICE_ID: ${{ secrets.NORTHFLANK_LMS_SERVICE_ID || 'elevate-lms' }}
       DEPLOY_BRANCH: main
-      NORTHFLANK_EPHEMERAL_STORAGE_MB: "32768"
+      NORTHFLANK_EPHEMERAL_STORAGE_MB: "65536"
 
     steps:
       - name: Checkout
@@ -65,6 +65,9 @@ jobs:
 
       - name: Configure Northflank services
         run: pnpm tsx scripts/northflank/configure-services.ts --execute
+
+      - name: Patch Northflank build ephemeral storage
+        run: pnpm tsx scripts/northflank/patch-ephemeral-storage.ts --execute
 
       - name: Verify health probes on /api/ping
         run: pnpm tsx scripts/northflank/verify-health-checks.ts

--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -50,7 +50,7 @@ jobs:
       NORTHFLANK_LMS_SERVICE_ID: ${{ secrets.NORTHFLANK_LMS_SERVICE_ID || 'elevate-lms' }}
       NORTHFLANK_ADMIN_SERVICE_ID: ${{ secrets.NORTHFLANK_ADMIN_SERVICE_ID || 'elevate-admin' }}
       DEPLOY_BRANCH: main
-      NORTHFLANK_EPHEMERAL_STORAGE_MB: "32768"
+      NORTHFLANK_EPHEMERAL_STORAGE_MB: "65536"
 
     steps:
       - name: Checkout
@@ -72,6 +72,9 @@ jobs:
 
       - name: Configure Northflank services
         run: pnpm tsx scripts/northflank/configure-services.ts --execute
+
+      - name: Patch Northflank build ephemeral storage
+        run: pnpm tsx scripts/northflank/patch-ephemeral-storage.ts --execute
 
       - name: Verify health probes on /api/ping
         run: pnpm tsx scripts/northflank/verify-health-checks.ts

--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -32,15 +32,15 @@ COPY packages/db/package.json packages/db/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
-# Install from manifests only (no source yet) so peak disk is not repo + store + node_modules.
-# pnpm store lives on a BuildKit cache mount (not committed to the image layer).
+# Install from manifests only (no source yet). pnpm store + node_modules use BuildKit cache mounts.
 # Do NOT use --package-import-method=copy - it duplicates every package and causes ENOSPC.
 # Do NOT run `pnpm fetch` - it fills disk before install on tight Northflank builders.
 ENV HUSKY=0
 ENV CI=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN --mount=type=cache,id=pnpm-northflank-admin,target=/pnpm/store \
+RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/pnpm/store \
+    --mount=type=cache,id=pnpm-northflank-admin-node_modules,target=/app/node_modules \
     pnpm config set store-dir /pnpm/store \
     && pnpm install --frozen-lockfile \
     && pnpm store prune
@@ -70,36 +70,33 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV SKIP_ENV_VALIDATION=true
 
-RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
+RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/pnpm/store \
+    --mount=type=cache,id=pnpm-northflank-admin-node_modules,target=/app/node_modules \
+    pnpm config set store-dir /pnpm/store \
+    && pnpm install --frozen-lockfile \
+    && pnpm store prune \
+    && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && cd apps/admin \
     && pnpm exec next build \
     && cd ../.. \
-    && node scripts/prune-admin-standalone.mjs
-
-# Bundle ws for runtime (custom server.js). Do NOT npm install ws in slim stage - peer-resolve fails.
-RUN set -eux; \
-  mkdir -p /export/ws; \
-  WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")"; \
-  cp -a "${WS_DIR}/." /export/ws/; \
-  test -f /export/ws/package.json
-
-# Bundle sharp + linux x64 @img bindings (runtime npm install fails in slim CI images)
-RUN set -eux; \
-  mkdir -p /export/sharp-node_modules/@img; \
-  SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")"; \
-  cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/; \
-  for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
-    node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
-    name="$(basename "$pkg")"; \
-    cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
-  done; \
-  test -f /export/sharp-node_modules/sharp/package.json; \
-  test -d /export/sharp-node_modules/@img/sharp-linux-x64
-
-# pdf-parse → pdfjs-dist → @napi-rs/canvas (must survive standalone + prune)
-RUN node scripts/export-admin-pdf-deps.mjs \
-  && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+    && node scripts/prune-admin-standalone.mjs \
+    && mkdir -p /export/ws \
+    && WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")" \
+    && cp -a "${WS_DIR}/." /export/ws/ \
+    && test -f /export/ws/package.json \
+    && mkdir -p /export/sharp-node_modules/@img \
+    && SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")" \
+    && cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/ \
+    && for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
+      node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
+      name="$(basename "$pkg")"; \
+      cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
+    done \
+    && test -f /export/sharp-node_modules/sharp/package.json \
+    && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
+    && node scripts/export-admin-pdf-deps.mjs \
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
 
 # --- runtime (same as Dockerfile.admin) ---
 FROM node:20-bookworm-slim

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -32,12 +32,13 @@ COPY packages/db/package.json packages/db/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
-# See Dockerfile.northflank-admin — install before COPY . . + BuildKit pnpm store cache.
+# See Dockerfile.northflank-admin — store + node_modules on BuildKit cache mounts.
 ENV HUSKY=0
 ENV CI=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN --mount=type=cache,id=pnpm-northflank-lms,target=/pnpm/store \
+RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/pnpm/store \
+    --mount=type=cache,id=pnpm-northflank-lms-node_modules,target=/app/node_modules \
     pnpm config set store-dir /pnpm/store \
     && pnpm install --frozen-lockfile \
     && pnpm store prune
@@ -65,23 +66,25 @@ ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV SKIP_ENV_VALIDATION=true
 
-RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
+RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/pnpm/store \
+    --mount=type=cache,id=pnpm-northflank-lms-node_modules,target=/app/node_modules \
+    pnpm config set store-dir /pnpm/store \
+    && pnpm install --frozen-lockfile \
+    && pnpm store prune \
+    && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && pnpm exec next build \
-    && node scripts/prune-standalone.mjs
-
-# Bundle sharp + linux x64 @img bindings (runtime npm install fails in slim CI images)
-RUN set -eux; \
-  mkdir -p /export/sharp-node_modules/@img; \
-  SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")"; \
-  cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/; \
-  for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
-    node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
-    name="$(basename "$pkg")"; \
-    cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
-  done; \
-  test -f /export/sharp-node_modules/sharp/package.json; \
-  test -d /export/sharp-node_modules/@img/sharp-linux-x64
+    && node scripts/prune-standalone.mjs \
+    && mkdir -p /export/sharp-node_modules/@img \
+    && SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")" \
+    && cp -a "${SHARP_DIR}/." /export/sharp-node_modules/sharp/ \
+    && for pkg in node_modules/.pnpm/@img+sharp-linux-x64@*/node_modules/@img/sharp-linux-x64 \
+      node_modules/.pnpm/@img+sharp-libvips-linux-x64@*/node_modules/@img/sharp-libvips-linux-x64; do \
+      name="$(basename "$pkg")"; \
+      cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
+    done \
+    && test -f /export/sharp-node_modules/sharp/package.json \
+    && test -d /export/sharp-node_modules/@img/sharp-linux-x64
 
 # --- runtime (Dockerfile.package layout) ---
 FROM node:20-bookworm-slim

--- a/docs/audits/northflank-pnpm-fetch-enospc-audit.md
+++ b/docs/audits/northflank-pnpm-fetch-enospc-audit.md
@@ -47,9 +47,10 @@ WARN GET https://registry.npmjs.org/... error (ERR_PNPM_ENOSPC). Will retry ...
 
 1. Remove the separate **`pnpm fetch`** layer (never use on Northflank).
 2. **`pnpm install --frozen-lockfile`** from workspace manifests **before** `COPY . .` so install peak is not repo + store + `node_modules`.
-3. **BuildKit cache mount** for the pnpm store (`/pnpm/store`) so the store is not written into the image layer.
+3. **BuildKit cache mounts** for the pnpm store (`/pnpm/store`) **and** `node_modules` so hardlinks do not duplicate the lockfile onto the image layer (store-only mount still ENOSPC’d at ~1.7k/1964 packages with 32GB API setting).
 4. **`pnpm store prune`** after install; **`rm -rf /app/.pnpm-store`** after `COPY . .` if anything landed on `/app`.
 5. **`.dockerignore`**: exclude `export/`, `cloudflare-workers/`, `fly-containers/` from build context.
+6. **POST `/services/{id}/build-options`** with `storage.ephemeralStorage.storageSize` (65536 MB in deploy workflows) in addition to combined-service PATCH.
 
 This lowers peak disk versus fetch + offline install or `/app/.pnpm-store` in-layer on a small volume.
 

--- a/scripts/northflank/configure-services.ts
+++ b/scripts/northflank/configure-services.ts
@@ -16,6 +16,7 @@
 import {
   combinedServicePatchPath,
   nfFetch,
+  projectApiPath,
   resolveAdminServiceId,
   resolveLmsServiceId,
   resolveProjectId,
@@ -155,6 +156,21 @@ async function main() {
         method: 'PATCH',
         body: JSON.stringify(patch),
       });
+      const buildOptionsBody = {
+        storage: { ephemeralStorage: { storageSize: ephemeralStorageSize } },
+      };
+      try {
+        await nfFetch(projectApiPath(projectId, `/services/${service.id}/build-options`), {
+          method: 'POST',
+          body: JSON.stringify(buildOptionsBody),
+        });
+        console.log(`[build-options-ok] ${service.id} ephemeral ${ephemeralStorageSize}MB`);
+      } catch (e) {
+        console.warn(
+          `[build-options-warn] ${service.id}:`,
+          e instanceof Error ? e.message.slice(0, 200) : e,
+        );
+      }
       const appliedBuild =
         response?.billing?.buildPlan ??
         response?.buildSettings?.billing?.buildPlan ??


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

PR #267 merged the pnpm store cache mount and install-before-`COPY` pattern, but **Deploy Admin** still failed with `ERR_PNPM_ENOSPC` at `mkdir '/app/node_modules/.pnpm/...'` (~1717/1964 packages). Northflank reported `buildEphemeralMB=32768` via PATCH, but peak disk during install still looked like a ~2GB effective limit — likely because **only the store** was on a cache mount while `node_modules` duplicated packages onto the image layer.

## Changes

- **Dockerfile.northflank-admin** / **Dockerfile.northflank-lms**
  - Add BuildKit cache mount for `/app/node_modules` (separate cache id from store)
  - Second install + `next build` + runtime exports in **one RUN** (same cache mounts)
- **deploy-admin.yml** / **deploy-lms.yml**
  - `NORTHFLANK_EPHEMERAL_STORAGE_MB=65536`
  - Run `patch-ephemeral-storage.ts --execute` after `configure-services`
- **configure-services.ts**
  - POST `/services/{id}/build-options` with ephemeral storage (Northflank API source of truth for build jobs)

## Verification

After merge, expect Northflank build logs to pass `pnpm install` without ENOSPC and reach `next build` / `prune-*-standalone`.

Supersedes the remaining deploy gap from #267.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ENOSPC build failures by adding `node_modules` cache mounts and doubling ephemeral disk to 64GB
> - Adds separate BuildKit cache mounts for both the pnpm store and `/app/node_modules` in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/270/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/270/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e); the previous store-only cache was still exhausting disk space.
> - Consolidates multiple `RUN` steps (sharp, `@img`, ws, pdf deps) into single layers in both Dockerfiles to reduce intermediate layer disk usage.
> - Doubles `NORTHFLANK_EPHEMERAL_STORAGE_MB` from 32768 to 65536 in both deploy workflows and adds a "Patch Northflank build ephemeral storage" step that calls [patch-ephemeral-storage.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/270/files#diff-33ad6d95f4e1f1781ae0265922efd7270375e1fb1e9b9a5db1e72b3deca5face).
> - Updates [configure-services.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/270/files#diff-a265b10d2431129186c98763c8797fd8b25744b06999524db56b532cf7a5dea9) to POST build-options per service via `/services/{id}/build-options` to persist the ephemeral storage size on Northflank.
> - Risk: each build now runs `pnpm install --frozen-lockfile` twice (once in the cache-priming step, once in the main build step).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e4c3f2d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->