### PR TITLE
fix(docker): align admin PDF export path with /export mount

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -84,7 +84,7 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     done \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
-    && node scripts/export-admin-pdf-deps.mjs \
+    && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
     && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
 
 # --- runtime (same as Dockerfile.admin) ---

--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -8,7 +8,9 @@ import { createRequire } from 'node:module';
 
 const require = createRequire(import.meta.url);
 const root = process.cwd();
-const exportRoot = join(root, 'export', 'pdf-node_modules');
+// Northflank/AWS Dockerfiles export ws/sharp under /export; local dev uses ./export
+const exportBase = process.env.EXPORT_ROOT ?? join(root, 'export');
+const exportRoot = join(exportBase, 'pdf-node_modules');
 
 function copyDir(src, destRelative) {
   // destRelative uses slashes e.g. "@napi-rs/canvas" → export/pdf-node_modules/@napi-rs/canvas


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Northflank admin Docker builds were failing at the final builder step after `export-admin-pdf-deps.mjs` printed `done`. The script wrote PDF runtime deps to `/app/export/pdf-node_modules`, while ws/sharp exports and the Dockerfile verification use `/export/` at the filesystem root.

## Fix

- `export-admin-pdf-deps.mjs` respects `EXPORT_ROOT` (defaults to `./export` for local dev)
- `Dockerfile.northflank-admin` sets `EXPORT_ROOT=/export` when running the export script

## Verification

```bash
EXPORT_ROOT=/tmp/export-test node scripts/export-admin-pdf-deps.mjs
test -f /tmp/export-test/pdf-node_modules/@napi-rs/canvas/package.json
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Align admin PDF export path with `/export` mount in Docker build
> - [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/285/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) now prefixes the `export-admin-pdf-deps.mjs` script invocation with `EXPORT_ROOT=/export`, matching the `/export` volume mount.
> - [scripts/export-admin-pdf-deps.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/285/files#diff-6008e504749ec4e549578b5971e34032f88e4e8b024a078fb3f215409361abbe) reads `EXPORT_ROOT` from the environment to set the base export directory, falling back to `./export` for local dev.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 367cf0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->