### PR TITLE
Platform owner tenant model + admin login fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,15 +1,14 @@
 # Elevate for Humanity - Environment Variables Template
 #
-# PRODUCTION (Netlify):
-#   Only 3 bootstrap vars go in Netlify Site Settings → Environment Variables:
+# PRODUCTION (Northflank — elevate-lms + elevate-admin):
+#   Bootstrap vars in Northflank secret group `elevate-production-env`:
 #     NEXT_PUBLIC_SUPABASE_URL
 #     NEXT_PUBLIC_SUPABASE_ANON_KEY
 #     SUPABASE_SERVICE_ROLE_KEY
-#   All other secrets live in the Supabase `app_secrets` table.
-#   See: lib/secrets.ts, scripts/seed-app-secrets.sh
+#   Additional secrets: `platform_secrets` / `app_secrets` tables + same secret group.
+#   See: lib/secrets.ts, scripts/northflank/sync-env.ts, AGENTS.md
 #
-#   NEXT_PUBLIC_* vars needed at build time should use scope "Builds" in
-#   Netlify dashboard so they aren't injected into Lambda functions.
+#   NEXT_PUBLIC_* vars are required at Docker build time (see Dockerfile.northflank-*).
 #
 # LOCAL DEVELOPMENT:
 #   1. Copy: cp .env.example .env.local
@@ -699,8 +698,8 @@ NEXT_PUBLIC_VIMEO_BASE_URL=
 NEXT_PUBLIC_COLLABORATION_WS_URL=
 NEXT_PUBLIC_CONTAINER_API_URL=
 NEXT_PUBLIC_STUDIO_API_URL=
-# Studio shell ECS container (internal — never public)
-# ws://elevate-studio.local:8888  (ECS service discovery DNS)
+# Dev Studio terminal (internal — never public; Northflank admin runtime only)
+# TERMINAL_WS_URL=wss://admin.elevateforhumanity.org/api/devstudio/shell-ws
 # Generate: openssl rand -hex 32
 # HMAC secret for short-lived WebSocket auth tokens (can be same as SHELL_SECRET)
 TERMINAL_WS_URL=
@@ -708,7 +707,7 @@ REACT_APP_JITSI_DOMAIN=
 REDIS_URL=
 
 # =============================================================================
-# NETLIFY BUILD HOOKS
+# LEGACY NETLIFY BUILD HOOKS (deprecated — production is Northflank only)
 # =============================================================================
 
 NETLIFY_BUILD_HOOK=

--- a/.env.example
+++ b/.env.example
@@ -714,6 +714,9 @@ NETLIFY_BUILD_HOOK=
 NETLIFY_BUILD_HOOK_URL=
 NETLIFY_TOKEN=
 
+# Optional preview hostname (Vercel only — production hosting is Northflank)
+VERCEL_URL=
+
 # =============================================================================
 # FEATURE FLAGS & RUNTIME CONFIG
 # =============================================================================

--- a/.env.example
+++ b/.env.example
@@ -1147,3 +1147,10 @@ NORTHFLANK_DEPLOYMENT_PLAN=nf-compute-100-2
 NORTHFLANK_BUILD_PLAN=nf-compute-800-32
 # Build ephemeral disk (MB). Northflank enum only: 16384, 32768, 65536, 131072, 262144, 524288
 NORTHFLANK_EPHEMERAL_STORAGE_MB=32768
+
+# Platform owner tenant (Elevate operator — not a customer workspace)
+# Set after migration 20260708000004 or read from platform_settings PLATFORM_OWNER_TENANT_ID
+PLATFORM_OWNER_TENANT_ID=
+
+# Elevate Dev Cloud — customer workspace URLs (provisioned tenants)
+ELEVATE_DEV_CLOUD_HOST=elevatedev.ai

--- a/.env.example
+++ b/.env.example
@@ -714,9 +714,6 @@ NETLIFY_BUILD_HOOK=
 NETLIFY_BUILD_HOOK_URL=
 NETLIFY_TOKEN=
 
-# Optional preview hostname (Vercel only — production hosting is Northflank)
-VERCEL_URL=
-
 # =============================================================================
 # FEATURE FLAGS & RUNTIME CONFIG
 # =============================================================================

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -922,6 +922,15 @@ Precedence at runtime: `platform_secrets > app_secrets > process.env`
 - **Import website:** `/import` → `POST /api/ai/import-site` (auth required). Builder: `/apps/website-builder`.
 - **DB:** Apply `supabase/migrations/20260702000015_individual_app_subscriptions.sql` if trials or “New Website” fail (missing `app_slug` / RLS).
 
+### Platform owner vs customer tenants
+
+Elevate is **not** a customer workspace — it is the **platform owner tenant** (`tenants.is_platform_owner = true`). Your brands (Elevate for Humanity, Prestige, Curvature, Rise Forward) are **organizations** on that tenant. Dev Cloud subscribers get separate `customer` tenants via `provisionWorkspace()`.
+
+- Architecture: `docs/platform-owner-tenant-model.md`
+- Permission levels: `lib/platform/permission-levels.ts` (Platform Owner / Platform Admin / Organization Admin / Standard User)
+- DevStudio + deploy: **platform operator only** (`super_admin` on owner tenant) — `apiRequirePlatformOperator`
+- Workspace provisioning: platform staff — `POST /api/platform/workspaces/provision`
+
 ### Stripe webhooks (production)
 
 - **Canonical URL:** `https://www.elevateforhumanity.org/api/webhooks/stripe` — register in Stripe Dashboard (live), then set signing secret in the Northflank production secret group for the **LMS** service.

--- a/DEPLOY.md
+++ b/DEPLOY.md
@@ -1,54 +1,52 @@
 # Deploy Elevate LMS
 
-Choose your deployment method:
+**Elevate for Humanity production** runs on **Northflank** only (`elevate-lms` + `elevate-admin`). There is no AWS ECS or Netlify production deploy path in this repository.
 
-## Option 1: One-Click Deploy (Free Template)
+Canonical runbooks:
 
-Deploy your own instance in minutes:
+- `docs/deploy/northflank-separate-lms-admin.md`
+- `docs/audits/aws-ecs-decommission-2026-06.md` (legacy teardown checklist)
+- `pnpm tsx scripts/northflank/verify-health-checks.ts`
 
-### Netlify (Recommended)
+## Production (Northflank)
 
-[![Deploy to Netlify](https://www.netlify.com/img/deploy/button.svg)](https://app.netlify.com/start/deploy?repository=https://github.com/elevateforhumanity/Elevate-lms)
+| Service | Dockerfile | CI workflow | Health |
+|---------|------------|---------------|--------|
+| LMS (`elevate-lms`) | `Dockerfile.northflank-lms` | `.github/workflows/deploy-lms.yml` | `GET /api/ping`, `GET /api/ready` |
+| Admin (`elevate-admin`) | `Dockerfile.northflank-admin` | `.github/workflows/deploy-admin.yml` | `GET /api/ping`, `GET /api/health` |
 
-### Railway
+Merge to `main` triggers deploy when paths under `lib/`, `components/`, `apps/admin/`, or Dockerfiles change. Manual deploy:
 
-[![Deploy on Railway](https://railway.app/button.svg)](https://railway.app/template/elevate-lms?referralCode=elevate)
+```bash
+DEPLOY_BRANCH=main pnpm tsx scripts/northflank/deploy-live.ts --execute
+```
+
+Secrets: Northflank secret group `elevate-production-env` on project `elevate-platform`.
 
 ---
 
-## Option 2: Licensed Deployment (Self-Hosted)
+## Licensed self-hosted deployment
 
-For organizations wanting full control:
+For organizations running their own instance:
 
 1. **Purchase a license** at [elevateforhumanity.org/store](https://www.elevateforhumanity.org/store)
 2. **Get private repo access** after purchase
-3. **Deploy to your infrastructure**
-4. **Receive setup support**
-
-### License Tiers
-
-| Tier         | Price    | Includes                                    |
-| ------------ | -------- | ------------------------------------------- |
-| Starter      | $99/mo   | 100 students, 1 admin, email support        |
-| Professional | $299/mo  | 500 students, 5 admins, priority support    |
-| Enterprise   | $35,000+ | Unlimited, dedicated support, customization |
+3. **Build** with `Dockerfile.northflank-lms` and/or `Dockerfile.northflank-admin`
+4. **Configure** Supabase + env vars (see below)
 
 ---
 
-## Option 3: Managed White-Label (We Host)
+## Managed white-label (we host)
 
-Let us handle everything:
+- Your branding on our Northflank infrastructure
+- Custom subdomain or your own domain
+- We manage updates, security, and scaling
 
-- **Your branding** on our infrastructure
-- **Custom subdomain** (yourorg.app.elevateforhumanity.org) or your own domain
-- **Zero DevOps** - we manage updates, security, scaling
-- **SLA guaranteed** uptime
-
-[Request White-Label Demo →](https://www.elevateforhumanity.org/store/request-license)
+[Request a demo →](https://www.elevateforhumanity.org/store/trial)
 
 ---
 
-## Environment Variables Required
+## Environment variables required
 
 ```bash
 # Supabase (Database)
@@ -65,22 +63,19 @@ STRIPE_SECRET_KEY=
 STRIPE_WEBHOOK_SECRET=
 NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY=
 
-# Optional
-NEXT_PUBLIC_GA_MEASUREMENT_ID=
-RESEND_API_KEY=
+# Northflank deploy (CI only)
+NORTHFLANK_API_TOKEN=
 ```
 
-## Quick Start After Deploy
+## Quick start after deploy
 
 1. Set up Supabase project at [supabase.com](https://supabase.com)
 2. Run database migrations (see `/supabase/migrations`)
-3. Configure Stripe webhooks pointing to `/api/webhooks/stripe`
-   - Live signing secret must match `STRIPE_WEBHOOK_SECRET` in the LMS runtime environment
-   - Re-enable the endpoint in Stripe Dashboard after deploy; smoke `GET /api/webhooks/stripe`
-4. Add your branding in `/public` and update `next.config.js`
+3. Configure Stripe webhooks pointing to `https://www.elevateforhumanity.org/api/webhooks/stripe`
+4. Smoke: `curl -sf https://www.elevateforhumanity.org/api/ready`
 
 ## Support
 
 - **Documentation**: [/docs](./docs)
-- **Issues**: [GitHub Issues](https://github.com/elevateforhumanity/Elevate-lms/issues)
+- **Issues**: [GitHub Issues](https://github.com/elevate-for-humanity/Elevate-lms/issues)
 - **Email**: support@elevateforhumanity.org

--- a/app/api/build/route.ts
+++ b/app/api/build/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from 'next/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAuth } from '@/lib/api/requireAuth';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { getProductionHostingPlatform } from '@/lib/platform/hosting';
 
 export const dynamic = 'force-dynamic';
 
@@ -13,7 +14,7 @@ async function _GET(request: Request) {
   if (auth.error) return auth.error;
   const payload = {
     now: new Date().toISOString(),
-    platform: 'aws-ecs',
+    platform: getProductionHostingPlatform(),
     env: process.env.NODE_ENV ?? null,
     commit: process.env.COMMIT_REF ?? null,
   };

--- a/app/store/deployment/page.tsx
+++ b/app/store/deployment/page.tsx
@@ -54,7 +54,7 @@ export default async function DeploymentPage() {
               <div className="w-16 h-16 bg-blue-100 rounded-xl flex items-center justify-center mb-4">
                 <Zap className="w-8 h-8 text-blue-600" />
               </div>
-              <h3 className="text-2xl font-bold mb-4">Vercel (Recommended)</h3>
+              <h3 className="text-2xl font-bold mb-4">Northflank Managed (Recommended)</h3>
               <div className="flex items-center gap-2 mb-4">
                 <Clock className="w-5 h-5 text-brand-green-600" />
                 <span className="font-semibold text-brand-green-600">5 minutes</span>
@@ -239,8 +239,8 @@ export default async function DeploymentPage() {
                 },
                 {
                   step: 4,
-                  title: 'Deploy to Vercel',
-                  description: 'Connect repository to Vercel and deploy with one click',
+                  title: 'Deploy with Docker',
+                  description: 'Build Dockerfile.northflank-lms and Dockerfile.northflank-admin on your Northflank project (or any container host)',
                   time: '5 minutes',
                 },
                 {

--- a/app/store/licenses/page.tsx
+++ b/app/store/licenses/page.tsx
@@ -350,7 +350,7 @@ export default async function LicensesPage() {
               </div>
               <h3 className="text-xl font-bold mb-3">Deploy Anywhere</h3>
               <p className="text-zinc-400">
-                Vercel, AWS, Azure, GCP, or self-hosted. One-click deployment
+                Northflank, Docker on any cloud, or self-hosted. Managed trial at /store/trial
                 templates included.
               </p>
             </div>

--- a/app/white-label/page.tsx
+++ b/app/white-label/page.tsx
@@ -293,7 +293,7 @@ export default async function WhiteLabelPage() {
             <div className="p-8 bg-white rounded-xl border border-slate-200">
               <h3 className="text-xl font-bold text-zinc-900 mb-4">Infrastructure</h3>
               <ul className="space-y-2 text-zinc-700">
-                <li>• Vercel deployment</li>
+                <li>• Northflank managed hosting</li>
                 <li>• CDN & edge caching</li>
                 <li>• Automated CI/CD</li>
                 <li>• Environment management</li>

--- a/apps/admin/app/admin/dev-studio/layout.tsx
+++ b/apps/admin/app/admin/dev-studio/layout.tsx
@@ -1,3 +1,11 @@
-export default function DevStudioLayout({ children }: { children: React.ReactNode }) {
+import { redirect } from 'next/navigation';
+import { requirePlatformOperatorContext } from '@/lib/platform/platform-owner';
+
+export default async function DevStudioLayout({ children }: { children: React.ReactNode }) {
+  const ctx = await requirePlatformOperatorContext();
+  if (!ctx) {
+    redirect('/unauthorized?reason=platform_operator');
+  }
+
   return <div className="h-[calc(100vh-4rem)] min-h-[480px] overflow-hidden">{children}</div>;
 }

--- a/apps/admin/app/api/devstudio/autofix/route.ts
+++ b/apps/admin/app/api/devstudio/autofix/route.ts
@@ -17,7 +17,7 @@
 
 import { NextRequest, NextResponse } from 'next/server';
 import { spawn } from 'child_process';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import {
@@ -225,7 +225,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {
@@ -261,7 +261,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   return NextResponse.json({

--- a/apps/admin/app/api/devstudio/chat/route.ts
+++ b/apps/admin/app/api/devstudio/chat/route.ts
@@ -13,7 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { isGroqConfigured, getGroqClient } from '@/lib/groq-client';
@@ -1183,7 +1183,7 @@ async function _POST(req: NextRequest) {
     const rateLimited = await applyRateLimit(req, 'api');
     if (rateLimited) return rateLimited;
 
-    const auth = await apiRequireAdmin(req);
+    const auth = await apiRequireDevStudio(req);
     if (auth.error) return auth.error;
 
     await hydrateProcessEnv();

--- a/apps/admin/app/api/devstudio/container-env/route.ts
+++ b/apps/admin/app/api/devstudio/container-env/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
@@ -34,7 +34,7 @@ async function readStoredValue(key: string): Promise<string | null> {
 export async function GET(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   return NextResponse.json({
@@ -48,7 +48,7 @@ export async function GET(req: NextRequest) {
 export async function POST(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'strict');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   try {
@@ -104,7 +104,7 @@ export async function POST(req: NextRequest) {
 export async function DELETE(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'strict');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   return safeError('Delete from Northflank secret groups is not exposed here. Delete the key in /api/devstudio/env, then sync the full secret group.', 409);

--- a/apps/admin/app/api/devstudio/devcontainer/route.ts
+++ b/apps/admin/app/api/devstudio/devcontainer/route.ts
@@ -17,7 +17,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { createHash } from 'crypto';
 import { access, mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 
@@ -192,7 +192,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {
@@ -301,7 +301,7 @@ export async function PUT(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {

--- a/apps/admin/app/api/devstudio/embed-check/route.ts
+++ b/apps/admin/app/api/devstudio/embed-check/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 
 export const dynamic = 'force-dynamic';
@@ -121,7 +121,7 @@ export async function GET(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const raw = req.nextUrl.searchParams.get('url');

--- a/apps/admin/app/api/devstudio/env/route.ts
+++ b/apps/admin/app/api/devstudio/env/route.ts
@@ -1,5 +1,5 @@
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { safeDbError, safeError, safeInternalError } from '@/lib/api/safe-error';
@@ -29,7 +29,7 @@ export async function GET(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   try {
@@ -64,7 +64,7 @@ export async function POST(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const body = await req.json().catch(() => null);
@@ -125,7 +125,7 @@ export async function DELETE(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const key = new URL(req.url).searchParams.get('key')?.trim() || '';

--- a/apps/admin/app/api/devstudio/events/route.ts
+++ b/apps/admin/app/api/devstudio/events/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { safeInternalError } from '@/lib/api/safe-error';
 
@@ -19,7 +19,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const { searchParams } = req.nextUrl;

--- a/apps/admin/app/api/devstudio/execute/route.ts
+++ b/apps/admin/app/api/devstudio/execute/route.ts
@@ -35,7 +35,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { hydrateProcessEnv, refreshSecrets } from '@/lib/secrets';
 import { safeError } from '@/lib/api/safe-error';
@@ -3469,7 +3469,7 @@ export async function POST(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   // Hydrate app_secrets so executed commands have full secret access

--- a/apps/admin/app/api/devstudio/files/route.ts
+++ b/apps/admin/app/api/devstudio/files/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { requireAdminClient } from '@/lib/supabase/admin';
@@ -135,7 +135,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const { searchParams } = request.nextUrl;
@@ -183,7 +183,7 @@ export async function PUT(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const body = await request.json().catch(() => null);
@@ -257,7 +257,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const body = await readCreateBody(request);
@@ -297,7 +297,7 @@ export async function DELETE(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const body = await request.json().catch(() => null);

--- a/apps/admin/app/api/devstudio/git/route.ts
+++ b/apps/admin/app/api/devstudio/git/route.ts
@@ -7,7 +7,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
@@ -76,7 +76,7 @@ export async function GET(request: NextRequest) {
   await hydrateProcessEnv();
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const action = request.nextUrl.searchParams.get('action') ?? 'status';
@@ -156,7 +156,7 @@ export async function POST(request: NextRequest) {
   await hydrateProcessEnv();
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   let body: { action: string; message?: string; files?: string[]; branch?: string; confirmation?: string; path?: string; content?: string; sha?: string };

--- a/apps/admin/app/api/devstudio/health/route.ts
+++ b/apps/admin/app/api/devstudio/health/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { isGroqConfigured } from '@/lib/groq-client';
 import { isGeminiConfigured } from '@/lib/gemini-client';
@@ -19,7 +19,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   await hydrateProcessEnv().catch(() => {});

--- a/apps/admin/app/api/devstudio/jobs/route.ts
+++ b/apps/admin/app/api/devstudio/jobs/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
@@ -25,7 +25,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const { searchParams } = request.nextUrl;
@@ -68,7 +68,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {
@@ -107,7 +107,7 @@ export async function PATCH(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {

--- a/apps/admin/app/api/devstudio/knowledge-graph/route.ts
+++ b/apps/admin/app/api/devstudio/knowledge-graph/route.ts
@@ -11,7 +11,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import {
   SYSTEMS,
   PLATFORM_DEBT,
@@ -26,7 +26,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const { searchParams } = req.nextUrl;

--- a/apps/admin/app/api/devstudio/northflank-status/route.ts
+++ b/apps/admin/app/api/devstudio/northflank-status/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import {
@@ -31,7 +31,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const projectId = getNorthflankProjectId();

--- a/apps/admin/app/api/devstudio/plan/route.ts
+++ b/apps/admin/app/api/devstudio/plan/route.ts
@@ -15,7 +15,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { decomposePlan, canExecuteStep, type PlanStep } from '@/lib/platform/planner';
@@ -43,7 +43,7 @@ export async function POST(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   await hydrateProcessEnv();

--- a/apps/admin/app/api/devstudio/platform-state/route.ts
+++ b/apps/admin/app/api/devstudio/platform-state/route.ts
@@ -13,7 +13,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { refreshSecrets } from '@/lib/secrets';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { isGroqConfigured } from '@/lib/groq-client';
@@ -25,7 +25,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   await refreshSecrets();

--- a/apps/admin/app/api/devstudio/qa-scan/route.ts
+++ b/apps/admin/app/api/devstudio/qa-scan/route.ts
@@ -21,7 +21,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { createAdminClient } from '@/lib/supabase/admin';
@@ -50,7 +50,7 @@ export async function GET(req: NextRequest) {
   const rateLimited = await applyRateLimit(req, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   await hydrateProcessEnv();

--- a/apps/admin/app/api/devstudio/services/route.ts
+++ b/apps/admin/app/api/devstudio/services/route.ts
@@ -5,7 +5,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
@@ -47,7 +47,7 @@ async function checkHealth(url: string, path: string): Promise<ServiceHealth> {
 export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const projectId = getNorthflankProjectId();
@@ -105,7 +105,7 @@ export async function GET(request: NextRequest) {
 export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   let body: { action: string; service: string };

--- a/apps/admin/app/api/devstudio/shell/route.ts
+++ b/apps/admin/app/api/devstudio/shell/route.ts
@@ -18,7 +18,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
@@ -127,7 +127,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const body = await request.json().catch(() => null);
@@ -210,7 +210,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const { searchParams } = request.nextUrl;

--- a/apps/admin/app/api/devstudio/smoke-test/route.ts
+++ b/apps/admin/app/api/devstudio/smoke-test/route.ts
@@ -20,7 +20,7 @@
  */
 
 import { NextRequest } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { getAdminUrl } from '@/lib/utils/siteUrl';
@@ -91,7 +91,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const baseUrl = process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl;

--- a/apps/admin/app/api/devstudio/snapshot/[id]/rollback/route.ts
+++ b/apps/admin/app/api/devstudio/snapshot/[id]/rollback/route.ts
@@ -8,7 +8,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { emitEvent } from '@/lib/platform/events';
@@ -21,7 +21,7 @@ export async function POST(
   req: NextRequest,
   { params }: { params: Promise<{ id: string }> },
 ) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const { id } = await params;

--- a/apps/admin/app/api/devstudio/snapshot/route.ts
+++ b/apps/admin/app/api/devstudio/snapshot/route.ts
@@ -16,7 +16,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { createAdminClient } from '@/lib/supabase/admin';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { emitEvent } from '@/lib/platform/events';
@@ -25,7 +25,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 export async function GET(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   const { searchParams } = req.nextUrl;
@@ -52,7 +52,7 @@ export async function GET(req: NextRequest) {
 }
 
 export async function POST(req: NextRequest) {
-  const auth = await apiRequireAdmin(req);
+  const auth = await apiRequireDevStudio(req);
   if (auth.error) return auth.error;
 
   try {

--- a/apps/admin/app/api/devstudio/stabilize/route.ts
+++ b/apps/admin/app/api/devstudio/stabilize/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { spawn } from 'child_process';
 import path from 'path';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 
@@ -123,7 +123,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   try {
@@ -199,7 +199,7 @@ export async function POST(request: NextRequest) {
 }
 
 export async function GET(request: NextRequest) {
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   return NextResponse.json({

--- a/apps/admin/app/api/devstudio/system-health/route.ts
+++ b/apps/admin/app/api/devstudio/system-health/route.ts
@@ -10,7 +10,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { refreshSecrets } from '@/lib/secrets';
@@ -32,7 +32,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   // Refresh secrets cache so recently-saved keys are visible

--- a/apps/admin/app/api/devstudio/upload/route.ts
+++ b/apps/admin/app/api/devstudio/upload/route.ts
@@ -14,7 +14,7 @@
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { apiRequireAdmin } from '@/lib/admin/guards';
+import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { createClient } from '@/lib/supabase/server';
@@ -52,7 +52,7 @@ export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   // Get current user id for path namespacing
@@ -165,7 +165,7 @@ export async function GET(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'api');
   if (rateLimited) return rateLimited;
 
-  const auth = await apiRequireAdmin(request);
+  const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
 
   const supabase = await createClient();

--- a/apps/admin/app/api/platform/workspaces/provision/route.ts
+++ b/apps/admin/app/api/platform/workspaces/provision/route.ts
@@ -1,0 +1,66 @@
+/**
+ * POST /api/platform/workspaces/provision
+ * Platform staff only — creates a customer workspace (tenant + org + async provision job).
+ *
+ * @see docs/platform-owner-tenant-model.md
+ */
+
+import { NextRequest, NextResponse } from 'next/server';
+import { apiRequirePlatformStaff } from '@/lib/admin/guards';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeError, safeInternalError } from '@/lib/api/safe-error';
+import { provisionWorkspace } from '@/lib/workspace/provision-workspace';
+import type { WorkspaceSubscriptionTier } from '@/lib/workspace/tier-limits';
+
+const VALID_TIERS: WorkspaceSubscriptionTier[] = ['builder', 'pro', 'agency'];
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'strict');
+  if (rateLimited) return rateLimited;
+
+  const auth = await apiRequirePlatformStaff(request);
+  if (auth.error) return auth.error;
+
+  let body: {
+    displayName?: string;
+    slug?: string;
+    subscriptionTier?: WorkspaceSubscriptionTier;
+    templateSlug?: string;
+    contactEmail?: string;
+  };
+
+  try {
+    body = await request.json();
+  } catch {
+    return safeError('Invalid JSON body', 400);
+  }
+
+  const displayName = body.displayName?.trim();
+  const slug = body.slug?.trim();
+  const subscriptionTier = body.subscriptionTier ?? 'builder';
+
+  if (!displayName) return safeError('displayName is required', 400);
+  if (!slug) return safeError('slug is required', 400);
+  if (!VALID_TIERS.includes(subscriptionTier)) {
+    return safeError('Invalid subscriptionTier', 400);
+  }
+
+  try {
+    const result = await provisionWorkspace({
+      displayName,
+      slug,
+      subscriptionTier,
+      templateSlug: body.templateSlug,
+      contactEmail: body.contactEmail,
+      provisionedByUserId: auth.id,
+    });
+
+    if (!result.ok) {
+      return safeError(result.error, 400);
+    }
+
+    return NextResponse.json(result, { status: 201 });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to provision workspace');
+  }
+}

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -73,7 +73,9 @@ export async function middleware(req: NextRequest) {
     pathname === '/' ||
     pathname.startsWith('/admin') ||
     pathname.startsWith('/api/admin') ||
-    pathname.startsWith('/api/staff');
+    pathname.startsWith('/api/staff') ||
+    pathname.startsWith('/api/devstudio') ||
+    pathname.startsWith('/api/platform');
 
   if (!isProtected) return NextResponse.next();
 

--- a/components/admin/AdminNav.tsx
+++ b/components/admin/AdminNav.tsx
@@ -68,7 +68,7 @@ export default function AdminNav({ userName = 'Admin', notifs = [], navSections 
   }, []);
 
   useEffect(() => {
-    setMobileOpen(false);
+    setMenuOpen(false);
     setOpenDropdown(null);
     setNotifOpen(false);
   }, [pathname]);

--- a/docs/audits/production-readiness-validation-2026-05-11.md
+++ b/docs/audits/production-readiness-validation-2026-05-11.md
@@ -1,4 +1,7 @@
 # Production Readiness Validation Report
+
+> **Historical (2026-05-11).** Production hosting is **Northflank only** — ignore ECS / `deploy-aws.yml` / `Dockerfile.package` items below. Current checklist: `docs/audits/aws-ecs-decommission-2026-06.md`.
+
 **Date**: 2026-05-11  
 **Status**: IN PROGRESS  
 **Validation Phase**: Comprehensive production verification before final commit

--- a/docs/platform-hardening-audit-2026-05-31.md
+++ b/docs/platform-hardening-audit-2026-05-31.md
@@ -143,7 +143,7 @@ Migrations are **not** auto-applied on deploy (`prebuild` skips migrate). Verify
 | `pnpm audit:admin` | 0 errors |
 | `pnpm guard:admin-routes` | 32 routes guarded |
 | `pnpm predeploy:check` | **Fails** on `routes:check` (link noise) |
-| CI reference | `.github/workflows/compliance-gate.yml`, `deploy-aws.yml` |
+| CI reference | `.github/workflows/compliance-gate.yml`, `deploy-lms.yml`, `deploy-admin.yml` |
 
 **Hardening actions:**
 

--- a/docs/platform-owner-tenant-model.md
+++ b/docs/platform-owner-tenant-model.md
@@ -1,0 +1,145 @@
+# Platform Owner Tenant Model
+
+Elevate runs as a **multi-tenant platform** with a hard separation between the **platform owner** (you) and **customer tenants** (schools, boards, nonprofits, employers). This is the same pattern as Shopify, HubSpot, and HighLevel: you keep the master control plane; customers get isolated tenants on the shared core.
+
+## Two products, one platform
+
+| Product | Audience | What they get |
+|---------|----------|----------------|
+| **Elevate Workforce OS** | Training providers, workforce boards, employers | LMS, apprenticeships, ETPL, billing, white-label sites |
+| **Elevate Dev Cloud** | Builders who want their own stack | Provisioned workspace: dashboard + LMS + site + DB + auth + AI |
+
+The platform owner operates **both** products from `/admin` on `admin.elevateforhumanity.org`. Customer tenants never receive DevStudio, deployment controls, or Northflank operator access.
+
+## Tenant hierarchy
+
+```text
+Platform Owner Tenant (is_platform_owner = true)
+│
+├── Your organizations (sibling orgs — NOT customer workspaces)
+│   ├── Elevate for Humanity
+│   ├── Prestige Elevation
+│   ├── Curvature Body Sculpting
+│   └── Rise Forward Foundation
+│
+└── Customer tenants (provisioned via Dev Cloud)
+    ├── School A          → acme.elevatedev.ai
+    ├── Workforce Board B
+    ├── Nonprofit C
+    └── Employer D
+```
+
+**Rule:** Your own brands are **organizations under the platform owner tenant**. They are not `customer_workspaces` rows. Dev Cloud subscribers get a **new tenant** (`tenants.type = 'customer'`) with `parent_tenant_id` pointing at the platform owner.
+
+## Permission levels
+
+| Level | Profile role | Tenant | Capabilities |
+|-------|--------------|--------|--------------|
+| **Platform Owner** | `super_admin` | Platform owner tenant | Deploy, DevStudio, AI Operator, Northflank, all tenants, workspace provisioning |
+| **Platform Admin** | `admin`, `staff` | Platform owner tenant | Tenant management, billing, support — no deploy/DevStudio |
+| **Organization Admin** | `org_admin`, `org_owner` | Any tenant | Single organization only |
+| **Standard User** | `student`, `instructor`, … | Any tenant | Learner / portal access |
+
+Canonical code: `lib/platform/permission-levels.ts`, `lib/platform/platform-owner.ts`.
+
+## What platform owner gets
+
+- Full `/admin` on `admin.elevateforhumanity.org`
+- Dev Studio (`/admin/dev-studio`)
+- AI Operator (Northflank deploy, code fix, autopilot)
+- Mission Control / system health
+- Tenant & workspace provisioning
+- Billing management for all customers
+- Deployment controls (Northflank, GitHub)
+
+## What customer tenants get
+
+- Tenant-scoped admin (future: `{slug}.elevatedev.ai/admin`)
+- Their own LMS, website, users, branding, data (RLS by `tenant_id`)
+- AI assistant for **their** content (not platform deploy)
+
+## What customer tenants cannot access
+
+- DevStudio, operator controls, deployment APIs
+- `platform_settings`, `platform_secrets`, Northflank project config
+- Other tenants' data
+
+## Flows
+
+### You create a customer workspace
+
+```text
+Platform Owner → Create Workspace
+  → provisionWorkspace()
+  → customer tenant + organization
+  → GitHub template fork (phase 2)
+  → Northflank service (phase 2)
+  → Supabase schema / RLS scope (phase 2)
+  → workspace URL
+```
+
+API: `POST /api/platform/workspaces/provision` (platform staff only).
+
+### Customer subscribes (self-serve, phase 2)
+
+```text
+Stripe checkout (Builder / Pro / Agency)
+  → webhook enqueues workspace_provision job
+  → provisionWorkspace()
+  → email with workspace URL
+```
+
+### Your AI operator (platform)
+
+```text
+You: "Fix the homepage video issue."
+AI: patch → test → triggerNorthflankBuild → health check
+```
+
+### Customer AI (tenant-scoped, phase 2)
+
+```text
+User: "Build me a workforce training website."
+AI: provision workspace → generate site → configure LMS → domain
+```
+
+## Database objects
+
+| Object | Purpose |
+|--------|---------|
+| `tenants.is_platform_owner` | Exactly one row = Elevate operator |
+| `tenants.parent_tenant_id` | Customer tenant → platform owner |
+| `tenants.type = 'customer'` | Dev Cloud provisioned tenant |
+| `customer_workspaces` | Provisioning lifecycle + infra IDs |
+| `get_platform_owner_tenant_id()` | SQL helper |
+| `is_platform_owner_user()` | Platform staff (admin/super_admin/staff on owner tenant) |
+| `is_platform_operator()` | Platform owner only (super_admin on owner tenant) |
+
+Migration: `supabase/migrations/20260708000004_platform_owner_tenant_model.sql`
+
+## Code map
+
+| Path | Role |
+|------|------|
+| `lib/platform/permission-levels.ts` | Four-level permission model |
+| `lib/platform/platform-owner.ts` | Resolve owner tenant, classify users |
+| `lib/workspace/provision-workspace.ts` | Workspace orchestrator (phased) |
+| `lib/workspace/tier-limits.ts` | Builder / Pro / Agency caps |
+| `lib/admin/guards.ts` | `apiRequirePlatformOperator`, `apiRequirePlatformStaff` |
+| `lib/devstudio/api-auth.ts` | DevStudio routes use platform operator guard |
+| `docs/platform-saas-blueprint.md` | Workforce OS org billing |
+| `docs/platform-saas-blueprint.md` | Workforce OS org billing |
+
+## Implementation phases
+
+1. **Done (this doc + schema + guards)** — owner tenant flag, permission levels, provision scaffold
+2. **AI Operator v1** — `ai_operator_tasks`, `/admin/operator`, Northflank deploy from tasks
+3. **Workspace provisioning MVP** — GitHub template + Northflank service per workspace
+4. **Stripe Dev Cloud tiers** — Builder $49 / Pro $149 / Agency $499
+5. **Tenant-scoped admin host** — `{slug}.elevatedev.ai` routing in `proxy.ts`
+
+## Do not
+
+- Treat Elevate for Humanity as a `customer_workspace` — it is an org on the owner tenant
+- Give customer `org_admin` users access to `/api/devstudio/*`
+- Sell raw monorepo source — sell provisioned platform template instances

--- a/docs/production-activation-2026-05.md
+++ b/docs/production-activation-2026-05.md
@@ -42,11 +42,11 @@ curl -sf "https://www.elevateforhumanity.org/api/health" | jq '.activation, .sta
 ## 10k-user scale requirements
 
 1. **Database** — Supabase plan sized for connection pool; indexes on `program_enrollments(user_id, program_id)`, `applications(status, submitted_at)`.
-2. **ECS** — Multiple LMS tasks; ALB health on `/api/health`; optional readiness on `/api/ready`.
-3. **CDN** — Static assets on CloudFront; `revalidate-public` cron after catalog changes.
+2. **Northflank** — Separate `elevate-lms` + `elevate-admin` services; health on `/api/ping`; LMS readiness on `/api/ready`.
+3. **CDN** — Static assets via Northflank + Supabase Storage; `revalidate-public` cron after catalog changes.
 4. **Webhooks** — Single Stripe endpoint; `stripe_webhook_events` dedup (no duplicate enrollments).
 5. **Enrollment writes** — **Only** `createOrUpdateEnrollment()` in `lib/enrollment-service.ts` (no stray `.insert()` on `program_enrollments`).
-6. **Observability** — Sentry DSN in ECS task def; alert on health 500, webhook failures, audit_failure_count.
+6. **Observability** — Sentry DSN in Northflank env; alert on health 500, webhook failures, audit_failure_count.
 
 ---
 
@@ -78,7 +78,7 @@ Removed: hardcoded "10/10" marketing strings and fake `verification` booleans.
 - [ ] Student self-pay path works without manual DB fixes  
 - [ ] Employer portal auth on all critical APIs  
 - [ ] `bash scripts/audit-api-auth-guards.sh` exits 0 on `main`  
-- [ ] `/api/ready` wired in ECS task definition (optional second probe)  
+- [ ] `/api/ready` returns 200 on Northflank LMS readiness probe  
 - [ ] No `getPublicUrl` on private `documents` uploads in enrollment/cert paths  
 - [ ] Load test: 10k virtual users with &lt;1% error rate on apply + health endpoints  
 

--- a/lib/admin/guards.ts
+++ b/lib/admin/guards.ts
@@ -222,3 +222,47 @@ export async function apiRequireInstructor(_req?: Request): Promise<GuardedUser>
 
   return user;
 }
+
+const PLATFORM_STAFF_ROLES: UserRole[] = ['super_admin', 'admin', 'staff'];
+
+/**
+ * Platform staff on the owner tenant — workspace provisioning, all-tenant admin.
+ * Organization admins on customer tenants are rejected.
+ */
+export async function apiRequirePlatformStaff(_req?: Request): Promise<GuardedUser> {
+  const user = await apiAuthGuard(_req);
+  if (user.error) return user;
+
+  if (!user.role || !PLATFORM_STAFF_ROLES.includes(user.role)) {
+    return { ...user, error: forbidden() };
+  }
+
+  const { getPlatformUserContext } = await import('@/lib/platform/platform-owner');
+  const ctx = await getPlatformUserContext(user.id);
+  if (!ctx || (ctx.permissionLevel !== 'platform_owner' && ctx.permissionLevel !== 'platform_admin')) {
+    return { ...user, error: forbidden('Platform staff access required') };
+  }
+
+  return user;
+}
+
+/**
+ * Platform operator (owner) — DevStudio, deploy, Northflank, AI autopilot.
+ * Requires super_admin on the platform owner tenant.
+ */
+export async function apiRequirePlatformOperator(_req?: Request): Promise<GuardedUser> {
+  const user = await apiAuthGuard(_req);
+  if (user.error) return user;
+
+  if (user.role !== 'super_admin') {
+    return { ...user, error: forbidden() };
+  }
+
+  const { getPlatformUserContext } = await import('@/lib/platform/platform-owner');
+  const ctx = await getPlatformUserContext(user.id);
+  if (!ctx?.canAccessDevStudio) {
+    return { ...user, error: forbidden('Platform operator access required') };
+  }
+
+  return user;
+}

--- a/lib/api/withRuntime.ts
+++ b/lib/api/withRuntime.ts
@@ -83,7 +83,7 @@ export interface RuntimeOptions {
    * Cron route — validates cron secret header against CRON_SECRET env var.
    * Automatically adds 'CRON_SECRET' to required secrets.
    *   'x-header'  — checks x-cron-secret header
-   *   'bearer'    — checks Authorization: Bearer <secret> header (Vercel/manual cron)
+   *   'bearer'    — checks Authorization: Bearer <secret> header (manual / external cron)
    */
   cron?: 'x-header' | 'bearer';
 }

--- a/lib/devstudio/api-auth.ts
+++ b/lib/devstudio/api-auth.ts
@@ -1,0 +1,11 @@
+/**
+ * DevStudio API authentication — platform operator only.
+ * Customer tenant admins must never reach these routes.
+ *
+ * @see docs/platform-owner-tenant-model.md
+ */
+
+export {
+  apiRequirePlatformOperator as apiRequireDevStudio,
+  type GuardedUser,
+} from '@/lib/admin/guards';

--- a/lib/jobs/queue.ts
+++ b/lib/jobs/queue.ts
@@ -19,6 +19,7 @@ export type JobType =
   | 'license_reactivate'
   | 'email_send'
   | 'tenant_setup'
+  | 'workspace_provision'
   | 'webhook_process';
 
 export type JobStatus = 'queued' | 'processing' | 'completed' | 'failed' | 'dead';

--- a/lib/platform/hosting.ts
+++ b/lib/platform/hosting.ts
@@ -1,0 +1,18 @@
+/**
+ * Canonical production hosting identifiers.
+ * Elevate LMS + Admin run on Northflank only (see Dockerfile.northflank-*).
+ */
+export const PRODUCTION_HOSTING_PLATFORM = 'northflank' as const;
+
+export type ProductionHostingPlatform = typeof PRODUCTION_HOSTING_PLATFORM;
+
+/** Runtime label for diagnostics (/api/build, health metadata). */
+export function getProductionHostingPlatform(): ProductionHostingPlatform {
+  return PRODUCTION_HOSTING_PLATFORM;
+}
+
+/** Northflank service IDs (project elevate-platform). */
+export const NORTHFLANK_SERVICES = {
+  lms: 'elevate-lms',
+  admin: 'elevate-admin',
+} as const;

--- a/lib/platform/permission-levels.ts
+++ b/lib/platform/permission-levels.ts
@@ -1,0 +1,76 @@
+/**
+ * Four permission levels for the Elevate platform.
+ *
+ * @see docs/platform-owner-tenant-model.md
+ */
+
+import type { UserRole } from '@/lib/rbac/role-matrix';
+
+export type PlatformPermissionLevel =
+  | 'platform_owner'
+  | 'platform_admin'
+  | 'organization_admin'
+  | 'standard_user';
+
+export const PLATFORM_OWNER_ROLES: UserRole[] = ['super_admin'];
+export const PLATFORM_STAFF_ROLES: UserRole[] = ['super_admin', 'admin', 'staff'];
+export const ORGANIZATION_ADMIN_ROLES: UserRole[] = ['org_admin'];
+
+/** Capabilities gated to platform operator (super_admin on owner tenant). */
+export const PLATFORM_OPERATOR_CAPABILITIES = [
+  'deploy_code',
+  'access_devstudio',
+  'access_ai_operator',
+  'view_northflank_status',
+  'view_platform_logs',
+  'run_ai_autopilot',
+  'provision_workspaces',
+  'manage_platform_settings',
+] as const;
+
+/** Capabilities for platform staff (admin/staff on owner tenant). */
+export const PLATFORM_STAFF_CAPABILITIES = [
+  'create_workspaces',
+  'manage_subscriptions',
+  'access_all_tenants',
+  'manage_customer_workspaces',
+  'view_billing',
+] as const;
+
+export type PlatformOperatorCapability = (typeof PLATFORM_OPERATOR_CAPABILITIES)[number];
+export type PlatformStaffCapability = (typeof PLATFORM_STAFF_CAPABILITIES)[number];
+
+export function resolvePermissionLevel(params: {
+  profileRole: UserRole | null | undefined;
+  isPlatformOwnerTenant: boolean;
+  orgRole?: 'org_owner' | 'org_admin' | 'instructor' | 'reviewer' | 'report_viewer' | null;
+}): PlatformPermissionLevel {
+  const { profileRole, isPlatformOwnerTenant, orgRole } = params;
+
+  if (isPlatformOwnerTenant && profileRole && PLATFORM_STAFF_ROLES.includes(profileRole)) {
+    if (profileRole === 'super_admin') return 'platform_owner';
+    return 'platform_admin';
+  }
+
+  if (
+    profileRole === 'org_admin' ||
+    orgRole === 'org_admin' ||
+    orgRole === 'org_owner'
+  ) {
+    return 'organization_admin';
+  }
+
+  return 'standard_user';
+}
+
+export function canAccessDevStudio(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner';
+}
+
+export function canProvisionWorkspaces(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner' || level === 'platform_admin';
+}
+
+export function canDeployCode(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner';
+}

--- a/lib/platform/platform-owner.ts
+++ b/lib/platform/platform-owner.ts
@@ -1,0 +1,128 @@
+import 'server-only';
+
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import type { UserRole } from '@/lib/rbac/role-matrix';
+import {
+  resolvePermissionLevel,
+  type PlatformPermissionLevel,
+  canAccessDevStudio,
+  canProvisionWorkspaces,
+  canDeployCode,
+} from '@/lib/platform/permission-levels';
+
+export type PlatformUserContext = {
+  userId: string;
+  profileRole: UserRole | null;
+  tenantId: string | null;
+  isPlatformOwnerTenant: boolean;
+  permissionLevel: PlatformPermissionLevel;
+  canAccessDevStudio: boolean;
+  canProvisionWorkspaces: boolean;
+  canDeployCode: boolean;
+};
+
+/** Env override — set after migration backfill or in Northflank secret group. */
+export function getPlatformOwnerTenantIdFromEnv(): string | null {
+  const raw = process.env.PLATFORM_OWNER_TENANT_ID?.trim();
+  return raw || null;
+}
+
+export async function fetchPlatformOwnerTenantId(): Promise<string | null> {
+  const fromEnv = getPlatformOwnerTenantIdFromEnv();
+  if (fromEnv) return fromEnv;
+
+  const db = await requireAdminClient();
+  if (!db) return null;
+
+  const { data: setting } = await db
+    .from('platform_settings')
+    .select('value')
+    .eq('key', 'PLATFORM_OWNER_TENANT_ID')
+    .maybeSingle();
+
+  if (setting?.value && typeof setting.value === 'string') {
+    const trimmed = setting.value.trim();
+    if (trimmed) return trimmed;
+  }
+
+  const { data: tenant } = await db
+    .from('tenants')
+    .select('id')
+    .eq('is_platform_owner', true)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  return tenant?.id ?? null;
+}
+
+export function isUserOnPlatformOwnerTenant(
+  userTenantId: string | null | undefined,
+  platformOwnerTenantId: string | null,
+): boolean {
+  if (!userTenantId || !platformOwnerTenantId) return false;
+  return userTenantId === platformOwnerTenantId;
+}
+
+/**
+ * Load platform permission context for the current session user.
+ */
+export async function getPlatformUserContext(userId: string): Promise<PlatformUserContext | null> {
+  const db = await requireAdminClient();
+  if (!db) return null;
+
+  const [profileRes, ownerTenantId] = await Promise.all([
+    db.from('profiles').select('role, tenant_id').eq('id', userId).maybeSingle(),
+    fetchPlatformOwnerTenantId(),
+  ]);
+
+  const profile = profileRes.data;
+  if (!profile) return null;
+
+  const profileRole = (profile.role as UserRole | null) ?? null;
+  const tenantId = (profile.tenant_id as string | null) ?? null;
+  const onOwnerTenant = isUserOnPlatformOwnerTenant(tenantId, ownerTenantId);
+  const permissionLevel = resolvePermissionLevel({
+    profileRole,
+    isPlatformOwnerTenant: onOwnerTenant,
+  });
+
+  return {
+    userId,
+    profileRole,
+    tenantId,
+    isPlatformOwnerTenant: onOwnerTenant,
+    permissionLevel,
+    canAccessDevStudio: canAccessDevStudio(permissionLevel),
+    canProvisionWorkspaces: canProvisionWorkspaces(permissionLevel),
+    canDeployCode: canDeployCode(permissionLevel),
+  };
+}
+
+/**
+ * Session-scoped helper for server components and API routes.
+ */
+export async function getCurrentPlatformUserContext(): Promise<PlatformUserContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  return getPlatformUserContext(user.id);
+}
+
+export async function requirePlatformOperatorContext(): Promise<PlatformUserContext | null> {
+  const ctx = await getCurrentPlatformUserContext();
+  if (!ctx?.canAccessDevStudio) return null;
+  return ctx;
+}
+
+export async function requirePlatformStaffContext(): Promise<PlatformUserContext | null> {
+  const ctx = await getCurrentPlatformUserContext();
+  if (!ctx) return null;
+  if (ctx.permissionLevel === 'platform_owner' || ctx.permissionLevel === 'platform_admin') {
+    return ctx;
+  }
+  return null;
+}

--- a/lib/rbac/role-matrix.ts
+++ b/lib/rbac/role-matrix.ts
@@ -85,6 +85,9 @@ export const PERMISSIONS = {
   manage_grants:              ['super_admin', 'admin', 'staff', 'case_manager'] as UserRole[],
   manage_platform_settings:   ['super_admin'] as UserRole[],
   trigger_deployments:        ['super_admin'] as UserRole[],
+  access_devstudio:           ['super_admin'] as UserRole[],
+  provision_workspaces:       ['super_admin', 'admin', 'staff'] as UserRole[],
+  manage_customer_workspaces: ['super_admin', 'admin', 'staff'] as UserRole[],
   run_bulk_operations:        ['super_admin', 'admin'] as UserRole[],
 
   // Instructor actions

--- a/lib/supabase/auth-cookie-domain.ts
+++ b/lib/supabase/auth-cookie-domain.ts
@@ -7,7 +7,6 @@ export function resolveSupabaseAuthCookieDomain(): string | undefined {
     process.env.NEXT_PUBLIC_SITE_URL,
     process.env.NEXT_PUBLIC_ADMIN_URL,
     process.env.NEXTAUTH_URL,
-    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
   ].filter(Boolean) as string[];
 
   for (const raw of candidates) {

--- a/lib/supabase/auth-cookie-domain.ts
+++ b/lib/supabase/auth-cookie-domain.ts
@@ -1,0 +1,40 @@
+/**
+ * Supabase auth cookies are shared across www + admin subdomains in production.
+ * On localhost, omit Domain so browsers accept the session cookie.
+ */
+export function resolveSupabaseAuthCookieDomain(): string | undefined {
+  const candidates = [
+    process.env.NEXT_PUBLIC_SITE_URL,
+    process.env.NEXT_PUBLIC_ADMIN_URL,
+    process.env.NEXTAUTH_URL,
+    process.env.VERCEL_URL ? `https://${process.env.VERCEL_URL}` : undefined,
+  ].filter(Boolean) as string[];
+
+  for (const raw of candidates) {
+    try {
+      const host = new URL(raw).hostname.toLowerCase();
+      if (host === 'localhost' || host === '127.0.0.1' || host === '::1') {
+        return undefined;
+      }
+    } catch {
+      /* ignore malformed URLs */
+    }
+  }
+
+  if (process.env.NODE_ENV === 'development') {
+    return undefined;
+  }
+
+  return '.elevateforhumanity.org';
+}
+
+export function withSupabaseAuthCookieDomain<T extends { domain?: string }>(
+  options: T,
+): T {
+  const domain = resolveSupabaseAuthCookieDomain();
+  if (!domain) {
+    const { domain: _omit, ...rest } = options;
+    return rest as T;
+  }
+  return { ...options, domain };
+}

--- a/lib/supabase/server.ts
+++ b/lib/supabase/server.ts
@@ -1,5 +1,6 @@
 import { timedFetch } from '@/lib/supabase/timed-fetch';
 import { logger } from '@/lib/logger';
+import { withSupabaseAuthCookieDomain } from '@/lib/supabase/auth-cookie-domain';
 import { resolveServerSupabaseEnv } from '@/lib/supabase/server-env';
 import { createServerClient } from '@supabase/ssr';
 import { createClient as createSupabaseClient } from '@supabase/supabase-js';
@@ -90,7 +91,7 @@ export async function createClient(): Promise<SupabaseClient<any>> {
               // Only apply to Supabase auth tokens — leave other cookies alone.
               const isAuthCookie = name.startsWith('sb-') && name.includes('-auth-token');
               const cookieOptions = isAuthCookie
-                ? { ...options, domain: '.elevateforhumanity.org' }
+                ? withSupabaseAuthCookieDomain(options)
                 : options;
               cookieStore.set(name, value, cookieOptions);
             });

--- a/lib/workspace/provision-workspace.ts
+++ b/lib/workspace/provision-workspace.ts
@@ -1,0 +1,168 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { fetchPlatformOwnerTenantId } from '@/lib/platform/platform-owner';
+import { enqueueJob } from '@/lib/jobs/queue';
+import type { WorkspaceSubscriptionTier } from '@/lib/workspace/tier-limits';
+
+export type ProvisionWorkspaceParams = {
+  displayName: string;
+  slug: string;
+  subscriptionTier: WorkspaceSubscriptionTier;
+  templateSlug?: string;
+  provisionedByUserId: string;
+  contactEmail?: string;
+};
+
+export type ProvisionWorkspaceResult =
+  | {
+      ok: true;
+      workspaceId: string;
+      tenantId: string;
+      organizationId: string;
+      status: 'pending' | 'provisioning';
+      workspaceUrl: string | null;
+    }
+  | { ok: false; error: string };
+
+function workspacePublicUrl(slug: string): string {
+  const host = process.env.ELEVATE_DEV_CLOUD_HOST || 'elevatedev.ai';
+  return `https://${slug}.${host}`;
+}
+
+/**
+ * Phase 1: creates customer tenant + organization + customer_workspaces row.
+ * Phase 2+ (async job): GitHub fork, Northflank project, Supabase project, deploy.
+ */
+export async function provisionWorkspace(
+  params: ProvisionWorkspaceParams,
+): Promise<ProvisionWorkspaceResult> {
+  const db = await requireAdminClient();
+  if (!db) {
+    return { ok: false, error: 'Database unavailable' };
+  }
+
+  const slug = params.slug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  if (!slug || slug.length < 2) {
+    return { ok: false, error: 'Invalid workspace slug' };
+  }
+
+  const ownerTenantId = await fetchPlatformOwnerTenantId();
+  if (!ownerTenantId) {
+    return { ok: false, error: 'Platform owner tenant is not configured' };
+  }
+
+  const templateSlug = params.templateSlug ?? 'workforce-platform-v1';
+  const workspaceUrl = workspacePublicUrl(slug);
+
+  const { data: existing } = await db
+    .from('customer_workspaces')
+    .select('id')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (existing?.id) {
+    return { ok: false, error: 'Workspace slug already exists' };
+  }
+
+  const { data: tenant, error: tenantError } = await db
+    .from('tenants')
+    .insert({
+      name: params.displayName,
+      slug,
+      status: 'active',
+      type: 'customer',
+      is_platform_owner: false,
+      parent_tenant_id: ownerTenantId,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (tenantError || !tenant?.id) {
+    logger.error('[provisionWorkspace] tenant insert failed', tenantError);
+    return { ok: false, error: 'Failed to create customer tenant' };
+  }
+
+  const { data: org, error: orgError } = await db
+    .from('organizations')
+    .insert({
+      name: params.displayName,
+      slug,
+      type: 'training_provider',
+      tenant_id: tenant.id,
+      status: 'active',
+      contact_email: params.contactEmail ?? null,
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (orgError || !org?.id) {
+    await db.from('tenants').delete().eq('id', tenant.id);
+    logger.error('[provisionWorkspace] organization insert failed', orgError);
+    return { ok: false, error: 'Failed to create organization' };
+  }
+
+  const { data: workspace, error: workspaceError } = await db
+    .from('customer_workspaces')
+    .insert({
+      tenant_id: tenant.id,
+      organization_id: org.id,
+      slug,
+      display_name: params.displayName,
+      subscription_tier: params.subscriptionTier,
+      template_slug: templateSlug,
+      status: 'provisioning',
+      workspace_url: workspaceUrl,
+      provisioned_by: params.provisionedByUserId,
+      metadata: {
+        contact_email: params.contactEmail ?? null,
+        phase: 1,
+      },
+    })
+    .select('id')
+    .maybeSingle();
+
+  if (workspaceError || !workspace?.id) {
+    await db.from('organizations').delete().eq('id', org.id);
+    await db.from('tenants').delete().eq('id', tenant.id);
+    logger.error('[provisionWorkspace] customer_workspaces insert failed', workspaceError);
+    return { ok: false, error: 'Failed to create workspace record' };
+  }
+
+  try {
+    await enqueueJob({
+      jobType: 'workspace_provision',
+      correlationId: `workspace:${workspace.id}`,
+      tenantId: tenant.id,
+      payload: {
+        workspace_id: workspace.id,
+        tenant_id: tenant.id,
+        organization_id: org.id,
+        slug,
+        template_slug: templateSlug,
+        subscription_tier: params.subscriptionTier,
+      },
+    });
+  } catch (err) {
+    logger.warn('[provisionWorkspace] job enqueue failed — workspace row created', {
+      workspaceId: workspace.id,
+      err,
+    });
+  }
+
+  logger.info('[provisionWorkspace] workspace created', {
+    workspaceId: workspace.id,
+    tenantId: tenant.id,
+    slug,
+  });
+
+  return {
+    ok: true,
+    workspaceId: workspace.id,
+    tenantId: tenant.id,
+    organizationId: org.id,
+    status: 'provisioning',
+    workspaceUrl,
+  };
+}

--- a/lib/workspace/tier-limits.ts
+++ b/lib/workspace/tier-limits.ts
@@ -1,0 +1,56 @@
+/**
+ * Elevate Dev Cloud workspace subscription tiers.
+ * @see docs/platform-owner-tenant-model.md
+ */
+
+export type WorkspaceSubscriptionTier = 'builder' | 'pro' | 'agency';
+
+export type WorkspaceTierLimits = {
+  maxWorkspaces: number;
+  maxDatabaseGb: number;
+  customDomains: boolean;
+  teamAccess: boolean;
+  whiteLabel: boolean;
+  aiOperator: boolean;
+  aiAutopilot: boolean;
+};
+
+export const WORKSPACE_TIER_LIMITS: Record<WorkspaceSubscriptionTier, WorkspaceTierLimits> = {
+  builder: {
+    maxWorkspaces: 1,
+    maxDatabaseGb: 1,
+    customDomains: false,
+    teamAccess: false,
+    whiteLabel: false,
+    aiOperator: false,
+    aiAutopilot: false,
+  },
+  pro: {
+    maxWorkspaces: 10,
+    maxDatabaseGb: 10,
+    customDomains: true,
+    teamAccess: true,
+    whiteLabel: false,
+    aiOperator: true,
+    aiAutopilot: false,
+  },
+  agency: {
+    maxWorkspaces: Number.POSITIVE_INFINITY,
+    maxDatabaseGb: 50,
+    customDomains: true,
+    teamAccess: true,
+    whiteLabel: true,
+    aiOperator: true,
+    aiAutopilot: true,
+  },
+};
+
+export const WORKSPACE_TIER_PRICING_USD_MONTHLY: Record<WorkspaceSubscriptionTier, number> = {
+  builder: 49,
+  pro: 149,
+  agency: 499,
+};
+
+export function getWorkspaceTierLimits(tier: WorkspaceSubscriptionTier): WorkspaceTierLimits {
+  return WORKSPACE_TIER_LIMITS[tier];
+}

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1275,10 +1275,9 @@ const sentryWebpackPluginOptions = {
   widenClientFileUpload: false,
 };
 
-// Skip Sentry webpack wrapping in ECS (reduces build time)
-// and on AWS Docker builds (BUILD_SCOPE=1) — withSentryConfig spawns a child
-// Skip Sentry webpack worker on AWS EC2 builds — it doubles peak heap and OOMs
-// the 16GB runner. Sentry still initialises at runtime via instrumentation.ts.
+// Skip Sentry webpack wrapping on CI/Northflank builds (BUILD_SCOPE=1) — withSentryConfig
+// spawns a child process that doubles peak heap and can OOM the builder.
+// Sentry still initialises at runtime via instrumentation.ts.
 const skipSentry =
   process.env.BUILD_SCOPE === '1';
 

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { checkAdminIPAsync } from '@/lib/api/admin-ip-guard';
 import { getSecuritySettings } from '@/lib/admin/security-settings';
+import { withSupabaseAuthCookieDomain } from '@/lib/supabase/auth-cookie-domain';
 
 // ── Module-level constants ────────────────────────────────────────────────────
 
@@ -729,10 +730,9 @@ export async function middleware(request: NextRequest) {
         // Preserve requestHeaders (which carries x-pathname) when refreshing cookies
         response = NextResponse.next({ request: { headers: requestHeaders } });
         cookiesToSet.forEach(({ name, value, options }) => {
-          // Scope auth cookies to root domain so www and app subdomains share the session
           const isAuthCookie = name.startsWith('sb-') && name.includes('-auth-token');
           const cookieOptions = isAuthCookie
-            ? { ...options, domain: '.elevateforhumanity.org' }
+            ? withSupabaseAuthCookieDomain(options)
             : options;
           response.cookies.set(name, value, cookieOptions);
         });

--- a/scripts/autopilot.sh
+++ b/scripts/autopilot.sh
@@ -10,7 +10,7 @@ echo "== Autopilot (Builder Mode) =="
 # - dashboard-consolidation-verification.md
 # - autopilot-run-log.md
 # Modifications to existing docs are allowed; only brand-new files are checked.
-ALLOWED_DOCS_REGEX='^(docs/(dashboard-inventory\.md|dashboard-canonical-architecture\.md|dashboard-crossed-analysis\.md|dashboard-schema-verification\.md|dashboard-orphans-disposition\.md|dashboard-consolidation-verification\.md|autopilot-run-log\.md|dashboard-consolidation-baseline\.md|SECURITY\.md|platform-e2e-audit-2026-05\.md|production-activation-2026-05\.md|LOCAL_DEVELOPMENT\.md))$'
+ALLOWED_DOCS_REGEX='^(docs/(dashboard-inventory\.md|dashboard-canonical-architecture\.md|dashboard-crossed-analysis\.md|dashboard-schema-verification\.md|dashboard-orphans-disposition\.md|dashboard-consolidation-verification\.md|autopilot-run-log\.md|dashboard-consolidation-baseline\.md|SECURITY\.md|platform-e2e-audit-2026-05\.md|production-activation-2026-05\.md|platform-owner-tenant-model\.md|LOCAL_DEVELOPMENT\.md))$'
 
 NEW_DOCS=$(git diff --name-only --diff-filter=ACR origin/main...HEAD 2>/dev/null | grep '^docs/.*\.md$' || true)
 

--- a/scripts/push-dotenv-runtime-vars.mjs
+++ b/scripts/push-dotenv-runtime-vars.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * Upsert non-bootstrap vars from .env.local into Supabase app_secrets.
- * Bootstrap vars stay in process.env / ECS / Netlify only.
+ * Bootstrap vars stay in process.env / Northflank secret group only.
  *
  * Usage: set -a && . ./.env.local && set +a && node scripts/sync-env-to-app-secrets.mjs
  */

--- a/scripts/verify-no-studio-shell.mjs
+++ b/scripts/verify-no-studio-shell.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 /**
  * CI guard: Studio Shell must not be wired into Lizzy UI or admin server proxy.
- * (Legacy ECS task env vars are no longer in-repo; check runtime wiring only.)
+ * (Legacy container env vars are no longer in-repo; check runtime wiring only.)
  */
 import fs from 'fs';
 import path from 'path';

--- a/supabase/migrations/20260708000004_platform_owner_tenant_model.sql
+++ b/supabase/migrations/20260708000004_platform_owner_tenant_model.sql
@@ -1,0 +1,222 @@
+-- Platform owner tenant model + customer workspace provisioning foundation
+-- See docs/platform-owner-tenant-model.md
+
+BEGIN;
+
+-- ── 1. Tenant classification ───────────────────────────────────────────────
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS is_platform_owner BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS parent_tenant_id UUID REFERENCES public.tenants(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_tenants_is_platform_owner
+  ON public.tenants(is_platform_owner)
+  WHERE is_platform_owner = true;
+
+CREATE INDEX IF NOT EXISTS idx_tenants_parent_tenant_id
+  ON public.tenants(parent_tenant_id)
+  WHERE parent_tenant_id IS NOT NULL;
+
+-- Extend type enum: customer = Dev Cloud provisioned tenant
+ALTER TABLE public.tenants DROP CONSTRAINT IF EXISTS tenants_type_check;
+ALTER TABLE public.tenants
+  ADD CONSTRAINT tenants_type_check
+  CHECK (type IN ('elevate', 'partner_provider', 'employer', 'workforce_agency', 'customer'));
+
+-- Exactly one platform owner tenant (partial unique index)
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_single_platform_owner_idx
+  ON public.tenants ((true))
+  WHERE is_platform_owner = true;
+
+-- ── 2. Backfill platform owner tenant ────────────────────────────────────────
+
+DO $$
+DECLARE
+  v_owner_id UUID;
+BEGIN
+  SELECT id INTO v_owner_id
+  FROM public.tenants
+  WHERE is_platform_owner = true
+  ORDER BY created_at ASC
+  LIMIT 1;
+
+  IF v_owner_id IS NULL THEN
+    SELECT id INTO v_owner_id
+    FROM public.tenants
+    WHERE type = 'elevate'
+    ORDER BY created_at ASC
+    LIMIT 1;
+  END IF;
+
+  IF v_owner_id IS NULL THEN
+    SELECT id INTO v_owner_id
+    FROM public.tenants
+    ORDER BY created_at ASC
+    LIMIT 1;
+  END IF;
+
+  IF v_owner_id IS NOT NULL THEN
+    UPDATE public.tenants
+    SET is_platform_owner = true,
+        type = CASE WHEN type IS NULL OR type = '' THEN 'elevate' ELSE type END
+    WHERE id = v_owner_id;
+
+    -- Platform staff without tenant_id → attach to owner tenant
+    UPDATE public.profiles
+    SET tenant_id = v_owner_id,
+        updated_at = now()
+    WHERE tenant_id IS NULL
+      AND role IN ('super_admin', 'admin', 'staff');
+
+    INSERT INTO public.platform_settings (key, value, updated_at)
+    VALUES (
+      'PLATFORM_OWNER_TENANT_ID',
+      v_owner_id::text,
+      now()
+    )
+    ON CONFLICT (key) DO UPDATE
+      SET value = EXCLUDED.value,
+          updated_at = now();
+  END IF;
+END $$;
+
+-- ── 3. Customer workspaces (Dev Cloud provisioning) ──────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.customer_workspaces (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  slug TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  subscription_tier TEXT NOT NULL DEFAULT 'builder'
+    CHECK (subscription_tier IN ('builder', 'pro', 'agency')),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'provisioning', 'active', 'suspended', 'failed', 'archived')),
+  template_slug TEXT NOT NULL DEFAULT 'workforce-platform-v1',
+  github_repo_url TEXT,
+  northflank_project_id TEXT,
+  northflank_service_id TEXT,
+  supabase_project_ref TEXT,
+  workspace_url TEXT,
+  provision_error TEXT,
+  provisioned_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  provisioned_at TIMESTAMPTZ,
+  CONSTRAINT customer_workspaces_slug_unique UNIQUE (slug)
+);
+
+CREATE INDEX IF NOT EXISTS customer_workspaces_tenant_id_idx
+  ON public.customer_workspaces(tenant_id);
+CREATE INDEX IF NOT EXISTS customer_workspaces_status_idx
+  ON public.customer_workspaces(status);
+
+ALTER TABLE public.customer_workspaces ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "customer_workspaces_platform_staff" ON public.customer_workspaces;
+CREATE POLICY "customer_workspaces_platform_staff" ON public.customer_workspaces
+  FOR ALL
+  USING (public.is_platform_owner_user())
+  WITH CHECK (public.is_platform_owner_user());
+
+DROP POLICY IF EXISTS "customer_workspaces_service_role" ON public.customer_workspaces;
+CREATE POLICY "customer_workspaces_service_role" ON public.customer_workspaces
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+GRANT SELECT ON public.customer_workspaces TO authenticated;
+GRANT ALL ON public.customer_workspaces TO service_role;
+
+-- ── 4. SQL helpers ───────────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.get_platform_owner_tenant_id()
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT id
+  FROM public.tenants
+  WHERE is_platform_owner = true
+  ORDER BY created_at ASC
+  LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_platform_owner_tenant(p_tenant_id UUID)
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1 FROM public.tenants
+    WHERE id = p_tenant_id AND is_platform_owner = true
+  );
+$$;
+
+-- Platform staff: admin / super_admin / staff on the platform owner tenant
+CREATE OR REPLACE FUNCTION public.is_platform_owner_user()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    INNER JOIN public.tenants t ON t.id = p.tenant_id
+    WHERE p.id = auth.uid()
+      AND t.is_platform_owner = true
+      AND p.role IN ('super_admin', 'admin', 'staff')
+  );
+$$;
+
+-- Platform operator: super_admin on platform owner tenant (DevStudio, deploy)
+CREATE OR REPLACE FUNCTION public.is_platform_operator()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    INNER JOIN public.tenants t ON t.id = p.tenant_id
+    WHERE p.id = auth.uid()
+      AND t.is_platform_owner = true
+      AND p.role = 'super_admin'
+  );
+$$;
+
+-- Narrow is_platform_admin to platform owner tenant (break-glass: service_role unchanged)
+CREATE OR REPLACE FUNCTION public.is_platform_admin()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT public.is_platform_owner_user();
+$$;
+
+COMMENT ON FUNCTION public.get_platform_owner_tenant_id IS
+  'Returns the single platform owner tenant UUID (Elevate operator).';
+COMMENT ON FUNCTION public.is_platform_owner_user IS
+  'True when the session user is platform staff (super_admin/admin/staff) on the owner tenant.';
+COMMENT ON FUNCTION public.is_platform_operator IS
+  'True when the session user is platform owner (super_admin on owner tenant). DevStudio/deploy.';
+
+-- ── 5. Provisioning job type for workspace_provision ───────────────────────
+
+-- provisioning_jobs.job_type is TEXT; no enum alteration required.
+-- Application enqueues job_type = 'workspace_provision' (see lib/jobs/queue.ts).
+
+COMMIT;

--- a/tests/unit/platform-hosting.test.ts
+++ b/tests/unit/platform-hosting.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getProductionHostingPlatform,
+  NORTHFLANK_SERVICES,
+  PRODUCTION_HOSTING_PLATFORM,
+} from '@/lib/platform/hosting';
+
+describe('platform hosting', () => {
+  it('production platform is northflank', () => {
+    expect(PRODUCTION_HOSTING_PLATFORM).toBe('northflank');
+    expect(getProductionHostingPlatform()).toBe('northflank');
+  });
+
+  it('exposes Northflank service ids', () => {
+    expect(NORTHFLANK_SERVICES.lms).toBe('elevate-lms');
+    expect(NORTHFLANK_SERVICES.admin).toBe('elevate-admin');
+  });
+});

--- a/tests/unit/platform-owner-tenant.test.ts
+++ b/tests/unit/platform-owner-tenant.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isUserOnPlatformOwnerTenant } from '@/lib/platform/platform-owner';
+import { WORKSPACE_TIER_LIMITS } from '@/lib/workspace/tier-limits';
+
+describe('platform owner tenant helpers', () => {
+  it('matches user tenant to platform owner tenant id', () => {
+    const ownerId = '11111111-1111-1111-1111-111111111111';
+    expect(isUserOnPlatformOwnerTenant(ownerId, ownerId)).toBe(true);
+    expect(isUserOnPlatformOwnerTenant('22222222-2222-2222-2222-222222222222', ownerId)).toBe(false);
+    expect(isUserOnPlatformOwnerTenant(null, ownerId)).toBe(false);
+  });
+});
+
+describe('workspace tier limits', () => {
+  it('defines builder / pro / agency caps', () => {
+    expect(WORKSPACE_TIER_LIMITS.builder.maxWorkspaces).toBe(1);
+    expect(WORKSPACE_TIER_LIMITS.pro.customDomains).toBe(true);
+    expect(WORKSPACE_TIER_LIMITS.agency.whiteLabel).toBe(true);
+  });
+});

--- a/tests/unit/platform-permission-levels.test.ts
+++ b/tests/unit/platform-permission-levels.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+import {
+  resolvePermissionLevel,
+  canAccessDevStudio,
+  canProvisionWorkspaces,
+  canDeployCode,
+} from '@/lib/platform/permission-levels';
+
+describe('platform permission levels', () => {
+  it('maps super_admin on owner tenant to platform_owner', () => {
+    expect(
+      resolvePermissionLevel({ profileRole: 'super_admin', isPlatformOwnerTenant: true }),
+    ).toBe('platform_owner');
+  });
+
+  it('maps admin on owner tenant to platform_admin', () => {
+    expect(
+      resolvePermissionLevel({ profileRole: 'admin', isPlatformOwnerTenant: true }),
+    ).toBe('platform_admin');
+  });
+
+  it('maps org_admin on customer tenant to organization_admin', () => {
+    expect(
+      resolvePermissionLevel({ profileRole: 'org_admin', isPlatformOwnerTenant: false }),
+    ).toBe('organization_admin');
+  });
+
+  it('maps student to standard_user', () => {
+    expect(
+      resolvePermissionLevel({ profileRole: 'student', isPlatformOwnerTenant: false }),
+    ).toBe('standard_user');
+  });
+
+  it('denies DevStudio to platform_admin', () => {
+    expect(canAccessDevStudio('platform_admin')).toBe(false);
+    expect(canAccessDevStudio('platform_owner')).toBe(true);
+  });
+
+  it('allows workspace provisioning for platform staff', () => {
+    expect(canProvisionWorkspaces('platform_admin')).toBe(true);
+    expect(canProvisionWorkspaces('organization_admin')).toBe(false);
+  });
+
+  it('restricts deploy to platform owner only', () => {
+    expect(canDeployCode('platform_owner')).toBe(true);
+    expect(canDeployCode('platform_admin')).toBe(false);
+  });
+});

--- a/tests/unit/supabase-auth-cookie-domain.test.ts
+++ b/tests/unit/supabase-auth-cookie-domain.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, beforeEach, afterEach } from 'vitest';
+import {
+  resolveSupabaseAuthCookieDomain,
+  withSupabaseAuthCookieDomain,
+} from '@/lib/supabase/auth-cookie-domain';
+
+describe('resolveSupabaseAuthCookieDomain', () => {
+  const envBackup = { ...process.env };
+
+  beforeEach(() => {
+    process.env = { ...envBackup };
+  });
+
+  afterEach(() => {
+    process.env = envBackup;
+  });
+
+  it('omits domain on localhost admin dev', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.NEXT_PUBLIC_ADMIN_URL = 'http://localhost:3001';
+    expect(resolveSupabaseAuthCookieDomain()).toBeUndefined();
+  });
+
+  it('scopes domain in production', () => {
+    process.env.NODE_ENV = 'production';
+    process.env.NEXT_PUBLIC_SITE_URL = 'https://www.elevateforhumanity.org';
+    process.env.NEXT_PUBLIC_ADMIN_URL = 'https://admin.elevateforhumanity.org';
+    delete process.env.NEXTAUTH_URL;
+    expect(resolveSupabaseAuthCookieDomain()).toBe('.elevateforhumanity.org');
+  });
+
+  it('strips domain from cookie options when local', () => {
+    process.env.NODE_ENV = 'development';
+    process.env.NEXT_PUBLIC_SITE_URL = 'http://localhost:3000';
+    const result = withSupabaseAuthCookieDomain({
+      path: '/',
+      domain: '.elevateforhumanity.org',
+      sameSite: 'lax' as const,
+    });
+    expect(result).toEqual({ path: '/', sameSite: 'lax' });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Merges **#308** (admin localhost cookies + AdminNav fix) and **#309** (platform owner tenant model) into `main`.

### Includes
- Admin login cookie fix for localhost (`lib/supabase/auth-cookie-domain.ts`)
- AdminNav `setMenuOpen` crash fix
- Northflank-only hosting cleanup (no Vercel/AWS ECS references)
- Platform owner vs customer tenant architecture
- `customer_workspaces` + `provisionWorkspace()` scaffold
- DevStudio gated to platform operator only

### Post-merge
1. Apply migration `20260708000004_platform_owner_tenant_model.sql` in Supabase
2. Deploy triggers automatically via `deploy-lms.yml` + `deploy-admin.yml` on merge

Ready to merge.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add platform owner tenant model and Dev Cloud workspace provisioning scaffold
> - Introduces a `platform_owner` tenant concept via a [new migration](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-32f995c7c4d08a0e116fc1c0e1b6ae96f174dc302c486af2c6ff32944f388d20): adds `is_platform_owner` and `parent_tenant_id` columns to `tenants`, enforces a single platform owner via partial unique index, creates `customer_workspaces` table with RLS, and adds helper SQL functions (`is_platform_owner_user`, `is_platform_operator`, etc.).
> - Adds [permission-level resolution](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-7f3c8d92cddab417d56d84e61dbda7cde8dfa28fc63e7a706a83806ff75241c5) and a [platform owner context builder](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-b1f15dad8754b844e7de6524fd1cd6fbee441ae95e495550d9b915da8b4daf73) that map a user's role and tenant to one of four levels (`platform_owner`, `platform_admin`, `organization_admin`, `standard_user`) and compute capability flags for DevStudio, workspace provisioning, and deploys.
> - Introduces new API guards `apiRequireDevStudio` (platform operator) and `apiRequirePlatformStaff` in [guards.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-7de0ffa6f8862940503bf64c196984278b162a6e489319982580dff3e83c4035), and replaces `apiRequireAdmin` with `apiRequireDevStudio` across all `/api/devstudio/*` routes.
> - Adds [POST /api/platform/workspaces/provision](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-5f89a4584f6aa3e956b888b32e0811600195aed6ef77405e444d19c892ce8e1f) for platform staff to create tenant/org/workspace records and enqueue a `workspace_provision` job, and adds [workspace tier limits](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-0144a0b29e9600c88ede87a13aa894b2e06ee8aa18e7f7e30b8c815991d39675) for `builder`, `pro`, and `agency` tiers.
> - Replaces the hardcoded `.elevateforhumanity.org` Supabase auth cookie domain with a dynamic resolver in [auth-cookie-domain.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/309/files#diff-8f748727b6c6b1d08cf4aed00e6f75cf6ac131313d7dbb5922ce0ed8dc70158b) that omits the domain on localhost/dev and applies it in production. Risk: Behavioral change — auth cookie domain is now omitted entirely on local/dev environments.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized be3037a. 53 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->