### PR TITLE
fix(northflank): pnpm store-only cache mount (ERR_PNPM_ENOSPC)

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -59,17 +59,14 @@ ENV SKIP_ENV_VALIDATION=true
 ENV HUSKY=0
 ENV CI=true
 
-# Unified pnpm cache mount (store + node_modules on same FS). Split install vs build
-# so next build output does not exhaust cache disk in the same layer as pnpm install.
-# Cache id is service-specific — do not share admin/lms ids on one builder.
-RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
-    mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
-    && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
+# pnpm store on BuildKit cache (10GB cap); node_modules on /app builder disk (32GB+ ephemeral).
+# Unified store+modules mount exhausts /mnt/pnpm-cache → ERR_PNPM_ENOSPC during install.
+RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/mnt/pnpm-store \
+    mkdir -p /mnt/pnpm-store \
+    && printf '%s\n' 'store-dir=/mnt/pnpm-store' >> .npmrc \
     && pnpm install --frozen-lockfile --ignore-scripts
 
-RUN --mount=type=cache,id=pnpm-northflank-admin-unified,target=/mnt/pnpm-cache \
-    ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
-    && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
+RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && test -x /app/node_modules/next/dist/bin/next \
     && cd apps/admin \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -57,15 +57,13 @@ ENV SKIP_ENV_VALIDATION=true
 ENV HUSKY=0
 ENV CI=true
 
-# Unified pnpm cache mount — install and build in separate RUN layers (same cache id).
-RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
-    mkdir -p /mnt/pnpm-cache/store /mnt/pnpm-cache/node_modules \
-    && printf '%s\n' 'store-dir=/mnt/pnpm-cache/store' 'modules-dir=/mnt/pnpm-cache/node_modules' >> .npmrc \
+# pnpm store on BuildKit cache; node_modules on /app builder disk (avoids ENOSPC on unified mount).
+RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/mnt/pnpm-store \
+    mkdir -p /mnt/pnpm-store \
+    && printf '%s\n' 'store-dir=/mnt/pnpm-store' >> .npmrc \
     && pnpm install --frozen-lockfile --ignore-scripts
 
-RUN --mount=type=cache,id=pnpm-northflank-lms-unified,target=/mnt/pnpm-cache \
-    ln -sfn /mnt/pnpm-cache/node_modules /app/node_modules \
-    && test -n "$NEXT_PUBLIC_SUPABASE_URL" \
+RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \
     && test -x /app/node_modules/next/dist/bin/next \
     && node /app/node_modules/next/dist/bin/next build \


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Northflank builds fail with `ERR_PNPM_ENOSPC` on `/mnt/pnpm-cache` when both `store-dir` and `modules-dir` share the 10GB BuildKit cache mount.

## Fix

- Cache **only** `store-dir` on `/mnt/pnpm-store`
- Install `node_modules` to `/app` (builder ephemeral disk, 32GB+)
- Remove symlink + second cache mount on build RUN

Applies to `Dockerfile.northflank-admin` and `Dockerfile.northflank-lms`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pnpm store-only cache mount in Northflank Dockerfiles to resolve ERR_PNPM_ENOSPC
> - Replaces the unified `/mnt/pnpm-cache` BuildKit mount (covering both store and `node_modules`) with a store-only mount at `/mnt/pnpm-store` in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/282/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/282/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e).
> - Updates `.npmrc` to set only `store-dir`, removing the `modules-dir` override so `node_modules` is written directly to `/app` instead of a cache-backed directory.
> - Removes the symlink from `/mnt/pnpm-cache/node_modules` to `/app/node_modules` and drops the cache mount from the subsequent build `RUN` layer.
> - Behavioral Change: `node_modules` no longer persists across builds in the BuildKit cache; only the pnpm content-addressable store is cached.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 831cd60.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->