### PR TITLE
fix(admin): StatsOverviewBar operational null fallback

### DIFF
--- a/components/admin/dashboard/StatsOverviewBar.tsx
+++ b/components/admin/dashboard/StatsOverviewBar.tsx
@@ -2,7 +2,21 @@
 // Renders a horizontal stats bar with key all-time and period metrics.
 import Link from 'next/link';
 import { Users, BookOpen, DollarSign, BadgeCheck, FileText, TrendingUp } from 'lucide-react';
-import type { AdminDashboardData } from './types';
+import type { AdminDashboardData, OperationalCounts } from './types';
+
+const EMPTY_OPERATIONAL: OperationalCounts = {
+  needsReview: 0,
+  needsReviewDetail: 'Dashboard data is temporarily unavailable',
+  atRisk: 0,
+  complianceAlerts: 0,
+  complianceAlertsSeverity: null,
+  newToday: 0,
+  newTodayDetail: 'Dashboard data is temporarily unavailable',
+  newAppsToday: 0,
+  newLeadsToday: 0,
+  newEnrollmentsToday: 0,
+  revenueThisMonthCents: 0,
+};
 
 interface Props {
   data: AdminDashboardData;
@@ -56,7 +70,7 @@ export function StatsOverviewBar({ data }: Props) {
   };
   const totalStudents = data.totalStudents ?? 0;
   const revenueAllTimeCents = data.revenueAllTimeCents ?? 0;
-  const operational = data.operational;
+  const operational = data.operational ?? EMPTY_OPERATIONAL;
 
   return (
     <div className="mb-6">


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Macroscope review: guard `data.operational` in `StatsOverviewBar` with a full `OperationalCounts` fallback so degraded dashboard data cannot throw on `newAppsToday` / `newLeadsToday` / `newEnrollmentsToday` access.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix null fallback for `operational` data in `StatsOverviewBar`
> When `data.operational` is undefined, the component previously crashed attempting to read properties of `undefined`. This adds an `EMPTY_OPERATIONAL` constant with zeroed counts and default strings as a fallback via the `??` operator in [StatsOverviewBar.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/306/files#diff-20803225720dc9fd2b4e45e901338d7994ab293ceedb5016154709c47d1a2506).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 21865c4.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->