### PR TITLE
fix(northflank): unblock deploy — next binary after pnpm cache install

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -71,7 +71,10 @@ RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && pnpm --filter @elevate/admin run build \
+    && test -x /app/node_modules/next/dist/bin/next \
+    && cd apps/admin \
+    && node /app/node_modules/next/dist/bin/next build \
+    && cd ../.. \
     && node scripts/prune-admin-standalone.mjs \
     && mkdir -p /export/ws \
     && WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")" \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -67,7 +67,8 @@ RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && pnpm exec next build \
+    && test -x /app/node_modules/next/dist/bin/next \
+    && node /app/node_modules/next/dist/bin/next build \
     && node scripts/prune-standalone.mjs \
     && mkdir -p /export/sharp-node_modules/@img \
     && SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")" \


### PR DESCRIPTION
Northflank builds pass pnpm install (unified cache) then fail with `next: not found` / `pnpm exec next`. Invoke `node /app/node_modules/next/dist/bin/next build` explicitly after symlink.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile changes with no runtime or application logic impact; main risk is wrong working directory for admin if `cd apps/admin` were misaligned with Next config.
> 
> **Overview**
> Unblocks Northflank CI/CD builds that were failing after a successful `pnpm install` with unified cache (`next: not found` / broken `pnpm exec next`).
> 
> Both **Dockerfile.northflank-admin** and **Dockerfile.northflank-lms** now verify `/app/node_modules/next/dist/bin/next` is executable, then run **`node …/next build`** instead of `pnpm --filter @elevate/admin run build` (admin) or `pnpm exec next build` (LMS). Admin additionally **`cd apps/admin`** before the build and returns to repo root so the app directory matches the previous filtered build behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6476fdab8c726fa193d5af83acb713804ebdded1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Next.js build in Northflank Dockerfiles by invoking binary directly after pnpm cache install
> - Replaces `pnpm exec next build` / pnpm filtered build with an explicit `node` invocation of the project-installed Next.js binary in both [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/274/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/274/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e).
> - Adds an executable check for the Next.js binary before running the build to surface missing-binary errors clearly.
> - The admin Dockerfile also explicitly `cd`s into `apps/admin` before building and returns to repo root afterward.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6476fda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->