### PR TITLE
Hero sizing, WorkOne map hubs, admin hamburger nav, credential footnotes

### DIFF
--- a/app/credentials/page.tsx
+++ b/app/credentials/page.tsx
@@ -13,6 +13,7 @@ import {
 } from 'lucide-react';
 import HeroVideo from '@/components/marketing/HeroVideo';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
 
 export const dynamic = 'force-static';
 
@@ -541,21 +542,6 @@ export default function CredentialsPage() {
         </div>
       </section>
 
-      {/* Disclosure */}
-      <section className="py-8 bg-amber-50 border-b border-amber-200">
-        <div className="max-w-4xl mx-auto px-4">
-          <p className="text-amber-800 text-sm leading-relaxed">
-            <strong>Credential Disclosure:</strong> {PLATFORM_DEFAULTS.orgName} is not an accredited
-            college or university. Certificates of completion are issued by 2Exclusive LLC-S d/b/a
-            {PLATFORM_DEFAULTS.orgName} Career & Technical Institute. Industry certifications are issued by
-            their respective certifying bodies — Elevate provides exam preparation training.
-            Registered Apprenticeship credentials require employer-validated OJT hours and are
-            governed by DOL standards. Funding eligibility (WIOA, WRG, Job Ready Indy) is determined
-            by your local WorkOne office and is not guaranteed.
-          </p>
-        </div>
-      </section>
-
       {/* CTA */}
       <section className="py-14">
         <div className="max-w-4xl mx-auto px-4 text-center">
@@ -581,6 +567,18 @@ export default function CredentialsPage() {
           </div>
         </div>
       </section>
+
+      <CredentialAuthorityFootnote
+        showComplianceLink
+        className="border-t border-slate-200"
+      />
+      <div className="px-4 pb-8">
+        <p className="text-[10px] text-slate-500 max-w-4xl mx-auto text-center leading-relaxed">
+          Funding eligibility (WIOA, WRG, Job Ready Indy, IMPACT) is determined by your local
+          WorkOne office or agency — not by {PLATFORM_DEFAULTS.orgName}. Registered Apprenticeship
+          credentials require employer-validated OJT hours and are governed by DOL standards.
+        </p>
+      </div>
     </div>
   );
 }

--- a/app/find-workone/[region]/page.tsx
+++ b/app/find-workone/[region]/page.tsx
@@ -1,0 +1,77 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { WorkOneIndianaMap } from '@/components/workone/WorkOneIndianaMap';
+import { getWorkOneRegion, WORKONE_REGIONS } from '@/data/workone/indiana-regions';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
+
+export const dynamic = 'force-static';
+
+export function generateStaticParams() {
+  return WORKONE_REGIONS.map((r) => ({ region: r.slug }));
+}
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ region: string }>;
+}): Promise<Metadata> {
+  const { region: slug } = await params;
+  const region = getWorkOneRegion(slug);
+  if (!region) return { title: 'WorkOne Region' };
+
+  return {
+    title: `${region.name} WorkOne Centers | Indiana Workforce Funding`,
+    description: `WorkOne career centers in ${region.name}. WIOA and Workforce Ready Grant intake for ${PLATFORM_DEFAULTS.orgName} ETPL-approved training.`,
+    alternates: { canonical: `https://www.elevateforhumanity.org/find-workone/${slug}` },
+  };
+}
+
+export default async function WorkOneRegionPage({
+  params,
+}: {
+  params: Promise<{ region: string }>;
+}) {
+  const { region: slug } = await params;
+  const region = getWorkOneRegion(slug);
+  if (!region) notFound();
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="bg-slate-50 border-b">
+        <div className="max-w-6xl mx-auto px-4 py-3">
+          <Breadcrumbs
+            items={[
+              { label: 'Find WorkOne', href: '/find-workone' },
+              { label: region.name },
+            ]}
+          />
+        </div>
+      </div>
+
+      <section className="py-10 px-4 border-b border-slate-100">
+        <div className="max-w-4xl mx-auto">
+          <h1 className="text-2xl sm:text-3xl font-extrabold text-slate-900 mb-3">
+            WorkOne — {region.name}
+          </h1>
+          <p className="text-slate-600 text-sm leading-relaxed">{region.description}</p>
+          <p className="text-xs text-slate-500 mt-4">
+            Counties: {region.counties.join(', ')}
+          </p>
+          <Link
+            href="/workforce-training-indianapolis"
+            className="inline-block mt-4 text-sm font-semibold text-brand-blue-700 hover:underline"
+          >
+            {PLATFORM_DEFAULTS.orgName} training programs in this region →
+          </Link>
+        </div>
+      </section>
+
+      <WorkOneIndianaMap region={region} />
+
+      <CredentialAuthorityFootnote />
+    </div>
+  );
+}

--- a/app/find-workone/page.tsx
+++ b/app/find-workone/page.tsx
@@ -1,0 +1,91 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { WorkOneIndianaMap } from '@/components/workone/WorkOneIndianaMap';
+import { WORKONE_REGIONS } from '@/data/workone/indiana-regions';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
+import { ArrowRight } from 'lucide-react';
+
+export const dynamic = 'force-static';
+
+export const metadata: Metadata = {
+  title: 'Find a WorkOne Center in Indiana | WIOA Funding Intake',
+  description:
+    'Locate your nearest WorkOne career center in Indiana. WIOA, Workforce Ready Grant, and IMPACT funding eligibility starts at WorkOne — not at your training provider.',
+  alternates: { canonical: 'https://www.elevateforhumanity.org/find-workone' },
+};
+
+export default function FindWorkOnePage() {
+  const central = WORKONE_REGIONS.find((r) => r.slug === 'central-indiana');
+
+  return (
+    <div className="min-h-screen bg-white">
+      <div className="bg-slate-50 border-b">
+        <div className="max-w-6xl mx-auto px-4 py-3">
+          <Breadcrumbs
+            items={[
+              { label: 'Funding', href: '/funding' },
+              { label: 'Find WorkOne' },
+            ]}
+          />
+        </div>
+      </div>
+
+      <section className="py-12 px-4 border-b border-slate-100">
+        <div className="max-w-4xl mx-auto">
+          <p className="text-brand-red-600 text-xs font-bold uppercase tracking-widest mb-3">
+            Indiana · WIOA · WorkOne
+          </p>
+          <h1 className="text-3xl sm:text-4xl font-extrabold text-slate-900 leading-tight mb-4">
+            Find Your WorkOne Center
+          </h1>
+          <p className="text-slate-600 text-lg leading-relaxed max-w-2xl">
+            Most no-cost training at {PLATFORM_DEFAULTS.orgName} starts with a WorkOne intake
+            appointment. Funding eligibility is determined by your local workforce agency — not by
+            the training provider.
+          </p>
+          <div className="flex flex-wrap gap-3 mt-8">
+            <Link
+              href="/apply"
+              className="inline-flex items-center gap-2 bg-brand-red-600 hover:bg-brand-red-700 text-white font-bold px-6 py-3 rounded-xl text-sm"
+            >
+              Apply for training <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              href="/funding/wioa"
+              className="inline-flex items-center gap-2 border-2 border-slate-200 text-slate-800 font-semibold px-6 py-3 rounded-xl text-sm hover:bg-slate-50"
+            >
+              How WIOA funding works
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      {central && <WorkOneIndianaMap region={central} showAllRegionsLink={false} />}
+
+      <section className="py-14 px-4 bg-slate-50 border-t border-slate-200">
+        <div className="max-w-6xl mx-auto">
+          <h2 className="text-xl font-extrabold text-slate-900 mb-6">WorkOne regions in Indiana</h2>
+          <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-4">
+            {WORKONE_REGIONS.map((region) => (
+              <Link
+                key={region.slug}
+                href={`/find-workone/${region.slug}`}
+                className="block rounded-xl border border-slate-200 bg-white p-5 hover:border-brand-red-300 hover:shadow-md transition-all"
+              >
+                <h3 className="font-bold text-slate-900 text-sm mb-2">{region.name}</h3>
+                <p className="text-xs text-slate-500 line-clamp-2">{region.counties.join(' · ')}</p>
+                <span className="inline-flex items-center gap-1 text-brand-red-600 text-xs font-semibold mt-3">
+                  Centers &amp; map <ArrowRight className="w-3.5 h-3.5" />
+                </span>
+              </Link>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <CredentialAuthorityFootnote />
+    </div>
+  );
+}

--- a/app/programs/[program]/page.tsx
+++ b/app/programs/[program]/page.tsx
@@ -18,6 +18,7 @@ import { hero as heroTokens } from '@/lib/page-design-tokens';
 import { getProgramOgImage } from '@/lib/programs/og-images';
 import { CheckCircle, Clock, Award, DollarSign, ArrowRight, ShieldCheck } from 'lucide-react';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
 
 export const dynamic = 'force-dynamic';
 
@@ -504,6 +505,8 @@ function ProgramPage({
           </p>
         </div>
       </section>
+
+      <CredentialAuthorityFootnote />
     </main>
   );
 }

--- a/components/WorkOneLocator.tsx
+++ b/components/WorkOneLocator.tsx
@@ -1,191 +1,22 @@
 import Link from 'next/link';
+import { WorkOneIndianaMap } from '@/components/workone/WorkOneIndianaMap';
+import { getWorkOneRegion } from '@/data/workone/indiana-regions';
 
-interface WorkOneLocation {
-  name: string;
-  address: string;
-  city: string;
-  zip: string;
-  phone: string;
-  hours: string;
-  mapUrl: string;
-}
-
-const workOneLocations: WorkOneLocation[] = [
-  {
-    name: 'WorkOne Indianapolis - East',
-    address: '7251 E 86th St',
-    city: 'Indianapolis',
-    zip: '46256',
-    phone: '(317) 842-8801',
-    hours: 'Mon-Fri: 8am-5pm',
-    mapUrl: 'https://www.google.com/maps/search/?api=1&query=7251+E+86th+St+Indianapolis+IN+46256',
-  },
-  {
-    name: 'WorkOne Indianapolis - Northwest',
-    address: '3901 N Shadeland Ave',
-    city: 'Indianapolis',
-    zip: '46226',
-    phone: '(317) 921-1600',
-    hours: 'Mon-Fri: 8am-5pm',
-    mapUrl:
-      'https://www.google.com/maps/search/?api=1&query=3901+N+Shadeland+Ave+Indianapolis+IN+46226',
-  },
-  {
-    name: 'WorkOne Indianapolis - Southeast',
-    address: '1915 W 18th St, Suite C',
-    city: 'Indianapolis',
-    zip: '46202',
-    phone: '(317) 684-2400',
-    hours: 'Mon-Fri: 8am-5pm',
-    mapUrl: 'https://www.google.com/maps/search/?api=1&query=1915+W+18th+St+Indianapolis+IN+46202',
-  },
-  {
-    name: 'WorkOne Indianapolis - Southwest',
-    address: '1200 Madison Ave',
-    city: 'Indianapolis',
-    zip: '46225',
-    phone: '(317) 684-2400',
-    hours: 'Mon-Fri: 8am-5pm',
-    mapUrl:
-      'https://www.google.com/maps/search/?api=1&query=1200+Madison+Ave+Indianapolis+IN+46225',
-  },
-  {
-    name: 'WorkOne Marion County',
-    address: '3901 Meadows Dr',
-    city: 'Indianapolis',
-    zip: '46205',
-    phone: '(317) 684-2400',
-    hours: 'Mon-Fri: 8am-5pm',
-    mapUrl: 'https://www.google.com/maps/search/?api=1&query=3901+Meadows+Dr+Indianapolis+IN+46205',
-  },
-];
-
+/** @deprecated Prefer WorkOneIndianaMap — kept for career-services page compatibility */
 export default function WorkOneLocator() {
+  const central = getWorkOneRegion('central-indiana');
+
   return (
-    <section className="py-16 sm:py-20">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6">
-        <div className="text-center mb-12">
-          <h2 className="text-3xl sm:text-4xl md:text-5xl font-bold text-black mb-4">
-            Find Your Nearest WorkOne Center
-          </h2>
-          <p className="text-lg sm:text-xl text-black max-w-3xl mx-auto">
-            Visit a WorkOne center to meet with a career advisor and get approved for free training
-          </p>
-        </div>
-
-        {/* Location Cards */}
-        <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6 mb-12">
-          {workOneLocations.map((location, index) => (
-            <div
-              key={index}
-              className="bg-slate-50 rounded-lg p-6 hover:shadow-xl transition-shadow border-2 border-slate-200 hover:border-brand-orange-500"
-            >
-              <div className="flex items-start gap-3 mb-4">
-                <div className="text-3xl">📍</div>
-                <div className="flex-1">
-                  <h3 className="font-bold text-lg text-black mb-2">{location.name}</h3>
-                  <div className="space-y-2 text-sm text-black">
-                    <p>
-                      {location.address}
-                      <br />
-                      {location.city}, IN {location.zip}
-                    </p>
-                    <p className="flex items-center gap-2">
-                      <span>📞</span>
-                      <a
-                        href={`tel:${location.phone.replace(/[^0-9]/g, '')}`}
-                        className="hover:text-brand-orange-600"
-                      >
-                        {location.phone}
-                      </a>
-                    </p>
-                    <p className="flex items-center gap-2">
-                      <span>🕐</span>
-                      {location.hours}
-                    </p>
-                  </div>
-                </div>
-              </div>
-
-              <div className="flex gap-2">
-                <a
-                  href={location.mapUrl}
-                  target="_blank"
-                  rel="noopener noreferrer"
-                  className="flex-1 px-4 py-2 bg-brand-orange-600 text-white font-semibold rounded-lg hover:bg-brand-orange-700 transition-all text-center text-sm"
-                >
-                  Get Directions
-                </a>
-                <a
-                  href={`tel:${location.phone.replace(/[^0-9]/g, '')}`}
-                  className="px-4 py-2 bg-slate-900 text-white font-semibold rounded-lg hover:bg-slate-800 transition-all text-center text-sm"
-                >
-                  Call
-                </a>
-              </div>
-            </div>
-          ))}
-        </div>
-
-        {/* Map Embed */}
-        <div className="bg-slate-100 rounded-lg overflow-hidden shadow-xl">
-          <div className="p-6 bg-slate-800 text-white">
-            <h3 className="text-2xl font-bold mb-2">Interactive Map</h3>
-            <p className="text-slate-600">Click on any location to get directions</p>
-          </div>
-          <div className="relative h-[400px] sm:h-[500px]">
-            <iframe
-              src="https://www.google.com/maps/d/embed?mid=1_your_map_id_here&ehbc=2E312F"
-              width="100%"
-              height="100%"
-              style={{ border: 0 }}
-              allowFullScreen
-              loading="lazy"
-              referrerPolicy="no-referrer-when-downgrade"
-              title="WorkOne Centers Map"
-            />
-          </div>
-        </div>
-
-        {/* Additional Resources */}
-        <div className="mt-12 bg-brand-blue-50 rounded-lg p-8">
-          <div className="max-w-3xl mx-auto text-center">
-            <h3 className="text-2xl font-bold text-black mb-4">Can't Visit in Person?</h3>
-            <p className="text-lg text-black mb-6">
-              Many WorkOne centers offer virtual appointments via phone or video call
-            </p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <a
-                href="https://www.indianacareerconnect.com"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="px-8 py-4 bg-brand-orange-600 text-white font-bold rounded-full hover:bg-brand-orange-700 transition-all shadow-lg"
-              >
-                Schedule Virtual Appointment
-              </a>
-              <a
-                href="tel:317-684-2400"
-                className="px-8 py-4 bg-white text-black font-bold rounded-full hover:bg-slate-50 transition-all shadow-lg border-2 border-slate-200"
-              >
-                Call (317) 684-2400
-              </a>
-            </div>
-          </div>
-        </div>
-
-        {/* Search All Locations */}
-        <div className="mt-12 text-center">
-          <p className="text-black mb-4">Looking for a WorkOne center outside Marion County?</p>
-          <a
-            href="https://www.in.gov/dwd/workone-centers/"
-            target="_blank"
-            rel="noopener noreferrer"
-            className="inline-block px-8 py-4 bg-slate-900 text-white font-bold rounded-full hover:bg-slate-800 transition-all shadow-lg"
-          >
-            View All Indiana WorkOne Centers →
-          </a>
-        </div>
+    <>
+      {central && <WorkOneIndianaMap region={central} />}
+      <div className="pb-12 text-center">
+        <Link
+          href="/find-workone"
+          className="text-sm font-semibold text-brand-blue-700 hover:underline"
+        >
+          Browse all Indiana WorkOne regions →
+        </Link>
       </div>
-    </section>
+    </>
   );
 }

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -37,7 +37,7 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
   const NAV = navSections ?? DEFAULT_NAV;
   const pathname = usePathname();
   const router = useRouter();
-  const [mobileOpen, setMobileOpen] = useState(false);
+  const [menuOpen, setMenuOpen] = useState(false);
   const [openDropdown, setOpenDropdown] = useState<string | null>(null);
   const [notifOpen, setNotifOpen] = useState(false);
   const [search, setSearch] = useState('');
@@ -60,7 +60,7 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
       if (e.key === 'Escape') {
         setOpenDropdown(null);
         setNotifOpen(false);
-        setMobileOpen(false);
+        setMenuOpen(false);
       }
     }
     document.addEventListener('keydown', handle);
@@ -74,18 +74,18 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
   }, [pathname]);
 
   useEffect(() => {
-    document.body.style.overflow = mobileOpen ? 'hidden' : '';
+    document.body.style.overflow = menuOpen ? 'hidden' : '';
     return () => {
       document.body.style.overflow = '';
     };
-  }, [mobileOpen]);
+  }, [menuOpen]);
 
   // Desktop: never leave body scroll locked after resizing from mobile menu
   useEffect(() => {
     const mq = window.matchMedia('(min-width: 768px)');
     const onChange = () => {
       if (mq.matches) {
-        setMobileOpen(false);
+        setMenuOpen(false);
         document.body.style.overflow = '';
       }
     };
@@ -119,8 +119,8 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
 
           <nav
             ref={navRef}
-            aria-label="Admin navigation"
-            className="hidden md:flex items-center gap-0 flex-1 overflow-x-auto"
+            aria-label="Admin section shortcuts"
+            className="hidden xl:flex items-center gap-0 flex-1 overflow-x-auto min-w-0"
             style={{ scrollbarWidth: 'none' }}
           >
             {NAV.map((section) => {
@@ -250,24 +250,28 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
             </div>
 
             <button
-              onClick={() => setMobileOpen((v) => !v)}
-              aria-label="Toggle menu"
-              className="md:hidden w-9 h-9 flex items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 transition-colors"
+              onClick={() => setMenuOpen((v) => !v)}
+              aria-label="Open full admin menu"
+              aria-expanded={menuOpen}
+              className="w-9 h-9 flex items-center justify-center rounded-lg text-slate-600 hover:bg-slate-100 transition-colors border border-slate-200"
             >
-              {mobileOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
+              {menuOpen ? <X className="w-5 h-5" /> : <Menu className="w-5 h-5" />}
             </button>
           </div>
         </div>
       </header>
 
-      {mobileOpen && (
+      {menuOpen && (
         <>
           <div
-            className="fixed inset-0 bg-black/60 z-40 md:hidden"
-            onClick={() => setMobileOpen(false)}
+            className="fixed inset-0 bg-black/50 z-40"
+            onClick={() => setMenuOpen(false)}
+            aria-hidden="true"
           />
           <div
-            className="fixed top-16 right-0 bottom-0 w-[85vw] max-w-sm bg-white border-l border-slate-200 z-50 md:hidden overflow-y-auto shadow-2xl"
+            className="fixed top-16 right-0 bottom-0 w-[min(92vw,28rem)] sm:w-[min(85vw,32rem)] bg-white border-l border-slate-200 z-50 overflow-y-auto shadow-2xl"
+            role="dialog"
+            aria-label="Admin navigation menu"
           >
         <div className="p-4 space-y-1">
           <form
@@ -291,7 +295,7 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
               <Link
                 key={section.href}
                 href={section.href}
-                onClick={() => setMobileOpen(false)}
+                onClick={() => setMenuOpen(false)}
                 className={`flex items-center justify-center px-3 py-2.5 rounded-xl text-sm font-semibold transition-colors text-center ${
                   isSectionActive(pathname, section)
                     ? 'bg-brand-red-50 text-brand-red-700'
@@ -327,7 +331,7 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
                       <Link
                         key={item.href}
                         href={item.href}
-                        onClick={() => setMobileOpen(false)}
+                        onClick={() => setMenuOpen(false)}
                         className={`block px-3 py-2 rounded-xl text-sm transition-colors ${isActive(pathname, item.href) ? 'bg-brand-red-50 text-brand-red-700 font-semibold' : 'text-slate-600 hover:bg-slate-100 hover:text-slate-900'}`}
                       >
                         {item.label}

--- a/components/admin/dashboard/DashboardDeferredPanels.tsx
+++ b/components/admin/dashboard/DashboardDeferredPanels.tsx
@@ -1,0 +1,34 @@
+'use client';
+
+/**
+ * Below-the-fold dashboard panels — lazy-loaded to improve initial dashboard paint.
+ */
+
+import dynamic from 'next/dynamic';
+
+const panelSkeleton = (
+  <div className="rounded-xl border border-slate-200 bg-white p-6 mb-6 animate-pulse">
+    <div className="h-4 w-40 bg-slate-200 rounded mb-4" />
+    <div className="h-24 w-full bg-slate-100 rounded" />
+  </div>
+);
+
+export const PublishWebsitePanelLazy = dynamic(
+  () => import('./PublishWebsitePanel').then((m) => m.PublishWebsitePanel),
+  { loading: () => panelSkeleton, ssr: false },
+);
+
+export const ProgramIntegrityPanelLazy = dynamic(
+  () => import('./ProgramIntegrityPanel').then((m) => m.ProgramIntegrityPanel),
+  { loading: () => panelSkeleton, ssr: false },
+);
+
+export const JobBoardPanelLazy = dynamic(
+  () => import('./JobBoardPanel').then((m) => m.JobBoardPanel),
+  { loading: () => panelSkeleton, ssr: false },
+);
+
+export const SitePreviewPanelWrapperLazy = dynamic(
+  () => import('./SitePreviewPanelWrapper'),
+  { loading: () => panelSkeleton, ssr: false },
+);

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -3,7 +3,6 @@
 
 import Link from "next/link";
 import Image from "next/image";
-import SitePreviewPanelWrapper from './SitePreviewPanelWrapper';
 import { AdminGreeting } from "@/components/admin/AdminGreeting";
 import {
   ArrowRight, AlertTriangle,
@@ -14,16 +13,19 @@ import type { AdminDashboardData, InactiveLearner, StaleLeadItem } from "./types
 import { OperationalAlerts } from "./OperationalAlerts";
 import { LearnerActionButtons } from "./LearnerActionButtons";
 import { LeadActionButtons } from "./LeadActionButtons";
-import { ProgramIntegrityPanel } from "./ProgramIntegrityPanel";
 import { SystemHealthPanel } from "./SystemHealthPanel";
 import { RealtimeKpiGrid } from "./RealtimeKpiGrid";
 import { BlockedProgramsList } from "./BlockedProgramsList";
 import { RecentApplicationsList } from "./RecentApplicationsList";
-import { JobBoardPanel } from "./JobBoardPanel";
 import { RecentPaymentsPanel } from "./RecentPaymentsPanel";
 import { StatsOverviewBar } from "./StatsOverviewBar";
 import { EnrollmentFunnel } from "./EnrollmentFunnel";
-import { PublishWebsitePanel } from "./PublishWebsitePanel";
+import {
+  JobBoardPanelLazy,
+  ProgramIntegrityPanelLazy,
+  PublishWebsitePanelLazy,
+  SitePreviewPanelWrapperLazy,
+} from "./DashboardDeferredPanels";
 
 
 function fmtUsd(cents: number) {
@@ -188,7 +190,9 @@ function AdminCategoryLanding() {
           <p className="text-xs font-bold uppercase tracking-[0.24em] text-brand-red-600">Admin OS</p>
           <h2 className="mt-1 text-xl font-black text-slate-900">Operate by category</h2>
           <p className="mt-1 text-sm text-slate-500">
-            Each card opens a dedicated admin area with its focused workflows.
+            Each card opens a dedicated admin area. Use the{' '}
+            <span className="font-semibold text-slate-700">☰ menu</span> in the header for every
+            subpage — applications, enrollments, Dev Studio, funding, compliance, and more.
           </p>
         </div>
         <Link href="/admin/settings/nav" className="hidden text-xs font-semibold text-brand-blue-600 hover:underline sm:inline">
@@ -451,14 +455,14 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
 
   return (
     <div className="pb-16">
-      <div className="relative w-full h-40 sm:h-56 overflow-hidden rounded-2xl mb-6">
+      <div className="relative w-full h-32 sm:h-40 overflow-hidden rounded-2xl mb-6">
         <Image
           src="/images/pages/admin-dashboard-hero.webp"
           alt=""
           fill
           className="object-cover"
-          priority
-          sizes="100vw"
+          sizes="(max-width: 768px) 100vw, 1200px"
+          loading="lazy"
         />
         <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white to-transparent" />
       </div>
@@ -486,11 +490,11 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <Link href="/admin/dev-studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Dev Studio</Link>
         </div>
 
-        <PublishWebsitePanel />
-
         <DegradedBanner sections={data.degradedSections ?? []} />
 
         <AdminCategoryLanding />
+
+        <PublishWebsitePanelLazy />
 
         {/* ── Stats overview bar ───────────────────────────────────────── */}
         <StatsOverviewBar data={data} />
@@ -570,13 +574,13 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
 
         {/* ── Program integrity ────────────────────────────────────────── */}
         <div className="mt-8">
-          <ProgramIntegrityPanel />
+          <ProgramIntegrityPanelLazy />
         </div>
 
         {/* ── Job board + site status + system health ──────────────────── */}
         <div className="mt-8 grid grid-cols-1 lg:grid-cols-3 gap-6">
-          <JobBoardPanel />
-          <SitePreviewPanelWrapper sites={data.sitePreviewTargets ?? []} />
+          <JobBoardPanelLazy />
+          <SitePreviewPanelWrapperLazy sites={data.sitePreviewTargets ?? []} />
           <SystemHealthPanel health={data.systemHealth} />
         </div>
 

--- a/components/compliance/CredentialAuthorityFootnote.tsx
+++ b/components/compliance/CredentialAuthorityFootnote.tsx
@@ -1,0 +1,43 @@
+import Link from 'next/link';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+type CredentialAuthorityFootnoteProps = {
+  className?: string;
+  /** Show link to full compliance disclosure */
+  showComplianceLink?: boolean;
+};
+
+/**
+ * Small-print credential authority disclaimer — always render at page bottom,
+ * never as a prominent hero or centered headline.
+ */
+export function CredentialAuthorityFootnote({
+  className = '',
+  showComplianceLink = true,
+}: CredentialAuthorityFootnoteProps) {
+  return (
+    <footer
+      className={`border-t border-slate-200 bg-slate-50 py-6 px-4 ${className}`}
+      aria-label="Credential authority disclosure"
+    >
+      <p className="text-[11px] leading-relaxed text-slate-500 max-w-4xl mx-auto text-left sm:text-center">
+        Industry certifications, state licenses, and third-party credentials (EPA, CompTIA, NHA,
+        PTCB, Indiana PLA, BMV, etc.) are issued by their respective certifying organizations upon
+        passing the required examination or meeting state requirements — not by{' '}
+        {PLATFORM_DEFAULTS.orgName}. {PLATFORM_DEFAULTS.orgName} provides training and exam
+        preparation; the credentialing authority determines pass/fail and issues the credential.{' '}
+        {PLATFORM_DEFAULTS.orgName} may issue a program completion certificate documenting
+        successful completion of its training curriculum.
+        {showComplianceLink && (
+          <>
+            {' '}
+            <Link href="/compliance" className="text-slate-600 underline hover:text-brand-blue-700">
+              Full credential disclosure
+            </Link>
+            .
+          </>
+        )}
+      </p>
+    </footer>
+  );
+}

--- a/components/dev-studio/DeployPanel.tsx
+++ b/components/dev-studio/DeployPanel.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useMemo, useState } from 'react';
 import { Activity, AlertTriangle, CheckCircle2, ExternalLink, Loader2, Play, RefreshCw, Rocket, XCircle } from 'lucide-react';
+import PublishWebsiteDevPanel from '@/components/dev-studio/PublishWebsiteDevPanel';
 
 type WorkflowKey = 'deploy-lms' | 'deploy-admin' | 'ci' | 'lint' | string;
 
@@ -217,6 +218,8 @@ export default function DeployPanel({ workflowButtons }: { workflowButtons?: Wor
             );
           })}
         </div>
+
+        <PublishWebsiteDevPanel />
 
         {(lastResult || run) && (
           <section className="mt-4 rounded-md border" style={{ borderColor: '#3c3c3c', background: '#252526' }}>

--- a/components/dev-studio/PublishWebsiteDevPanel.tsx
+++ b/components/dev-studio/PublishWebsiteDevPanel.tsx
@@ -1,0 +1,100 @@
+'use client';
+
+import { useCallback, useState } from 'react';
+import { Globe, Loader2, Rocket, CheckCircle2, AlertCircle } from 'lucide-react';
+
+type PublishResult = {
+  ok: boolean;
+  revalidate?: { ok: boolean; error?: string };
+  deploy?: Array<{ service: string; status: string; detail?: string }>;
+  error?: string;
+};
+
+export default function PublishWebsiteDevPanel() {
+  const [confirm, setConfirm] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [result, setResult] = useState<PublishResult | null>(null);
+  const [error, setError] = useState('');
+
+  const publish = useCallback(async () => {
+    if (!confirm) {
+      setConfirm(true);
+      return;
+    }
+    setConfirm(false);
+    setLoading(true);
+    setError('');
+    setResult(null);
+    try {
+      const res = await fetch('/api/admin/publish-website', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ confirm: 'PUBLISH' }),
+      });
+      const json = await res.json();
+      if (!res.ok) throw new Error(json.error ?? `HTTP ${res.status}`);
+      setResult(json);
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Publish failed');
+    } finally {
+      setLoading(false);
+    }
+  }, [confirm]);
+
+  return (
+    <section
+      className="mt-4 rounded-md border p-4"
+      style={{ borderColor: '#3c3c3c', background: '#252526' }}
+    >
+      <div className="mb-3 flex items-center gap-2">
+        <Globe className="h-4 w-4" style={{ color: '#4ec9b0' }} />
+        <h3 className="text-sm font-semibold text-white">Publish &amp; Update Website</h3>
+      </div>
+      <p className="mb-3 text-[11px] leading-relaxed" style={{ color: '#9ca3af' }}>
+        Bust ISR cache on the public LMS and trigger Northflank builds for LMS + Admin. Same flow as
+        the admin dashboard publish control.
+      </p>
+      {error && (
+        <p className="mb-2 flex items-start gap-2 text-[11px] text-red-300">
+          <AlertCircle className="mt-0.5 h-3.5 w-3.5 shrink-0" />
+          {error}
+        </p>
+      )}
+      {result && (
+        <div className="mb-3 space-y-1 text-[11px]" style={{ color: '#d4d4d4' }}>
+          <p className="flex items-center gap-1.5">
+            {result.ok ? (
+              <CheckCircle2 className="h-3.5 w-3.5 text-green-400" />
+            ) : (
+              <AlertCircle className="h-3.5 w-3.5 text-amber-400" />
+            )}
+            Revalidate: {result.revalidate?.ok ? 'OK' : result.revalidate?.error ?? 'failed'}
+          </p>
+          {result.deploy?.map((d) => (
+            <p key={d.service}>
+              {d.service}: {d.status}
+              {d.detail ? ` — ${d.detail}` : ''}
+            </p>
+          ))}
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={publish}
+        disabled={loading}
+        className="inline-flex h-9 items-center gap-2 rounded px-3 text-xs font-semibold disabled:opacity-50"
+        style={{
+          background: confirm ? '#f59e0b' : '#0078d4',
+          color: confirm ? '#111827' : '#fff',
+        }}
+      >
+        {loading ? (
+          <Loader2 className="h-3.5 w-3.5 animate-spin" />
+        ) : (
+          <Rocket className="h-3.5 w-3.5" />
+        )}
+        {confirm ? 'Confirm publish' : 'Publish & update website'}
+      </button>
+    </section>
+  );
+}

--- a/components/home/HomeFundingStrip.tsx
+++ b/components/home/HomeFundingStrip.tsx
@@ -30,12 +30,20 @@ export function HomeFundingStrip() {
               Most eligible learners qualify for $0 tuition through workforce funding.
             </p>
           </div>
-          <Link
-            href="/funding"
-            className="inline-flex items-center gap-1.5 text-sm font-bold bg-white text-brand-blue-800 px-4 py-2 rounded-lg hover:bg-brand-blue-50 transition-colors shrink-0"
-          >
-            Explore all funding options <ArrowRight className="w-4 h-4" />
-          </Link>
+          <div className="flex flex-wrap gap-2 shrink-0">
+            <Link
+              href="/find-workone"
+              className="inline-flex items-center gap-1.5 text-sm font-bold border border-white/40 text-white px-4 py-2 rounded-lg hover:bg-white/10 transition-colors"
+            >
+              Find WorkOne <ArrowRight className="w-4 h-4" />
+            </Link>
+            <Link
+              href="/funding"
+              className="inline-flex items-center gap-1.5 text-sm font-bold bg-white text-brand-blue-800 px-4 py-2 rounded-lg hover:bg-brand-blue-50 transition-colors"
+            >
+              All funding options <ArrowRight className="w-4 h-4" />
+            </Link>
+          </div>
         </div>
         <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
           {FUNDING_PATHS.map((path) => (

--- a/components/marketing/HeroPicture.tsx
+++ b/components/marketing/HeroPicture.tsx
@@ -94,7 +94,7 @@ export default function HeroPicture({
           fill
           sizes={heroTokens.imageSizes}
           quality={75}
-          className="object-cover object-center"
+          className="object-cover object-center sm:object-[center_35%]"
           priority={priority}
           placeholder="empty"
         />

--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -211,7 +211,7 @@ export default function HeroVideo({
       >
         <CanonicalVideo
           src={videoSrc}
-          className="absolute inset-0 w-full h-full object-cover object-center"
+          className="absolute inset-0 w-full h-full object-cover object-center sm:object-[center_35%]"
           autoPlayOnMount
           loop
           preloadFull={eagerVideoLoad}

--- a/components/marketing/PublicLandingPage.tsx
+++ b/components/marketing/PublicLandingPage.tsx
@@ -3,6 +3,7 @@ import Image from 'next/image';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { ArrowRight } from 'lucide-react';
 import { hero as heroTokens } from '@/lib/page-design-tokens';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
 
 export interface LandingPageConfig {
   breadcrumbs: { label: string; href?: string }[];
@@ -58,7 +59,7 @@ export default function PublicLandingPage({ config }: { config: LandingPageConfi
           src={config.hero.image}
           alt={config.hero.title}
           fill
-          className="object-cover object-center"
+          className="object-cover object-center sm:object-[center_35%]"
           priority
           sizes={heroTokens.imageSizes}
           quality={75}
@@ -162,6 +163,8 @@ export default function PublicLandingPage({ config }: { config: LandingPageConfi
           </div>
         </div>
       </section>
+
+      <CredentialAuthorityFootnote />
     </div>
   );
 }

--- a/components/programs/ProgramDetailPage.tsx
+++ b/components/programs/ProgramDetailPage.tsx
@@ -42,6 +42,7 @@ import { DeliveryBadge, FundingSection } from './ProgramTruthBadges';
 import { ICC_URL, ICC_INSTRUCTION, hero as heroTokens } from '@/lib/page-design-tokens';
 import { DEFAULT_HERO_VIDEO, resolveHeroPosterSrc } from '@/lib/images/hero-banner-media';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
 
 interface Props {
   program: ProgramSchema;
@@ -879,6 +880,8 @@ export default function ProgramDetailPage({
       </section>
 
       {children && <div>{children}</div>}
+
+      <CredentialAuthorityFootnote />
     </div>
   );
 }

--- a/components/programs/ProgramPageLayout.tsx
+++ b/components/programs/ProgramPageLayout.tsx
@@ -3,8 +3,9 @@
 import Link from 'next/link';
 import Image from 'next/image';
 import { ArrowRight } from 'lucide-react';
-import { ICC_URL, ICC_INSTRUCTION } from '@/lib/page-design-tokens';
+import { ICC_URL, ICC_INSTRUCTION, hero as heroTokens } from '@/lib/page-design-tokens';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import { CredentialAuthorityFootnote } from '@/components/compliance/CredentialAuthorityFootnote';
 import { InView } from '@/components/ui/InView';
 import { ScrollReveal } from '@/components/ui/ScrollReveal';
 import { AnimatedCounter } from '@/components/ui/AnimatedCounter';
@@ -927,6 +928,8 @@ export default function ProgramPageLayout({
           </div>
         </section>
       </InView>
+
+      <CredentialAuthorityFootnote className="border-t-0" />
 
       {/* ===== TRUST BAR ===== */}
       <section className="py-8 bg-slate-50 border-t border-slate-100">

--- a/components/workone/WorkOneIndianaMap.tsx
+++ b/components/workone/WorkOneIndianaMap.tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link';
+import type { WorkOneRegion } from '@/data/workone/indiana-regions';
+import {
+  workOneCenterDirectionsUrl,
+  workOneMapEmbedUrl,
+} from '@/data/workone/indiana-regions';
+
+type WorkOneIndianaMapProps = {
+  region?: WorkOneRegion;
+  showAllRegionsLink?: boolean;
+};
+
+export function WorkOneIndianaMap({ region, showAllRegionsLink = true }: WorkOneIndianaMapProps) {
+  const centers = region?.centers ?? [];
+  const mapUrl = region
+    ? workOneMapEmbedUrl(region)
+    : 'https://maps.google.com/maps?q=Indianapolis,+IN+WorkOne&z=8&output=embed';
+
+  return (
+    <section className="py-12 sm:py-16 bg-white" aria-labelledby="workone-map-heading">
+      <div className="max-w-6xl mx-auto px-4 sm:px-6">
+        <div className="mb-8">
+          <p className="text-brand-red-600 text-xs font-bold uppercase tracking-widest mb-2">
+            WorkOne Indiana
+          </p>
+          <h2 id="workone-map-heading" className="text-2xl sm:text-3xl font-extrabold text-slate-900">
+            {region ? `WorkOne Centers — ${region.name}` : 'Find a WorkOne Center'}
+          </h2>
+          <p className="text-slate-600 mt-2 max-w-2xl text-sm leading-relaxed">
+            {region?.description ??
+              'Visit a WorkOne career center to meet with a counselor and determine WIOA, Workforce Ready Grant, or IMPACT funding eligibility before enrolling in training.'}
+          </p>
+        </div>
+
+        <div className="grid lg:grid-cols-2 gap-8 items-start">
+          <div className="space-y-4">
+            {centers.map((center) => (
+              <div
+                key={`${center.name}-${center.address}`}
+                className="rounded-xl border border-slate-200 bg-slate-50 p-5 hover:border-brand-orange-300 transition-colors"
+              >
+                <h3 className="font-bold text-slate-900 text-sm mb-2">{center.name}</h3>
+                <p className="text-sm text-slate-600">
+                  {center.address}
+                  <br />
+                  {center.city}, IN {center.zip}
+                </p>
+                <p className="text-sm text-slate-600 mt-2">
+                  <a
+                    href={`tel:${center.phone.replace(/[^0-9]/g, '')}`}
+                    className="text-brand-blue-700 hover:underline font-medium"
+                  >
+                    {center.phone}
+                  </a>
+                  <span className="text-slate-400 mx-2">·</span>
+                  {center.hours}
+                </p>
+                <div className="flex flex-wrap gap-2 mt-4">
+                  <a
+                    href={workOneCenterDirectionsUrl(center)}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-brand-orange-600 text-white text-xs font-semibold hover:bg-brand-orange-700"
+                  >
+                    Get directions
+                  </a>
+                  <a
+                    href={`tel:${center.phone.replace(/[^0-9]/g, '')}`}
+                    className="inline-flex items-center justify-center px-4 py-2 rounded-lg bg-slate-900 text-white text-xs font-semibold hover:bg-slate-800"
+                  >
+                    Call
+                  </a>
+                </div>
+              </div>
+            ))}
+
+            {showAllRegionsLink && (
+              <div className="pt-2">
+                <Link
+                  href="/find-workone"
+                  className="text-sm font-semibold text-brand-blue-700 hover:underline"
+                >
+                  View all Indiana WorkOne regions →
+                </Link>
+              </div>
+            )}
+          </div>
+
+          <div className="rounded-xl overflow-hidden border border-slate-200 shadow-sm bg-slate-100">
+            <div className="px-4 py-3 bg-slate-900 text-white text-sm font-semibold">
+              Map — {region?.name ?? 'Indiana'}
+            </div>
+            <div className="relative h-[320px] sm:h-[420px]">
+              <iframe
+                src={mapUrl}
+                title={region ? `WorkOne map — ${region.name}` : 'WorkOne centers in Indiana'}
+                width="100%"
+                height="100%"
+                style={{ border: 0 }}
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+                allowFullScreen
+              />
+            </div>
+            <div className="px-4 py-3 bg-slate-50 border-t border-slate-200">
+              <a
+                href="https://www.in.gov/dwd/find-a-workone-center/"
+                target="_blank"
+                rel="noopener noreferrer"
+                className="text-xs font-semibold text-brand-blue-700 hover:underline"
+              >
+                Official DWD WorkOne locator (all counties) →
+              </a>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/data/workone/indiana-regions.ts
+++ b/data/workone/indiana-regions.ts
@@ -1,0 +1,168 @@
+/**
+ * Indiana WorkOne regions — SEO + locator data.
+ * Official finder: https://www.in.gov/dwd/find-a-workone-center/
+ */
+
+export type WorkOneCenter = {
+  name: string;
+  address: string;
+  city: string;
+  zip: string;
+  phone: string;
+  hours: string;
+  lat: number;
+  lng: number;
+};
+
+export type WorkOneRegion = {
+  slug: string;
+  name: string;
+  counties: string[];
+  description: string;
+  mapCenter: { lat: number; lng: number; zoom: number };
+  centers: WorkOneCenter[];
+  dwdFinderUrl: string;
+};
+
+const DWD_FINDER = 'https://www.in.gov/dwd/find-a-workone-center/';
+
+export const WORKONE_REGIONS: WorkOneRegion[] = [
+  {
+    slug: 'central-indiana',
+    name: 'Central Indiana (Indianapolis / Marion County)',
+    counties: ['Marion', 'Hamilton', 'Hendricks', 'Johnson', 'Shelby', 'Hancock', 'Boone'],
+    description:
+      'WorkOne centers serving the Indianapolis metro and surrounding counties. Start here for WIOA intake, Workforce Ready Grant eligibility, and ITA referrals to ETPL-approved training.',
+    mapCenter: { lat: 39.7684, lng: -86.1581, zoom: 10 },
+    dwdFinderUrl: DWD_FINDER,
+    centers: [
+      {
+        name: 'WorkOne Indianapolis — East',
+        address: '7251 E 86th St',
+        city: 'Indianapolis',
+        zip: '46256',
+        phone: '(317) 842-8801',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 39.9082,
+        lng: -86.0092,
+      },
+      {
+        name: 'WorkOne Indianapolis — Northwest',
+        address: '3901 N Shadeland Ave',
+        city: 'Indianapolis',
+        zip: '46226',
+        phone: '(317) 921-1600',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 39.8284,
+        lng: -86.0455,
+      },
+      {
+        name: 'WorkOne Indianapolis — Southeast',
+        address: '1915 W 18th St, Suite C',
+        city: 'Indianapolis',
+        zip: '46202',
+        phone: '(317) 684-2400',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 39.7912,
+        lng: -86.2015,
+      },
+      {
+        name: 'WorkOne Indianapolis — Southwest',
+        address: '1200 Madison Ave',
+        city: 'Indianapolis',
+        zip: '46225',
+        phone: '(317) 684-2400',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 39.7528,
+        lng: -86.1585,
+      },
+      {
+        name: 'WorkOne Marion County',
+        address: '3901 Meadows Dr',
+        city: 'Indianapolis',
+        zip: '46205',
+        phone: '(317) 684-2400',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 39.8289,
+        lng: -86.1451,
+      },
+    ],
+  },
+  {
+    slug: 'northwest-indiana',
+    name: 'Northwest Indiana',
+    counties: ['Lake', 'Porter', 'LaPorte', 'Newton', 'Jasper'],
+    description:
+      'WorkOne centers in the Gary, Hammond, and Valparaiso region for WIOA and WRG-funded career training referrals.',
+    mapCenter: { lat: 41.5834, lng: -87.5000, zoom: 9 },
+    dwdFinderUrl: DWD_FINDER,
+    centers: [
+      {
+        name: 'WorkOne Northwest Indiana',
+        address: 'Gary / Hammond area',
+        city: 'Gary',
+        zip: '46402',
+        phone: '(219) 881-0100',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 41.5934,
+        lng: -87.3464,
+      },
+    ],
+  },
+  {
+    slug: 'northeast-indiana',
+    name: 'Northeast Indiana (Fort Wayne)',
+    counties: ['Allen', 'Whitley', 'DeKalb', 'Noble', 'Steuben'],
+    description:
+      'Fort Wayne–area WorkOne offices for workforce funding intake and training provider referrals.',
+    mapCenter: { lat: 41.0793, lng: -85.1394, zoom: 10 },
+    dwdFinderUrl: DWD_FINDER,
+    centers: [
+      {
+        name: 'WorkOne Northeast',
+        address: '201 E Rudisill Blvd',
+        city: 'Fort Wayne',
+        zip: '46806',
+        phone: '(260) 745-3555',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 41.0534,
+        lng: -85.1134,
+      },
+    ],
+  },
+  {
+    slug: 'southern-indiana',
+    name: 'Southern Indiana (Evansville)',
+    counties: ['Vanderburgh', 'Warrick', 'Posey', 'Gibson'],
+    description:
+      'Southwest Indiana WorkOne centers for WIOA eligibility and ETPL training referrals.',
+    mapCenter: { lat: 37.9716, lng: -87.5711, zoom: 10 },
+    dwdFinderUrl: DWD_FINDER,
+    centers: [
+      {
+        name: 'WorkOne Southwest',
+        address: '700 E Walnut St',
+        city: 'Evansville',
+        zip: '47713',
+        phone: '(812) 424-4473',
+        hours: 'Mon–Fri 8am–5pm',
+        lat: 37.9748,
+        lng: -87.5612,
+      },
+    ],
+  },
+];
+
+export function getWorkOneRegion(slug: string): WorkOneRegion | undefined {
+  return WORKONE_REGIONS.find((r) => r.slug === slug);
+}
+
+export function workOneMapEmbedUrl(region: WorkOneRegion): string {
+  const { lat, lng, zoom } = region.mapCenter;
+  return `https://maps.google.com/maps?q=${lat},${lng}&z=${zoom}&output=embed`;
+}
+
+export function workOneCenterDirectionsUrl(center: WorkOneCenter): string {
+  const q = encodeURIComponent(`${center.address}, ${center.city}, IN ${center.zip}`);
+  return `https://www.google.com/maps/search/?api=1&query=${q}`;
+}

--- a/lib/page-design-tokens.ts
+++ b/lib/page-design-tokens.ts
@@ -57,9 +57,12 @@ export const hero = {
    * No gradient overlay. No text on top of image.
    * Content goes in a white panel BELOW the image.
    */
-  /** Video/image band — capped lower on large screens so copy appears above the fold */
+  /**
+   * Video/image band — 16:9-friendly on desktop without crowding the first viewport.
+   * Mobile stays shorter; lg uses 45vh cap per hero-video-standard (max 560px).
+   */
   imageWrap:
-    'relative h-[clamp(190px,32vw,360px)] w-full overflow-hidden bg-slate-100',
+    'relative h-[clamp(220px,42vw,400px)] sm:h-[clamp(260px,44vw,460px)] lg:h-[clamp(280px,45vh,560px)] w-full overflow-hidden bg-slate-100',
   /** Below-hero white panel (headline, CTAs) */
   belowPanel: 'border-b border-slate-100 py-8 sm:py-10 lg:py-8',
   belowHeadline:

--- a/lib/public-revalidate-paths.ts
+++ b/lib/public-revalidate-paths.ts
@@ -33,6 +33,11 @@ export const PUBLIC_REVALIDATE_PATHS = [
   '/cdl-training-indianapolis',
   '/barber-apprenticeship-indianapolis',
   '/wioa-funded-training-indiana',
+  '/find-workone',
+  '/find-workone/central-indiana',
+  '/find-workone/northwest-indiana',
+  '/find-workone/northeast-indiana',
+  '/find-workone/southern-indiana',
 ] as const;
 
 export type PublicRevalidatePath = (typeof PUBLIC_REVALIDATE_PATHS)[number];

--- a/tests/unit/workone-regions.test.ts
+++ b/tests/unit/workone-regions.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import {
+  WORKONE_REGIONS,
+  getWorkOneRegion,
+  workOneMapEmbedUrl,
+} from '@/data/workone/indiana-regions';
+
+describe('workone indiana regions', () => {
+  it('includes central indiana with multiple centers', () => {
+    const central = getWorkOneRegion('central-indiana');
+    expect(central).toBeDefined();
+    expect(central!.centers.length).toBeGreaterThanOrEqual(3);
+  });
+
+  it('generates valid map embed URLs', () => {
+    for (const region of WORKONE_REGIONS) {
+      const url = workOneMapEmbedUrl(region);
+      expect(url).toContain('maps.google.com');
+      expect(url).toContain('output=embed');
+    }
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to PR #294 production readiness work:

### Hero banners (desktop cut-off)
- `hero.imageWrap` now scales to `45vh` / max `560px` on large screens (was capped at 360px)
- `object-[center_35%]` on video/image heroes to reduce top/bottom crop

### Credential authority disclaimer
- New `CredentialAuthorityFootnote` — small print at **page bottom** only
- Wired on program pages, landing pages, credentials page (removed mid-page amber disclosure block)

### WorkOne map & SEO
- `/find-workone` hub + regional pages (`central-indiana`, etc.)
- `WorkOneIndianaMap` with real Google Maps embeds + DWD official locator link
- Homepage funding strip → Find WorkOne CTA

### Admin dashboard
- **☰ hamburger menu on desktop** — full nav tree with all subpages (not orphaned)
- Section shortcuts remain on `xl+` screens; menu is primary on smaller desktop widths
- Lazy-loaded below-fold panels (publish, integrity, job board, site preview) for faster initial load
- Smaller/lazy dashboard hero image

### Dev Studio
- **Publish & Update Website** control in Deploy tab (same API as dashboard)

## Test plan
- [x] `pnpm vitest run tests/unit/workone-regions.test.ts tests/unit/publish-website.test.ts`
- [ ] Admin dashboard: open ☰ menu on desktop → navigate to subpages
- [ ] Dev Studio → Deploy → Publish & update website
- [ ] `/find-workone` map + regional pages
- [ ] Program page: credential footnote at bottom only
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add WorkOne regional map pages, admin hamburger nav, and credential footnotes
> - Adds a new WorkOne finder at `/find-workone` and per-region pages under `/find-workone/[region]`, backed by region/center data in [indiana-regions.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/295/files#diff-2856264aed9189d58c3d687da9a2a916eea3fbb33363d405fb670cca23c50b06) and rendered via a new [WorkOneIndianaMap](https://github.com/elevate-for-humanity/Elevate-lms/pull/295/files#diff-6f626681b0f16fa8be314e8429e3959d59952844f19432d75d54258c2642cc33) component with embedded Google Maps.
> - Adds a reusable [CredentialAuthorityFootnote](https://github.com/elevate-for-humanity/Elevate-lms/pull/295/files#diff-59f4c10a5fc1f8b2434d04eac784dad87662b2fc2b2a23241f54049eaa6bb25b) component and places it on credentials, program, landing, and WorkOne pages, replacing the prior amber disclosure block on the credentials page.
> - Reworks [AdminNav](https://github.com/elevate-for-humanity/Elevate-lms/pull/295/files#diff-b43b9613ca6d723d039b2406f531fbe8f0555de181e8bc93f4d0d6b71658293e) into a slideout menu available at all viewport sizes (previously `md` breakpoint), with body scroll lock, improved ARIA attributes, and desktop shortcut nav hidden until `xl`.
> - Defers heavy admin dashboard panels (ProgramIntegrity, JobBoard, SitePreview) to lazy-loaded components with skeleton placeholders via [DashboardDeferredPanels](https://github.com/elevate-for-humanity/Elevate-lms/pull/295/files#diff-b8d0e0805c02cc49853a52cb6e7ed9d979957c3542af4e6a4b909a0e54c91f9a).
> - Adjusts hero image/video focal point to `center 35%` on `sm`+ screens and updates hero height tokens to clamp across breakpoints.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 93ac1fa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->