### PR TITLE
fix(docker): prune admin builder disk before runtime COPY

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -87,6 +87,9 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
     && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
 
+# Drop node_modules + marketing-only assets before runtime COPY (BuildKit ENOSPC).
+RUN node scripts/prune-admin-builder-disk.mjs
+
 # --- runtime (same as Dockerfile.admin) ---
 FROM node:20-bookworm-slim
 

--- a/scripts/prune-admin-builder-disk.mjs
+++ b/scripts/prune-admin-builder-disk.mjs
@@ -1,0 +1,33 @@
+/**
+ * Free builder disk before admin runtime COPY layers.
+ * Admin does not need the full LMS marketing asset tree or node_modules
+ * after standalone + /export copies are prepared.
+ */
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+
+const paths = [
+  'node_modules',
+  'apps/admin/.next/cache',
+  '.next/cache',
+  'public/audio',
+  'public/images/hvac-diagrams',
+  'public/images/artlist',
+  'public/images/hp',
+  'public/images/demos',
+  'public/images/barber-clipper-options',
+];
+
+for (const rel of paths) {
+  const abs = join(root, rel);
+  try {
+    rmSync(abs, { recursive: true, force: true });
+    console.log(`[prune-admin-builder] removed ${rel}`);
+  } catch (err) {
+    console.warn(`[prune-admin-builder] skip ${rel}:`, err instanceof Error ? err.message : err);
+  }
+}
+
+console.log('[prune-admin-builder] done');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Admin Northflank builds now pass the builder stage (PDF export path fixed in #285) but fail during runtime-stage `COPY` with:

```
no space left on device ... public/images/hvac-diagrams/ref-pressure-zones.png
```

The builder retains ~2.3GB `node_modules` plus 165MB `public/images` (including 51MB `hvac-diagrams` unused by admin) until BuildKit compresses layers for the runtime stage.

## Fix

- Add `scripts/prune-admin-builder-disk.mjs` to remove `node_modules`, build caches, and marketing-only image trees after `/export` copies complete
- Run it as a separate builder `RUN` before the runtime stage in `Dockerfile.northflank-admin`

## Verification

Prune script is idempotent and only targets paths admin does not need at runtime.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prune `node_modules` and marketing assets in admin Docker builder before runtime COPY
> Adds a new [prune-admin-builder-disk.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/286/files#diff-a7048677e35c34565d6c321e14ca45f29870684d4b7d1f8854102bce4177ab09) script and a `RUN` step in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/286/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) to delete `node_modules`, Next.js caches, and selected `public/images` subdirectories from the builder stage before the runtime `COPY` layers execute. This reduces the data copied into the runtime image layer by removing directories that are no longer needed at that point in the build.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c2884e6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->