### PR TITLE
fix(security): gate portal routes + admin dashboard ERR_DASHBOARD_LOAD

### DIFF
--- a/app/dashboards/page.tsx
+++ b/app/dashboards/page.tsx
@@ -19,57 +19,62 @@ import {
 
 export const metadata: Metadata = {
   title: 'Portals & Dashboards',
-  description: 'Access student portal, employer portal, LMS, staff portal, and more.',
+  description: 'Sign in to access student, employer, LMS, and staff portals.',
+  robots: { index: false, follow: false },
 };
 
-const portals = [
+type PortalLink = {
+  name: string;
+  description: string;
+  href: string;
+  icon: typeof GraduationCap;
+  color: string;
+  /** Marketing pages anyone can browse without signing in */
+  marketing?: boolean;
+};
+
+const portals: PortalLink[] = [
   {
     name: 'Student Portal',
     description: 'Track your enrollment, courses, and progress',
-    href: '/learner/dashboard',
+    href: '/login?redirect=/learner/dashboard',
     icon: GraduationCap,
     color: 'bg-blue-500',
-    public: true,
   },
   {
     name: 'LMS Dashboard',
     description: 'Access your courses and learning materials',
-    href: '/lms',
+    href: '/login?redirect=/lms/courses',
     icon: BookOpen,
     color: 'bg-indigo-500',
-    public: true,
   },
   {
     name: 'Employer Portal',
     description: 'Post jobs, hire graduates, access WOTC credits',
-    href: '/employer/dashboard',
+    href: '/login?redirect=/employer/dashboard',
     icon: Building2,
     color: 'bg-brand-green-500',
-    public: true,
   },
   {
     name: 'Partner Portal',
     description: 'Track referrals and partnership metrics',
-    href: '/partner',
+    href: '/login?redirect=/partner/dashboard',
     icon: Briefcase,
     color: 'bg-purple-500',
-    public: true,
   },
   {
     name: 'Staff Portal',
     description: 'Manage students, attendance, and reports',
-    href: '/admin/staff-portal',
+    href: '/login?redirect=/admin/staff-portal/dashboard',
     icon: Users,
     color: 'bg-orange-500',
-    public: false,
   },
   {
     name: 'Admin Portal',
     description: 'Full platform administration',
-    href: '/admin',
+    href: '/login?redirect=/admin/dashboard',
     icon: Shield,
     color: 'bg-red-500',
-    public: false,
   },
   {
     name: 'VITA Tax Services',
@@ -77,7 +82,7 @@ const portals = [
     href: '/community-services',
     icon: DollarSign,
     color: 'bg-emerald-500',
-    public: true,
+    marketing: true,
   },
   {
     name: 'Tax Filing Services',
@@ -85,7 +90,7 @@ const portals = [
     href: '/community-services',
     icon: Zap,
     color: 'bg-yellow-500',
-    public: true,
+    marketing: true,
   },
   {
     name: 'Career Services',
@@ -93,7 +98,7 @@ const portals = [
     href: '/career-services',
     icon: UserCheck,
     color: 'bg-teal-500',
-    public: true,
+    marketing: true,
   },
   {
     name: 'Training Programs',
@@ -101,7 +106,7 @@ const portals = [
     href: '/programs',
     icon: LayoutDashboard,
     color: 'bg-cyan-500',
-    public: true,
+    marketing: true,
   },
 ];
 
@@ -137,85 +142,72 @@ export default async function PortalsPage() {
     if (dest) redirect(dest);
   }
 
-  // Unauthenticated — show portal directory
-  return PortalsDirectory();
+  return <PortalsDirectory />;
 }
 
 function PortalsDirectory() {
+  const signInPortals = portals.filter((p) => !p.marketing);
+  const marketingPortals = portals.filter((p) => p.marketing);
+
   return (
     <div className="min-h-screen bg-gradient-to-b from-slate-900 to-slate-800 py-16">
       <div className="max-w-6xl mx-auto px-4">
-        {/* Header */}
         <div className="text-center mb-12">
           <h1 className="text-4xl font-bold text-white mb-4">Portals & Dashboards</h1>
           <p className="text-xl text-slate-300 max-w-2xl mx-auto">
-            Access all {PLATFORM_DEFAULTS.orgName} services, training portals, and dashboards
+            Sign in to access {PLATFORM_DEFAULTS.orgName} training portals and role dashboards
           </p>
         </div>
 
-        {/* Public Portals */}
         <div className="mb-12">
-          <h2 className="text-2xl font-bold text-white mb-6">Public Access</h2>
+          <h2 className="text-2xl font-bold text-white mb-6">Sign in required</h2>
           <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {portals
-              .filter((p) => p.public)
-              .map((portal) => (
-                <Link
-                  key={portal.href}
-                  href={portal.href}
-                  className="bg-white rounded-xl p-6 hover:shadow-xl transition-all hover:-translate-y-1 group"
+            {signInPortals.map((portal) => (
+              <Link
+                key={portal.href}
+                href={portal.href}
+                className="bg-white rounded-xl p-6 hover:shadow-xl transition-all hover:-translate-y-1 group"
+              >
+                <div
+                  className={`w-14 h-14 rounded-xl flex items-center justify-center mb-4 ${portal.color}`}
                 >
-                  <div
-                    className={`w-14 h-14 rounded-xl flex items-center justify-center mb-4 ${portal.color}`}
-                  >
-                    <portal.icon className="w-7 h-7 text-white" />
-                  </div>
-                  <h3 className="font-bold text-xl text-slate-900 group-hover:text-blue-600 transition mb-2">
-                    {portal.name}
-                  </h3>
-                  <p className="text-slate-600 mb-4">{portal.description}</p>
-                  <span className="inline-flex items-center text-blue-600 font-medium">
-                    Access Portal <ArrowRight className="w-4 h-4 ml-1" />
-                  </span>
-                </Link>
-              ))}
+                  <portal.icon className="w-7 h-7 text-white" />
+                </div>
+                <h3 className="font-bold text-xl text-slate-900 group-hover:text-blue-600 transition mb-2">
+                  {portal.name}
+                </h3>
+                <p className="text-slate-600 mb-4">{portal.description}</p>
+                <span className="inline-flex items-center text-blue-600 font-medium">
+                  Sign in <ArrowRight className="w-4 h-4 ml-1" />
+                </span>
+              </Link>
+            ))}
           </div>
         </div>
 
-        {/* Staff/Admin Portals */}
         <div>
-          <h2 className="text-2xl font-bold text-white mb-6">Staff & Admin Access</h2>
-          <div className="grid md:grid-cols-2 gap-6">
-            {portals
-              .filter((p) => !p.public)
-              .map((portal) => (
-                <Link
-                  key={portal.href}
-                  href={portal.href}
-                  className="bg-white/10 backdrop-blur rounded-xl p-6 hover:bg-white/20 transition group border border-white/20"
+          <h2 className="text-2xl font-bold text-white mb-6">Public resources</h2>
+          <div className="grid md:grid-cols-2 lg:grid-cols-4 gap-6">
+            {marketingPortals.map((portal) => (
+              <Link
+                key={portal.name}
+                href={portal.href}
+                className="bg-white/10 backdrop-blur rounded-xl p-6 hover:bg-white/20 transition group border border-white/20"
+              >
+                <div
+                  className={`w-12 h-12 rounded-lg flex items-center justify-center mb-4 ${portal.color}`}
                 >
-                  <div className="flex items-start gap-4">
-                    <div
-                      className={`w-12 h-12 rounded-lg flex items-center justify-center ${portal.color}`}
-                    >
-                      <portal.icon className="w-6 h-6 text-white" />
-                    </div>
-                    <div>
-                      <h3 className="font-bold text-lg text-white group-hover:text-blue-300 transition">
-                        {portal.name}
-                      </h3>
-                      <p className="text-slate-400 text-sm">{portal.description}</p>
-                      <span className="inline-flex items-center text-blue-400 text-sm mt-2">
-                        Login Required <ArrowRight className="w-3 h-3 ml-1" />
-                      </span>
-                    </div>
-                  </div>
-                </Link>
-              ))}
+                  <portal.icon className="w-6 h-6 text-white" />
+                </div>
+                <h3 className="font-bold text-lg text-white group-hover:text-blue-300 transition">
+                  {portal.name}
+                </h3>
+                <p className="text-slate-400 text-sm mt-2">{portal.description}</p>
+              </Link>
+            ))}
           </div>
         </div>
 
-        {/* Quick Actions */}
         <div className="mt-12 bg-blue-600 rounded-2xl p-8 text-center">
           <h2 className="text-2xl font-bold text-white mb-4">Need Help Getting Started?</h2>
           <p className="text-blue-100 mb-6">

--- a/app/portals/page.tsx
+++ b/app/portals/page.tsx
@@ -24,6 +24,7 @@ export const metadata: Metadata = {
   alternates: {
     canonical: 'https://www.elevateforhumanity.org/portals',
   },
+  robots: { index: false, follow: false },
   title: 'Portals',
   description:
     'Sign in to your Elevate portal — learner, apprentice, employer, partner, instructor, case manager, mentor, or staff.',

--- a/apps/admin/app/admin/dashboard/error.tsx
+++ b/apps/admin/app/admin/dashboard/error.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { AlertTriangle, RefreshCw } from 'lucide-react';
 
 export default function DashboardError({

--- a/apps/admin/app/admin/instructor/page.tsx
+++ b/apps/admin/app/admin/instructor/page.tsx
@@ -158,12 +158,10 @@ export default function InstructorPortalLanding() {
           </p>
           <div className="flex flex-wrap justify-center gap-4">
             <Link
-              href={`${process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl}/login?redirect=/instructor/dashboard`}
-              target="_blank"
-              rel="noopener noreferrer"
+              href="/login?redirect=/admin/instructor/dashboard"
               className="px-8 py-4 bg-brand-blue-600 text-white font-bold rounded-lg hover:bg-brand-blue-700 transition"
             >
-              Sign In
+              Instructor sign in
             </Link>
             <Link
               href={`${process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl}/apply?role=instructor`}

--- a/apps/admin/app/unauthorized/page.tsx
+++ b/apps/admin/app/unauthorized/page.tsx
@@ -40,20 +40,12 @@ export default function UnauthorizedPage() {
             Signed in as <span className="text-slate-300">{email}</span>
           </p>
         )}
-        <div className="flex flex-col gap-2">
-          <button
-            onClick={handleSignOut}
-            className="w-full px-4 py-2 bg-red-900 hover:bg-red-800 text-red-200 text-sm font-medium rounded-lg transition-colors"
-          >
-            Sign Out &amp; Try Different Account
-          </button>
-          <a
-            href="/login"
-            className="inline-block px-4 py-2 bg-slate-800 hover:bg-slate-700 text-slate-300 text-sm font-medium rounded-lg transition-colors"
-          >
-            Back to Login
-          </a>
-        </div>
+        <button
+          onClick={handleSignOut}
+          className="w-full px-4 py-2 bg-red-900 hover:bg-red-800 text-red-200 text-sm font-medium rounded-lg transition-colors"
+        >
+          Sign out and use a different account
+        </button>
       </div>
     </div>
   );

--- a/components/portal/ApprenticeClockInStatus.tsx
+++ b/components/portal/ApprenticeClockInStatus.tsx
@@ -1,0 +1,114 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { Clock, Loader2, MapPin } from 'lucide-react';
+
+type TimeclockContext = {
+  programName?: string;
+  activeShift?: {
+    clockInAt: string;
+    lunchStartAt: string | null;
+    lunchEndAt: string | null;
+  } | null;
+  allowedSites?: { id: string; name: string }[];
+};
+
+export function ApprenticeClockInStatus() {
+  const [ctx, setCtx] = useState<TimeclockContext | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/timeclock/context');
+        const data = await res.json();
+        if (!res.ok) {
+          if (!cancelled) {
+            setError(data.error || 'Timeclock unavailable');
+          }
+          return;
+        }
+        if (!cancelled) setCtx(data);
+      } catch {
+        if (!cancelled) setError('Could not load timeclock status');
+      } finally {
+        if (!cancelled) setLoading(false);
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (loading) {
+    return (
+      <div className="flex items-center gap-2 text-sm text-slate-500 py-2">
+        <Loader2 className="w-4 h-4 animate-spin" />
+        Checking shift status…
+      </div>
+    );
+  }
+
+  if (error || !ctx) {
+    return (
+      <p className="text-sm text-slate-600">
+        <Link href="/apprentice/timeclock" className="text-brand-blue-600 font-medium hover:underline">
+          Open timeclock
+        </Link>{' '}
+        to clock in at your work site.
+      </p>
+    );
+  }
+
+  const active = ctx.activeShift;
+  const siteName = ctx.allowedSites?.[0]?.name;
+
+  if (active?.clockInAt) {
+    const onLunch = active.lunchStartAt && !active.lunchEndAt;
+    return (
+      <div className="rounded-lg border border-brand-green-200 bg-brand-green-50 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+        <div className="flex items-start gap-2">
+          <span className="mt-1 w-2.5 h-2.5 rounded-full bg-brand-green-500 animate-pulse shrink-0" />
+          <div>
+            <p className="text-sm font-semibold text-brand-green-800">
+              {onLunch ? 'On lunch break' : 'Currently clocked in'}
+            </p>
+            <p className="text-xs text-brand-green-700 mt-0.5">
+              Since {new Date(active.clockInAt).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })}
+              {siteName ? ` · ${siteName}` : ''}
+            </p>
+          </div>
+        </div>
+        <Link
+          href="/apprentice/timeclock"
+          className="inline-flex items-center gap-1.5 text-sm font-semibold text-brand-green-800 hover:underline"
+        >
+          <Clock className="w-4 h-4" />
+          Manage shift
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-lg border border-slate-200 bg-slate-50 px-4 py-3 flex flex-wrap items-center justify-between gap-3">
+      <div className="flex items-start gap-2 text-sm text-slate-700">
+        <MapPin className="w-4 h-4 mt-0.5 text-slate-500 shrink-0" />
+        <span>
+          Not clocked in
+          {siteName ? ` · ${siteName}` : ''}. Use GPS at your shop to start a shift.
+        </span>
+      </div>
+      <Link
+        href="/apprentice/timeclock"
+        className="inline-flex items-center gap-1.5 rounded-lg bg-brand-green-600 px-3 py-2 text-sm font-semibold text-white hover:bg-brand-green-700"
+      >
+        <Clock className="w-4 h-4" />
+        Clock in
+      </Link>
+    </div>
+  );
+}

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -26,6 +26,7 @@ import {
   BARBER_STUDENT_APP_SHORT_LABEL,
 } from '@/lib/barber/student-app';
 import { BarberStudentAppDownload } from '@/components/portal/BarberStudentAppDownload';
+import { ApprenticeClockInStatus } from '@/components/portal/ApprenticeClockInStatus';
 import {
   apprenticeshipDocumentsPath,
   apprenticeshipLmsCoursePath,
@@ -511,6 +512,10 @@ export function ApprenticePortalShell({
               </div>
             )}
           </div>
+        </div>
+
+        <div className="mb-5">
+          <ApprenticeClockInStatus />
         </div>
 
         {/* Quick actions + onboarding */}

--- a/lib/admin/degraded-dashboard-data.ts
+++ b/lib/admin/degraded-dashboard-data.ts
@@ -35,6 +35,7 @@ export function getDegradedAdminDashboardData(): AdminDashboardData {
     recentActivity: [],
     recentStudents: [],
     recentApplications: [],
+    pendingApplications: [],
     blockedPrograms: [],
     inactiveLearners: [],
     pendingSubmissions: [],

--- a/lib/admin/get-admin-dashboard-data.ts
+++ b/lib/admin/get-admin-dashboard-data.ts
@@ -1065,7 +1065,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
 
   return {
     counts: {
-      pendingApplications: pendingApps,
+      pendingApplications: totalPendingCount,
       activeEnrollments:     activeEnrollCount,
       revenueThisMonthCents: revenueThisMonthCents,
       certificatesIssued:    certsCount,
@@ -1084,6 +1084,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     recentActivity: recentActivityItems,
     recentStudents,
     recentApplications,
+    pendingApplications: pendingApps,
     blockedPrograms,
     inactiveLearners,
     pendingSubmissions,

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -980,6 +980,8 @@ const nextConfig = {
       // Canonical forgot-pw (request form): /reset-password
       // Canonical set-new-password: /auth/reset-password
       { source: '/auth/signin', destination: '/login', permanent: true },
+      { source: '/sign-in', destination: '/login', permanent: true },
+      { source: '/signin', destination: '/login', permanent: true },
       { source: '/auth/signup', destination: '/signup', permanent: true },
       { source: '/register', destination: '/signup', permanent: true },
       { source: '/auth/forgot-password', destination: '/reset-password', permanent: true },
@@ -1276,7 +1278,7 @@ const sentryWebpackPluginOptions = {
   widenClientFileUpload: false,
 };
 
-// Skip Sentry webpack wrapping in production Docker builds (reduces build time)
+// Skip Sentry webpack wrapping in ECS (reduces build time)
 // and on AWS Docker builds (BUILD_SCOPE=1) — withSentryConfig spawns a child
 // Skip Sentry webpack worker on AWS EC2 builds — it doubles peak heap and OOMs
 // the 16GB runner. Sentry still initialises at runtime via instrumentation.ts.

--- a/proxy.ts
+++ b/proxy.ts
@@ -118,6 +118,9 @@ const PROTECTED_ROUTES: Record<string, string[]> = {
   '/provider/':                ['provider_admin', 'admin', 'super_admin'],
   '/creator/':                 ['creator', 'admin', 'super_admin'],
 
+  // ── Instructor (LMS host redirects /instructor/* to admin in production) ───
+  '/instructor/':              ['instructor', 'admin', 'super_admin', 'staff'],
+
   // ── Learner portals ───────────────────────────────────────────────────────
   '/learner/':                 ['student', 'admin', 'super_admin', 'staff', 'instructor'],
 
@@ -177,8 +180,12 @@ const AUTH_REQUIRED_ROUTES = [
   '/proctor/',
   '/proctor',
   '/learner/',
+  '/student-portal',
+  '/instructor/',
   '/apprentice',
   '/portal/',
+  '/portals',
+  '/dashboards',
   '/case-manager/',
   '/case-manager',
   '/account/',
@@ -258,6 +265,8 @@ const NOINDEX_PREFIXES = [
   '/workforce-board',
   '/employer',
   '/student-portal',
+  '/portals',
+  '/dashboards',
   '/partner/',
   '/mentor/',
   '/hub/',

--- a/tests/unit/portal-auth-routes.test.ts
+++ b/tests/unit/portal-auth-routes.test.ts
@@ -1,0 +1,36 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+/**
+ * Regression: portal and dashboard paths must be auth-gated in proxy.ts middleware.
+ */
+describe('portal auth route coverage (proxy.ts)', () => {
+  const proxySource = readFileSync(resolve(process.cwd(), 'proxy.ts'), 'utf8');
+
+  const requiredAuthPrefixes = [
+    '/learner/',
+    '/lms/',
+    '/portal/',
+    '/portals',
+    '/dashboards',
+    '/student-portal',
+    '/instructor/',
+    '/employer/dashboard',
+    '/partner/dashboard',
+    '/case-manager/',
+  ];
+
+  it.each(requiredAuthPrefixes)('AUTH_REQUIRED_ROUTES includes %s', (prefix) => {
+    expect(proxySource).toContain(`'${prefix}'`);
+  });
+
+  it('PROTECTED_ROUTES includes instructor prefix', () => {
+    expect(proxySource).toContain("'/instructor/':");
+  });
+
+  it('NOINDEX covers portal directory pages', () => {
+    expect(proxySource).toMatch(/NOINDEX_PREFIXES[\s\S]*'\/portals'/);
+    expect(proxySource).toMatch(/NOINDEX_PREFIXES[\s\S]*'\/dashboards'/);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Closes portal security gaps and merges the critical admin dashboard fixes from #290 (without reverting #295 admin nav).

### Portal security
- **Middleware (`proxy.ts`)**: auth-required for `/portals`, `/dashboards`, `/instructor/`, `/student-portal`; instructor role gate; noindex for portal directories
- **`/dashboards`**: stops linking directly to protected dashboards without login — all portal tiles use `login?redirect=…`
- **`/portals`**: `robots: noindex`
- **Regression tests**: `tests/unit/portal-auth-routes.test.ts`

### Admin dashboard (#290 fixes)
- Fix `ERR_DASHBOARD_LOAD` — missing `Link` import in `dashboard/error.tsx`
- Fix `counts.pendingApplications` (was array, now number) + add `pendingApplications` list field
- `/sign-in` and `/signin` → `/login` redirects

### Apprentice portals
- `ApprenticeClockInStatus` on industry portal dashboards (barber-specific shell features preserved)

## Deploy note

Merging to `main` triggers Northflank LMS + Admin deploy workflows (~15–25 min each).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Gate portal and dashboard routes behind authentication and fix admin dashboard load error
> - Adds `/portals`, `/dashboards`, `/student-portal`, and `/instructor/` to `AUTH_REQUIRED_ROUTES` in [proxy.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/296/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775), so unauthenticated users are redirected before reaching these pages.
> - Role-gates instructor routes via `PROTECTED_ROUTES` and sets `noindex/nofollow` headers for portal and dashboard directory paths in middleware.
> - Redirects `/sign-in` and `/signin` permanently to `/login`; portal links now route unauthenticated users through `/login?redirect=<destination>`.
> - Fixes admin dashboard load error by adding `pendingApplications` to the degraded fallback in [lib/admin/degraded-dashboard-data.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/296/files#diff-49082a884dedfc12380fe4eb1504a992c3904236d70085d4e6b967551498ad8c) and correcting the pending count field in [lib/admin/get-admin-dashboard-data.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/296/files#diff-4ddbac60a95ba611906cf7cd3f035c9ec9ef60a0733024d11ccffba8e89464df).
> - Adds a live timeclock status widget (`ApprenticeClockInStatus`) to the apprentice portal shell dashboard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6836709.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->