### PR TITLE
fix(northflank): drop BuildKit pnpm cache mount

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -59,12 +59,9 @@ ENV SKIP_ENV_VALIDATION=true
 ENV HUSKY=0
 ENV CI=true
 
-# pnpm store on BuildKit cache (10GB cap); node_modules on /app builder disk (32GB+ ephemeral).
-# Unified store+modules mount exhausts /mnt/pnpm-cache → ERR_PNPM_ENOSPC during install.
-RUN --mount=type=cache,id=pnpm-northflank-admin-store,target=/mnt/pnpm-store \
-    mkdir -p /mnt/pnpm-store \
-    && printf '%s\n' 'store-dir=/mnt/pnpm-store' >> .npmrc \
-    && pnpm install --frozen-lockfile --ignore-scripts
+# Install on /app builder ephemeral disk (32GB via patch-ephemeral-storage). No BuildKit
+# cache mount — shared store cache was exhausting disk (ERR_PNPM_ENOSPC) on nf builders.
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -57,11 +57,8 @@ ENV SKIP_ENV_VALIDATION=true
 ENV HUSKY=0
 ENV CI=true
 
-# pnpm store on BuildKit cache; node_modules on /app builder disk (avoids ENOSPC on unified mount).
-RUN --mount=type=cache,id=pnpm-northflank-lms-store,target=/mnt/pnpm-store \
-    mkdir -p /mnt/pnpm-store \
-    && printf '%s\n' 'store-dir=/mnt/pnpm-store' >> .npmrc \
-    && pnpm install --frozen-lockfile --ignore-scripts
+# Install on /app builder ephemeral disk (32GB). No BuildKit cache mount (ENOSPC on shared store).
+RUN pnpm install --frozen-lockfile --ignore-scripts
 
 RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -n "$NEXT_PUBLIC_SUPABASE_ANON_KEY" \


### PR DESCRIPTION
Plain pnpm install on 32GB builder disk. Fixes ERR_PNPM_ENOSPC.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI/Docker build-only change with no runtime app logic; main downside is slower uncached pnpm installs on Northflank.
> 
> **Overview**
> **Fixes Northflank image builds failing with `ERR_PNPM_ENOSPC`** by changing how dependencies are installed in the admin and LMS Northflank Dockerfiles.
> 
> Both builders no longer use BuildKit `--mount=type=cache` for a shared pnpm store under `/mnt/pnpm-store` or append `store-dir` to `.npmrc`. Install is now a single **`pnpm install --frozen-lockfile --ignore-scripts`** on the builder’s **~32GB ephemeral `/app` disk**, so the store and `node_modules` stay on local disk instead of a cache mount that was filling up.
> 
> **Trade-off:** pnpm store layer caching across builds is gone, so installs may take longer, but builds should complete reliably.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ea97d87d86d1585688129af34365e363d558d0e4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Drop BuildKit pnpm cache mount from Northflank Dockerfiles
> Replaces the BuildKit `--mount=type=cache` pnpm install steps in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/284/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/284/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) with a plain `RUN pnpm install --frozen-lockfile --ignore-scripts`. The custom `/mnt/pnpm-store` creation and `.npmrc` `store-dir` override are also removed, so pnpm uses its default store location. Risk: builds lose layer caching for the pnpm store, which may increase build times.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ea97d87.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->