### PR TITLE
fix(routes): resolve business-administration canonical redirect chain (Macroscope #302)

### DIFF
--- a/app/programs/business/page.tsx
+++ b/app/programs/business/page.tsx
@@ -155,7 +155,10 @@ export default function BusinessProgramsPage() {
                       </h3>
                       <div className="mt-2 flex flex-wrap gap-3 text-sm text-slate-600">
                         <span>{p.duration}</span>
-                        <span className="text-brand-green-600 font-semibold">{p.salary}/yr avg</span>
+                        <span className="text-brand-green-600 font-semibold">
+                          {p.salary}
+                          {/^\$/.test(p.salary) ? '/yr avg' : ''}
+                        </span>
                       </div>
                       <div className="mt-3 text-brand-red-600 font-semibold text-sm group-hover:underline">
                         Learn More →

--- a/app/programs/business/page.tsx
+++ b/app/programs/business/page.tsx
@@ -1,0 +1,173 @@
+import { Metadata } from 'next';
+import Link from 'next/link';
+import Image from 'next/image';
+import ProgramPageLayout from '@/components/programs/ProgramPageLayout';
+import type { ProgramPageConfig } from '@/components/programs/ProgramPageLayout';
+import { InView } from '@/components/ui/InView';
+import { ScrollReveal } from '@/components/ui/ScrollReveal';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { PUBLIC_PROGRAM_DURATION_RANGE } from '@/lib/programs/marketing-duration';
+
+export const dynamic = 'force-static';
+export const revalidate = 86400;
+
+export const metadata: Metadata = {
+  title: 'Business & Finance Training Programs | Indianapolis',
+  description:
+    'Bookkeeping, business administration, office administration, entrepreneurship, and project management. WIOA and Workforce Ready Grant funding available.',
+  alternates: { canonical: 'https://www.elevateforhumanity.org/programs/business' },
+  openGraph: {
+    title: 'Business & Finance Training Programs | Indianapolis',
+    description:
+      'Bookkeeping, business administration, office administration, entrepreneurship, and project management.',
+    url: 'https://www.elevateforhumanity.org/programs/business',
+    siteName: PLATFORM_DEFAULTS.orgName,
+    images: [
+      {
+        url: '/images/og-image.jpg',
+        width: 1200,
+        height: 630,
+        alt: 'Business & Finance Training Programs | Indianapolis',
+      },
+    ],
+    type: 'website',
+  },
+};
+
+const programs = [
+  {
+    title: 'Business Administration',
+    duration: '8 weeks',
+    salary: '$42,000',
+    href: '/programs/business-administration',
+    image: '/images/business/office-admin.webp',
+  },
+  {
+    title: 'Bookkeeping & QuickBooks',
+    duration: '8 weeks',
+    salary: '$45,000',
+    href: '/programs/bookkeeping',
+    image: '/images/business/professional-2.jpg',
+  },
+  {
+    title: 'Office Administration',
+    duration: '6 weeks',
+    salary: '$40,000',
+    href: '/programs/office-administration',
+    image: '/images/business/office-admin.webp',
+  },
+  {
+    title: 'Entrepreneurship',
+    duration: '8 weeks',
+    salary: 'Varies',
+    href: '/programs/entrepreneurship',
+    image: '/images/business/professional-2.jpg',
+  },
+  {
+    title: 'Project Management',
+    duration: '8 weeks',
+    salary: '$75,000',
+    href: '/programs/project-management',
+    image: '/images/pages/admin-automation-hero.webp',
+  },
+  {
+    title: 'Finance & Accounting Pathway',
+    duration: '6–16 weeks',
+    salary: '$48,000',
+    href: '/programs/finance-bookkeeping-accounting',
+    image: '/images/pages/finance-accounting.webp',
+  },
+];
+
+const config: ProgramPageConfig = {
+  pageKey: 'business',
+  title: 'Business & Finance Programs',
+  subtitle:
+    'Administrative, bookkeeping, entrepreneurship, and project management pathways with industry-recognized credentials.',
+  badge: 'Funding Available',
+  badgeColor: 'green',
+  duration: PUBLIC_PROGRAM_DURATION_RANGE,
+  cost: 'WorkOne funding available',
+  format: 'In-person and hybrid, Indianapolis',
+  credential: 'QuickBooks · MOS · Certiport',
+  overview:
+    'Business programs prepare you for office administration, bookkeeping, small business ownership, and project coordination roles. Training combines applied software skills, workplace readiness, and credential exam preparation.',
+  highlights: [
+    'QuickBooks and office productivity certification prep',
+    'WIOA and Workforce Ready Grant eligibility on eligible programs',
+    'Career placement support through employer partners',
+    'Flexible cohort and self-paced options by program',
+    'Stackable credentials from bookkeeping through administration',
+  ],
+  overviewImage: '/images/business/office-admin.webp',
+  overviewImageAlt: 'Business students in office training',
+  salaryNumber: 45000,
+  salaryLabel: 'Average starting salary across business programs',
+  salaryPrefix: '$',
+  credentials: ['QuickBooks Certified User', 'Microsoft Office Specialist', 'ACT WorkKeys NCRC'],
+  steps: [
+    { title: 'Apply Online', desc: 'Complete our application in about 5 minutes.' },
+    { title: 'Funding Review', desc: 'Work with an advisor on WIOA or self-pay options.' },
+    { title: 'Start Training', desc: 'Begin coursework and hands-on labs.' },
+    { title: 'Earn Credential', desc: 'Complete certification exams and career placement steps.' },
+  ],
+  breadcrumbs: [{ label: 'Programs', href: '/programs' }, { label: 'Business Programs' }],
+  faqs: [
+    {
+      question: 'Which business program should I start with?',
+      answer:
+        'Office Administration and Bookkeeping are common entry points. Business Administration is ideal if you want a broader management pathway.',
+    },
+    {
+      question: 'Is funding available?',
+      answer:
+        'Many business programs are WIOA-eligible for qualified Indiana residents. Funding approval is not guaranteed.',
+    },
+  ],
+};
+
+export default function BusinessProgramsPage() {
+  return (
+    <ProgramPageLayout config={config}>
+      <InView>
+        <section className="py-16 bg-slate-50">
+          <div className="max-w-6xl mx-auto px-4 sm:px-6">
+            <h2 className="text-2xl sm:text-3xl font-bold text-slate-900 mb-8">Programs in this sector</h2>
+            <div className="grid sm:grid-cols-2 lg:grid-cols-3 gap-6">
+              {programs.map((p) => (
+                <ScrollReveal key={p.href}>
+                  <Link
+                    href={p.href}
+                    className="group block bg-white rounded-2xl border border-slate-200 overflow-hidden shadow-sm hover:shadow-md transition-shadow"
+                  >
+                    <div className="relative h-40">
+                      <Image
+                        src={p.image}
+                        alt={p.title}
+                        fill
+                        className="object-cover"
+                        sizes="(max-width: 768px) 100vw, 400px"
+                      />
+                    </div>
+                    <div className="p-5">
+                      <h3 className="font-bold text-slate-900 group-hover:text-brand-red-600 transition-colors">
+                        {p.title}
+                      </h3>
+                      <div className="mt-2 flex flex-wrap gap-3 text-sm text-slate-600">
+                        <span>{p.duration}</span>
+                        <span className="text-brand-green-600 font-semibold">{p.salary}/yr avg</span>
+                      </div>
+                      <div className="mt-3 text-brand-red-600 font-semibold text-sm group-hover:underline">
+                        Learn More →
+                      </div>
+                    </div>
+                  </Link>
+                </ScrollReveal>
+              ))}
+            </div>
+          </div>
+        </section>
+      </InView>
+    </ProgramPageLayout>
+  );
+}

--- a/lib/guide/page-guides.ts
+++ b/lib/guide/page-guides.ts
@@ -296,32 +296,32 @@ export const TAX_OFFICE_GUIDES: Record<string, PageGuide> = {
         id: 'welcome',
         type: 'welcome',
         message:
-          "Welcome to the Elevate Tax Office! I'm David. Whether you need your taxes done or want to become a tax preparer yourself, I'll guide you through.",
+          "Welcome! I'm David. If you're exploring bookkeeping or finance credentials, I can point you to our active business programs.",
       },
       {
         id: 'explain',
         type: 'explain',
         message:
-          'We offer two things: Tax preparation services (we do your taxes), and Tax Preparer Training (become a certified tax professional yourself).',
+          'Our finance pathway covers bookkeeping, QuickBooks certification, and office administration — stackable credentials for accounting support roles.',
       },
       {
         id: 'tip',
         type: 'tip',
         message:
-          "Thinking about a career in tax preparation? It's great side income - preparers earn $50-150 per return during tax season. Our training gets you certified in 8 weeks.",
-        action: { label: 'See Bookkeeping Training', href: '/programs/bookkeeping' },
+          'Bookkeeping is a strong entry point: QuickBooks certification, WIOA funding for eligible participants, and a clear path into office and accounting roles.',
+        action: { label: 'See Bookkeeping Program', href: '/programs/bookkeeping' },
       },
     ],
     quickTips: [
-      'Tax prep services available year-round',
-      'Become a certified preparer in 8 weeks',
-      'Earn $50-150 per return',
+      'Bookkeeping & QuickBooks certification',
+      'Finance pathway includes multiple tiers',
+      'WIOA funding for eligible participants',
     ],
   },
 
   'tax-preparation-training': {
     pageId: 'tax-preparation-training',
-    pageName: 'Tax Preparer Training',
+    pageName: 'Finance & Bookkeeping Training',
     avatarName: 'David',
     avatarImage: '/images/pages/store-guide-1.webp',
     messages: [
@@ -329,40 +329,40 @@ export const TAX_OFFICE_GUIDES: Record<string, PageGuide> = {
         id: 'welcome',
         type: 'welcome',
         message:
-          'Want to become a tax preparer? This is one of the best side hustles out there. 8 weeks of training, then you can earn $50-150 per return during tax season.',
+          'Exploring a career in bookkeeping or office finance? Our active programs prepare you for QuickBooks certification and accounting support roles.',
       },
       {
         id: 'explain',
         type: 'explain',
         message:
-          "You'll learn federal and state tax law, how to use professional tax software, and how to handle different return types - W-2s, 1099s, self-employment, deductions.",
+          "You'll learn bookkeeping fundamentals, payroll basics, and QuickBooks — the skills employers expect for entry-level accounting and office roles.",
       },
       {
         id: 'how-to',
         type: 'how-to',
         message:
-          "The training is 8 weeks, mostly online with some in-person sessions. You'll practice on real scenarios. After passing the exam, you get your PTIN and can start preparing returns.",
+          'Programs run 6–16 weeks depending on track. Training blends online coursework with instructor support and certification exam prep.',
       },
       {
         id: 'tip',
         type: 'tip',
         message:
-          "Many of our graduates do 100+ returns per season. At $75 average per return, that's $7,500+ in extra income. Some go full-time and open their own tax offices.",
-        action: { label: 'Enroll Now', href: '/apply?program=bookkeeping' },
+          'Start with Bookkeeping for the fastest path to a credential, or explore the full Finance & Accounting pathway for stacked certifications.',
+        action: { label: 'View Finance Pathway', href: '/programs/finance-bookkeeping-accounting' },
       },
       {
         id: 'upsell',
         type: 'upsell',
         message:
-          'Want to open your own tax office? We have a Tax Business Toolkit that includes everything - software, marketing materials, client management system.',
-        action: { label: 'See Tax Business Toolkit', href: '/store/digital/tax-business-toolkit' },
+          'Ready to apply? Bookkeeping cohorts enroll through our standard application — an advisor will review funding options with you.',
+        action: { label: 'Apply for Bookkeeping', href: '/apply?program=bookkeeping' },
       },
     ],
     quickTips: [
-      '8 weeks to certification',
-      'Earn $50-150 per return',
-      'Work from home or office',
-      'Great seasonal income',
+      'QuickBooks certification prep',
+      'Stackable finance credentials',
+      'WIOA funding for eligible participants',
+      'Career placement support',
     ],
   },
 };

--- a/lib/programs/catalog-sectors.ts
+++ b/lib/programs/catalog-sectors.ts
@@ -54,7 +54,7 @@ const SECTOR_PRESENTATION: Record<
   },
   business: {
     title: 'Business & Finance',
-    href: '/programs/business-administration',
+    href: '/programs/business',
     image: '/images/business/office-admin.webp',
     description:
       'Bookkeeping, Office Administration, and Entrepreneurship programs.',

--- a/lib/routes/canonical-routes.json
+++ b/lib/routes/canonical-routes.json
@@ -564,11 +564,6 @@
       "permanent": true
     },
     {
-      "source": "/programs/business-administration",
-      "destination": "/programs/business",
-      "permanent": true
-    },
-    {
       "source": "/programs/early-childhood-education",
       "destination": "/contact?program=early-childhood-education",
       "permanent": true

--- a/scripts/validate-programs.mjs
+++ b/scripts/validate-programs.mjs
@@ -230,7 +230,6 @@ const SECTOR_GROUPS = {
   business: ['bookkeeping','office-administration','entrepreneurship','project-management',
     'business-administration','hospitality','finance-bookkeeping-accounting'],
   transport: ['cdl-training'],
-  tax: ['bookkeeping'],
 };
 const slugToSector = {};
 for (const [sector, slugs] of Object.entries(SECTOR_GROUPS)) {

--- a/tests/unit/canonical-program-redirects.test.ts
+++ b/tests/unit/canonical-program-redirects.test.ts
@@ -23,6 +23,11 @@ describe('canonical program redirects', () => {
     expect(bad.map((r) => r.source)).toEqual([]);
   });
 
+  it('does not redirect /programs/business-administration away from its canonical URL', () => {
+    const bad = redirects.find((r) => r.source === '/programs/business-administration');
+    expect(bad).toBeUndefined();
+  });
+
   it('legacy slugs redirect to real program or funding pages', () => {
     const map = new Map(programRedirects.map((r) => [r.source, r.destination]));
     expect(map.get('/programs/cpr-aed')).toBe('/programs/cpr-first-aid');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged PR #302 + Macroscope review [#4441809074](https://github.com/elevate-for-humanity/Elevate-lms/pull/302#pullrequestreview-4441809074).

### Business canonical redirect (original PR scope)
- Removed `business-administration → business` redirect chain
- Restored `/programs/business` sector landing page
- Regression test for canonical URL integrity

### Macroscope PR #302 review fixes (this commit)
1. **`lib/guide/page-guides.ts`** — Tax office avatar guides no longer describe tax-preparation training while linking to bookkeeping. Copy now matches active programs (`/programs/bookkeeping`, `/programs/finance-bookkeeping-accounting`). We do **not** restore `/programs/tax-preparation` (archived in #302).
2. **`scripts/validate-programs.mjs`** — Removed `tax: ['bookkeeping']` sector group that overwrote `slugToSector['bookkeeping']` and broke cross-sector media validation.

## Test plan

- [x] `pnpm vitest run tests/unit/canonical-program-redirects.test.ts`
- [x] `node scripts/check-redirect-conflicts.mjs`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add /programs/business page and resolve business-administration canonical redirect chain
> - Adds a new static Next.js page at `/programs/business` ([page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/303/files#diff-325b1a99de880db827831dcafab2f958b44042b44fc51fac1546cf8a9ed3b76d)) rendering Business & Finance sector programs with SEO metadata, six program cards, and animated layout via `ProgramPageLayout`.
> - Updates the business sector card href in [catalog-sectors.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/303/files#diff-bd62202f68fab61f5b4af7efd8f2de23fbaae9c1498c50768d0cf7ab01b75ebc) from `/programs/business-administration` to `/programs/business`.
> - Removes the legacy `/programs/business-administration` → `/programs/business` redirect entry from [canonical-routes.json](https://github.com/elevate-for-humanity/Elevate-lms/pull/303/files#diff-0e33ce3b74ee0953007267ebf3a7e8c9d73eb86d8e4cc397ba9135c7e11a06d8) now that the destination page exists and the old slug is no longer referenced.
> - Updates guide copy in [page-guides.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/303/files#diff-a8832fdc9f4eed0eab5226f05707f85772ea7c334fe88f5a2402210067e32da0) to reference bookkeeping and finance credentials instead of tax services.
> - Adds a unit test asserting no redirect exists for `/programs/business-administration`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f7e7dd1.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->