### PR TITLE
fix(admin): ERR_DASHBOARD_LOAD, nav polish, portal clock-in status

### DIFF
--- a/apps/admin/app/admin/dashboard/error.tsx
+++ b/apps/admin/app/admin/dashboard/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 
 export default function DashboardError({

--- a/apps/admin/app/admin/instructor/page.tsx
+++ b/apps/admin/app/admin/instructor/page.tsx
@@ -158,12 +158,10 @@ export default function InstructorPortalLanding() {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
-              href={`${process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl}/login?redirect=/instructor/dashboard`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/login?redirect=/admin/instructor/dashboard"
               className="px-8 py-4 bg-brand-blue-600 text-white font-bold rounded-lg hover:bg-brand-blue-700 transition"
             >
-              Sign In
+              Instructor sign in
             </Link>
             <Link
               href={`${process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl}/apply?role=instructor`}

--- a/apps/admin/app/admin/staff-portal/page.tsx
+++ b/apps/admin/app/admin/staff-portal/page.tsx
@@ -176,30 +176,6 @@ export default async function StaffPortalLanding() {
           ))}
         </div>
 
-        {/* Not logged in CTA */}
-        {!user && (
-          <div className="bg-white rounded-xl border p-8 text-center">
-            <h2 className="text-xl font-bold text-slate-900 mb-2">Sign In to Access Staff Tools</h2>
-            <p className="text-slate-500 mb-6">
-              Your dashboard, payroll, handbook, and student management tools are available after
-              signing in.
-            </p>
-            <div className="flex flex-wrap justify-center gap-3">
-              <Link
-                href="/login?redirect=/admin/staff-portal"
-                className="px-6 py-3 bg-brand-blue-600 text-white font-bold rounded-xl hover:bg-brand-blue-700"
-              >
-                Sign In
-              </Link>
-              <Link
-                href="/onboarding/staff"
-                className="px-6 py-3 bg-white text-slate-900 font-bold rounded-xl hover:bg-slate-200"
-              >
-                New Staff Onboarding
-              </Link>
-            </div>
-          </div>
-        )}
       </div>
     </div>
   );

--- a/apps/admin/app/unauthorized/page.tsx
+++ b/apps/admin/app/unauthorized/page.tsx
@@ -40,20 +40,12 @@ export default function UnauthorizedPage() {
             Signed in as <span className="text-slate-300">{email}</span>
           </p>
         )}
-        <div className="flex flex-col gap-2">
-          <button
-            onClick={handleSignOut}
-            className="w-full px-4 py-2 bg-red-900 hover:bg-red-800 text-red-200 text-sm font-medium rounded-lg transition-colors"
-          >
-            Sign Out &amp; Try Different Account
-          </button>
-          <a
-            href="/login"
-            className="inline-block px-4 py-2 bg-slate-800 hover:bg-slate-700 text-slate-300 text-sm font-medium rounded-lg transition-colors"
-          >
-            Back to Login
-          </a>
-        </div>
+        <button
+          onClick={handleSignOut}
+          className="w-full px-4 py-2 bg-red-900 hover:bg-red-800 text-red-200 text-sm font-medium rounded-lg transition-colors"
+        >
+          Sign out and use a different account
+        </button>
       </div>
     </div>
   );

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -41,7 +41,6 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [notifOpen, setNotifOpen] = useState(false);
   const [search, setSearch] = useState('');
-  const [mobileExpanded, setMobileExpanded] = useState<string | null>(null);
   const navRef = useRef<HTMLDivElement>(null);
   const notifRef = useRef<HTMLDivElement>(null);
   const unread = notifs.filter((n) => n.unread).length;
@@ -302,39 +301,34 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
               </Link>
             ))}
           </div>
-          <p className="text-xs font-bold uppercase tracking-widest text-slate-400 px-1 mb-2">All Sections</p>
+          <p className="text-xs font-bold uppercase tracking-widest text-slate-400 px-1 mb-2">All Pages</p>
 
           {NAV.map((section) => {
             const active = isSectionActive(pathname, section);
-            const expanded = mobileExpanded === section.label;
             return (
               <div
                 key={section.label}
-                className="border-b border-slate-200 pb-1 mb-1 last:border-0"
+                className="border-b border-slate-200 pb-2 mb-2 last:border-0"
               >
-                <button
-                  onClick={() => setMobileExpanded(expanded ? null : section.label)}
-                  className={`w-full flex items-center justify-between px-3 py-3 rounded-xl text-sm font-bold transition-colors ${active ? 'text-brand-red-700 bg-brand-red-50' : 'text-slate-700 hover:bg-slate-100 hover:text-slate-900'}`}
+                <Link
+                  href={section.href}
+                  onClick={() => setMobileOpen(false)}
+                  className={`block px-3 py-2 rounded-xl text-sm font-bold transition-colors ${active ? 'text-brand-red-700 bg-brand-red-50' : 'text-slate-800 hover:bg-slate-100'}`}
                 >
                   {section.label}
-                  <ChevronDown
-                    className={`w-4 h-4 text-slate-400 transition-transform ${expanded ? 'rotate-180' : ''}`}
-                  />
-                </button>
-                {expanded && (
-                  <div className="ml-3 mt-1 mb-2 space-y-0.5">
-                    {section.items.map((item) => (
-                      <Link
-                        key={item.href}
-                        href={item.href}
-                        onClick={() => setMobileOpen(false)}
-                        className={`block px-3 py-2 rounded-xl text-sm transition-colors ${isActive(pathname, item.href) ? 'bg-brand-red-50 text-brand-red-700 font-semibold' : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'}`}
-                      >
-                        {item.label}
-                      </Link>
-                    ))}
-                  </div>
-                )}
+                </Link>
+                <div className="ml-2 mt-1 space-y-0.5">
+                  {section.items.map((item) => (
+                    <Link
+                      key={item.href}
+                      href={item.href}
+                      onClick={() => setMobileOpen(false)}
+                      className={`block px-3 py-2 rounded-xl text-sm transition-colors ${isActive(pathname, item.href) ? 'bg-brand-red-50 text-brand-red-700 font-semibold' : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'}`}
+                    >
+                      {item.label}
+                    </Link>
+                  ))}
+                </div>
               </div>
             );
           })}

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -4,7 +4,6 @@
 import Link from "next/link";
 import Image from "next/image";
 import SitePreviewPanelWrapper from './SitePreviewPanelWrapper';
-import { AdminGreeting } from "@/components/admin/AdminGreeting";
 import {
   ArrowRight, AlertTriangle,
   Activity, TrendingUp, Inbox, Users, FileText,
@@ -441,7 +440,6 @@ function RecentActivity({ items }: { items: { id: string; title: string; timesta
 }
 
 export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
-  const firstName = data.profile?.full_name?.split(' ')[0] ?? 'Admin';
   const today = new Date().toLocaleDateString('en-US', {
     weekday: 'long',
     month: 'long',
@@ -459,30 +457,16 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           priority
           sizes="100vw"
         />
-        <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white to-transparent" />
       </div>
 
       <div className="pt-2">
 
         {/* Header */}
         <div className="mb-6">
-          <p className="text-sm text-slate-500 mb-0.5" suppressHydrationWarning>
-            <AdminGreeting name={firstName} /> · {today}
-          </p>
           <h1 className="text-2xl sm:text-3xl font-black text-slate-900">Admin Dashboard</h1>
-          <p className="text-slate-500 text-sm mt-1">Monitor operations, learner progress, compliance, and revenue.</p>
-        </div>
-        {/* Quick-action strip — mobile only. Desktop has the full nav bar. */}
-        <div className="md:hidden flex gap-2 overflow-x-auto pb-2 mb-6 -mx-4 px-4 scrollbar-none">
-          <Link href="/admin/applications?status=submitted,pending,in_review,pending_admin_review" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-slate-900 text-white text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-800 transition-colors">Review Applications</Link>
-          <Link href="/admin/compliance" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Compliance</Link>
-          <Link href="/admin/documents/templates" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Document Templates</Link>
-          <Link href="/admin/studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Course Templates</Link>
-          <Link href="/admin/crm/leads" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">CRM Queue</Link>
-          <Link href="/admin/students" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Students</Link>
-          <Link href="/admin/enrollments" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Enrollments</Link>
-          <Link href="/admin/reports" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Reports</Link>
-          <Link href="/admin/dev-studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Dev Studio</Link>
+          <p className="text-slate-500 text-sm mt-1" suppressHydrationWarning>
+            {today} · Monitor operations, learner progress, compliance, and revenue.
+          </p>
         </div>
 
         <DegradedBanner sections={data.degradedSections ?? []} />

--- a/components/portal/ApprenticeClockInStatus.tsx
+++ b/components/portal/ApprenticeClockInStatus.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Clock, Loader2, MapPin } from 'lucide-react';
+
+type TimeclockContext = {
+  programName?: string;
+  activeShift?: {
+    clockInAt: string;
+    lunchStartAt: string | null;
+    lunchEndAt: string | null;
+  } | null;
+  allowedSites?: { id: string; name: string }[];
+};
+
+export function ApprenticeClockInStatus() {
+  const [ctx, setCtx] = useState<TimeclockContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/timeclock/context');
+        const data = await res.json();
+        if (!res.ok) {
+          if (!cancelled) {
+            setError(data.error || 'Timeclock unavailable');
+          }
+          return;
+        }
+        if (!cancelled) setCtx(data);
+      } catch {
+        if (!cancelled) setError('Could not load timeclock status');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-slate-500 py-2">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Checking shift status…
+      </div>
+    );
+  }
+
+  if (error || !ctx) {
+    return (
+      <p className="text-sm text-slate-600">
+        <Link href="/apprentice/timeclock" className="text-brand-blue-600 font-medium hover:underline">
+          Open timeclock
+        </Link>{' '}
+        to clock in at your work site.
+      </p>
+    );
+  }
+
+  const active = ctx.activeShift;
+  const siteName = ctx.allowedSites?.[0]?.name;
+
+  if (active?.clockInAt) {
+    const onLunch = active.lunchStartAt && !active.lunchEndAt;
+    return (
+      <div className="rounded-lg border border-brand-green-200 bg-brand-green-50 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <span className="mt-1 w-2.5 h-2.5 rounded-full bg-brand-green-500 animate-pulse shrink-0" />
+          <div>
+            <p className="text-sm font-semibold text-brand-green-800">
+              {onLunch ? 'On lunch break' : 'Currently clocked in'}
+            </p>
+            <p className="text-xs text-brand-green-700 mt-0.5">
+              Since {new Date(active.clockInAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              {siteName ? ` · ${siteName}` : ''}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/apprentice/timeclock"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-brand-green-800 hover:underline"
+        >
+          <Clock className="w-4 h-4" />
+          Manage shift
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-start gap-2 text-sm text-slate-700">
+        <MapPin className="w-4 h-4 mt-0.5 text-slate-500 shrink-0" />
+        <span>
+          Not clocked in
+          {siteName ? ` · ${siteName}` : ''}. Use GPS at your shop to start a shift.
+        </span>
+      </div>
+      <Link
+        href="/apprentice/timeclock"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-brand-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-green-700"
+      >
+        <Clock className="w-4 h-4" />
+        Clock in
+      </Link>
+    </div>
+  );
+}

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -25,6 +25,7 @@ import {
   apprenticeshipLmsCoursePath,
   apprenticeshipOrientationPath,
 } from '@/lib/portal/program-portal-paths';
+import { ApprenticeClockInStatus } from '@/components/portal/ApprenticeClockInStatus';
 
 export interface ApprenticePortalConfig {
   programSlug: string;
@@ -492,6 +493,11 @@ export function ApprenticePortalShell({
               </div>
             )}
           </div>
+        </div>
+
+        {/* Live shift status */}
+        <div className="mb-5">
+          <ApprenticeClockInStatus />
         </div>
 
         {/* Quick actions + onboarding */}

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -21,6 +21,7 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
         videoSrcMobile={banner.videoSrcMobile}
         eagerVideoLoad
         compactBelowHero
+        analyticsName={banner.analyticsName}
         voiceoverSrc={banner.voiceoverSrc}
         microLabel={banner.microLabel}
         belowHeroHeadline={banner.belowHeroHeadline}

--- a/lib/admin/degraded-dashboard-data.ts
+++ b/lib/admin/degraded-dashboard-data.ts
@@ -35,6 +35,7 @@ export function getDegradedAdminDashboardData(): AdminDashboardData {
     recentActivity: [],
     recentStudents: [],
     recentApplications: [],
+    pendingApplications: [],
     blockedPrograms: [],
     inactiveLearners: [],
     pendingSubmissions: [],

--- a/lib/admin/get-admin-dashboard-data.ts
+++ b/lib/admin/get-admin-dashboard-data.ts
@@ -1065,7 +1065,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
 
   return {
     counts: {
-      pendingApplications: pendingApps,
+      pendingApplications: totalPendingCount,
       activeEnrollments:     activeEnrollCount,
       revenueThisMonthCents: revenueThisMonthCents,
       certificatesIssued:    certsCount,
@@ -1084,6 +1084,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     recentActivity: recentActivityItems,
     recentStudents,
     recentApplications,
+    pendingApplications: pendingApps,
     blockedPrograms,
     inactiveLearners,
     pendingSubmissions,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -980,6 +980,8 @@ const nextConfig = {
       // Canonical forgot-pw (request form): /reset-password
       // Canonical set-new-password: /auth/reset-password
       { source: '/auth/signin', destination: '/login', permanent: true },
+      { source: '/sign-in', destination: '/login', permanent: true },
+      { source: '/signin', destination: '/login', permanent: true },
       { source: '/auth/signup', destination: '/signup', permanent: true },
       { source: '/register', destination: '/signup', permanent: true },
       { source: '/auth/forgot-password', destination: '/reset-password', permanent: true },


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Production status (no revert)

**Current live deploy:** PR #289 (both LMS + Admin Northflank workflows **success** as of 2026-06-05). I did **not** trigger any rollback or rebuild of older images.

| Service | Last green deploy | Notes |
|---------|-------------------|--------|
| LMS | #289 `27009646581` | Smoke + SHA verify passed |
| Admin | #289 `27009646603` | Build + smoke passed |

Earlier failures (#284–#288) were ENOSPC / SHA-metadata issues — superseded by #289.

## Fixes in this PR

### Admin dashboard (`ERR_DASHBOARD_LOAD`)
- **Root cause:** `dashboard/error.tsx` used `<Link>` without importing it — any dashboard error showed generic `ERR_DASHBOARD_LOAD` instead of recovery UI
- **Data bug:** `counts.pendingApplications` was set to an array instead of `totalPendingCount`; added missing `pendingApplications` list field

### Admin UX
- Mobile hamburger shows **all subpages** expanded (no accordion tap required)
- Removed duplicate mobile quick-action strip + duplicate greeting under nav
- Single sign-out CTA on unauthorized page; instructor sign-in points to `/login?redirect=/admin/instructor/dashboard`

### Apprentice clock-in
- New `ApprenticeClockInStatus` on industry portal dashboards (`/portal/barber`, etc.) — live shift status + clock-in link
- Full timeclock remains at `/apprentice/timeclock` (GPS + geofence + lunch)

### Routes
- `/sign-in` and `/signin` → `/login` (fixes smoke test; live after LMS deploy)

## Deploy note

Merging to `main` will **forward-deploy** only (admin + LMS workflows). It will **not** revert production. Expect ~15–25 min Northflank builds.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ERR_DASHBOARD_LOAD, add apprentice clock-in status, and polish admin nav
> - Fixes the dashboard load error by adding the missing `pendingApplications` field to both the live and degraded dashboard data in [get-admin-dashboard-data.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-4ddbac60a95ba611906cf7cd3f035c9ec9ef60a0733024d11ccffba8e89464df) and [degraded-dashboard-data.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-49082a884dedfc12380fe4eb1504a992c3904236d70085d4e6b967551498ad8c)
> - Adds a live clock-in status card to the apprentice portal in [ApprenticeClockInStatus.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-80ff82986681ad89b8bdd45a534d073b8ad605b524088df2048133308c4c98df), fetching shift state from `/api/timeclock/context` and showing current shift details or a prompt to clock in
> - Refactors [AdminNav.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-b43b9613ca6d723d039b2406f531fbe8f0555de181e8bc93f4d0d6b71658293e) mobile behavior: section headers are now direct links instead of expand/collapse toggles, items are always visible, and the label changes from 'All Sections' to 'All Pages'
> - Removes the personalized greeting and mobile quick-action strip from [DashboardShell.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-92df382a44bacb0fbe7c2d88a100ba8c11fdf3ae91cd3eb1f6d705aa953b4d92); the subheader now shows the current date
> - Adds permanent redirects from `/sign-in` and `/signin` to `/login` in [next.config.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/290/files#diff-18c049b08c4a0f5ab451c598aeb2c4848bb9d7877b51ca3e5effb94a225814d2), and updates the instructor portal sign-in link to use an internal route with redirect
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8ddeee4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->