### PR TITLE
fix(admin): harden dashboard against ERR_DASHBOARD_LOAD render crashes

### DIFF
--- a/apps/admin/app/admin/dashboard/page.tsx
+++ b/apps/admin/app/admin/dashboard/page.tsx
@@ -2,6 +2,7 @@ import { Suspense } from 'react';
 import { Metadata } from 'next';
 import { getAdminDashboardData } from '@/lib/admin/get-admin-dashboard-data';
 import { getDegradedAdminDashboardData } from '@/lib/admin/degraded-dashboard-data';
+import { normalizeAdminDashboardData } from '@/lib/admin/normalize-dashboard-data';
 import { AdminDashboardContent } from '@/components/admin/dashboard/DashboardShell';
 import { logger } from '@/lib/logger';
 import DashboardLoading from './loading';
@@ -17,10 +18,10 @@ export const metadata: Metadata = {
 async function DashboardContent() {
   let data;
   try {
-    data = await getAdminDashboardData();
+    data = normalizeAdminDashboardData(await getAdminDashboardData());
   } catch (err) {
     logger.error('[AdminDashboardPage] Dashboard data load failed; rendering degraded dashboard', err);
-    data = getDegradedAdminDashboardData();
+    data = normalizeAdminDashboardData(getDegradedAdminDashboardData());
   }
   return <AdminDashboardContent data={data} />;
 }

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -501,7 +501,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
         <StatsOverviewBar data={data} />
 
         {/* ── KPI cards ────────────────────────────────────────────────── */}
-        {data.kpis.length > 0 && (
+        {(data.kpis?.length ?? 0) > 0 && (
           <div className="mb-6">
             <RealtimeKpiGrid kpis={data.kpis} />
           </div>
@@ -525,7 +525,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <div className="space-y-4">
             <EnrollmentFunnel data={data} />
             <RecentActivity items={data.recentActivity} />
-            {data.recentApplications.length > 0 && (
+            {(data.recentApplications?.length ?? 0) > 0 && (
               <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
                 <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between">
                   <div className="flex items-center gap-2">
@@ -546,7 +546,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
 
         {/* ── Top programs + unpublished programs ──────────────────────── */}
         <div className="mt-8 grid grid-cols-1 lg:grid-cols-2 gap-6">
-          {data.topPrograms.length > 0 && (
+          {(data.topPrograms?.length ?? 0) > 0 && (
             <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
               <div className="px-4 sm:px-6 py-4 border-b border-slate-100 flex items-center justify-between">
                 <div className="flex items-center gap-2">
@@ -568,7 +568,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
               </div>
             </div>
           )}
-          {data.blockedPrograms.length > 0 && (
+          {(data.blockedPrograms?.length ?? 0) > 0 && (
             <BlockedProgramsList items={data.blockedPrograms} />
           )}
         </div>
@@ -583,7 +583,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <JobBoardPanelLazy />
           <LizzyContainerWrapperLazy
             sites={data.sitePreviewTargets ?? []}
-            isSuperAdmin={data.isSuperAdmin}
+            isSuperAdmin={data.isSuperAdmin === true}
             pendingApplications={data.recentApplications}
             pendingApplicationsCount={data.counts.pendingApplications}
             pendingProgramHolders={data.counts.pendingProgramHolders}

--- a/components/admin/dashboard/StatsOverviewBar.tsx
+++ b/components/admin/dashboard/StatsOverviewBar.tsx
@@ -46,7 +46,17 @@ function fmt(cents: number) {
 }
 
 export function StatsOverviewBar({ data }: Props) {
-  const { counts, totalStudents, revenueAllTimeCents, operational } = data;
+  const counts = data.counts ?? {
+    pendingApplications: 0,
+    activeEnrollments: 0,
+    revenueThisMonthCents: 0,
+    certificatesIssued: 0,
+    pendingProgramHolders: 0,
+    pendingDocuments: 0,
+  };
+  const totalStudents = data.totalStudents ?? 0;
+  const revenueAllTimeCents = data.revenueAllTimeCents ?? 0;
+  const operational = data.operational;
 
   return (
     <div className="mb-6">

--- a/components/admin/dashboard/types.ts
+++ b/components/admin/dashboard/types.ts
@@ -222,4 +222,6 @@ export interface AdminDashboardData {
   /** Non-empty when one or more non-critical sections failed to load. */
   degradedSections: DegradedSection[];
   systemHealth: SystemHealth;
+  /** Derived from admin profile role — gates Lizzy secrets panel. */
+  isSuperAdmin?: boolean;
 }

--- a/lib/admin/degraded-dashboard-data.ts
+++ b/lib/admin/degraded-dashboard-data.ts
@@ -64,6 +64,7 @@ export function getDegradedAdminDashboardData(): AdminDashboardData {
       },
     ],
     degradedSections: ['dashboard_data'],
+    isSuperAdmin: false,
     systemHealth: {
       stripeWebhookOk: false,
       stripeIssuingOk: false,

--- a/lib/admin/get-admin-dashboard-data.ts
+++ b/lib/admin/get-admin-dashboard-data.ts
@@ -1099,5 +1099,6 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     sitePreviewTargets,
     degradedSections,
     systemHealth,
+    isSuperAdmin: adminProfile?.role === 'super_admin',
   };
 }

--- a/lib/admin/normalize-dashboard-data.ts
+++ b/lib/admin/normalize-dashboard-data.ts
@@ -1,0 +1,75 @@
+import { getDegradedAdminDashboardData } from '@/lib/admin/degraded-dashboard-data';
+import type { AdminDashboardData, DashboardCounts } from '@/components/admin/dashboard/types';
+
+function asArray<T>(value: T[] | null | undefined): T[] {
+  return Array.isArray(value) ? value : [];
+}
+
+function asCount(value: unknown, fallback = 0): number {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (Array.isArray(value)) return value.length;
+  return fallback;
+}
+
+function normalizeCounts(
+  counts: Partial<DashboardCounts> | null | undefined,
+  pendingApplicationsListLength: number,
+): DashboardCounts {
+  const base = getDegradedAdminDashboardData().counts;
+  const raw = counts ?? {};
+  return {
+    pendingApplications: asCount(raw.pendingApplications, pendingApplicationsListLength),
+    activeEnrollments: asCount(raw.activeEnrollments, base.activeEnrollments),
+    revenueThisMonthCents: asCount(raw.revenueThisMonthCents, base.revenueThisMonthCents),
+    certificatesIssued: asCount(raw.certificatesIssued, base.certificatesIssued),
+    pendingProgramHolders: asCount(raw.pendingProgramHolders, base.pendingProgramHolders),
+    pendingDocuments: asCount(raw.pendingDocuments, base.pendingDocuments),
+  };
+}
+
+/** Guarantee a complete dashboard payload so render never throws on undefined sections. */
+export function normalizeAdminDashboardData(
+  input: Partial<AdminDashboardData> | null | undefined,
+): AdminDashboardData {
+  const fallback = getDegradedAdminDashboardData();
+  if (!input) return fallback;
+
+  const pendingApplications = asArray(input.pendingApplications);
+  const recentApplications = asArray(input.recentApplications);
+
+  return {
+    ...fallback,
+    ...input,
+    counts: normalizeCounts(input.counts, pendingApplications.length || recentApplications.length),
+    revenueAllTimeCents: asCount(input.revenueAllTimeCents, fallback.revenueAllTimeCents),
+    totalStudents: asCount(input.totalStudents, fallback.totalStudents),
+    recentPayments: asArray(input.recentPayments),
+    operational: { ...fallback.operational, ...input.operational },
+    priorities: asArray(input.priorities),
+    kpis: asArray(input.kpis),
+    enrollmentTrend: asArray(input.enrollmentTrend),
+    studentStatuses: asArray(input.studentStatuses),
+    topPrograms: asArray(input.topPrograms),
+    recentActivity: asArray(input.recentActivity),
+    recentStudents: asArray(input.recentStudents),
+    recentApplications,
+    pendingApplications,
+    blockedPrograms: asArray(input.blockedPrograms),
+    inactiveLearners: asArray(input.inactiveLearners),
+    pendingSubmissions: asArray(input.pendingSubmissions),
+    complianceAlerts: asArray(input.complianceAlerts),
+    staleLeads: asArray(input.staleLeads),
+    pendingWioaDocs: asCount(input.pendingWioaDocs, fallback.pendingWioaDocs),
+    stalledApplications: asArray(input.stalledApplications),
+    noOutcomeEnrollments: asArray(input.noOutcomeEnrollments),
+    missingFundingEnrollments: asArray(input.missingFundingEnrollments),
+    profile: input.profile ?? fallback.profile,
+    generatedAt: input.generatedAt ?? fallback.generatedAt,
+    sitePreviewTargets: asArray(input.sitePreviewTargets).length
+      ? asArray(input.sitePreviewTargets)
+      : fallback.sitePreviewTargets,
+    degradedSections: asArray(input.degradedSections),
+    systemHealth: { ...fallback.systemHealth, ...input.systemHealth },
+    isSuperAdmin: input.isSuperAdmin === true,
+  };
+}

--- a/tests/unit/normalize-dashboard-data.test.ts
+++ b/tests/unit/normalize-dashboard-data.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest';
+import { normalizeAdminDashboardData } from '@/lib/admin/normalize-dashboard-data';
+
+describe('normalizeAdminDashboardData', () => {
+  it('fills missing arrays and coerces array counts to numbers', () => {
+    const normalized = normalizeAdminDashboardData({
+      counts: {
+        pendingApplications: [{ id: '1' }, { id: '2' }] as unknown as number,
+        activeEnrollments: 3,
+        revenueThisMonthCents: 0,
+        certificatesIssued: 0,
+        pendingProgramHolders: 0,
+        pendingDocuments: 0,
+      },
+    });
+
+    expect(normalized.counts.pendingApplications).toBe(2);
+    expect(Array.isArray(normalized.kpis)).toBe(true);
+    expect(Array.isArray(normalized.recentApplications)).toBe(true);
+    expect(normalized.isSuperAdmin).toBe(false);
+  });
+
+  it('returns degraded fallback for null input', () => {
+    const normalized = normalizeAdminDashboardData(null);
+    expect(normalized.degradedSections).toContain('dashboard_data');
+    expect(normalized.counts.pendingApplications).toBe(0);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Admin `/admin/dashboard` can hit the route error boundary (`ERR_DASHBOARD_LOAD`) even when `getAdminDashboardData()` succeeds. The boundary fires on **render** when optional sections are undefined or when `counts.pendingApplications` is accidentally an array (legacy bug).

## Fix

- Add `normalizeAdminDashboardData()` to guarantee a complete payload (arrays, counts, fallbacks)
- Normalize in `page.tsx` for both live and degraded paths
- Defensive optional chaining in `DashboardShell` for kpis / recentApplications / topPrograms
- Set `isSuperAdmin` from admin profile role (Lizzy secrets panel)
- Unit tests for normalization

## Test plan

- [x] `pnpm vitest run tests/unit/normalize-dashboard-data.test.ts`
- [ ] After deploy: `/admin/dashboard` loads with nav + degraded banner instead of full-page error when DB sections fail
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden admin dashboard against render crashes from missing or malformed data
> - Introduces `normalizeAdminDashboardData` in [`lib/admin/normalize-dashboard-data.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/305/files#diff-8bec560e7d9088ea92319dda40d046b33a2108e633de6a641510d378f57b83c8) to coerce null/undefined arrays, numeric fields, and booleans to safe defaults before render.
> - Wraps both successful and degraded dashboard payloads with this normalizer in [`app/admin/dashboard/page.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/305/files#diff-1ad5bfa6c903365c0c8fb5915e0ff7bfc9dd15ad3f407f764e89d455b3853697).
> - Updates [`components/admin/dashboard/DashboardShell.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/305/files#diff-92df382a44bacb0fbe7c2d88a100ba8c11fdf3ae91cd3eb1f6d705aa953b4d92) to use optional chaining and nullish coalescing on array fields, preventing throws when arrays are undefined.
> - Adds `isSuperAdmin` (derived from admin profile role) to the dashboard data shape and degraded fallback, passed as a strict boolean to `LizzyContainerWrapperLazy`.
> - [`components/admin/dashboard/StatsOverviewBar.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/305/files#diff-20803225720dc9fd2b4e45e901338d7994ab293ceedb5016154709c47d1a2506) now falls back to zeros when `counts`, `totalStudents`, or `revenueAllTimeCents` are missing.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized d142be0. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->