### PR TITLE
fix(northflank): audit pnpm cache mount — split install vs build

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -61,13 +61,16 @@ ENV CI=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
-# Single cache volume for store + node_modules so pnpm hardlinks (no copyfile ENOSPC).
-# Do NOT use separate /pnpm/store and /app/node_modules mounts — different FS forces copy.
+# Unified pnpm cache mount (store + node_modules on same FS). Split install vs build
+# so next build output does not exhaust cache disk in the same layer as pnpm install.
+# Cache id is service-specific — do not share admin/lms ids on one builder.
 RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
-    && pnpm install --frozen-lockfile --ignore-scripts \
-    && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
+    && pnpm install --frozen-lockfile --ignore-scripts
+
+RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
+    ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && test -x /app/node_modules/next/dist/bin/next \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -59,11 +59,14 @@ ENV CI=true
 ENV PUPPETEER_SKIP_DOWNLOAD=true
 ENV PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
 
+# Unified pnpm cache mount — install and build in separate RUN layers (same cache id).
 RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
     mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
     && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
-    && pnpm install --frozen-lockfile --ignore-scripts \
-    && ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
+    && pnpm install --frozen-lockfile --ignore-scripts
+
+RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
+    ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
     && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && test -x /app/node_modules/next/dist/bin/next \

--- a/docs/audits/node-20-bookworm-slim-runtime-audit.md
+++ b/docs/audits/node-20-bookworm-slim-runtime-audit.md
@@ -1,0 +1,151 @@
+# Audit: `FROM docker.io/library/node:20-bookworm-slim` (runtime stage)
+
+**Date:** 2026-06-05  
+**Trigger:** Northflank build logs resolve the runtime base as `docker.io/library/node:20-bookworm-slim` (implicit registry for `FROM node:20-bookworm-slim`).
+
+## Where this image is used
+
+| Dockerfile | Stage | Image reference | Production |
+|------------|-------|-----------------|------------|
+| `Dockerfile.northflank-admin` | runtime | `node:20-bookworm-slim` | **Northflank `elevate-admin`** |
+| `Dockerfile.northflank-lms` | runtime | `node:20-bookworm-slim` | **Northflank `elevate-lms`** |
+| `Dockerfile.package` | single | `node:20-bookworm-slim` | Legacy ECS LMS package (prebuilt standalone) |
+| `Dockerfile.admin` | single | `public.ecr.aws/docker/library/node:20-bookworm-slim` | Legacy ECS admin package (same bits, AWS ECR mirror) |
+
+**Builder stages** (not slim): `node:20-bookworm` full image with `build-essential`, Cairo/Pango dev libs for native compile in `Dockerfile.northflank-*`.
+
+## What `docker.io/library/node:20-bookworm-slim` is
+
+- Official Node.js image on Docker Hub (`library/node`).
+- **Debian 12 (bookworm)** minimal variant — no compiler toolchain, smaller than `node:20-bookworm`.
+- Tag **`20-bookworm-slim` is floating** — tracks latest Node 20.x on bookworm slim (not pinned to repo `.node-version` **20.19.2**).
+
+Northflank/BuildKit logs the fully qualified name; behavior is identical to `FROM node:20-bookworm-slim` in the Dockerfiles.
+
+## Runtime stage pattern (Northflank)
+
+Both Northflank Dockerfiles use a **multi-stage** layout:
+
+```
+builder  → node:20-bookworm        (compile native deps, next build)
+runtime  → node:20-bookworm-slim   (standalone server only)
+```
+
+### Packages installed on slim (Northflank admin + LMS)
+
+```dockerfile
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ca-certificates \
+    curl \
+    fonts-liberation \
+    && rm -rf /var/lib/apt/lists/*
+```
+
+| Package | Purpose |
+|---------|---------|
+| `ca-certificates` | HTTPS to Supabase, Stripe, etc. |
+| `curl` | `HEALTHCHECK` → `/api/ping` |
+| `fonts-liberation` | PDF/canvas text rendering (admin PDF stack) |
+
+### Native Node modules copied from builder (not installed on slim)
+
+| Service | Copied into slim runtime |
+|---------|--------------------------|
+| **Admin** | `sharp` + `@img/*`, `@napi-rs/canvas`, `pdf-parse`, `pdfjs-dist`, `ws` |
+| **LMS** | `sharp` + `@img/*` only |
+
+Admin build **fails closed** if PDF stack missing:
+
+```dockerfile
+RUN node -e "require('@napi-rs/canvas'); require('pdf-parse'); console.log('[admin] pdf runtime ok')"
+```
+
+Native bindings are **built on full bookworm** and copied to slim — valid because both stages share the same Debian bookworm glibc.
+
+## Findings
+
+### 1. Node version drift (low)
+
+| Source | Version |
+|--------|---------|
+| `.node-version` | `20.19.2` (pinned) |
+| Docker tag | `20-bookworm-slim` (floating latest 20.x) |
+
+**Risk:** CI/dev on 20.19.2, production slim image may pick up 20.20+ on next base image refresh.  
+**Mitigation (optional):** Pin `node:20.19.2-bookworm-slim@sha256:…` in Dockerfiles.
+
+### 2. Northflank admin slim missing ffmpeg/chromium (medium)
+
+`Dockerfile.package` (legacy LMS runtime) installs on slim:
+
+```dockerfile
+ffmpeg \
+chromium \
+```
+
+`Dockerfile.northflank-admin` **does not**. Routes that shell out to system binaries (e.g. `app/api/media/enhance-video*`, Remotion render pipeline comments in `app/api/videos/generate/route.ts`) expect **ffmpeg/chromium on the container**.
+
+| Workload | Likely host today | Gap |
+|----------|-------------------|-----|
+| Admin lesson video generation | Intended: admin container | May fail if Remotion/ffmpeg not bundled and binaries absent |
+| LMS www marketing + learner app | `elevate-lms` slim | ffmpeg/chromium often **not** needed (no video factory on LMS split) |
+
+**Recommendation:** Add `ffmpeg` + `chromium` (+ `PUPPETEER_EXECUTABLE_PATH` env) to **`Dockerfile.northflank-admin` runtime only**, matching `Dockerfile.package`, if video generation must run on Northflank admin without ECS.
+
+### 3. ECR vs docker.io (informational)
+
+`Dockerfile.admin` pulls from `public.ecr.aws/docker/library/…` (AWS mirror of Docker Official Images). Northflank uses `docker.io/library/…` directly. **Same image content**; ECR avoids Docker Hub rate limits on AWS builders only.
+
+### 4. Security posture (good)
+
+| Control | Admin/LMS Northflank slim |
+|---------|---------------------------|
+| Non-root user | `nextjs` (uid 1001) |
+| Minimal apt footprint | 3 packages (+ admin PDF test) |
+| No shell in HEALTHCHECK | `curl -sf` only |
+| `PORT` / `HOSTNAME` | `8080` / `0.0.0.0` (Northflank) vs `3000` on legacy `Dockerfile.admin` |
+
+### 5. PORT mismatch legacy vs Northflank (by design)
+
+| Image | `PORT` | Notes |
+|-------|--------|-------|
+| `Dockerfile.admin` | 3000 | ECS task definition historical |
+| `Dockerfile.northflank-admin` | 8080 | Northflank service + health probes |
+
+Do not merge ECS and Northflank task env without updating probes.
+
+## Comparison matrix
+
+| | northflank-admin slim | northflank-lms slim | Dockerfile.package slim |
+|--|----------------------|---------------------|-------------------------|
+| Base | `node:20-bookworm-slim` | same | same |
+| ffmpeg/chromium | **No** | No | **Yes** |
+| sharp | From builder | From builder | Host prebuild |
+| PDF/canvas | From builder + runtime test | No | N/A |
+| Custom server | `apps/admin/server.js` | `server.js` | `server.js` |
+| Healthcheck | `/api/ping:8080` | same | varies |
+
+## Recommended actions
+
+| Priority | Action |
+|----------|--------|
+| P1 (if video gen on NF admin) | Add `ffmpeg` + `chromium` to `Dockerfile.northflank-admin` runtime `apt-get` |
+| P2 | Pin `node:20.19.2-bookworm-slim` or digest for reproducible builds |
+| P3 | Document that **LMS** slim intentionally omits ffmpeg/chromium (workloads live on admin) |
+| — | Keep builder on **full** `node:20-bookworm` — do not move native compile to slim |
+
+## Verification
+
+After changing the slim stage:
+
+```bash
+# Image build (local)
+docker build -f Dockerfile.northflank-admin -t elevate-admin:test .
+
+# Runtime smoke inside container
+docker run --rm elevate-admin:test node -e "require('sharp'); require('@napi-rs/canvas')"
+docker run --rm elevate-admin:test which ffmpeg chromium   # if added
+
+# Northflank
+pnpm tsx scripts/northflank/trigger-build.ts elevate-admin
+```

--- a/docs/audits/northflank-pnpm-cache-mount-audit.md
+++ b/docs/audits/northflank-pnpm-cache-mount-audit.md
@@ -1,0 +1,63 @@
+# Audit: `RUN --mount=type=cache,id=pnpm-northflank-*` (Northflank Docker builds)
+
+**Date:** 2026-06-05  
+**Scope:** `Dockerfile.northflank-admin`, `Dockerfile.northflank-lms`  
+**Related:** `docs/audits/northflank-pnpm-fetch-enospc-audit.md`
+
+## What the step does
+
+Both Dockerfiles use BuildKit cache mounts (not image layers) for pnpm:
+
+```dockerfile
+RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
+    mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
+    && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
+    && pnpm install --frozen-lockfile --ignore-scripts
+```
+
+| Piece | Purpose |
+|--------|---------|
+| `type=cache` | Persists pnpm store + `node_modules` across builds on Northflank builders |
+| `target=/mnt/pnpm-cache` | Single filesystem for store **and** modules-dir (hardlinks, no cross-FS copy) |
+| `id=pnpm-northflank-*-unified` | **Must be per-service** (`admin` vs `lms`) so graphs do not collide |
+| `.npmrc` `store-dir` + `modules-dir` | Keeps both trees on the mount; split mounts caused `ERR_PNPM_ENOSPC` / copyfile failures |
+
+**Do not use** a generic `id=pnpm-northflank` for both services — admin and LMS lockfiles resolve different graphs; a shared id can corrupt or bloat the cache.
+
+## Failure modes observed
+
+| Symptom | Cause | Mitigation |
+|---------|--------|------------|
+| `ERR_PNPM_ENOSPC` on `/mnt/pnpm-cache` or `/app/node_modules` | Build disk too small; install + `next build` + `.next` in **one** RUN layer | Split install RUN vs build RUN (same cache `id`) |
+| `ERR_PNPM_ENOSPC` with separate store + `node_modules` mounts | Different filesystems → pnpm copies instead of hardlinks | Unified mount only (current design) |
+| `pnpm fetch` exit 1 | Deprecated two-phase fetch; peak disk on small volume | Removed — use `pnpm install` only |
+| `next: not found` after `modules-dir` install | pnpm shim not on PATH when `node_modules` is symlinked | Invoke `node /app/node_modules/next/dist/bin/next build` (#275) |
+| Build timeout after ENOSPC retries | Northflank retries npm GET for hours | Fix disk + split layers; raise build ephemeral storage |
+
+## Current layout (post-audit fix)
+
+1. **RUN 1 (install):** cache mount → `pnpm install` only  
+2. **RUN 2 (build):** same cache `id` → symlink `node_modules` → `next build` → prune / sharp export  
+
+Same cache `id` on both RUN lines is **required** so RUN 2 sees RUN 1’s populated store.
+
+## Platform settings (not Dockerfile)
+
+- `scripts/northflank/configure-services.ts` — BuildKit `useCache: true`, `cacheStorageSize: 10240` MB  
+- `scripts/northflank/patch-ephemeral-storage.ts` — build ephemeral storage (target 32768 MB)  
+- Workflows: `deploy-admin.yml` / `deploy-lms.yml` run both before `trigger-build`
+
+## Verification commands
+
+```bash
+pnpm tsx scripts/northflank/fetch-build-logs.ts elevate-admin --grep ENOSPC
+pnpm tsx scripts/northflank/fetch-build-logs.ts elevate-lms --grep ENOSPC
+pnpm tsx scripts/northflank/dump-build-storage.ts
+```
+
+Success: log shows `pnpm install` in one step, `next build` in a later step, no `pnpm fetch`, no ENOSPC.
+
+## Intentionally not done
+
+- **`pnpm store prune` before `next build`** — removed in #276; pruning dropped packages still needed by the build graph.  
+- **Separate LMS/admin cache ids on one service** — correct; only one id per Dockerfile.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Audits and fixes the `RUN --mount=type=cache,id=pnpm-northflank-*` build steps that were failing with `ERR_PNPM_ENOSPC` on Northflank.

## Audit

Full write-up: `docs/audits/northflank-pnpm-cache-mount-audit.md`

| Finding | Status |
|---------|--------|
| Unified mount (`store-dir` + `modules-dir` on `/mnt/pnpm-cache`) | Correct — do not split mounts |
| Cache `id` must be per-service (`admin-unified` / `lms-unified`) | Correct — never use generic `pnpm-northflank` for both |
| Install + `next build` in **one** RUN layer | **Fixed** — split into two RUNs, same cache `id` |
| `pnpm fetch` / `store prune` before build | Already removed (#276) |

## Change

- **Dockerfile.northflank-admin** / **Dockerfile.northflank-lms**: RUN 1 = `pnpm install`; RUN 2 = symlink `node_modules` + `next build` + prune/sharp export. Both use the same BuildKit cache id so layer 2 reuses layer 1's store.

## Deploy

Merge → `deploy-admin` / `deploy-lms` workflows (or manual `trigger-build`) to pick up new Dockerfiles.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Split pnpm install and node_modules symlink into separate RUN layers in Northflank Dockerfiles
> - Splits the pnpm cache mount step in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/279/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/279/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) so `pnpm install --frozen-lockfile --ignore-scripts` runs in its own RUN layer, separate from the node_modules symlink creation and subsequent checks.
> - Both RUN layers share the same BuildKit cache mount id, so the pnpm store is reused across install and build stages.
> - Adds audit docs covering the pnpm cache mount strategy and the `node:20-bookworm-slim` runtime base image.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cf0d627.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->