### PR TITLE
fix(northflank): unblock deploy — next binary path

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -71,7 +71,10 @@ RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && pnpm --filter @elevate/admin run build \
+    && test -x /app/node_modules/next/dist/bin/next \
+    && cd apps/admin \
+    && node /app/node_modules/next/dist/bin/next build \
+    && cd ../.. \
     && node scripts/prune-admin-standalone.mjs \
     && mkdir -p /export/ws \
     && WS_DIR="$(node -p "require('path').dirname(require.resolve('ws/package.json',{paths:[require('path').join(process.cwd(),'apps/admin')]}))")" \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -67,7 +67,8 @@ RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
-    && pnpm exec next build \
+    && test -x /app/node_modules/next/dist/bin/next \
+    && node /app/node_modules/next/dist/bin/next build \
     && node scripts/prune-standalone.mjs \
     && mkdir -p /export/sharp-node_modules/@img \
     && SHARP_DIR="$(node -p "require('path').dirname(require.resolve('sharp/package.json'))")" \


### PR DESCRIPTION
Fixes Northflank build after unified pnpm cache: `next: not found` from pnpm exec/run.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-only Dockerfile changes with an explicit binary check; no auth, data, or runtime behavior is modified.
> 
> **Overview**
> Fixes Northflank Docker image builds that were failing with **`next: not found`** after the unified pnpm cache layout (`modules-dir` on a cache mount + symlink to `/app/node_modules`), where **`pnpm exec`** / **`pnpm --filter … run build`** no longer resolved the Next CLI reliably.
> 
> **`Dockerfile.northflank-admin`** and **`Dockerfile.northflank-lms`** now **`test -x`** on **`/app/node_modules/next/dist/bin/next`**, then run **`node …/next build`** instead of pnpm wrappers. The admin Dockerfile also **`cd`s into `apps/admin`** before build so the app root matches the previous filter-based build.
> 
> No runtime or application code changes—only the CI/build step that produces the standalone artifacts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6476fdab8c726fa193d5af83acb713804ebdded1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Next.js binary path in Northflank Dockerfiles to unblock deploy
> Both [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/275/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/275/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) were failing to build because the Next.js binary was not being found via `pnpm`. Both files now assert the binary exists and invoke it directly via `node` using the project-installed path, with `apps/admin` as the working directory for the admin build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6476fda.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->