### PR TITLE
fix(northflank): admin build via pnpm filter after cache install

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -66,14 +66,12 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
-    && pnpm install --frozen-lockfile \
+    && pnpm install --frozen-lockfile --ignore-scripts \
     && pnpm store prune \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && cd apps/admin \
-    && pnpm exec next build \
-    && cd ../.. \
+    && pnpm --filter @elevate/admin run build \
     && node scripts/prune-admin-standalone.mjs \
     && mkdir -p /export/ws \
     && WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")" \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -62,7 +62,7 @@ ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
-    && pnpm install --frozen-lockfile \
+    && pnpm install --frozen-lockfile --ignore-scripts \
     && pnpm store prune \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \


### PR DESCRIPTION
Follow-up #272: install succeeds on unified cache; next build failed with ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/CD Dockerfile-only changes; main tradeoff is skipping install scripts, which could affect native deps if anything relied on postinstall during that step.
> 
> **Overview**
> Fixes Northflank admin image builds that failed after unified pnpm cache install with **`ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL`** when running **`next build`** from **`apps/admin`**.
> 
> **`Dockerfile.northflank-admin`** now runs **`pnpm --filter @elevate/admin run build`** from the repo root instead of **`cd apps/admin && pnpm exec next build`**, so the build uses the workspace package script with the symlinked **`node_modules`** layout.
> 
> Both **`Dockerfile.northflank-admin`** and **`Dockerfile.northflank-lms`** add **`--ignore-scripts`** to **`pnpm install --frozen-lockfile`** during the cached install step, skipping dependency lifecycle scripts that can break or bloat that phase (LMS still builds with **`pnpm exec next build`** at the root).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2a0c527955a62374e8a2255d527758cb2aeaf6d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix admin build in Northflank Dockerfile to use pnpm workspace filter
> - Updates [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/273/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) to build the admin app via `pnpm --filter @elevate/admin run build` instead of `cd apps/admin && pnpm exec next build`.
> - Adds `--ignore-scripts` to `pnpm install` in both [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/273/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/273/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) to skip package lifecycle scripts during the cache install step.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2a0c527.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->