### PR TITLE
fix(northflank): revert 64GB ephemeral when project quota blocks it

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -43,7 +43,7 @@ jobs:
       NORTHFLANK_ADMIN_SERVICE_ID: ${{ secrets.NORTHFLANK_ADMIN_SERVICE_ID || 'elevate-admin' }}
       NORTHFLANK_LMS_SERVICE_ID: ${{ secrets.NORTHFLANK_LMS_SERVICE_ID || 'elevate-lms' }}
       DEPLOY_BRANCH: main
-      NORTHFLANK_EPHEMERAL_STORAGE_MB: "65536"
+      NORTHFLANK_EPHEMERAL_STORAGE_MB: "32768"
 
     steps:
       - name: Checkout

--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -50,7 +50,7 @@ jobs:
       NORTHFLANK_LMS_SERVICE_ID: ${{ secrets.NORTHFLANK_LMS_SERVICE_ID || 'elevate-lms' }}
       NORTHFLANK_ADMIN_SERVICE_ID: ${{ secrets.NORTHFLANK_ADMIN_SERVICE_ID || 'elevate-admin' }}
       DEPLOY_BRANCH: main
-      NORTHFLANK_EPHEMERAL_STORAGE_MB: "65536"
+      NORTHFLANK_EPHEMERAL_STORAGE_MB: "32768"
 
     steps:
       - name: Checkout

--- a/docs/audits/northflank-pnpm-fetch-enospc-audit.md
+++ b/docs/audits/northflank-pnpm-fetch-enospc-audit.md
@@ -50,7 +50,7 @@ WARN GET https://registry.npmjs.org/... error (ERR_PNPM_ENOSPC). Will retry ...
 3. **BuildKit cache mounts** for the pnpm store (`/pnpm/store`) **and** `node_modules` so hardlinks do not duplicate the lockfile onto the image layer (store-only mount still ENOSPC’d at ~1.7k/1964 packages with 32GB API setting).
 4. **`pnpm store prune`** after install; **`rm -rf /app/.pnpm-store`** after `COPY . .` if anything landed on `/app`.
 5. **`.dockerignore`**: exclude `export/`, `cloudflare-workers/`, `fly-containers/` from build context.
-6. **POST `/services/{id}/build-options`** with `storage.ephemeralStorage.storageSize` (65536 MB in deploy workflows) in addition to combined-service PATCH.
+6. **POST `/services/{id}/build-options`** with `storage.ephemeralStorage.storageSize` (32768 MB default; configure-services downgrades if project allowance is lower) in addition to combined-service PATCH.
 
 This lowers peak disk versus fetch + offline install or `/app/.pnpm-store` in-layer on a small volume.
 

--- a/scripts/northflank/configure-services.ts
+++ b/scripts/northflank/configure-services.ts
@@ -83,7 +83,17 @@ const billing = {
   buildPlan: process.env.NORTHFLANK_BUILD_PLAN || 'nf-compute-800-32',
 };
 
-const ephemeralStorageSize = resolveEphemeralStorageMb();
+function storageAllowanceCandidates(requestedMb: number): number[] {
+  const ordered = [requestedMb, 32768, 16384].filter(
+    (size, index, arr) => ALLOWED_EPHEMERAL_STORAGE_MB.includes(size as (typeof ALLOWED_EPHEMERAL_STORAGE_MB)[number]) && arr.indexOf(size) === index,
+  );
+  return ordered;
+}
+
+function isStorageAllowanceError(err: unknown): boolean {
+  const msg = err instanceof Error ? err.message : String(err);
+  return msg.includes('build resource allowance') || msg.includes('ephemeral storage exceeds');
+}
 
 const healthChecks = [
   {
@@ -120,51 +130,82 @@ async function main() {
   console.log(dryRun ? '=== DRY RUN ===' : '=== EXECUTE ===');
   console.log(`Project: ${projectId}`);
 
-  for (const service of SERVICES) {
-    const patch = {
-      billing,
-      runtimeEnvironment: service.runtimeEnvironment,
-      healthChecks,
-      buildSettings: {
-        storage: {
-          ephemeralStorage: {
-            storageSize: ephemeralStorageSize,
-          },
-        },
-        dockerfile: {
-          buildEngine: 'buildkit',
-          dockerFilePath: service.dockerfile,
-          dockerWorkDir: '/',
-          buildkit: BUILDKIT,
-        },
-      },
-      buildConfiguration: {
-        storage: {
-          ephemeralStorage: {
-            storageSize: ephemeralStorageSize,
-          },
-        },
-      },
-    };
+  const requestedEphemeralMb = resolveEphemeralStorageMb();
 
+  for (const service of SERVICES) {
     console.log(
-      `${dryRun ? '[dry-run]' : '[patch]'} ${service.id} -> ${service.dockerfile}, build ${billing.buildPlan}, runtime ${billing.deploymentPlan}, ephemeral ${ephemeralStorageSize}MB, health /api/ping`,
+      `${dryRun ? '[dry-run]' : '[patch]'} ${service.id} -> ${service.dockerfile}, build ${billing.buildPlan}, runtime ${billing.deploymentPlan}, ephemeral ${requestedEphemeralMb}MB (with allowance fallback), health /api/ping`,
     );
 
     if (!dryRun) {
-      const response = await nfFetch(combinedServicePatchPath(projectId, service.id), {
-        method: 'PATCH',
-        body: JSON.stringify(patch),
-      });
+      let response: Record<string, unknown> | undefined;
+      let appliedEphemeralMb = requestedEphemeralMb;
+
+      for (const storageMb of storageAllowanceCandidates(requestedEphemeralMb)) {
+        const patch = {
+          billing,
+          runtimeEnvironment: service.runtimeEnvironment,
+          healthChecks,
+          buildSettings: {
+            storage: {
+              ephemeralStorage: {
+                storageSize: storageMb,
+              },
+            },
+            dockerfile: {
+              buildEngine: 'buildkit',
+              dockerFilePath: service.dockerfile,
+              dockerWorkDir: '/',
+              buildkit: BUILDKIT,
+            },
+          },
+          buildConfiguration: {
+            storage: {
+              ephemeralStorage: {
+                storageSize: storageMb,
+              },
+            },
+          },
+        };
+
+        try {
+          response = await nfFetch<Record<string, unknown>>(
+            combinedServicePatchPath(projectId, service.id),
+            {
+              method: 'PATCH',
+              body: JSON.stringify(patch),
+            },
+          );
+          appliedEphemeralMb = storageMb;
+          if (storageMb !== requestedEphemeralMb) {
+            console.warn(
+              `[patch-fallback] ${service.id} ephemeral ${requestedEphemeralMb}MB rejected; applied ${storageMb}MB`,
+            );
+          }
+          break;
+        } catch (e) {
+          if (!isStorageAllowanceError(e) || storageMb === storageAllowanceCandidates(requestedEphemeralMb).at(-1)) {
+            throw e;
+          }
+          console.warn(
+            `[patch-retry] ${service.id} ephemeral ${storageMb}MB exceeds project allowance; trying smaller`,
+          );
+        }
+      }
+
+      if (!response) {
+        throw new Error(`Failed to patch ${service.id}`);
+      }
+
       const buildOptionsBody = {
-        storage: { ephemeralStorage: { storageSize: ephemeralStorageSize } },
+        storage: { ephemeralStorage: { storageSize: appliedEphemeralMb } },
       };
       try {
         await nfFetch(projectApiPath(projectId, `/services/${service.id}/build-options`), {
           method: 'POST',
           body: JSON.stringify(buildOptionsBody),
         });
-        console.log(`[build-options-ok] ${service.id} ephemeral ${ephemeralStorageSize}MB`);
+        console.log(`[build-options-ok] ${service.id} ephemeral ${appliedEphemeralMb}MB`);
       } catch (e) {
         console.warn(
           `[build-options-warn] ${service.id}:`,
@@ -180,8 +221,8 @@ async function main() {
         response?.deployment?.billing?.deploymentPlan ??
         billing.deploymentPlan;
       const appliedStorage =
-        response?.buildSettings?.storage?.ephemeralStorage?.storageSize ??
-        ephemeralStorageSize;
+        (response?.buildSettings as { storage?: { ephemeralStorage?: { storageSize?: number } } })
+          ?.storage?.ephemeralStorage?.storageSize ?? appliedEphemeralMb;
       const probes = Array.isArray(response?.healthChecks) ? response.healthChecks : healthChecks;
       const probeSummary = probes
         .map(


### PR DESCRIPTION
Follow-up to #270: 65536MB PATCH fails with project build resource allowance. Keep 32768MB in workflows; configure-services retries 32768 then 16384 on allowance errors.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/deploy configuration only; no application runtime or auth changes, with fallback improving deploy reliability on quota-limited projects.
> 
> **Overview**
> Reverts Northflank build **ephemeral storage** from **65536 MB to 32768 MB** in the **admin** and **LMS** deploy workflows so service PATCH calls stay within typical project build quotas (follow-up to a 64GB bump that the API rejected).
> 
> **`configure-services.ts`** no longer applies a single fixed size: it tries **`storageAllowanceCandidates`** (requested size, then **32768**, then **16384**) and, on **build resource allowance** / **ephemeral storage exceeds** errors, retries with the next smaller allowed value. The size that succeeds is used for the combined service PATCH and the **`/build-options`** POST, with warnings when a fallback is applied.
> 
> The **pnpm ENOSPC audit** doc is updated to document **32768 MB** as the default and the configure-script downgrade behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6c9bd12132340eb3e9e8096da56d68f41f0cb216. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Revert Northflank ephemeral storage to 32GB with automatic fallback on quota errors
> - Reduces `NORTHFLANK_EPHEMERAL_STORAGE_MB` from 65536 to 32768 in the [admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/271/files#diff-daf7602af3bf35582d4429f9815881f05a27a4b370b68700ab937b3b34834ee2) and [LMS](https://github.com/elevate-for-humanity/Elevate-lms/pull/271/files#diff-0c0c3d5abea19ae2d1f33f2b07e80b448a988a020b644b4d1606e681926887b4) deploy workflows to avoid project quota violations.
> - Adds `storageAllowanceCandidates()` in [configure-services.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/271/files#diff-a265b10d2431129186c98763c8797fd8b25744b06999524db56b532cf7a5dea9) that returns an ordered fallback list `[requested, 32768, 16384]` filtered to allowed sizes.
> - On a storage allowance error (detected by `isStorageAllowanceError()`), the script retries with the next smaller candidate and logs a warning when a fallback size is applied.
> - The accepted size is then used for both the combined service PATCH and the subsequent `/services/{id}/build-options` POST.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6c9bd12.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->