### PR TITLE
fix(docker): disable BuildKit cache and fix standalone .pnpm prune

### DIFF
--- a/scripts/northflank/configure-services.ts
+++ b/scripts/northflank/configure-services.ts
@@ -55,9 +55,10 @@ const SERVICES = [
   },
 ];
 
+// Registry layer cache was exhausting nf-buildkit overlay disk (ENOSPC on COPY).
 const BUILDKIT = {
-  useCache: true,
-  cacheStorageSize: 10240,
+  useCache: false,
+  cacheStorageSize: 0,
 };
 
 /** Northflank only accepts these MB values for build ephemeral storage. */

--- a/scripts/northflank/ensure-build-cache.ts
+++ b/scripts/northflank/ensure-build-cache.ts
@@ -1,6 +1,6 @@
 #!/usr/bin/env tsx
 /**
- * Ensure Northflank combined services use BuildKit layer cache (10GB).
+ * Ensure Northflank combined services BuildKit cache settings (disabled — ENOSPC).
  *
  *   pnpm tsx scripts/northflank/ensure-build-cache.ts --dry-run
  *   pnpm tsx scripts/northflank/ensure-build-cache.ts --execute
@@ -20,8 +20,8 @@ const SERVICES = [
 ];
 
 const BUILDKIT = {
-  useCache: true,
-  cacheStorageSize: 10240,
+  useCache: false,
+  cacheStorageSize: 0,
 };
 
 async function main() {

--- a/scripts/prune-standalone-lib.mjs
+++ b/scripts/prune-standalone-lib.mjs
@@ -33,8 +33,16 @@ export async function pruneStandaloneNodeModules(nodeModulesDir, prunePackages, 
     const entries = await readdir(pnpmDir);
     for (const entry of entries) {
       const shouldPrune = prunePackages.some((pkg) => {
-        const pnpmName = pkg.startsWith('@') ? pkg.replace('/', '+') : pkg;
-        return entry.startsWith(pnpmName + '@') || entry === pnpmName;
+        if (pkg.startsWith('@')) {
+          const slash = pkg.indexOf('/');
+          if (slash > 0) {
+            const scoped = pkg.slice(1).replace('/', '+') + '@';
+            return entry.startsWith(scoped);
+          }
+          // @esbuild → @esbuild+linux-x64@…, @remotion → @remotion+…
+          return entry.startsWith(`${pkg}+`) || entry.startsWith(`${pkg.slice(1)}+`);
+        }
+        return entry.startsWith(`${pkg}@`) || entry === pkg;
       });
       if (shouldPrune) {
         try {

--- a/scripts/prune-standalone-packages.mjs
+++ b/scripts/prune-standalone-packages.mjs
@@ -1,6 +1,7 @@
 /** Shared prune lists for LMS vs admin standalone output. */
 
 export const SHARED_STANDALONE_PRUNE_PACKAGES = [
+  '@esbuild/linux-x64',
   '@next/swc-linux-x64-gnu',
   '@next/swc-linux-x64-musl',
   '@next/swc-darwin-x64',


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Admin Northflank builds still fail with `no space left on device` during runtime-stage COPY of `standalone/node_modules/.pnpm/@esbuild+linux-x64@…`.

Contributing factors:
- 10GB BuildKit registry layer cache on shared nf-buildkit overlay
- `prune-standalone-lib.mjs` did not match scoped pnpm folders like `@esbuild+linux-x64@`

## Fix

- Disable BuildKit layer cache (`useCache: false`, `cacheStorageSize: 0`) in `configure-services.ts` and `ensure-build-cache.ts`
- Fix scoped-package `.pnpm` matching in `prune-standalone-lib.mjs`
- Add `@esbuild/linux-x64` to shared prune list

Deploy workflows run `configure-services.ts --execute`, so this applies on the next admin/LMS deploy.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Disable BuildKit cache and fix `pruneStandaloneNodeModules` scoped package matching
> - Disables BuildKit caching in [`configure-services.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/287/files#diff-a265b10d2431129186c98763c8797fd8b25744b06999524db56b532cf7a5dea9) and [`ensure-build-cache.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/287/files#diff-9549dc1d5218aa8413b27866fdaa8ec59d03cdc0feaf6e3f5d6026813417740f) by setting `useCache=false` and `cacheStorageSize=0` due to registry layer cache exhausting overlay disk (ENOSPC).
> - Fixes PNPM store entry matching in [`prune-standalone-lib.mjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/287/files#diff-8f88ccb6ab2ea7dea9b3f3536ccf9c3a1dbf7b3633000b800bc4e02d0b33b847) for scope-only patterns like `@esbuild` by matching both `@scope+` and `scope+` prefixes to catch platform-suffixed artifacts.
> - Adds `@esbuild/linux-x64` to the shared prune list in [`prune-standalone-packages.mjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/287/files#diff-d3bed54d59e320cb5926beee85849a52a061aa843bbdff2dae93afcbeee000ff).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 71624bd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->