### PR TITLE
fix(runtime): Northflank PDF canvas + ECONNRESET log noise

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -128,6 +128,7 @@ COPY --from=builder /app/public/hero-images ./apps/admin/public/hero-images
 COPY --from=builder /app/public/downloads ./apps/admin/public/downloads
 COPY --from=builder /app/remotion-src ./remotion-src
 COPY --from=builder /app/apps/admin/server.js ./apps/admin/server.js
+COPY --from=builder /app/lib/server/register-connection-guards.cjs ./lib/server/register-connection-guards.cjs
 RUN mkdir -p apps/admin/node_modules
 COPY --from=builder /export/ws ./apps/admin/node_modules/ws
 RUN test -f apps/admin/node_modules/ws/package.json

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -75,7 +75,9 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
       cp -a "$pkg" "/export/sharp-node_modules/@img/${name}"; \
     done \
     && test -f /export/sharp-node_modules/sharp/package.json \
-    && test -d /export/sharp-node_modules/@img/sharp-linux-x64
+    && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
+    && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
 
 RUN node scripts/prune-lms-builder-disk.mjs
 
@@ -101,10 +103,17 @@ COPY --from=builder /app/.next/standalone ./
 RUN mkdir -p node_modules
 COPY --from=builder /export/sharp-node_modules/sharp ./node_modules/sharp
 COPY --from=builder /export/sharp-node_modules/@img ./node_modules/@img
+COPY --from=builder /export/pdf-node_modules/@napi-rs ./node_modules/@napi-rs
+COPY --from=builder /export/pdf-node_modules/pdfjs-dist ./node_modules/pdfjs-dist
+COPY --from=builder /export/pdf-node_modules/pdf-parse ./node_modules/pdf-parse
 COPY --from=builder /app/.next/static ./.next/static
 COPY --from=builder /app/.next/server ./.next/server
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/remotion-src ./remotion-src
+COPY --from=builder /app/lib/server/register-connection-guards.cjs ./lib/server/register-connection-guards.cjs
+
+# Fail image build if PDF stack is missing (OCR + pdf-parse routes need canvas at runtime).
+RUN node -e "require('@napi-rs/canvas'); require('pdf-parse'); console.log('[lms] pdf runtime ok')"
 
 RUN addgroup --gid 1001 nodejs && \
     adduser --uid 1001 --ingroup nodejs --disabled-password --gecos "" nextjs && \

--- a/apps/admin/server.js
+++ b/apps/admin/server.js
@@ -4,6 +4,10 @@
  */
 'use strict';
 
+// Before Next boots — swallow benign client aborts (ECONNRESET / aborted).
+const { registerConnectionGuards } = require('../../lib/server/register-connection-guards.cjs');
+registerConnectionGuards();
+
 const fs = require('fs');
 const path = require('path');
 

--- a/instrumentation.ts
+++ b/instrumentation.ts
@@ -1,5 +1,8 @@
 export async function register() {
   if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { registerConnectionGuards } = await import('./lib/server/register-connection-guards.cjs');
+    registerConnectionGuards();
+
     // Load runtime secrets from Supabase into process.env.
     // Platform env vars are injected by Northflank at container start.
     const { applyNormalizedSupabaseUrlToEnv } = await import('./lib/supabase/normalize-url');

--- a/lib/server/register-connection-guards.cjs
+++ b/lib/server/register-connection-guards.cjs
@@ -1,0 +1,41 @@
+/**
+ * Suppress benign client-disconnect errors (ECONNRESET / "aborted") in production logs.
+ * Loaded from instrumentation (ESM) and apps/admin/server.js (CJS).
+ */
+'use strict';
+
+let registered = false;
+
+function isBenignConnectionError(err) {
+  if (!err || typeof err !== 'object') return false;
+
+  const code = typeof err.code === 'string' ? err.code : undefined;
+  const message = typeof err.message === 'string' ? err.message : '';
+  const name = typeof err.name === 'string' ? err.name : '';
+
+  if (code === 'ECONNRESET' || code === 'EPIPE' || code === 'ERR_STREAM_PREMATURE_CLOSE') {
+    return true;
+  }
+  if (name === 'AbortError') return true;
+  if (message === 'aborted' || message.toLowerCase().includes('aborted')) return true;
+
+  return false;
+}
+
+function registerConnectionGuards() {
+  if (registered) return;
+  registered = true;
+
+  const originalEmit = process.emit.bind(process);
+  process.emit = function patchedEmit(event, ...args) {
+    if (event === 'uncaughtException' && isBenignConnectionError(args[0])) {
+      return false;
+    }
+    if (event === 'unhandledRejection' && isBenignConnectionError(args[0])) {
+      return false;
+    }
+    return originalEmit(event, ...args);
+  };
+}
+
+module.exports = { isBenignConnectionError, registerConnectionGuards };

--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -1,6 +1,6 @@
 /**
  * Copy pdf-parse → pdfjs-dist → @napi-rs/canvas into /export/pdf-node_modules
- * for admin Docker runtime (same pattern as sharp/ws).
+ * for LMS + admin Northflank Docker runtimes (same pattern as sharp/ws).
  */
 import { cpSync, existsSync, mkdirSync, readdirSync } from 'node:fs';
 import { dirname, join } from 'node:path';

--- a/tests/unit/register-connection-guards.test.ts
+++ b/tests/unit/register-connection-guards.test.ts
@@ -1,0 +1,19 @@
+import { createRequire } from 'node:module';
+import { describe, expect, it } from 'vitest';
+
+const require = createRequire(import.meta.url);
+const { isBenignConnectionError } = require('../../lib/server/register-connection-guards.cjs');
+
+describe('isBenignConnectionError', () => {
+  it('treats ECONNRESET and aborted as benign', () => {
+    expect(isBenignConnectionError({ code: 'ECONNRESET' })).toBe(true);
+    expect(isBenignConnectionError({ code: 'EPIPE' })).toBe(true);
+    expect(isBenignConnectionError({ message: 'aborted', code: 'ECONNRESET' })).toBe(true);
+    expect(isBenignConnectionError({ name: 'AbortError' })).toBe(true);
+  });
+
+  it('does not treat real failures as benign', () => {
+    expect(isBenignConnectionError(new Error('database connection failed'))).toBe(false);
+    expect(isBenignConnectionError(null)).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Addresses Northflank production container log noise from June 4 deploys:

1. **`@napi-rs/canvas` / pdfjs warnings** — LMS standalone prunes `pdf-parse`, `pdfjs-dist`, and `@napi-rs/canvas`, but OCR/PDF API routes still need them at runtime. This mirrors the existing admin Northflank pattern: export PDF deps at build time and COPY into the runtime image with a build-time `require()` verify step.

2. **`ECONNRESET` / `aborted` uncaughtException** — Client disconnects during rolling deploys were logged as fatal crashes. Added a small `process.emit` guard (loaded from `instrumentation.ts` and early in `apps/admin/server.js`) that swallows benign connection-abort errors without masking real failures.

## Changes

- `Dockerfile.northflank-lms` — export + COPY PDF stack; runtime verify
- `Dockerfile.northflank-admin` — COPY connection guard module for custom server entry
- `lib/server/register-connection-guards.cjs` — shared guard implementation
- `instrumentation.ts` — register guards on Node.js cold start (LMS)
- `apps/admin/server.js` — register guards before Next boots
- `tests/unit/register-connection-guards.test.ts` — unit coverage

## Test plan

- [x] `pnpm vitest run tests/unit/register-connection-guards.test.ts`
- [ ] After merge + Northflank redeploy: confirm logs no longer show `Cannot find module '@napi-rs/canvas'` on LMS/admin startup
- [ ] Confirm `ECONNRESET` / `aborted` no longer appear as `⨯ uncaughtException` during deploy drain
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix PDF canvas support and suppress ECONNRESET log noise in Northflank runtime
> - Adds [`lib/server/register-connection-guards.cjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/304/files#diff-4d494ae5f4494092047ae1a8d236c47082d45805104ba30835d271ff6f36420c) which patches `process.emit` to swallow `uncaughtException`/`unhandledRejection` events for benign connection errors (ECONNRESET, EPIPE, ERR_STREAM_PREMATURE_CLOSE, AbortError, 'aborted'). This guard is registered early in both the LMS ([`instrumentation.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/304/files#diff-f09aee8b50d27529ea39a840fec449c430be26fc47991a3d2df90180c0e2bfc3)) and admin ([`apps/admin/server.js`](https://github.com/elevate-for-humanity/Elevate-lms/pull/304/files#diff-e87be1d419287e5f1d94c5d864dd67cb20607741230897430decea2028366855)) server boots.
> - Updates [`Dockerfile.northflank-lms`](https://github.com/elevate-for-humanity/Elevate-lms/pull/304/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) to export and bundle `@napi-rs/canvas`, `pdfjs-dist`, and `pdf-parse` into the final image, with a build-time assertion that these modules resolve correctly.
> - Updates [`Dockerfile.northflank-admin`](https://github.com/elevate-for-humanity/Elevate-lms/pull/304/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) to include `register-connection-guards.cjs` in the final image.
> - Risk: `process.emit` is monkey-patched globally at boot; any code that relies on observing these specific error events will no longer receive them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 550118c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->