### PR TITLE
fix(northflank): unified pnpm cache mount for ENOSPC

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -25,29 +25,16 @@ ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
 
-# Workspace manifests first - smaller layer before full COPY (see .dockerignore).
+# Workspace manifests first, then source (.dockerignore keeps context lean).
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
 COPY apps/admin/package.json apps/admin/package.json
 COPY packages/db/package.json packages/db/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
-# Install from manifests only (no source yet). pnpm store + node_modules use BuildKit cache mounts.
-# Do NOT use --package-import-method=copy - it duplicates every package and causes ENOSPC.
-# Do NOT run `pnpm fetch` - it fills disk before install on tight Northflank builders.
-ENV HUSKY=0
-ENV CI=true
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/pnpm/store \
-    --mount=type=cache,id=pnpm-northflank-admin-node_modules,target=/app/node_modules \
-    pnpm config set store-dir /pnpm/store \
-    && pnpm install --frozen-lockfile \
-    && pnpm store prune
-
 COPY . .
 
-RUN rm -rf /app/.pnpm-store
+RUN rm -rf /app/.pnpm-store /app/node_modules
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -69,12 +56,19 @@ ENV NEXT_PUBLIC_PUBLIC_SITE_URL=$NEXT_PUBLIC_PUBLIC_SITE_URL
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV SKIP_ENV_VALIDATION=true
+ENV HUSKY=0
+ENV CI=true
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/pnpm/store \
-    --mount=type=cache,id=pnpm-northflank-admin-node_modules,target=/app/node_modules \
-    pnpm config set store-dir /pnpm/store \
+# Single cache volume for store + node_modules so pnpm hardlinks (no copyfile ENOSPC).
+# Do NOT use separate /pnpm/store and /app/node_modules mounts — different FS forces copy.
+RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
+    mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
+    && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
     && pnpm install --frozen-lockfile \
     && pnpm store prune \
+    && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && cd apps/admin \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -32,20 +32,9 @@ COPY packages/db/package.json packages/db/package.json
 COPY packages/shared/package.json packages/shared/package.json
 COPY packages/ui/package.json packages/ui/package.json
 
-# See Dockerfile.northflank-admin — store + node_modules on BuildKit cache mounts.
-ENV HUSKY=0
-ENV CI=true
-ENV PUPPETEER_SKIP_DOWNLOAD=true
-ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/pnpm/store \
-    --mount=type=cache,id=pnpm-northflank-lms-node_modules,target=/app/node_modules \
-    pnpm config set store-dir /pnpm/store \
-    && pnpm install --frozen-lockfile \
-    && pnpm store prune
-
 COPY . .
 
-RUN rm -rf /app/.pnpm-store
+RUN rm -rf /app/.pnpm-store /app/node_modules
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -65,12 +54,17 @@ ENV NEXT_PUBLIC_PUBLIC_SITE_URL=$NEXT_PUBLIC_PUBLIC_SITE_URL
 ENV NEXT_PUBLIC_SUPABASE_URL=$NEXT_PUBLIC_SUPABASE_URL
 ENV NEXT_PUBLIC_SUPABASE_ANON_KEY=$NEXT_PUBLIC_SUPABASE_ANON_KEY
 ENV SKIP_ENV_VALIDATION=true
+ENV HUSKY=0
+ENV CI=true
+ENV PUPPETEER_SKIP_DOWNLOAD=true
+ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/pnpm/store \
-    --mount=type=cache,id=pnpm-northflank-lms-node_modules,target=/app/node_modules \
-    pnpm config set store-dir /pnpm/store \
+RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
+    mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
+    && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
     && pnpm install --frozen-lockfile \
     && pnpm store prune \
+    && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && pnpm exec next build \

--- a/docs/audits/northflank-pnpm-fetch-enospc-audit.md
+++ b/docs/audits/northflank-pnpm-fetch-enospc-audit.md
@@ -47,7 +47,7 @@ WARN GET https://registry.npmjs.org/... error (ERR_PNPM_ENOSPC). Will retry ...
 
 1. Remove the separate **`pnpm fetch`** layer (never use on Northflank).
 2. **`pnpm install --frozen-lockfile`** from workspace manifests **before** `COPY . .` so install peak is not repo + store + `node_modules`.
-3. **BuildKit cache mounts** for the pnpm store (`/pnpm/store`) **and** `node_modules` so hardlinks do not duplicate the lockfile onto the image layer (store-only mount still ENOSPC’d at ~1.7k/1964 packages with 32GB API setting).
+3. **One BuildKit cache mount** (`/mnt/pnpm-cache`) with `.npmrc` `store-dir` + `modules-dir` under it so pnpm hardlinks instead of `copyfile` across separate store vs `/app/node_modules` mounts (split mounts still ENOSPC’d in Northflank logs).
 4. **`pnpm store prune`** after install; **`rm -rf /app/.pnpm-store`** after `COPY . .` if anything landed on `/app`.
 5. **`.dockerignore`**: exclude `export/`, `cloudflare-workers/`, `fly-containers/` from build context.
 6. **POST `/services/{id}/build-options`** with `storage.ephemeralStorage.storageSize` (32768 MB default; configure-services downgrades if project allowance is lower) in addition to combined-service PATCH.


### PR DESCRIPTION
Northflank logs showed copyfile from /pnpm/store to /app/node_modules — split cache mounts are different filesystems.

- Single BuildKit cache at /mnt/pnpm-cache with store-dir + modules-dir in .npmrc
- One install+build RUN after full COPY; drop manifest-only pre-install
- Symlink /app/node_modules for tooling that expects the default path

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only Northflank Docker build steps and audit docs; runtime images still copy standalone artifacts and do not rely on the build-time node_modules symlink.
> 
> **Overview**
> Addresses **Northflank `ERR_PNPM_ENOSPC`** during Docker builds by changing how pnpm uses BuildKit cache in **`Dockerfile.northflank-admin`** and **`Dockerfile.northflank-lms`**.
> 
> **Unified cache mount:** Replaces separate `/pnpm/store` and `/app/node_modules` cache mounts with one mount at `/mnt/pnpm-cache`. Split mounts sat on different filesystems, so pnpm **copied** from store into `node_modules` and blew disk. The install RUN now appends `.npmrc` `store-dir` and `modules-dir` under that mount, runs **`pnpm install --frozen-lockfile`**, then **`ln -sfn`** so `/app/node_modules` points at the cached tree (hardlinks stay on one volume).
> 
> **Install timing:** Drops the **manifest-only pre-`COPY`** install layer; **`COPY . .`** happens first, **`rm -rf`** clears any stray `/app/.pnpm-store` and `/app/node_modules`, then a **single RUN** does install + `next build` + export/prune steps. CI env vars (`HUSKY`, `CI`, Puppeteer skip) move into that phase.
> 
> **Docs:** **`docs/audits/northflank-pnpm-fetch-enospc-audit.md`** item 3 now documents the unified mount instead of dual store/`node_modules` mounts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 82341456a9f547cf29abad0ed4f08986827a7a09. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ENOSPC errors in Northflank Dockerfiles by using a unified pnpm cache mount
> - Replaces separate BuildKit cache mounts for `/pnpm/store` and `/app/node_modules` with a single unified mount at `/mnt/pnpm-cache` in both [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/272/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/272/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e). Split mounts prevented hardlinking between the pnpm store and `node_modules`, causing ENOSPC during builds.
> - Removes the early pre-COPY `pnpm install` phase; install now runs once after full source copy, with `.npmrc` pointing `store-dir` and `modules-dir` to `/mnt/pnpm-cache`.
> - After install, `node_modules` is symlinked from `/mnt/pnpm-cache/node_modules` to `/app/node_modules`.
> - Updates [docs/audits/northflank-pnpm-fetch-enospc-audit.md](https://github.com/elevate-for-humanity/Elevate-lms/pull/272/files#diff-72a4309c96fbcd87a8b9959b57033aeb764fb6c592fdc2590ef5122a6b450986) to document the unified mount rationale.
> - Behavioral Change: `node_modules` is now a symlink rather than a directory directly under `/app`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8234145.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->