### PR TITLE
fix(security): lock down staff portal student PII access

### DIFF
--- a/apps/admin/app/admin/staff-portal/attendance/export/page.tsx
+++ b/apps/admin/app/admin/staff-portal/attendance/export/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import {
   Download,
   FileSpreadsheet,
@@ -23,15 +23,8 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic';
 
 export default async function ExportAttendancePage() {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    redirect('/login?redirect=/admin/staff-portal/attendance/export');
-  }
 
   // Fetch cohorts for filter
   const { data: cohorts } = await supabase.from('cohorts').select('id, name').order('name');

--- a/apps/admin/app/admin/staff-portal/attendance/page.tsx
+++ b/apps/admin/app/admin/staff-portal/attendance/page.tsx
@@ -2,6 +2,7 @@ import { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,6 +13,7 @@ export const metadata: Metadata = {
 };
 
 export default async function StaffPortalAttendancePage() {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
 
   // Fetch attendance records from database

--- a/apps/admin/app/admin/staff-portal/attendance/record/page.tsx
+++ b/apps/admin/app/admin/staff-portal/attendance/record/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
 import AttendanceRecordForm from './AttendanceRecordForm';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
@@ -14,24 +14,8 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic';
 
 export default async function RecordAttendancePage() {
+  const { user, profile } = await requireStaffPortalAccess();
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-
-  if (!user) {
-    redirect('/login?redirect=/admin/staff-portal/attendance/record');
-  }
-
-  const { data: profile } = await supabase
-    .from('profiles')
-    .select('role, full_name')
-    .eq('id', user.id)
-    .maybeSingle();
-
-  if (!profile || !['staff', 'instructor', 'admin', 'super_admin'].includes(profile.role)) {
-    redirect('/');
-  }
 
   // Fetch active students with their enrollments
   const { data: rawAttendEnrollments } = await supabase

--- a/apps/admin/app/admin/staff-portal/cases/[id]/page.tsx
+++ b/apps/admin/app/admin/staff-portal/cases/[id]/page.tsx
@@ -1,4 +1,4 @@
-export const revalidate = 3600;
+export const dynamic = 'force-dynamic';
 
 import { Metadata } from 'next';
 import { notFound } from 'next/navigation';

--- a/apps/admin/app/admin/staff-portal/cases/page.tsx
+++ b/apps/admin/app/admin/staff-portal/cases/page.tsx
@@ -1,5 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import { loadCaseFileSummaries } from '@/lib/case-file/loader';
 import { Search, Filter, ChevronRight, User } from 'lucide-react';
 
@@ -31,6 +32,7 @@ function StatusBadge({ status }: { status: string }) {
 }
 
 export default async function CaseFilesListPage() {
+  await requireStaffPortalAccess();
   const cases = await loadCaseFileSummaries({ limit: 50 });
 
   const formatDate = (date: string) => {

--- a/apps/admin/app/admin/staff-portal/courses/page.tsx
+++ b/apps/admin/app/admin/staff-portal/courses/page.tsx
@@ -1,8 +1,8 @@
 import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import { BookOpen, Search, Plus } from 'lucide-react';
 
 export const metadata: Metadata = {
@@ -13,11 +13,8 @@ export const metadata: Metadata = {
 export const dynamic = 'force-dynamic';
 
 export default async function StaffCoursesPage() {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect('/login?redirect=/admin/staff-portal/courses');
 
   // Fetch courses from training_programs table
   const { data: courses } = await supabase

--- a/apps/admin/app/admin/staff-portal/layout.tsx
+++ b/apps/admin/app/admin/staff-portal/layout.tsx
@@ -1,8 +1,16 @@
 /**
- * Staff portal layout — runs inside the admin shell.
- * Auth and nav are already handled by apps/admin/app/admin/layout.tsx.
- * Staff role is included in adminRoles there, so no additional gate needed.
+ * Staff portal — role gate + no static cache (student PII must never be ISR-cached).
  */
-export default function StaffPortalLayout({ children }: { children: React.ReactNode }) {
+import type { Metadata } from 'next';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
+
+export const dynamic = 'force-dynamic';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
+
+export default async function StaffPortalLayout({ children }: { children: React.ReactNode }) {
+  await requireStaffPortalAccess();
   return <>{children}</>;
 }

--- a/apps/admin/app/admin/staff-portal/page.tsx
+++ b/apps/admin/app/admin/staff-portal/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import Image from 'next/image';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
@@ -27,11 +28,8 @@ export const metadata: Metadata = {
 };
 
 export default async function StaffPortalLanding() {
+  const { user } = await requireStaffPortalAccess();
   const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
 
   // Fetch completion state if logged in
   let payrollDone = false;

--- a/apps/admin/app/admin/staff-portal/skills/page.tsx
+++ b/apps/admin/app/admin/staff-portal/skills/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import { CheckCircle, Circle, Star, BookOpen, Award, ChevronRight, TrendingUp } from 'lucide-react';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 
@@ -70,12 +70,8 @@ const SKILL_CATEGORIES = [
 ];
 
 export default async function StaffSkillsPage() {
+  const { user } = await requireStaffPortalAccess();
   const supabase = await createClient();
-
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect('/login?redirect=/admin/staff-portal/skills');
 
   // Fetch completed skills for this user
   const { data: userSkills } = await supabase

--- a/apps/admin/app/admin/staff-portal/students/page.tsx
+++ b/apps/admin/app/admin/staff-portal/students/page.tsx
@@ -1,7 +1,7 @@
 import { Metadata } from 'next';
 import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
 import Link from 'next/link';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 
 export const dynamic = 'force-dynamic';
 
@@ -12,11 +12,8 @@ export const metadata: Metadata = {
 };
 
 export default async function StudentsPage() {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
 
   const { data: students, count } = await supabase
     .from('profiles')

--- a/apps/admin/app/admin/staff-portal/users/page.tsx
+++ b/apps/admin/app/admin/staff-portal/users/page.tsx
@@ -1,136 +1,117 @@
 import { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import {
+  canManageStaffPortalUsers,
+  requireStaffPortalAccess,
+} from '@/lib/staff-portal/access';
 
 export const metadata: Metadata = {
   title: 'Staff Portal Users',
   description: 'Elevate For Humanity - Staff Portal Users page',
-  alternates: { canonical: 'https://www.elevateforhumanity.org/admin/staff-portal/users' },
+  robots: { index: false, follow: false },
 };
 
 export const dynamic = 'force-dynamic';
 
-import { createClient } from '@/lib/supabase/server';
-
 export default async function StaffPortalUsersPage() {
-  try {
-    const supabase = await createClient();
+  const { profile } = await requireStaffPortalAccess();
 
-    const {
-      data: { user },
-      error: userError,
-    } = await supabase.auth.getUser();
+  if (!canManageStaffPortalUsers(profile.role)) {
+    redirect('/unauthorized');
+  }
 
-    if (userError || !user) {
-      return (
-        <div className="min-h-screen flex items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-2xl font-bold text-black mb-2">Authentication Required</h1>
-            <p className="text-black">Please log in to access the staff portal.</p>
-          </div>
-        </div>
-      );
-    }
+  const supabase = await createClient();
+  const { data: users, error } = await supabase
+    .from('profiles')
+    .select('id, email, role, created_at, updated_at')
+    .order('created_at', { ascending: false })
+    .limit(100);
 
-    // Fetch users from profiles table
-    const { data: users, error } = await supabase
-      .from('profiles')
-      .select('id, email, role, created_at, updated_at')
-      .order('created_at', { ascending: false })
-      .limit(100);
-
-    if (error) {
-      return (
-        <div className="min-h-screen flex items-center justify-center">
-          <div className="text-center">
-            <h1 className="text-2xl font-bold text-red-600 mb-2">Error</h1>
-            <p className="text-black">Failed to load users. Please try again.</p>
-          </div>
-        </div>
-      );
-    }
-
-    return (
-      <div className="min-h-screen bg-slate-50 py-8">
-        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-          <div className="mb-8">
-            <h1 className="text-3xl font-bold text-black">User Management</h1>
-            <p className="mt-2 text-black">Manage user accounts and permissions</p>
-          </div>
-
-          <div className="bg-white shadow-md rounded-lg overflow-hidden">
-            <div className="px-6 py-4 border-b border-slate-200">
-              <h2 className="text-lg font-semibold text-black">All Users ({users?.length || 0})</h2>
-            </div>
-
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-slate-200">
-                <thead className="bg-slate-50">
-                  <tr>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
-                      Email
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
-                      Role
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
-                      Created
-                    </th>
-                    <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
-                      Last Updated
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-slate-200">
-                  {users && users.length > 0 ? (
-                    users.map((user) => (
-                      <tr key={user.id} className="hover:bg-slate-50">
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
-                          {user.email || 'N/A'}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap">
-                          <span
-                            className={`px-2 py-2 text-xs font-semibold rounded-full ${
-                              user.role === 'admin'
-                                ? 'bg-purple-100 text-purple-800'
-                                : user.role === 'staff'
-                                  ? 'bg-blue-100 text-blue-800'
-                                  : user.role === 'instructor'
-                                    ? 'bg-brand-green-100 text-brand-green-800'
-                                    : 'bg-slate-100 text-black'
-                            }`}
-                          >
-                            {user.role || 'user'}
-                          </span>
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
-                          {user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A'}
-                        </td>
-                        <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
-                          {user.updated_at ? new Date(user.updated_at).toLocaleDateString() : 'N/A'}
-                        </td>
-                      </tr>
-                    ))
-                  ) : (
-                    <tr>
-                      <td colSpan={4} className="px-6 py-8 text-center text-black">
-                        No users found
-                      </td>
-                    </tr>
-                  )}
-                </tbody>
-              </table>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  } catch (error) {
+  if (error) {
     return (
       <div className="min-h-screen flex items-center justify-center">
         <div className="text-center">
           <h1 className="text-2xl font-bold text-red-600 mb-2">Error</h1>
-          <p className="text-black">An unexpected error occurred.</p>
+          <p className="text-black">Failed to load users. Please try again.</p>
         </div>
       </div>
     );
   }
+
+  return (
+    <div className="min-h-screen bg-slate-50 py-8">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="mb-8">
+          <h1 className="text-3xl font-bold text-black">User Management</h1>
+          <p className="mt-2 text-black">Manage user accounts and permissions</p>
+        </div>
+
+        <div className="bg-white shadow-md rounded-lg overflow-hidden">
+          <div className="px-6 py-4 border-b border-slate-200">
+            <h2 className="text-lg font-semibold text-black">All Users ({users?.length || 0})</h2>
+          </div>
+
+          <div className="overflow-x-auto">
+            <table className="min-w-full divide-y divide-slate-200">
+              <thead className="bg-slate-50">
+                <tr>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
+                    Email
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
+                    Role
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
+                    Created
+                  </th>
+                  <th className="px-6 py-3 text-left text-xs font-medium text-black uppercase tracking-wider">
+                    Last Updated
+                  </th>
+                </tr>
+              </thead>
+              <tbody className="bg-white divide-y divide-slate-200">
+                {users && users.length > 0 ? (
+                  users.map((user) => (
+                    <tr key={user.id} className="hover:bg-slate-50">
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
+                        {user.email || 'N/A'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap">
+                        <span
+                          className={`px-2 py-2 text-xs font-semibold rounded-full ${
+                            user.role === 'admin'
+                              ? 'bg-purple-100 text-purple-800'
+                              : user.role === 'staff'
+                                ? 'bg-blue-100 text-blue-800'
+                                : user.role === 'instructor'
+                                  ? 'bg-brand-green-100 text-brand-green-800'
+                                  : 'bg-slate-100 text-black'
+                          }`}
+                        >
+                          {user.role || 'user'}
+                        </span>
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
+                        {user.created_at ? new Date(user.created_at).toLocaleDateString() : 'N/A'}
+                      </td>
+                      <td className="px-6 py-4 whitespace-nowrap text-sm text-black">
+                        {user.updated_at ? new Date(user.updated_at).toLocaleDateString() : 'N/A'}
+                      </td>
+                    </tr>
+                  ))
+                ) : (
+                  <tr>
+                    <td colSpan={4} className="px-6 py-8 text-center text-black">
+                      No users found
+                    </td>
+                  </tr>
+                )}
+              </tbody>
+            </table>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
 }

--- a/apps/admin/app/api/staff/my-students/route.ts
+++ b/apps/admin/app/api/staff/my-students/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { getTenantContext, TenantContextError } from '@/lib/tenant';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { isStaffPortalApiAuth, requireStaffPortalApi } from '@/lib/api/staff-portal-guard';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
@@ -14,21 +15,12 @@ async function _GET(request: Request) {
     const rateLimited = await applyRateLimit(request, 'api');
     if (rateLimited) return rateLimited;
 
-    // STEP 4D: Get tenant context - enforces tenant isolation
+    const auth = await requireStaffPortalApi();
+    if (!isStaffPortalApiAuth(auth)) return auth;
+
+    // Tenant context — enforces tenant isolation for student list
     const tenantContext = await getTenantContext();
-
     const supabase = await createClient();
-
-    // Get staff profile
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', tenantContext.userId)
-      .maybeSingle();
-
-    if (!profile || profile.role !== 'staff') {
-      return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
-    }
 
     // Get students in this tenant (RLS enforces tenant_id filtering)
     const { data: students, error } = await supabase

--- a/apps/admin/app/api/staff/qa-checklist/route.ts
+++ b/apps/admin/app/api/staff/qa-checklist/route.ts
@@ -38,7 +38,7 @@ async function _GET(request: Request) {
     const { data: completions, error: completionsError } = await supabase
       .from('qa_checklist_completions')
       .select('*')
-      .eq('user_id', user.id)
+      .eq('user_id', auth.userId)
       .gte('completed_at', `${today}T00:00:00`)
       .lte('completed_at', `${today}T23:59:59`);
 

--- a/apps/admin/app/api/staff/qa-checklist/route.ts
+++ b/apps/admin/app/api/staff/qa-checklist/route.ts
@@ -4,6 +4,7 @@ import { NextResponse } from 'next/server';
 import { parseBody } from '@/lib/api-helpers';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { isStaffPortalApiAuth, requireStaffPortalApi } from '@/lib/api/staff-portal-guard';
 export const runtime = 'nodejs';
 export const maxDuration = 60;
 
@@ -14,26 +15,11 @@ async function _GET(request: Request) {
     const rateLimited = await applyRateLimit(request, 'api');
     if (rateLimited) return rateLimited;
 
+    const auth = await requireStaffPortalApi();
+    if (!isStaffPortalApiAuth(auth)) return auth;
+
     const supabase = await createClient();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
-
-    // Get user role
-    const { data: profile } = await supabase
-      .from('profiles')
-      .select('role')
-      .eq('id', user.id)
-      .maybeSingle();
-
-    if (!profile) {
-      return NextResponse.json({ error: 'Profile not found' }, { status: 404 });
-    }
+    const profile = { role: auth.role };
 
     // Get checklists for user's role
     const { data: checklists, error: checklistsError } = await supabase
@@ -85,15 +71,10 @@ async function _POST(request: Request) {
     const rateLimited = await applyRateLimit(request, 'api');
     if (rateLimited) return rateLimited;
 
+    const auth = await requireStaffPortalApi();
+    if (!isStaffPortalApiAuth(auth)) return auth;
+
     const supabase = await createClient();
-
-    const {
-      data: { user },
-    } = await supabase.auth.getUser();
-
-    if (!user) {
-      return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
-    }
 
     const body = await parseBody<Record<string, any>>(request);
     const { checklist_id, notes } = body;
@@ -118,7 +99,7 @@ async function _POST(request: Request) {
       .from('qa_checklist_completions')
       .insert({
         checklist_id,
-        user_id: user.id,
+        user_id: auth.userId,
         notes: notes || null,
         completed_at: new Date().toISOString(),
       })

--- a/apps/admin/app/api/staff/skills/[skillId]/complete/route.ts
+++ b/apps/admin/app/api/staff/skills/[skillId]/complete/route.ts
@@ -1,8 +1,8 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { isStaffPortalApiAuth, requireStaffPortalApi } from '@/lib/api/staff-portal-guard';
 export const runtime = 'nodejs';
 
 export const dynamic = 'force-dynamic';
@@ -10,20 +10,18 @@ export const dynamic = 'force-dynamic';
 async function _POST(req: NextRequest, { params }: { params: Promise<{ skillId: string }> }) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
-  const supabase = await createClient();
+  const auth = await requireStaffPortalApi();
+  if (!isStaffPortalApiAuth(auth)) return auth;
+
   const db = await requireAdminClient();
   if (!db)
     return NextResponse.json({ error: 'Admin client failed to initialize' }, { status: 500 });
-  const {
-    data: { user },
-  } = await supabase.auth.getUser();
-  if (!user) return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
 
   const { skillId } = await params;
 
   await db.from('user_skills').upsert(
     {
-      user_id: user.id,
+      user_id: auth.userId,
       skill_name: skillId,
       proficiency: 3,
       proficiency_level: 'competent',

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -72,7 +72,8 @@ export async function middleware(req: NextRequest) {
   const isProtected =
     pathname === '/' ||
     pathname.startsWith('/admin') ||
-    pathname.startsWith('/api/admin');
+    pathname.startsWith('/api/admin') ||
+    pathname.startsWith('/api/staff');
 
   if (!isProtected) return NextResponse.next();
 

--- a/lib/api/staff-portal-guard.ts
+++ b/lib/api/staff-portal-guard.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { STAFF_PORTAL_ROLES } from '@/lib/staff-portal/access';
+
+export type StaffPortalApiAuth = {
+  userId: string;
+  role: string;
+};
+
+/**
+ * API routes under /api/staff/* — require authenticated staff-portal role.
+ */
+export async function requireStaffPortalApi(): Promise<StaffPortalApiAuth | NextResponse> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const { data: profile } = await supabase
+    .from('profiles')
+    .select('role')
+    .eq('id', user.id)
+    .maybeSingle();
+
+  if (!profile || !(STAFF_PORTAL_ROLES as readonly string[]).includes(profile.role)) {
+    return NextResponse.json({ error: 'Forbidden' }, { status: 403 });
+  }
+
+  return { userId: user.id, role: profile.role };
+}
+
+export function isStaffPortalApiAuth(
+  result: StaffPortalApiAuth | NextResponse,
+): result is StaffPortalApiAuth {
+  return 'userId' in result;
+}

--- a/lib/case-file/loader.ts
+++ b/lib/case-file/loader.ts
@@ -5,12 +5,14 @@
  */
 
 import { createClient } from '@/lib/supabase/server';
+import { requireStaffPortalAccess } from '@/lib/staff-portal/access';
 import { ParticipantCaseFile, CaseFileSummary, generateCaseNumber } from './types';
 
 /**
  * Load a complete participant case file
  */
 export async function loadCaseFile(participantId: string): Promise<ParticipantCaseFile | null> {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
 
   // Load profile
@@ -18,6 +20,7 @@ export async function loadCaseFile(participantId: string): Promise<ParticipantCa
     .from('profiles')
     .select('*')
     .eq('id', participantId)
+    .eq('role', 'student')
     .maybeSingle();
 
   if (profileError || !profile) {
@@ -219,6 +222,7 @@ export async function loadCaseFileSummaries(
     offset?: number;
   } = {},
 ): Promise<CaseFileSummary[]> {
+  await requireStaffPortalAccess();
   const supabase = await createClient();
   const { limit = 50, offset = 0 } = options;
 
@@ -235,6 +239,7 @@ export async function loadCaseFileSummaries(
       updated_at
     `,
     )
+    .eq('role', 'student')
     .order('updated_at', { ascending: false })
     .range(offset, offset + limit - 1);
 

--- a/lib/staff-portal/access.ts
+++ b/lib/staff-portal/access.ts
@@ -1,0 +1,26 @@
+import { requireRole, type AuthResult } from '@/lib/auth/require-role';
+
+/** Roles allowed to access staff-portal UI and student PII loaders/APIs. */
+export const STAFF_PORTAL_ROLES = [
+  'staff',
+  'admin',
+  'super_admin',
+  'advisor',
+] as const;
+
+export type StaffPortalRole = (typeof STAFF_PORTAL_ROLES)[number];
+
+/**
+ * Server-only gate for staff portal pages and case-file loaders.
+ * Redirects unauthenticated users to login and wrong roles to /unauthorized.
+ */
+export async function requireStaffPortalAccess(): Promise<AuthResult> {
+  return requireRole([...STAFF_PORTAL_ROLES]);
+}
+
+/** Roles that may list all portal accounts (not only learners). */
+export const STAFF_PORTAL_USER_ADMIN_ROLES = ['admin', 'super_admin'] as const;
+
+export function canManageStaffPortalUsers(role: string): boolean {
+  return (STAFF_PORTAL_USER_ADMIN_ROLES as readonly string[]).includes(role);
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

**P0:** Staff portal was exposing student/admin PII without consistent auth and could ISR-cache case files.

## Root causes

1. **`revalidate = 3600`** on `staff-portal/cases/[id]` — case files with email/phone/address could be statically cached.
2. **Empty staff-portal layout** — no role gate; relied only on parent admin layout.
3. **`loadCaseFile` / `loadCaseFileSummaries`** — no auth; listed **all** `profiles`, not only students.
4. **`users/page.tsx`** — rendered "Authentication Required" HTML instead of redirecting; listed all users for any session.
5. **`/api/staff/*`** not in admin middleware — unauthenticated API access surface (routes had partial checks).

## Fixes

- `requireStaffPortalAccess()` on staff-portal layout + `force-dynamic`
- Case loaders: staff roles only + `role=student` filter
- Remove ISR from case detail page
- Users page: admin/super_admin only; proper redirects
- Middleware: protect `/api/staff/*`
- Shared `lib/api/staff-portal-guard.ts` for staff APIs

## Deploy

Merge and redeploy **elevate-admin** on Northflank immediately.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Lock down staff portal student PII access with a centralized role gate
> - Adds [lib/staff-portal/access.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/278/files#diff-59d7a1c80dd7b7cf70072afcb76042d53550da34d26664844df7fe0ab965cc66) defining `STAFF_PORTAL_ROLES`, `requireStaffPortalAccess()`, and `canManageStaffPortalUsers()` as the single source of truth for staff portal authorization.
> - Adds [lib/api/staff-portal-guard.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/278/files#diff-6bb6a33af16e614e446eaec5fc7810428b32f2f160b3f6eb35eda6d1b5b5a849) with `requireStaffPortalApi()` and `isStaffPortalApiAuth()` to enforce role checks on `/api/staff/*` routes, returning 401/403 on failure.
> - Replaces manual `auth.getUser()` + redirect logic in all staff portal pages and API routes with calls to `requireStaffPortalAccess()` or `requireStaffPortalApi()`.
> - Adds a `role = 'student'` filter in `loadCaseFile` and `loadCaseFileSummaries` so case file loaders never return non-student PII.
> - Extends middleware to apply the IP allowlist and session check to `/api/staff/*` and adds `noindex/nofollow` robots metadata to sensitive pages.
> - Behavioral Change: `/api/staff/*` previously skipped middleware protections; staff portal pages now redirect to `/unauthorized` for insufficient roles rather than `/login` or `/`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cb44fd9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->