### PR TITLE
fix(docker): pnpm store on /app ephemeral disk + LMS builder prune

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -20,7 +20,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
-ENV PNPM_HOME="/pnpm"
+ENV PNPM_HOME="/app/.pnpm-home"
 ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
@@ -34,7 +34,7 @@ COPY packages/ui/package.json packages/ui/package.json
 
 COPY . .
 
-RUN rm -rf /app/.pnpm-store /app/node_modules
+RUN rm -rf /app/.pnpm-store /app/.pnpm-home /app/node_modules
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -21,7 +21,8 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 ENV COREPACK_ENABLE_DOWNLOAD_PROMPT=0
 RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
-ENV PNPM_HOME="/pnpm"
+# Keep pnpm store on /app ephemeral disk — /pnpm is a small platform mount (ENOSPC).
+ENV PNPM_HOME="/app/.pnpm-home"
 ENV PATH="$PNPM_HOME:$PATH"
 
 WORKDIR /app
@@ -34,7 +35,7 @@ COPY packages/ui/package.json packages/ui/package.json
 
 COPY . .
 
-RUN rm -rf /app/.pnpm-store /app/node_modules
+RUN rm -rf /app/.pnpm-store /app/.pnpm-home /app/node_modules
 
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
@@ -75,6 +76,8 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     done \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64
+
+RUN node scripts/prune-lms-builder-disk.mjs
 
 # --- runtime (Dockerfile.package layout) ---
 FROM node:20-bookworm-slim

--- a/scripts/northflank/verify-deployed-sha.ts
+++ b/scripts/northflank/verify-deployed-sha.ts
@@ -60,15 +60,33 @@ async function main() {
 
   console.log(`Expected production SHA (main): ${expected.slice(0, 12)}…\n`);
 
+  const maxAttempts = Number(process.env.NORTHFLANK_SHA_VERIFY_ATTEMPTS || 12);
+  const pollMs = Number(process.env.NORTHFLANK_SHA_VERIFY_POLL_MS || 15_000);
+
   for (const serviceId of services) {
-    const s = await nfFetch<ServiceStatus>(projectApiPath(projectId, `/services/${serviceId}`));
-    const deployed =
-      s.deployment?.internal?.deployedSHA ??
-      (s as { deployedSHA?: string }).deployedSHA;
-    const branch = s.vcsData?.projectBranch ?? s.deployment?.internal?.branch ?? '?';
-    const build = s.status?.build?.status ?? '?';
-    const deploy = s.status?.deployment?.status ?? '?';
-    const ok = shaMatches(deployed, expected);
+    let deployed: string | undefined;
+    let branch = '?';
+    let build = '?';
+    let deploy = '?';
+    let ok = false;
+
+    for (let attempt = 1; attempt <= maxAttempts; attempt++) {
+      const s = await nfFetch<ServiceStatus>(projectApiPath(projectId, `/services/${serviceId}`));
+      deployed =
+        s.deployment?.internal?.deployedSHA ??
+        (s as { deployedSHA?: string }).deployedSHA;
+      branch = s.vcsData?.projectBranch ?? s.deployment?.internal?.branch ?? '?';
+      build = s.status?.build?.status ?? '?';
+      deploy = s.status?.deployment?.status ?? '?';
+      ok = shaMatches(deployed, expected);
+      if (ok) break;
+      if (attempt < maxAttempts) {
+        console.log(
+          `${serviceId}: deployed SHA not updated yet (attempt ${attempt}/${maxAttempts}), waiting ${pollMs}ms…`,
+        );
+        await new Promise((resolve) => setTimeout(resolve, pollMs));
+      }
+    }
 
     console.log(
       `${serviceId}: branch=${branch} build=${build} deploy=${deploy}\n  deployed=${deployed?.slice(0, 12) ?? 'unknown'}…  ${ok ? '✅ current' : '❌ STALE'}`,

--- a/scripts/prune-lms-builder-disk.mjs
+++ b/scripts/prune-lms-builder-disk.mjs
@@ -1,0 +1,25 @@
+/**
+ * Free builder disk before LMS runtime COPY layers.
+ */
+import { rmSync } from 'node:fs';
+import { join } from 'node:path';
+
+const root = process.cwd();
+
+const paths = [
+  'node_modules',
+  '.next/cache',
+  'apps/admin',
+];
+
+for (const rel of paths) {
+  const abs = join(root, rel);
+  try {
+    rmSync(abs, { recursive: true, force: true });
+    console.log(`[prune-lms-builder] removed ${rel}`);
+  } catch (err) {
+    console.warn(`[prune-lms-builder] skip ${rel}:`, err instanceof Error ? err.message : err);
+  }
+}
+
+console.log('[prune-lms-builder] done');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

LMS Northflank builds still hit `ERR_PNPM_ENOSPC` with pnpm copying from `/pnpm/store` — a small platform mount separate from the 32GB `/app` ephemeral disk.

Admin deploy #287 built successfully but CI failed on SHA verify due to Northflank `deployedSHA` lagging behind rollout.

## Fix

- Set `PNPM_HOME=/app/.pnpm-home` in both Northflank Dockerfiles (store stays on ephemeral disk)
- Add `scripts/prune-lms-builder-disk.mjs` and run before LMS runtime COPY (mirror admin prune)
- Poll `deployedSHA` up to 12×15s in `verify-deployed-sha.ts` before failing CI

## Admin status

Deploy workflow run #27005201219: **Northflank build + deploy SUCCESS** (verify step only failed on stale SHA metadata).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pnpm store location to ephemeral disk and add LMS builder disk pruning
> - Moves `PNPM_HOME` from `/pnpm` to `/app/.pnpm-home` in both [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/288/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/288/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e), keeping pnpm's store on the ephemeral `/app` disk; cleanup steps remove this directory alongside the pnpm store and `node_modules`.
> - Adds [scripts/prune-lms-builder-disk.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/288/files#diff-4d322bcef0ee38c6ba2e63875ca91d5c64045df89b8de63de05a6eaa8793d34f), a new script run during the LMS build stage that deletes `node_modules`, `.next/cache`, and `apps/admin` before the runtime `COPY` layers to free builder disk space.
> - Updates [scripts/northflank/verify-deployed-sha.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/288/files#diff-cbc0dad9a4d4909546ad8c5be817694fe25ac14851bd66bd6a6a12b565542d3d) to poll for SHA verification (up to `NORTHFLANK_SHA_VERIFY_ATTEMPTS` attempts, default 12, with `NORTHFLANK_SHA_VERIFY_POLL_MS` delay, default 15s) instead of a single fetch-and-check.
> - Behavioral Change: SHA verification script now takes up to ~3 minutes to complete when a service is slow to update.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 5ff74e7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->