### PR TITLE
fix(northflank): stop store prune breaking Docker build

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -67,7 +67,6 @@ RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
     && pnpm install --frozen-lockfile --ignore-scripts \
-    && pnpm store prune \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -63,7 +63,6 @@ RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
     && pnpm install --frozen-lockfile --ignore-scripts \
-    && pnpm store prune \
     && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \


### PR DESCRIPTION
Northflank log: install Done in 57s then `Removed 1962 packages` from store prune before next build.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Docker-only change with no application runtime logic; tradeoff is slightly larger cache layers instead of a broken build.
> 
> **Overview**
> Removes **`pnpm store prune`** from the install layer in **`Dockerfile.northflank-admin`** and **`Dockerfile.northflank-lms`**, right after **`pnpm install --frozen-lockfile`**.
> 
> That prune was dropping packages from the unified BuildKit cache store before **`next build`**, which caused Northflank builds to fail after install (logs showed ~1962 packages removed). The rest of the install → symlink **`node_modules`** → build → prune-standalone flow is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5b4922ff9f66e158959833d9eb302c94933985b0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove `pnpm store prune` from Northflank Docker builds
> Removes the `pnpm store prune` step from the dependency install layer in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/276/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/276/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e). This step was breaking the Docker build process.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5b4922f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->