### PR TITLE
fix(barber): Prestige Elevation portal + student app download

### DIFF
--- a/app/enroll/confirmation/page.tsx
+++ b/app/enroll/confirmation/page.tsx
@@ -206,7 +206,7 @@ function EnrollConfirmationContent() {
                 <Lock className="w-5 h-5 text-slate-500" />
               </div>
               <div>
-                <p className="font-medium text-slate-700">Training Materials (Milady)</p>
+                <p className="font-medium text-slate-700">Prestige Elevation Barber Curriculum</p>
                 <p className="text-sm text-slate-500">Unlocks after approval + agreement</p>
               </div>
             </div>

--- a/app/workbooks/page.tsx
+++ b/app/workbooks/page.tsx
@@ -14,10 +14,11 @@ export const metadata: Metadata = {
 
 const workbooks = [
   {
-    program: 'Barbering/Cosmetology',
-    slug: 'barbering',
+    program: 'Prestige Elevation Barber Curriculum',
+    slug: 'barber-apprenticeship',
+    anchorId: 'prestige-elevation-barber',
     materials: [
-      { title: 'Theory Workbook', file: 'barbering-theory.pdf', pages: 120 },
+      { title: 'Prestige Elevation Workbook', file: 'barbering-theory.pdf', pages: 120 },
       { title: 'Practice Guide', file: 'barbering-practice.pdf', pages: 80 },
       { title: 'State Board Prep', file: 'barbering-exam-prep.pdf', pages: 60 },
       { title: 'Safety Procedures', file: 'barbering-safety.pdf', pages: 40 },
@@ -130,7 +131,11 @@ export default function WorkbooksPage() {
         {/* Workbooks by Program */}
         <div className="space-y-8">
           {workbooks.map((program: any) => (
-            <div key={program.slug} className="bg-white rounded-xl shadow-sm p-8">
+            <div
+              key={program.slug}
+              id={program.anchorId ?? program.slug}
+              className="bg-white rounded-xl shadow-sm p-8 scroll-mt-24"
+            >
               <div className="flex items-center gap-3 mb-6">
                 <GraduationCap aria-label="graduationcap" className="w-8 h-8 text-brand-blue-600" />
                 <h2 className="text-2xl font-bold text-black">{program.program}</h2>

--- a/app/workbooks/page.tsx
+++ b/app/workbooks/page.tsx
@@ -1,8 +1,9 @@
 export const dynamic = 'force-dynamic';
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { BookOpen, Download, FileText, GraduationCap } from 'lucide-react';
+import { BookOpen, Download, FileText, GraduationCap, ExternalLink } from 'lucide-react';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
 
 export const metadata: Metadata = {
   title: 'Program Workbooks',
@@ -18,10 +19,25 @@ const workbooks = [
     slug: 'barber-apprenticeship',
     anchorId: 'prestige-elevation-barber',
     materials: [
-      { title: 'Prestige Elevation Workbook', file: 'barbering-theory.pdf', pages: 120 },
-      { title: 'Practice Guide', file: 'barbering-practice.pdf', pages: 80 },
-      { title: 'State Board Prep', file: 'barbering-exam-prep.pdf', pages: 60 },
-      { title: 'Safety Procedures', file: 'barbering-safety.pdf', pages: 40 },
+      {
+        title: 'Prestige Elevation Workbook',
+        description: 'Full RTI curriculum — lessons, readings, video, and practice quizzes',
+        lmsHref: `/lms/courses/${BARBER_COURSE_ID}`,
+      },
+      {
+        title: 'Practice Guide',
+        file: 'barbering-practice.pdf',
+        pages: 80,
+        lmsHref: `/lms/courses/${BARBER_COURSE_ID}?activity=practice`,
+      },
+      {
+        title: 'State Board Prep',
+        lmsHref: '/apprentice/state-board',
+      },
+      {
+        title: 'Safety Procedures',
+        lmsHref: `/lms/courses/${BARBER_COURSE_ID}?activity=reading`,
+      },
     ],
   },
   {
@@ -142,25 +158,47 @@ export default function WorkbooksPage() {
               </div>
 
               <div className="grid md:grid-cols-2 gap-4">
-                {program.materials.map((material) => (
+                {program.materials.map((material: {
+                  title: string;
+                  file?: string;
+                  pages?: number;
+                  description?: string;
+                  lmsHref?: string;
+                }) => (
                   <div
-                    key={material.file}
+                    key={material.title}
                     className="border border-slate-200 rounded-lg p-4 hover:border-brand-blue-300 hover:shadow-md transition"
                   >
                     <div className="flex items-start justify-between gap-4">
                       <div className="flex-1">
                         <h3 className="font-bold text-black mb-1">{material.title}</h3>
-                        <p className="text-sm text-black">{material.pages} pages • PDF Format</p>
+                        <p className="text-sm text-black">
+                          {material.description ??
+                            (material.pages
+                              ? `${material.pages} pages • PDF Format`
+                              : 'Available in Elevate LMS')}
+                        </p>
                       </div>
-                      <a
-                        href={`/downloads/workbooks/${material.file}`}
-                        className="flex items-center gap-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700 transition text-sm font-medium whitespace-nowrap"
-                        download
-                        aria-label={`Download ${material.title}`}
-                      >
-                        <Download className="w-4 h-4" />
-                        Download
-                      </a>
+                      {material.lmsHref ? (
+                        <Link
+                          href={material.lmsHref}
+                          className="flex items-center gap-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700 transition text-sm font-medium whitespace-nowrap"
+                          aria-label={`Open ${material.title}`}
+                        >
+                          <ExternalLink className="w-4 h-4" />
+                          Open
+                        </Link>
+                      ) : material.file ? (
+                        <a
+                          href={`/downloads/workbooks/${material.file}`}
+                          className="flex items-center gap-2 px-4 py-2 bg-brand-blue-600 text-white rounded-lg hover:bg-brand-blue-700 transition text-sm font-medium whitespace-nowrap"
+                          download
+                          aria-label={`Download ${material.title}`}
+                        >
+                          <Download className="w-4 h-4" />
+                          Download
+                        </a>
+                      ) : null}
                     </div>
                   </div>
                 ))}

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -22,6 +22,11 @@ import {
 } from 'lucide-react';
 import { PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL } from '@/lib/barber/branding';
 import {
+  BARBER_STUDENT_APP_HOME,
+  BARBER_STUDENT_APP_SHORT_LABEL,
+} from '@/lib/barber/student-app';
+import { BarberStudentAppDownload } from '@/components/portal/BarberStudentAppDownload';
+import {
   apprenticeshipDocumentsPath,
   apprenticeshipLmsCoursePath,
   apprenticeshipOrientationPath,
@@ -223,6 +228,7 @@ export function ApprenticePortalShell({
   const rtiCourseLabelShort =
     apprenticeshipRtiLabel(config.programSlug, true) ?? 'Online Course';
   const workbookHref = apprenticeshipWorkbookHref(config.programSlug);
+  const isBarberApprentice = config.programSlug === 'barber-apprenticeship';
 
   const onboardingItems = [
     {
@@ -253,6 +259,9 @@ export function ApprenticePortalShell({
     { id: 'documents', label: 'Documents', href: documentsHref },
     { id: 'billing', label: 'Billing', href: '/apprentice/billing' },
     { id: 'handbook', label: 'Handbook', href: '/apprentice/handbook' },
+    ...(isBarberApprentice
+      ? [{ id: 'mobile-app', label: BARBER_STUDENT_APP_SHORT_LABEL, href: BARBER_STUDENT_APP_HOME }]
+      : []),
   ];
 
   return (
@@ -454,6 +463,8 @@ export function ApprenticePortalShell({
           </div>
         )}
 
+        {isBarberApprentice && <BarberStudentAppDownload variant="card" />}
+
         {/* Stats */}
         <div className="grid grid-cols-2 sm:grid-cols-4 gap-3">
           {[
@@ -573,6 +584,9 @@ export function ApprenticePortalShell({
                   <p className="text-xs text-slate-500">Payments & invoices</p>
                 </div>
               </Link>
+              {isBarberApprentice && (
+                <BarberStudentAppDownload variant="compact" accentText={config.accentText} />
+              )}
             </div>
           </div>
 

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -555,7 +555,7 @@ export function ApprenticePortalShell({
                   <FileText className={`w-5 h-5 ${config.accentText}`} />
                   <div>
                     <p className="font-semibold text-sm text-slate-900">{PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL}</p>
-                    <p className="text-xs text-slate-500">Download study materials</p>
+                    <p className="text-xs text-slate-500">Reading &amp; study materials</p>
                   </div>
                 </Link>
               )}
@@ -583,21 +583,30 @@ export function ApprenticePortalShell({
               {onboardingComplete && <span className="text-brand-green-600 ml-1">✓ Complete</span>}
             </h2>
             <ul className="space-y-2.5">
-              {onboardingItems.map((item) =>
-                item.done ? (
-                  <li key={item.label} className="flex items-center gap-2.5 text-sm text-slate-400">
-                    <span className="w-4 h-4 rounded-full bg-brand-green-500 inline-block flex-shrink-0" aria-hidden="true" />
-                    <span className="line-through">{item.label}</span>
-                  </li>
-                ) : (
-                  <li key={item.label}>
-                    <Link href={item.href} className="flex items-center gap-2.5 text-sm text-slate-800 hover:text-slate-900 group">
+              {onboardingItems.map((item) => (
+                <li key={item.label}>
+                  <Link
+                    href={item.href}
+                    className={`flex items-center gap-2.5 text-sm group ${
+                      item.done
+                        ? 'text-slate-500 hover:text-slate-700'
+                        : 'text-slate-800 hover:text-slate-900'
+                    }`}
+                  >
+                    {item.done ? (
+                      <span
+                        className="w-4 h-4 rounded-full bg-brand-green-500 inline-block flex-shrink-0"
+                        aria-hidden="true"
+                      />
+                    ) : (
                       <XCircle className="w-4 h-4 text-red-400 shrink-0" />
-                      <span className="group-hover:underline">{item.label}</span>
-                    </Link>
-                  </li>
-                ),
-              )}
+                    )}
+                    <span className={item.done ? 'line-through group-hover:no-underline' : 'group-hover:underline'}>
+                      {item.label}
+                    </span>
+                  </Link>
+                </li>
+              ))}
             </ul>
           </div>
         </div>
@@ -616,7 +625,7 @@ export function ApprenticePortalShell({
             >
               <BookOpen className={`w-5 h-5 ${config.accentText} mb-2`} />
               <p className="font-semibold text-sm text-slate-900">{rtiCourseLabelShort}</p>
-              <p className="text-xs text-slate-500 mt-0.5">Online RTI &amp; theory on Elevate LMS</p>
+              <p className="text-xs text-slate-500 mt-0.5">RTI lessons on Elevate LMS</p>
             </Link>
           ) : (
             <Link href="/apprentice/handbook" className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition">
@@ -632,7 +641,7 @@ export function ApprenticePortalShell({
             >
               <FileText className={`w-5 h-5 ${config.accentText} mb-2`} />
               <p className="font-semibold text-sm text-slate-900">{PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL}</p>
-              <p className="text-xs text-slate-500 mt-0.5">Printable study guides &amp; practice</p>
+              <p className="text-xs text-slate-500 mt-0.5">Open workbook in LMS</p>
             </Link>
           )}
           <Link href="/apprentice/transfer-hours" className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition">

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -20,10 +20,13 @@ import {
   Hammer,
   Droplets,
 } from 'lucide-react';
+import { PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL } from '@/lib/barber/branding';
 import {
   apprenticeshipDocumentsPath,
   apprenticeshipLmsCoursePath,
   apprenticeshipOrientationPath,
+  apprenticeshipRtiLabel,
+  apprenticeshipWorkbookHref,
 } from '@/lib/portal/program-portal-paths';
 
 export interface ApprenticePortalConfig {
@@ -215,6 +218,11 @@ export function ApprenticePortalShell({
   const orientationHref = apprenticeshipOrientationPath(config.programSlug);
   const documentsHref = apprenticeshipDocumentsPath(config.programSlug);
   const lmsCourseHref = apprenticeshipLmsCoursePath(config.programSlug);
+  const rtiCourseLabel =
+    apprenticeshipRtiLabel(config.programSlug) ?? 'Online Course';
+  const rtiCourseLabelShort =
+    apprenticeshipRtiLabel(config.programSlug, true) ?? 'Online Course';
+  const workbookHref = apprenticeshipWorkbookHref(config.programSlug);
 
   const onboardingItems = [
     {
@@ -237,7 +245,7 @@ export function ApprenticePortalShell({
   const navTabs = [
     { id: 'dashboard', label: 'Dashboard', href: config.portalPath },
     ...(lmsCourseHref
-      ? [{ id: 'course', label: 'Online Course', href: lmsCourseHref }]
+      ? [{ id: 'course', label: rtiCourseLabelShort, href: lmsCourseHref }]
       : []),
     { id: 'hours', label: 'Hours', href: '/apprentice/hours' },
     { id: 'timeclock', label: 'Timeclock', href: '/apprentice/timeclock' },
@@ -513,8 +521,8 @@ export function ApprenticePortalShell({
                 >
                   <BookOpen className={`w-5 h-5 ${config.accentText}`} />
                   <div>
-                    <p className="font-semibold text-sm text-slate-900">Milady Online Course</p>
-                    <p className="text-xs text-slate-500">RTI lessons &amp; practice</p>
+                    <p className="font-semibold text-sm text-slate-900">{rtiCourseLabel}</p>
+                    <p className="text-xs text-slate-500">Log in to RTI lessons &amp; practice</p>
                   </div>
                 </Link>
               )}
@@ -539,6 +547,18 @@ export function ApprenticePortalShell({
                   <p className="text-xs text-slate-500">Submit required files</p>
                 </div>
               </Link>
+              {workbookHref && (
+                <Link
+                  href={workbookHref}
+                  className="flex items-center gap-3 p-3 rounded-lg bg-slate-100 hover:bg-slate-200 transition"
+                >
+                  <FileText className={`w-5 h-5 ${config.accentText}`} />
+                  <div>
+                    <p className="font-semibold text-sm text-slate-900">{PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL}</p>
+                    <p className="text-xs text-slate-500">Download study materials</p>
+                  </div>
+                </Link>
+              )}
               <Link href="/apprentice/state-board" className="flex items-center gap-3 p-3 rounded-lg bg-slate-100 hover:bg-slate-200 transition">
                 <GraduationCap aria-label="graduationcap" className={`w-5 h-5 ${config.accentText}`} />
                 <div>
@@ -583,7 +603,7 @@ export function ApprenticePortalShell({
         </div>
 
         {/* Resources */}
-        <div className="grid sm:grid-cols-3 gap-3">
+        <div className={`grid gap-3 ${workbookHref ? 'sm:grid-cols-2 lg:grid-cols-4' : 'sm:grid-cols-3'}`}>
           <Link href="/apprentice/skills" className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition">
             <Award aria-label="award" className={`w-5 h-5 ${config.accentText} mb-2`} />
             <p className="font-semibold text-sm text-slate-900">Skills Checklist</p>
@@ -595,14 +615,24 @@ export function ApprenticePortalShell({
               className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition"
             >
               <BookOpen className={`w-5 h-5 ${config.accentText} mb-2`} />
-              <p className="font-semibold text-sm text-slate-900">Milady Course</p>
-              <p className="text-xs text-slate-500 mt-0.5">Online RTI &amp; theory</p>
+              <p className="font-semibold text-sm text-slate-900">{rtiCourseLabelShort}</p>
+              <p className="text-xs text-slate-500 mt-0.5">Online RTI &amp; theory on Elevate LMS</p>
             </Link>
           ) : (
             <Link href="/apprentice/handbook" className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition">
               <BookOpen className={`w-5 h-5 ${config.accentText} mb-2`} />
               <p className="font-semibold text-sm text-slate-900">Handbook</p>
               <p className="text-xs text-slate-500 mt-0.5">Rules & guidelines</p>
+            </Link>
+          )}
+          {workbookHref && (
+            <Link
+              href={workbookHref}
+              className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition"
+            >
+              <FileText className={`w-5 h-5 ${config.accentText} mb-2`} />
+              <p className="font-semibold text-sm text-slate-900">{PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL}</p>
+              <p className="text-xs text-slate-500 mt-0.5">Printable study guides &amp; practice</p>
             </Link>
           )}
           <Link href="/apprentice/transfer-hours" className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition">

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -540,7 +540,7 @@ export function ApprenticePortalShell({
                   <p className="text-xs text-slate-500">Record a competency</p>
                 </div>
               </Link>
-              <Link href="/apprentice/documents" className="flex items-center gap-3 p-3 rounded-lg bg-slate-100 hover:bg-slate-200 transition">
+              <Link href={documentsHref} className="flex items-center gap-3 p-3 rounded-lg bg-slate-100 hover:bg-slate-200 transition">
                 <FileText className={`w-5 h-5 ${config.accentText}`} />
                 <div>
                   <p className="font-semibold text-sm text-slate-900">Upload Document</p>

--- a/components/portal/ApprenticeSubNav.tsx
+++ b/components/portal/ApprenticeSubNav.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import Link from 'next/link';
+import { usePathname } from 'next/navigation';
+import {
+  APPRENTICE_PORTAL_CONFIGS,
+  type ApprenticePortalConfig,
+} from '@/components/portal/ApprenticePortalShell';
+import {
+  apprenticeshipDocumentsPath,
+  apprenticeshipLmsCoursePath,
+  apprenticeshipRtiLabel,
+} from '@/lib/portal/program-portal-paths';
+import {
+  BARBER_STUDENT_APP_HOME,
+  BARBER_STUDENT_APP_SHORT_LABEL,
+} from '@/lib/barber/student-app';
+
+function isActive(pathname: string, href: string, tabId: string): boolean {
+  if (tabId === 'dashboard') {
+    return pathname === href || pathname === '/apprentice';
+  }
+  if (tabId === 'course') {
+    return pathname.startsWith('/lms/courses/');
+  }
+  if (tabId === 'documents') {
+    return pathname.includes('/documents');
+  }
+  if (tabId === 'mobile-app') {
+    return pathname.startsWith('/pwa/barber');
+  }
+  return pathname === href || pathname.startsWith(`${href}/`);
+}
+
+export function ApprenticeSubNav({
+  programSlug,
+  config,
+}: {
+  programSlug: string;
+  config: ApprenticePortalConfig;
+}) {
+  const pathname = usePathname() ?? '';
+  const lmsCourseHref = apprenticeshipLmsCoursePath(programSlug);
+  const documentsHref = apprenticeshipDocumentsPath(programSlug);
+  const rtiCourseLabelShort =
+    apprenticeshipRtiLabel(programSlug, true) ?? 'Online Course';
+
+  const tabs = [
+    { id: 'dashboard', label: 'Dashboard', href: config.portalPath },
+    ...(lmsCourseHref
+      ? [{ id: 'course', label: rtiCourseLabelShort, href: lmsCourseHref }]
+      : []),
+    { id: 'hours', label: 'Hours', href: '/apprentice/hours' },
+    { id: 'timeclock', label: 'Timeclock', href: '/apprentice/timeclock' },
+    { id: 'competencies', label: 'Competencies', href: '/apprentice/competencies' },
+    { id: 'documents', label: 'Documents', href: documentsHref },
+    { id: 'billing', label: 'Billing', href: '/apprentice/billing' },
+    { id: 'handbook', label: 'Handbook', href: '/apprentice/handbook' },
+    ...(programSlug === 'barber-apprenticeship'
+      ? [{ id: 'mobile-app', label: BARBER_STUDENT_APP_SHORT_LABEL, href: BARBER_STUDENT_APP_HOME }]
+      : []),
+  ];
+
+  return (
+    <nav className="bg-white border-b border-slate-200 sticky top-0 z-30">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="flex overflow-x-auto gap-0" style={{ scrollbarWidth: 'none' }}>
+          {tabs.map((tab) => {
+            const active = isActive(pathname, tab.href, tab.id);
+            return (
+              <Link
+                key={tab.id}
+                href={tab.href}
+                className={`flex-shrink-0 px-4 py-3 text-sm font-medium border-b-2 transition-colors whitespace-nowrap ${
+                  active
+                    ? 'border-slate-900 text-slate-900'
+                    : 'border-transparent text-slate-500 hover:text-slate-700 hover:border-slate-300'
+                }`}
+              >
+                {tab.label}
+              </Link>
+            );
+          })}
+        </div>
+      </div>
+    </nav>
+  );
+}
+
+export function resolveApprenticeNavConfig(programSlug: string | null): {
+  programSlug: string;
+  config: ApprenticePortalConfig;
+} | null {
+  if (!programSlug) return null;
+  const config = APPRENTICE_PORTAL_CONFIGS[programSlug];
+  if (!config) return null;
+  return { programSlug, config };
+}

--- a/components/portal/BarberStudentAppDownload.tsx
+++ b/components/portal/BarberStudentAppDownload.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Download, Smartphone, ExternalLink } from 'lucide-react';
+import {
+  BARBER_STUDENT_APP_HOME,
+  BARBER_STUDENT_APP_LABEL,
+} from '@/lib/barber/student-app';
+
+interface BeforeInstallPromptEvent extends Event {
+  prompt: () => Promise<void>;
+  userChoice: Promise<{ outcome: 'accepted' | 'dismissed' }>;
+}
+
+interface Props {
+  /** compact = quick-action row; card = dashboard promo block */
+  variant?: 'compact' | 'card';
+  accentText?: string;
+}
+
+export function BarberStudentAppDownload({
+  variant = 'card',
+  accentText = 'text-amber-600',
+}: Props) {
+  const [installPrompt, setInstallPrompt] = useState<BeforeInstallPromptEvent | null>(null);
+  const [installing, setInstalling] = useState(false);
+  const [isStandalone, setIsStandalone] = useState(false);
+
+  useEffect(() => {
+    const standalone = window.matchMedia('(display-mode: standalone)').matches;
+    setIsStandalone(standalone);
+
+    const onBeforeInstallPrompt = (event: Event) => {
+      event.preventDefault();
+      setInstallPrompt(event as BeforeInstallPromptEvent);
+    };
+
+    window.addEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+    return () => window.removeEventListener('beforeinstallprompt', onBeforeInstallPrompt);
+  }, []);
+
+  const handleInstall = async () => {
+    if (!installPrompt) return;
+    setInstalling(true);
+    try {
+      await installPrompt.prompt();
+      await installPrompt.userChoice;
+      setInstallPrompt(null);
+    } finally {
+      setInstalling(false);
+    }
+  };
+
+  if (isStandalone) {
+    return null;
+  }
+
+  if (variant === 'compact') {
+    return (
+      <Link
+        href={BARBER_STUDENT_APP_HOME}
+        className="flex items-center gap-3 p-3 rounded-lg bg-slate-100 hover:bg-slate-200 transition"
+      >
+        <Smartphone className={`w-5 h-5 ${accentText}`} />
+        <div>
+          <p className="font-semibold text-sm text-slate-900">{BARBER_STUDENT_APP_LABEL}</p>
+          <p className="text-xs text-slate-500">Clock in, hours &amp; training on your phone</p>
+        </div>
+      </Link>
+    );
+  }
+
+  return (
+    <section className="rounded-xl border border-brand-blue-200 bg-brand-blue-50 p-5">
+      <div className="flex flex-col sm:flex-row sm:items-center gap-4">
+        <div className="flex items-start gap-3 flex-1">
+          <div className="w-11 h-11 rounded-xl bg-brand-blue-600 flex items-center justify-center shrink-0">
+            <Smartphone className="w-6 h-6 text-white" />
+          </div>
+          <div>
+            <h2 className="font-bold text-slate-900 text-sm">Download the {BARBER_STUDENT_APP_LABEL}</h2>
+            <p className="text-xs text-slate-600 mt-1">
+              Clock in at your shop with GPS verification, log hours, and open Prestige Elevation
+              coursework from your phone. Add to your home screen — works like a native app.
+            </p>
+            <p className="text-xs text-slate-500 mt-2">
+              On iPhone: open the link in Safari, tap Share, then &quot;Add to Home Screen&quot;.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+          {installPrompt ? (
+            <button
+              type="button"
+              onClick={handleInstall}
+              disabled={installing}
+              className="inline-flex items-center justify-center gap-2 bg-brand-blue-600 text-white px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-brand-blue-700 disabled:opacity-60"
+            >
+              <Download className="w-4 h-4" />
+              {installing ? 'Installing…' : 'Install App'}
+            </button>
+          ) : null}
+          <Link
+            href={BARBER_STUDENT_APP_HOME}
+            className="inline-flex items-center justify-center gap-2 border border-brand-blue-600 bg-white text-brand-blue-700 px-5 py-2.5 rounded-lg text-sm font-semibold hover:bg-brand-blue-100/50"
+          >
+            <ExternalLink className="w-4 h-4" />
+            Open App
+          </Link>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/barber/branding.ts
+++ b/lib/barber/branding.ts
@@ -12,5 +12,6 @@ export const PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT = 'Prestige Elevation Co
 /** Printable / offline companion materials */
 export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL = 'Prestige Elevation Workbook';
 
-/** Anchor on /workbooks — barber RTI printable materials */
-export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF = '/workbooks#prestige-elevation-barber';
+/** Primary workbook entry — opens Prestige Elevation RTI reading materials in LMS */
+export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF =
+  '/lms/courses/3fb5ce19-1cde-434c-a8c6-f138d7d7aa17?activity=reading';

--- a/lib/barber/branding.ts
+++ b/lib/barber/branding.ts
@@ -7,4 +7,10 @@ export const PRESTIGE_ELEVATION_BARBER_CURRICULUM =
   'Prestige Elevation Barber Curriculum';
 
 /** Short label for nav tabs and compact UI */
-export const PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT = 'Barber Curriculum';
+export const PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT = 'Prestige Elevation Course';
+
+/** Printable / offline companion materials */
+export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL = 'Prestige Elevation Workbook';
+
+/** Anchor on /workbooks — barber RTI printable materials */
+export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF = '/workbooks#prestige-elevation-barber';

--- a/lib/barber/student-app.ts
+++ b/lib/barber/student-app.ts
@@ -1,0 +1,11 @@
+/**
+ * Barber apprentice mobile PWA — canonical routes for student portal links.
+ */
+
+export const BARBER_STUDENT_APP_HOME = '/pwa/barber';
+
+export const BARBER_STUDENT_APP_ONBOARDING = '/pwa/barber/onboarding';
+
+export const BARBER_STUDENT_APP_LABEL = 'Barber Apprentice App';
+
+export const BARBER_STUDENT_APP_SHORT_LABEL = 'Mobile App';

--- a/lib/portal/program-portal-paths.ts
+++ b/lib/portal/program-portal-paths.ts
@@ -1,3 +1,8 @@
+import {
+  PRESTIGE_ELEVATION_BARBER_CURRICULUM,
+  PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT,
+  PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF,
+} from '@/lib/barber/branding';
 import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
 
 /** Programs with a dedicated enrollment document upload flow under /programs/[slug]/documents */
@@ -16,9 +21,20 @@ const SELF_PAY_FUNDING_TYPES = new Set([
   'self_pay',
 ]);
 
-/** Canonical LMS course IDs for apprenticeship RTI (Milady / online coursework) */
+/** Canonical LMS course IDs for apprenticeship RTI (Elevate-hosted online coursework) */
 export const APPRENTICESHIP_LMS_COURSE_IDS: Record<string, string> = {
   'barber-apprenticeship': BARBER_COURSE_ID,
+};
+
+const APPRENTICESHIP_RTI_LABELS: Record<string, { full: string; short: string }> = {
+  'barber-apprenticeship': {
+    full: PRESTIGE_ELEVATION_BARBER_CURRICULUM,
+    short: PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT,
+  },
+};
+
+const APPRENTICESHIP_WORKBOOK_HREFS: Record<string, string> = {
+  'barber-apprenticeship': PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF,
 };
 
 export function apprenticeshipOrientationPath(programSlug: string): string {
@@ -35,6 +51,16 @@ export function apprenticeshipDocumentsPath(programSlug: string): string {
 export function apprenticeshipLmsCoursePath(programSlug: string): string | null {
   const courseId = APPRENTICESHIP_LMS_COURSE_IDS[programSlug];
   return courseId ? `/lms/courses/${courseId}` : null;
+}
+
+export function apprenticeshipRtiLabel(programSlug: string, short = false): string | null {
+  const labels = APPRENTICESHIP_RTI_LABELS[programSlug];
+  if (!labels) return null;
+  return short ? labels.short : labels.full;
+}
+
+export function apprenticeshipWorkbookHref(programSlug: string): string | null {
+  return APPRENTICESHIP_WORKBOOK_HREFS[programSlug] ?? null;
 }
 
 export function isWorkoneChecklistEligibleApplication(app: {

--- a/proxy.ts
+++ b/proxy.ts
@@ -123,6 +123,14 @@ const PROTECTED_ROUTES: Record<string, string[]> = {
 
   // ── Field portals — all require student role (or admin/staff oversight) ───
   '/portal/apprentice':        ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/barber':            ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/cosmetology':       ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/esthetician':       ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/nail-technician':   ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/culinary':          ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/electrical':        ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/portal/plumbing':          ['student', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/apprentice/':              ['student', 'admin', 'super_admin', 'staff', 'instructor'],
   '/portal/healthcare':        ['student', 'admin', 'super_admin', 'staff', 'instructor'],
   '/portal/technology':        ['student', 'admin', 'super_admin', 'staff', 'instructor'],
   '/portal/business':          ['student', 'admin', 'super_admin', 'staff', 'instructor'],

--- a/supabase/migrations/20260629000009_seed_barber_course_row.sql
+++ b/supabase/migrations/20260629000009_seed_barber_course_row.sql
@@ -18,9 +18,9 @@ INSERT INTO public.courses (
 )
 VALUES (
   '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17',
-  'Barber Apprenticeship',
+  'Prestige Elevation Barber Curriculum',
   'barber-apprenticeship',
-  'DOL-registered barber apprenticeship program. 2,000 OJT hours + 144 RTI hours. Indiana IPLA licensure pathway.',
+  'Prestige Elevation Barber Curriculum — 500 hours RTI + 1,500 hours OJT. Indiana DOL barber apprenticeship pathway.',
   'published',
   true,
   now(),

--- a/supabase/migrations/20260703000001_prestige_elevation_course_title.sql
+++ b/supabase/migrations/20260703000001_prestige_elevation_course_title.sql
@@ -1,0 +1,12 @@
+-- Align LMS course display name with Prestige Elevation branding (barber RTI).
+-- Safe to re-run. Apply manually in Supabase SQL Editor.
+
+UPDATE public.courses
+SET
+  title = 'Prestige Elevation Barber Curriculum',
+  description = 'Prestige Elevation Barber Curriculum — 500 hours of related technical instruction (RTI) for the Indiana DOL barber apprenticeship pathway.',
+  updated_at = now()
+WHERE id = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';
+
+-- Verify:
+-- SELECT id, title, slug, status FROM public.courses WHERE id = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';

--- a/tests/unit/barber-portal-quick-actions.test.ts
+++ b/tests/unit/barber-portal-quick-actions.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest';
+import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
+import {
+  apprenticeshipDocumentsPath,
+  apprenticeshipLmsCoursePath,
+  apprenticeshipOrientationPath,
+  apprenticeshipRtiLabel,
+  apprenticeshipWorkbookHref,
+} from '@/lib/portal/program-portal-paths';
+
+const SLUG = 'barber-apprenticeship';
+
+/** Canonical hrefs for /portal/barber Quick Actions + resources (student portal). */
+export const BARBER_PORTAL_QUICK_ACTION_HREFS = {
+  clockIn: '/apprentice/timeclock',
+  rtiCourse: `/lms/courses/${BARBER_COURSE_ID}`,
+  logHours: '/apprentice/hours/log',
+  logService: '/apprentice/competencies/log',
+  uploadDocument: '/programs/barber-apprenticeship/documents',
+  stateBoard: '/apprentice/state-board',
+  billing: '/apprentice/billing',
+  skills: '/apprentice/skills',
+  workbook: `/lms/courses/${BARBER_COURSE_ID}?activity=reading`,
+  transferHours: '/apprentice/transfer-hours',
+  orientation: '/programs/barber-apprenticeship/orientation',
+} as const;
+
+describe('barber apprentice portal quick actions', () => {
+  it('uses Prestige Elevation labels (not Milady)', () => {
+    expect(apprenticeshipRtiLabel(SLUG)).toBe('Prestige Elevation Barber Curriculum');
+    expect(apprenticeshipRtiLabel(SLUG, true)).toBe('Prestige Elevation Course');
+  });
+
+  it('resolves canonical LMS and document paths', () => {
+    expect(apprenticeshipLmsCoursePath(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.rtiCourse);
+    expect(apprenticeshipDocumentsPath(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.uploadDocument);
+    expect(apprenticeshipOrientationPath(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.orientation);
+    expect(apprenticeshipWorkbookHref(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.workbook);
+  });
+});

--- a/tests/unit/barber-portal-quick-actions.test.ts
+++ b/tests/unit/barber-portal-quick-actions.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
+import { BARBER_STUDENT_APP_HOME } from '@/lib/barber/student-app';
 import {
   apprenticeshipDocumentsPath,
   apprenticeshipLmsCoursePath,
@@ -23,6 +24,7 @@ export const BARBER_PORTAL_QUICK_ACTION_HREFS = {
   workbook: `/lms/courses/${BARBER_COURSE_ID}?activity=reading`,
   transferHours: '/apprentice/transfer-hours',
   orientation: '/programs/barber-apprenticeship/orientation',
+  mobileApp: BARBER_STUDENT_APP_HOME,
 } as const;
 
 describe('barber apprentice portal quick actions', () => {
@@ -36,5 +38,9 @@ describe('barber apprentice portal quick actions', () => {
     expect(apprenticeshipDocumentsPath(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.uploadDocument);
     expect(apprenticeshipOrientationPath(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.orientation);
     expect(apprenticeshipWorkbookHref(SLUG)).toBe(BARBER_PORTAL_QUICK_ACTION_HREFS.workbook);
+  });
+
+  it('exposes barber student mobile app download path', () => {
+    expect(BARBER_PORTAL_QUICK_ACTION_HREFS.mobileApp).toBe('/pwa/barber');
   });
 });

--- a/tests/unit/program-portal-paths.test.ts
+++ b/tests/unit/program-portal-paths.test.ts
@@ -2,8 +2,11 @@ import { describe, expect, it } from 'vitest';
 import {
   apprenticeshipLmsCoursePath,
   apprenticeshipOrientationPath,
+  apprenticeshipRtiLabel,
+  apprenticeshipWorkbookHref,
   isWorkoneChecklistEligibleApplication,
 } from '@/lib/portal/program-portal-paths';
+import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
 
 describe('program-portal-paths', () => {
   it('routes barber orientation to program page', () => {
@@ -12,9 +15,15 @@ describe('program-portal-paths', () => {
     );
   });
 
-  it('exposes barber Milady LMS course', () => {
-    expect(apprenticeshipLmsCoursePath('barber-apprenticeship')).toMatch(
-      /^\/lms\/courses\/[0-9a-f-]{36}$/,
+  it('routes barber RTI to Prestige Elevation LMS course', () => {
+    expect(apprenticeshipLmsCoursePath('barber-apprenticeship')).toBe(
+      `/lms/courses/${BARBER_COURSE_ID}`,
+    );
+    expect(apprenticeshipRtiLabel('barber-apprenticeship')).toBe(
+      'Prestige Elevation Barber Curriculum',
+    );
+    expect(apprenticeshipWorkbookHref('barber-apprenticeship')).toBe(
+      '/workbooks#prestige-elevation-barber',
     );
   });
 

--- a/tests/unit/program-portal-paths.test.ts
+++ b/tests/unit/program-portal-paths.test.ts
@@ -23,7 +23,7 @@ describe('program-portal-paths', () => {
       'Prestige Elevation Barber Curriculum',
     );
     expect(apprenticeshipWorkbookHref('barber-apprenticeship')).toBe(
-      '/workbooks#prestige-elevation-barber',
+      `/lms/courses/${BARBER_COURSE_ID}?activity=reading`,
     );
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Barber apprentice dashboard still showed **Milady** labels while RTI is delivered through the **Prestige Elevation Barber Curriculum** on Elevate LMS (`/lms/courses/3fb5ce19-1cde-434c-a8c6-f138d7d7aa17`). Students also need a clear path to install the **Barber Apprentice mobile app** (PWA at `/pwa/barber`).

## Changes

- **Apprentice portal** (`ApprenticePortalShell`): Quick actions, nav tab, and resource cards now say *Prestige Elevation Barber Curriculum* / *Prestige Elevation Course* and route to the canonical LMS course.
- **Student app download**: New `BarberStudentAppDownload` card + quick action on `/portal/barber`; **Mobile App** nav tab on portal and `/apprentice/*` sub-nav linking to `/pwa/barber` (PWA install prompt on supported browsers).
- **Workbook**: Added *Prestige Elevation Workbook* links to LMS reading tab (quick actions + resources).
- **Workbooks page**: Barber section renamed and anchored for deep links.
- **Enrollment confirmation**: Training materials label updated (no Milady).
- **Migrations** (manual apply in Supabase):
  - `20260703000001_prestige_elevation_course_title.sql` — sets LMS course title to *Prestige Elevation Barber Curriculum*.

## Verification

- `pnpm exec vitest run tests/unit/program-portal-paths.test.ts tests/unit/barber-portal-quick-actions.test.ts` — pass

## Manual step

Run `supabase/migrations/20260703000001_prestige_elevation_course_title.sql` in Supabase SQL Editor after merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Prestige Elevation Barber portal with LMS workbook links and student app download
> - Renames the barber program to 'Prestige Elevation Barber Curriculum' across the enrollment confirmation, workbooks page, and portal shell, with matching DB migrations to update course titles.
> - Updates [app/workbooks/page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/291/files#diff-91ccc1b1eaeef72e31620399ce65fc49eb0abe476057b54d0879022cee08a0d8) to link barber materials into Elevate LMS; material cards now show an 'Open' link for LMS content or a 'Download' button for files.
> - Adds a new [`BarberStudentAppDownload`](https://github.com/elevate-for-humanity/Elevate-lms/pull/291/files#diff-f6c8f49fcfd3a08f946d5ffef9fc9e9035563817e6c7a809018df8b407015fda) component that promotes the barber PWA, supports native browser install prompts, and suppresses itself in standalone mode.
> - Updates [`ApprenticePortalShell`](https://github.com/elevate-for-humanity/Elevate-lms/pull/291/files#diff-e72bcf8a34037279c934014b043521ad3f19e54219f86105a95cb57b26c3270c) to show dynamic RTI labels, a workbook quick action, and a 'Mobile App' tab with the download promo for barber apprentices.
> - Extends [`proxy.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/291/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775) to protect additional portal paths (`/portal/barber`, `/portal/cosmetology`, etc.) requiring student/admin/staff roles.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized fcca434.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->