### PR TITLE
feat(workspace): self-service provisioning + Northflank build fixes

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -85,7 +85,8 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
     && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
-    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json \
+    && test -f /export/pdf-node_modules/pdf-parse/package.json
 
 # Drop node_modules + marketing-only assets before runtime COPY (BuildKit ENOSPC).
 RUN node scripts/prune-admin-builder-disk.mjs

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -77,7 +77,8 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
     && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
-    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json \
+    && test -f /export/pdf-node_modules/pdf-parse/package.json
 
 RUN node scripts/prune-lms-builder-disk.mjs
 

--- a/app/api/operator/chat/route.ts
+++ b/app/api/operator/chat/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+/**
+ * POST /api/operator/chat
+ * Foundation: records operator task; AI execution is phase 2.
+ * Body: { workspaceId?, prompt }
+ */
+async function _POST(request: NextRequest) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const body = await request.json();
+    const prompt = typeof body.prompt === 'string' ? body.prompt.trim() : '';
+    if (!prompt) {
+      return safeError('prompt is required', 400);
+    }
+
+    const db = await requireAdminClient();
+    const { data: task } = await db
+      .from('operator_tasks')
+      .insert({
+        workspace_id: body.workspaceId ?? null,
+        created_by: auth.id,
+        task_type: 'chat',
+        status: 'queued',
+        prompt,
+        metadata: { phase: 1 },
+      } as Record<string, unknown>)
+      .select('id')
+      .maybeSingle();
+
+    return safeOk({
+      taskId: task?.id ?? null,
+      status: 'queued',
+      message: 'Operator task recorded. Autonomous execution ships in phase 2.',
+    });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to queue operator task');
+  }
+}
+
+export const POST = withRuntime(_POST);

--- a/app/api/operator/tasks/route.ts
+++ b/app/api/operator/tasks/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+/**
+ * GET /api/operator/tasks?workspaceId=
+ */
+async function _GET(request: NextRequest) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const workspaceId = new URL(request.url).searchParams.get('workspaceId');
+    const db = await requireAdminClient();
+
+    let query = db
+      .from('operator_tasks')
+      .select('id, task_type, status, prompt, result_summary, created_at, completed_at')
+      .order('created_at', { ascending: false })
+      .limit(25);
+
+    if (workspaceId) {
+      query = query.eq('workspace_id', workspaceId);
+    } else {
+      query = query.eq('created_by', auth.id);
+    }
+
+    const { data: tasks } = await query;
+    return safeOk({ tasks: tasks ?? [] });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to list operator tasks');
+  }
+}
+
+export const GET = withRuntime(_GET);

--- a/app/api/subscriptions/cancel/route.ts
+++ b/app/api/subscriptions/cancel/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+/**
+ * POST /api/subscriptions/cancel
+ * Marks organization subscription canceled (Stripe cancel-at-period-end is phase 2).
+ */
+async function _POST(request: NextRequest) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const db = await requireAdminClient();
+    const { data: profile } = await db
+      .from('profiles')
+      .select('tenant_id')
+      .eq('id', auth.id)
+      .maybeSingle();
+
+    const tenantId = profile?.tenant_id as string | null;
+    if (!tenantId) {
+      return safeError('No organization subscription found', 404);
+    }
+
+    const { error } = await db
+      .from('organization_subscriptions')
+      .update({
+        status: 'canceled',
+        canceled_at: new Date().toISOString(),
+        updated_at: new Date().toISOString(),
+      } as Record<string, unknown>)
+      .eq('organization_id', tenantId);
+
+    if (error) {
+      return safeError('Subscription record not found or could not be updated', 404);
+    }
+
+    return safeOk({ canceled: true });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to cancel subscription');
+  }
+}
+
+export const POST = withRuntime(_POST);

--- a/app/api/subscriptions/create/route.ts
+++ b/app/api/subscriptions/create/route.ts
@@ -1,0 +1,37 @@
+import { NextRequest } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { safeError, safeInternalError } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+
+/**
+ * POST /api/subscriptions/create
+ * Redirects authenticated users to platform SaaS checkout.
+ * Body: { planId: 'solo' | 'business' | 'professional', interval?: 'monthly' | 'annual' }
+ */
+async function _POST(request: NextRequest) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const body = await request.json();
+    const planId = body.planId ?? body.plan;
+    if (!planId) {
+      return safeError('planId is required', 400);
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.elevateforhumanity.org';
+    return Response.json(
+      {
+        ok: true,
+        checkoutPath: '/store/plans',
+        message: 'Use POST /api/store/platform-checkout for Stripe checkout',
+        redirectUrl: `${siteUrl}/store/plans?plan=${encodeURIComponent(String(planId))}`,
+      },
+      { status: 200 },
+    );
+  } catch (err) {
+    return safeInternalError(err, 'Failed to start subscription');
+  }
+}
+
+export const POST = withRuntime(_POST);

--- a/app/api/subscriptions/upgrade/route.ts
+++ b/app/api/subscriptions/upgrade/route.ts
@@ -1,0 +1,33 @@
+import { NextRequest } from 'next/server';
+import { apiAuthGuard } from '@/lib/admin/guards';
+import { safeError, safeInternalError } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+
+/**
+ * POST /api/subscriptions/upgrade
+ * Body: { planId, interval? }
+ */
+async function _POST(request: NextRequest) {
+  const auth = await apiAuthGuard(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const body = await request.json();
+    const planId = body.planId ?? body.plan;
+    if (!planId) {
+      return safeError('planId is required', 400);
+    }
+
+    const siteUrl = process.env.NEXT_PUBLIC_SITE_URL ?? 'https://www.elevateforhumanity.org';
+    return Response.json({
+      ok: true,
+      message: 'Complete upgrade via platform checkout',
+      checkoutApi: '/api/store/platform-checkout',
+      plansUrl: `${siteUrl}/store/plans?plan=${encodeURIComponent(String(planId))}`,
+    });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to start upgrade');
+  }
+}
+
+export const POST = withRuntime(_POST);

--- a/app/api/workspaces/create/route.ts
+++ b/app/api/workspaces/create/route.ts
@@ -1,0 +1,97 @@
+// PUBLIC ROUTE: self-service workspace trial signup
+import { NextRequest } from 'next/server';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { startWorkspaceTrial } from '@/lib/workspace/start-workspace-trial';
+import { logger } from '@/lib/logger';
+import { resend } from '@/lib/resend';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+async function sendWorkspaceWelcomeEmail(params: {
+  email: string;
+  organizationName: string;
+  dashboardUrl: string;
+  publicUrl: string;
+  trialEndsAt: string;
+}) {
+  if (!process.env.SENDGRID_API_KEY) return;
+
+  await resend.emails.send({
+    from: `${PLATFORM_DEFAULTS.emailFromName} <${PLATFORM_DEFAULTS.emailFromAddress}>`,
+    to: params.email,
+    subject: `Your workspace is ready — ${params.organizationName}`,
+    html: `
+      <h1>Your 14-day workspace trial is live</h1>
+      <p><strong>${params.organizationName}</strong> is ready to use.</p>
+      <p><a href="${params.dashboardUrl}">Open admin dashboard</a></p>
+      <p>Public site: <a href="${params.publicUrl}">${params.publicUrl}</a></p>
+      <p>Trial ends: ${new Date(params.trialEndsAt).toLocaleDateString()}</p>
+    `,
+  });
+}
+
+/**
+ * POST /api/workspaces/create
+ *
+ * Body: { organizationName, ownerEmail, ownerName?, industry?, plan? }
+ */
+async function _POST(request: NextRequest) {
+  await hydrateProcessEnv();
+
+  const rateLimited = await applyRateLimit(request, 'contact');
+  if (rateLimited) return rateLimited;
+
+  try {
+    const body = await request.json();
+    const organizationName =
+      body.organizationName ?? body.orgName ?? body.organization_name;
+    const ownerEmail = body.ownerEmail ?? body.email ?? body.owner_email;
+    const ownerName = body.ownerName ?? body.adminName ?? body.owner_name;
+    const industry = body.industry ?? body.programs;
+    const plan = body.plan ?? 'starter';
+
+    const result = await startWorkspaceTrial({
+      organizationName,
+      ownerEmail,
+      ownerName,
+      industry,
+      plan,
+    });
+
+    if (!result.ok) {
+      return safeError(result.error, result.status ?? 400);
+    }
+
+    try {
+      await sendWorkspaceWelcomeEmail({
+        email: ownerEmail.trim().toLowerCase(),
+        organizationName: organizationName.trim(),
+        dashboardUrl: result.dashboardUrl,
+        publicUrl: result.publicPreviewUrl,
+        trialEndsAt: result.trialEndsAt,
+      });
+    } catch (emailErr) {
+      logger.warn('[workspaces/create] welcome email failed', { emailErr });
+    }
+
+    return safeOk({
+      success: true,
+      tenantId: result.tenantId,
+      workspaceId: result.workspaceId,
+      organizationId: result.organizationId,
+      slug: result.slug,
+      workspaceUrl: result.workspaceUrl,
+      publicPreviewUrl: result.publicPreviewUrl,
+      dashboardUrl: result.dashboardUrl,
+      trialEndsAt: result.trialEndsAt,
+      status: result.status,
+    });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to create workspace');
+  }
+}
+
+export const POST = withRuntime(withApiAudit('/api/workspaces/create', _POST));

--- a/app/api/workspaces/delete/route.ts
+++ b/app/api/workspaces/delete/route.ts
@@ -1,0 +1,48 @@
+import { NextRequest } from 'next/server';
+import { apiRequireAdmin } from '@/lib/admin/guards';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+/**
+ * DELETE /api/workspaces/delete
+ * Body: { workspaceId }
+ * Soft-archives workspace; hard delete of Northflank resources is phase 2.
+ */
+async function _DELETE(request: NextRequest) {
+  const auth = await apiRequireAdmin(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const body = await request.json();
+    const workspaceId = body.workspaceId as string | undefined;
+    if (!workspaceId) {
+      return safeError('workspaceId is required', 400);
+    }
+
+    const db = await requireAdminClient();
+    const { data: workspace } = await db
+      .from('customer_workspaces')
+      .select('id, tenant_id')
+      .eq('id', workspaceId)
+      .maybeSingle();
+
+    if (!workspace?.id) {
+      return safeError('Workspace not found', 404);
+    }
+
+    await db
+      .from('customer_workspaces')
+      .update({
+        status: 'archived',
+        updated_at: new Date().toISOString(),
+      } as Record<string, unknown>)
+      .eq('id', workspace.id);
+
+    return safeOk({ archived: true, workspaceId });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to archive workspace');
+  }
+}
+
+export const DELETE = withRuntime(_DELETE);

--- a/app/api/workspaces/deploy/route.ts
+++ b/app/api/workspaces/deploy/route.ts
@@ -1,0 +1,71 @@
+import { NextRequest } from 'next/server';
+import { apiRequireAdmin } from '@/lib/admin/guards';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { enqueueJob } from '@/lib/jobs/queue';
+
+/**
+ * POST /api/workspaces/deploy
+ * Phase 2: enqueue Northflank build/deploy for a customer workspace.
+ * Body: { workspaceId }
+ */
+async function _POST(request: NextRequest) {
+  const auth = await apiRequireAdmin(request);
+  if (auth.error) return auth.error;
+
+  try {
+    const body = await request.json();
+    const workspaceId = body.workspaceId as string | undefined;
+    if (!workspaceId) {
+      return safeError('workspaceId is required', 400);
+    }
+
+    const db = await requireAdminClient();
+    const { data: workspace } = await db
+      .from('customer_workspaces')
+      .select('id, tenant_id, slug, status')
+      .eq('id', workspaceId)
+      .maybeSingle();
+
+    if (!workspace?.id) {
+      return safeError('Workspace not found', 404);
+    }
+
+    const { data: deployment } = await db
+      .from('workspace_deployments')
+      .insert({
+        workspace_id: workspace.id,
+        status: 'queued',
+        metadata: { requested_by: auth.id ?? null },
+      } as Record<string, unknown>)
+      .select('id')
+      .maybeSingle();
+
+    await enqueueJob({
+      jobType: 'workspace_provision',
+      correlationId: `workspace-deploy:${workspace.id}:${deployment?.id ?? 'new'}`,
+      tenantId: workspace.tenant_id as string,
+      payload: {
+        workspace_id: workspace.id,
+        action: 'deploy',
+        deployment_id: deployment?.id ?? null,
+      },
+    });
+
+    await db
+      .from('customer_workspaces')
+      .update({ status: 'provisioning', updated_at: new Date().toISOString() } as Record<string, unknown>)
+      .eq('id', workspace.id);
+
+    return safeOk({
+      deploymentId: deployment?.id ?? null,
+      status: 'queued',
+      message: 'Deploy job queued (Northflank integration phase 2)',
+    });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to queue workspace deploy');
+  }
+}
+
+export const POST = withRuntime(_POST);

--- a/app/api/workspaces/status/route.ts
+++ b/app/api/workspaces/status/route.ts
@@ -1,0 +1,34 @@
+// PUBLIC ROUTE: workspace provisioning status poll (slug or workspaceId)
+import { NextRequest } from 'next/server';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeError, safeInternalError, safeOk } from '@/lib/api/safe-error';
+import { withRuntime } from '@/lib/api/withRuntime';
+import { getWorkspaceStatus } from '@/lib/workspace/get-workspace-status';
+
+async function _GET(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'public');
+  if (rateLimited) return rateLimited;
+
+  const { searchParams } = new URL(request.url);
+  const workspaceId = searchParams.get('workspaceId') ?? searchParams.get('id') ?? undefined;
+  const slug = searchParams.get('slug') ?? undefined;
+
+  if (!workspaceId && !slug) {
+    return safeError('workspaceId or slug is required', 400);
+  }
+
+  try {
+    const record = await getWorkspaceStatus({ workspaceId, slug });
+    if (!record) {
+      return safeError('Workspace not found', 404);
+    }
+
+    return safeOk({
+      workspace: record,
+    });
+  } catch (err) {
+    return safeInternalError(err, 'Failed to load workspace status');
+  }
+}
+
+export const GET = withRuntime(_GET);

--- a/app/start-trial/page.tsx
+++ b/app/start-trial/page.tsx
@@ -1,0 +1,206 @@
+'use client';
+
+import { useState } from 'react';
+import Link from 'next/link';
+import { Loader2, ArrowRight } from 'lucide-react';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+
+type CreateResult = {
+  ok: boolean;
+  workspaceUrl?: string;
+  publicPreviewUrl?: string;
+  dashboardUrl?: string;
+  slug?: string;
+  trialEndsAt?: string;
+  error?: string;
+};
+
+export default function StartTrialPage() {
+  const [organizationName, setOrganizationName] = useState('');
+  const [ownerEmail, setOwnerEmail] = useState('');
+  const [ownerName, setOwnerName] = useState('');
+  const [industry, setIndustry] = useState('');
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [result, setResult] = useState<CreateResult | null>(null);
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError(null);
+    setResult(null);
+
+    try {
+      const res = await fetch('/api/workspaces/create', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          organizationName,
+          ownerEmail,
+          ownerName,
+          industry,
+          plan: 'starter',
+        }),
+      });
+
+      const data = await res.json();
+      if (!res.ok) {
+        setError(data.error ?? 'Failed to create workspace');
+        return;
+      }
+
+      setResult({
+        ok: true,
+        workspaceUrl: data.workspaceUrl,
+        publicPreviewUrl: data.publicPreviewUrl,
+        dashboardUrl: data.dashboardUrl,
+        slug: data.slug,
+        trialEndsAt: data.trialEndsAt,
+      });
+    } catch {
+      setError('Network error. Please try again.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen bg-slate-50">
+      <div className="mx-auto max-w-2xl px-4 py-12">
+        <Breadcrumbs
+          items={[
+            { label: 'Home', href: '/' },
+            { label: 'Start free trial', href: '/start-trial' },
+          ]}
+        />
+
+        <h1 className="mt-6 text-3xl font-bold text-slate-900">Start your 14-day workspace trial</h1>
+        <p className="mt-3 text-slate-600">
+          Get your own training platform — LMS, website, and admin dashboard. No credit card required.
+        </p>
+
+        {result?.ok ? (
+          <div className="mt-8 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+            <h2 className="text-xl font-semibold text-slate-900">Your workspace is ready</h2>
+            <p className="mt-2 text-slate-600">
+              <span className="font-medium text-slate-900">{result.slug}</span> is live for 14 days.
+            </p>
+            <ul className="mt-4 space-y-2 text-sm text-slate-700">
+              {result.publicPreviewUrl ? (
+                <li>
+                  Public site:{' '}
+                  <a className="text-brand-blue-600 hover:underline" href={result.publicPreviewUrl}>
+                    {result.publicPreviewUrl}
+                  </a>
+                </li>
+              ) : null}
+              {result.dashboardUrl ? (
+                <li>
+                  Admin:{' '}
+                  <a className="text-brand-blue-600 hover:underline" href={result.dashboardUrl}>
+                    Open dashboard
+                  </a>
+                </li>
+              ) : null}
+            </ul>
+            <Link
+              href={result.dashboardUrl ?? '/login'}
+              className="mt-6 inline-flex items-center gap-2 rounded-lg bg-brand-red-600 px-5 py-3 text-sm font-semibold text-white hover:bg-brand-red-700"
+            >
+              Go to dashboard
+              <ArrowRight className="h-4 w-4" />
+            </Link>
+          </div>
+        ) : (
+          <form onSubmit={handleSubmit} className="mt-8 space-y-5 rounded-xl border border-slate-200 bg-white p-6 shadow-sm">
+            <div>
+              <label htmlFor="organizationName" className="block text-sm font-medium text-slate-700">
+                Organization name
+              </label>
+              <input
+                id="organizationName"
+                name="organizationName"
+                required
+                minLength={2}
+                value={organizationName}
+                onChange={(e) => setOrganizationName(e.target.value)}
+                placeholder="Acme Training Academy"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900"
+              />
+            </div>
+            <div>
+              <label htmlFor="ownerName" className="block text-sm font-medium text-slate-700">
+                Your name
+              </label>
+              <input
+                id="ownerName"
+                name="ownerName"
+                value={ownerName}
+                onChange={(e) => setOwnerName(e.target.value)}
+                placeholder="Jane Smith"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900"
+              />
+            </div>
+            <div>
+              <label htmlFor="ownerEmail" className="block text-sm font-medium text-slate-700">
+                Work email
+              </label>
+              <input
+                id="ownerEmail"
+                name="ownerEmail"
+                type="email"
+                required
+                value={ownerEmail}
+                onChange={(e) => setOwnerEmail(e.target.value)}
+                placeholder="you@company.com"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900"
+              />
+            </div>
+            <div>
+              <label htmlFor="industry" className="block text-sm font-medium text-slate-700">
+                Industry (optional)
+              </label>
+              <input
+                id="industry"
+                name="industry"
+                value={industry}
+                onChange={(e) => setIndustry(e.target.value)}
+                placeholder="Barber school, HVAC, workforce training…"
+                className="mt-1 w-full rounded-lg border border-slate-300 px-3 py-2 text-slate-900"
+              />
+            </div>
+            {error ? (
+              <p className="rounded-lg bg-brand-red-50 px-3 py-2 text-sm text-brand-red-700" role="alert">
+                {error}
+              </p>
+            ) : null}
+            <button
+              type="submit"
+              disabled={loading}
+              className="inline-flex w-full items-center justify-center gap-2 rounded-lg bg-brand-red-600 px-5 py-3 text-sm font-semibold text-white hover:bg-brand-red-700 disabled:opacity-60"
+            >
+              {loading ? (
+                <>
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                  Creating workspace…
+                </>
+              ) : (
+                'Create workspace — 14 days free'
+              )}
+            </button>
+            <p className="text-center text-xs text-slate-500">
+              Already have an account?{' '}
+              <Link href="/login" className="text-brand-blue-600 hover:underline">
+                Sign in
+              </Link>
+              {' · '}
+              <Link href="/store/trial" className="text-brand-blue-600 hover:underline">
+                Advanced trial options
+              </Link>
+            </p>
+          </form>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -30,6 +30,9 @@ const adminConfig = {
     parallelServerBuildTraces: false,
   },
 
+  // edge-tts ships index.ts as its entry (uncompiled TS) — same as root LMS config.
+  transpilePackages: ['edge-tts'],
+
   // Resolve @/* to repo root so shared lib/, components/, types/ work
   webpack(config) {
     config.resolve.alias['@'] = ROOT;
@@ -120,6 +123,7 @@ const adminConfig = {
     '@opentelemetry/resources',
     '@opentelemetry/semantic-conventions',
     'sharp',
+    // edge-tts: transpilePackages only (conflicts if also listed here)
     // ws — custom server.js only
     'ws',
     // Document OCR / extract admin APIs

--- a/docs/platform-owner-tenant-model.md
+++ b/docs/platform-owner-tenant-model.md
@@ -1,0 +1,39 @@
+# Platform owner tenant model
+
+Elevate operates two products on one Northflank deployment:
+
+| Product | Audience |
+|---------|----------|
+| **Elevate Workforce OS** | Elevate for Humanity + partner brands (owner tenant) |
+| **Elevate Dev Cloud** | Customer-provisioned workspaces (Gitpod/Replit-style) |
+
+## Hierarchy
+
+```text
+Platform owner tenant (is_platform_owner = true)
+  ├── organizations[]     — Elevate brands (siblings, not nested customers)
+  └── customer tenants (type = customer, parent_tenant_id = owner)
+        ├── organizations (default org)
+        ├── customer_workspaces
+        └── organization_subscriptions (billing)
+```
+
+## Workspace provisioning
+
+- **API:** `POST /api/workspaces/create` (public trial)
+- **Lib:** `lib/workspace/provision-workspace.ts`, `lib/workspace/start-workspace-trial.ts`
+- **Tables:** `customer_workspaces`, `workspace_deployments`, `workspace_domains`
+- **Phase 2:** `workspace_provision` job → GitHub fork, Northflank service, custom domain
+
+## Permission levels
+
+See `lib/platform/permission-levels.ts`:
+
+1. Platform owner (`super_admin` on owner tenant)
+2. Platform admin (`admin`/`staff` on owner tenant)
+3. Organization admin
+4. Standard user
+
+## Migration
+
+Apply `supabase/migrations/20260709000001_workspace_provisioning_foundation.sql` in Supabase SQL Editor.

--- a/lib/jobs/queue.ts
+++ b/lib/jobs/queue.ts
@@ -19,7 +19,8 @@ export type JobType =
   | 'license_reactivate'
   | 'email_send'
   | 'tenant_setup'
-  | 'webhook_process';
+  | 'webhook_process'
+  | 'workspace_provision';
 
 export type JobStatus = 'queued' | 'processing' | 'completed' | 'failed' | 'dead';
 

--- a/lib/platform/permission-levels.ts
+++ b/lib/platform/permission-levels.ts
@@ -1,0 +1,52 @@
+/**
+ * Four permission levels for the Elevate platform.
+ *
+ * @see docs/platform-owner-tenant-model.md
+ */
+
+import type { UserRole } from '@/lib/rbac/role-matrix';
+
+export type PlatformPermissionLevel =
+  | 'platform_owner'
+  | 'platform_admin'
+  | 'organization_admin'
+  | 'standard_user';
+
+export const PLATFORM_OWNER_ROLES: UserRole[] = ['super_admin'];
+export const PLATFORM_STAFF_ROLES: UserRole[] = ['super_admin', 'admin', 'staff'];
+export const ORGANIZATION_ADMIN_ROLES: UserRole[] = ['org_admin'];
+
+export function resolvePermissionLevel(params: {
+  profileRole: UserRole | null | undefined;
+  isPlatformOwnerTenant: boolean;
+  orgRole?: 'org_owner' | 'org_admin' | 'instructor' | 'reviewer' | 'report_viewer' | null;
+}): PlatformPermissionLevel {
+  const { profileRole, isPlatformOwnerTenant, orgRole } = params;
+
+  if (isPlatformOwnerTenant && profileRole && PLATFORM_STAFF_ROLES.includes(profileRole)) {
+    if (profileRole === 'super_admin') return 'platform_owner';
+    return 'platform_admin';
+  }
+
+  if (
+    profileRole === 'org_admin' ||
+    orgRole === 'org_admin' ||
+    orgRole === 'org_owner'
+  ) {
+    return 'organization_admin';
+  }
+
+  return 'standard_user';
+}
+
+export function canAccessDevStudio(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner';
+}
+
+export function canProvisionWorkspaces(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner' || level === 'platform_admin';
+}
+
+export function canDeployCode(level: PlatformPermissionLevel): boolean {
+  return level === 'platform_owner';
+}

--- a/lib/platform/platform-owner.ts
+++ b/lib/platform/platform-owner.ts
@@ -1,0 +1,106 @@
+import 'server-only';
+
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import type { UserRole } from '@/lib/rbac/role-matrix';
+import {
+  resolvePermissionLevel,
+  type PlatformPermissionLevel,
+  canAccessDevStudio,
+  canProvisionWorkspaces,
+  canDeployCode,
+} from '@/lib/platform/permission-levels';
+
+export type PlatformUserContext = {
+  userId: string;
+  profileRole: UserRole | null;
+  tenantId: string | null;
+  isPlatformOwnerTenant: boolean;
+  permissionLevel: PlatformPermissionLevel;
+  canAccessDevStudio: boolean;
+  canProvisionWorkspaces: boolean;
+  canDeployCode: boolean;
+};
+
+export function getPlatformOwnerTenantIdFromEnv(): string | null {
+  const raw = process.env.PLATFORM_OWNER_TENANT_ID?.trim();
+  return raw || null;
+}
+
+export async function fetchPlatformOwnerTenantId(): Promise<string | null> {
+  const fromEnv = getPlatformOwnerTenantIdFromEnv();
+  if (fromEnv) return fromEnv;
+
+  const db = await requireAdminClient();
+  if (!db) return null;
+
+  const { data: setting } = await db
+    .from('platform_settings')
+    .select('value')
+    .eq('key', 'PLATFORM_OWNER_TENANT_ID')
+    .maybeSingle();
+
+  if (setting?.value && typeof setting.value === 'string') {
+    const trimmed = setting.value.trim();
+    if (trimmed) return trimmed;
+  }
+
+  const { data: tenant } = await db
+    .from('tenants')
+    .select('id')
+    .eq('is_platform_owner', true)
+    .order('created_at', { ascending: true })
+    .limit(1)
+    .maybeSingle();
+
+  return tenant?.id ?? null;
+}
+
+export function isUserOnPlatformOwnerTenant(
+  userTenantId: string | null | undefined,
+  platformOwnerTenantId: string | null,
+): boolean {
+  if (!userTenantId || !platformOwnerTenantId) return false;
+  return userTenantId === platformOwnerTenantId;
+}
+
+export async function getPlatformUserContext(userId: string): Promise<PlatformUserContext | null> {
+  const db = await requireAdminClient();
+  if (!db) return null;
+
+  const [profileRes, ownerTenantId] = await Promise.all([
+    db.from('profiles').select('role, tenant_id').eq('id', userId).maybeSingle(),
+    fetchPlatformOwnerTenantId(),
+  ]);
+
+  const profile = profileRes.data;
+  if (!profile) return null;
+
+  const profileRole = (profile.role as UserRole | null) ?? null;
+  const tenantId = (profile.tenant_id as string | null) ?? null;
+  const onOwnerTenant = isUserOnPlatformOwnerTenant(tenantId, ownerTenantId);
+  const permissionLevel = resolvePermissionLevel({
+    profileRole,
+    isPlatformOwnerTenant: onOwnerTenant,
+  });
+
+  return {
+    userId,
+    profileRole,
+    tenantId,
+    isPlatformOwnerTenant: onOwnerTenant,
+    permissionLevel,
+    canAccessDevStudio: canAccessDevStudio(permissionLevel),
+    canProvisionWorkspaces: canProvisionWorkspaces(permissionLevel),
+    canDeployCode: canDeployCode(permissionLevel),
+  };
+}
+
+export async function getCurrentPlatformUserContext(): Promise<PlatformUserContext | null> {
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+  if (!user) return null;
+  return getPlatformUserContext(user.id);
+}

--- a/lib/workspace/get-workspace-status.ts
+++ b/lib/workspace/get-workspace-status.ts
@@ -1,0 +1,54 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+
+export type WorkspaceStatusRecord = {
+  id: string;
+  slug: string;
+  displayName: string;
+  status: string;
+  workspaceUrl: string | null;
+  ownerEmail: string | null;
+  subscriptionTier: string;
+  trialEndsAt: string | null;
+  provisionError: string | null;
+  createdAt: string;
+  provisionedAt: string | null;
+};
+
+export async function getWorkspaceStatus(params: {
+  workspaceId?: string;
+  slug?: string;
+}): Promise<WorkspaceStatusRecord | null> {
+  const db = await requireAdminClient();
+  if (!params.workspaceId && !params.slug) return null;
+
+  let query = db
+    .from('customer_workspaces')
+    .select(
+      'id, slug, display_name, status, workspace_url, owner_email, subscription_tier, trial_ends_at, provision_error, created_at, provisioned_at',
+    );
+
+  if (params.workspaceId) {
+    query = query.eq('id', params.workspaceId);
+  } else if (params.slug) {
+    query = query.eq('slug', params.slug);
+  }
+
+  const { data } = await query.maybeSingle();
+  if (!data) return null;
+
+  return {
+    id: data.id as string,
+    slug: data.slug as string,
+    displayName: data.display_name as string,
+    status: data.status as string,
+    workspaceUrl: (data.workspace_url as string | null) ?? null,
+    ownerEmail: (data.owner_email as string | null) ?? null,
+    subscriptionTier: data.subscription_tier as string,
+    trialEndsAt: (data.trial_ends_at as string | null) ?? null,
+    provisionError: (data.provision_error as string | null) ?? null,
+    createdAt: data.created_at as string,
+    provisionedAt: (data.provisioned_at as string | null) ?? null,
+  };
+}

--- a/lib/workspace/provision-workspace.ts
+++ b/lib/workspace/provision-workspace.ts
@@ -1,0 +1,180 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { fetchPlatformOwnerTenantId } from '@/lib/platform/platform-owner';
+import { enqueueJob } from '@/lib/jobs/queue';
+import { normalizeWorkspaceTier } from '@/lib/workspace/tier-limits';
+
+export type ProvisionWorkspaceParams = {
+  displayName: string;
+  slug: string;
+  plan?: string;
+  templateSlug?: string;
+  provisionedByUserId?: string | null;
+  contactEmail?: string;
+  trialEndsAt?: string;
+};
+
+export type ProvisionWorkspaceResult =
+  | {
+      ok: true;
+      workspaceId: string;
+      tenantId: string;
+      organizationId: string;
+      status: 'pending' | 'provisioning' | 'active';
+      workspaceUrl: string;
+      publicPreviewUrl: string;
+      subscriptionTier: 'builder' | 'pro' | 'agency';
+    }
+  | { ok: false; error: string };
+
+export function workspacePublicUrl(slug: string): string {
+  const devCloudHost = process.env.ELEVATE_DEV_CLOUD_HOST?.trim();
+  if (devCloudHost) {
+    return `https://${slug}.${devCloudHost}`;
+  }
+  return `https://${slug}.app.elevateforhumanity.org`;
+}
+
+/**
+ * Phase 1: customer tenant + organization + customer_workspaces row + trial license.
+ * Phase 2 (async job): GitHub fork, Northflank service, custom domain, deploy.
+ */
+export async function provisionWorkspace(
+  params: ProvisionWorkspaceParams,
+): Promise<ProvisionWorkspaceResult> {
+  const db = await requireAdminClient();
+
+  const slug = params.slug.trim().toLowerCase().replace(/[^a-z0-9-]/g, '-');
+  if (!slug || slug.length < 2) {
+    return { ok: false, error: 'Invalid workspace slug' };
+  }
+
+  const ownerTenantId = await fetchPlatformOwnerTenantId();
+  if (!ownerTenantId) {
+    return { ok: false, error: 'Platform owner tenant is not configured' };
+  }
+
+  const subscriptionTier = normalizeWorkspaceTier(params.plan);
+  const templateSlug = params.templateSlug ?? 'workforce-platform-v1';
+  const workspaceUrl = workspacePublicUrl(slug);
+  const publicPreviewUrl = workspaceUrl;
+
+  const { data: existing } = await db
+    .from('customer_workspaces')
+    .select('id')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (existing?.id) {
+    return { ok: false, error: 'Workspace slug already exists' };
+  }
+
+  const { data: tenant, error: tenantError } = await db
+    .from('tenants')
+    .insert({
+      name: params.displayName,
+      slug,
+      status: 'active',
+      type: 'customer',
+      is_platform_owner: false,
+      parent_tenant_id: ownerTenantId,
+    } as Record<string, unknown>)
+    .select('id')
+    .maybeSingle();
+
+  if (tenantError || !tenant?.id) {
+    logger.error('[provisionWorkspace] tenant insert failed', tenantError);
+    return { ok: false, error: 'Failed to create customer tenant' };
+  }
+
+  const orgInsert: Record<string, unknown> = {
+    name: params.displayName,
+    slug,
+    type: 'training_provider',
+    status: 'active',
+    tenant_id: tenant.id,
+    contact_email: params.contactEmail ?? null,
+    domain: `${slug}.app.elevateforhumanity.org`,
+  };
+
+  const { data: org, error: orgError } = await db
+    .from('organizations')
+    .insert(orgInsert)
+    .select('id')
+    .maybeSingle();
+
+  if (orgError || !org?.id) {
+    await db.from('tenants').delete().eq('id', tenant.id);
+    logger.error('[provisionWorkspace] organization insert failed', orgError);
+    return { ok: false, error: 'Failed to create organization' };
+  }
+
+  const { data: workspace, error: workspaceError } = await db
+    .from('customer_workspaces')
+    .insert({
+      tenant_id: tenant.id,
+      organization_id: org.id,
+      slug,
+      display_name: params.displayName,
+      owner_email: params.contactEmail ?? null,
+      subscription_tier: subscriptionTier,
+      template_slug: templateSlug,
+      status: 'provisioning',
+      workspace_url: workspaceUrl,
+      trial_ends_at: params.trialEndsAt ?? null,
+      provisioned_by: params.provisionedByUserId ?? null,
+      metadata: {
+        contact_email: params.contactEmail ?? null,
+        phase: 1,
+      },
+    } as Record<string, unknown>)
+    .select('id')
+    .maybeSingle();
+
+  if (workspaceError || !workspace?.id) {
+    await db.from('organizations').delete().eq('id', org.id);
+    await db.from('tenants').delete().eq('id', tenant.id);
+    logger.error('[provisionWorkspace] customer_workspaces insert failed', workspaceError);
+    return { ok: false, error: 'Failed to create workspace record' };
+  }
+
+  try {
+    await enqueueJob({
+      jobType: 'workspace_provision',
+      correlationId: `workspace:${workspace.id}`,
+      tenantId: tenant.id,
+      payload: {
+        workspace_id: workspace.id,
+        tenant_id: tenant.id,
+        organization_id: org.id,
+        slug,
+        template_slug: templateSlug,
+        subscription_tier: subscriptionTier,
+      },
+    });
+  } catch (err) {
+    logger.warn('[provisionWorkspace] job enqueue failed — workspace row created', {
+      workspaceId: workspace.id,
+      err,
+    });
+  }
+
+  logger.info('[provisionWorkspace] workspace created', {
+    workspaceId: workspace.id,
+    tenantId: tenant.id,
+    slug,
+  });
+
+  return {
+    ok: true,
+    workspaceId: workspace.id,
+    tenantId: tenant.id,
+    organizationId: org.id,
+    status: 'provisioning',
+    workspaceUrl,
+    publicPreviewUrl,
+    subscriptionTier,
+  };
+}

--- a/lib/workspace/slug.ts
+++ b/lib/workspace/slug.ts
@@ -1,0 +1,48 @@
+const RESERVED_SLUGS = new Set([
+  'www',
+  'app',
+  'api',
+  'admin',
+  'dashboard',
+  'mail',
+  'support',
+  'help',
+  'docs',
+  'demo',
+  'store',
+  'login',
+]);
+
+export function slugifyWorkspaceName(name: string): string {
+  return name
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+}
+
+export function normalizeWorkspaceSlug(raw: string): string {
+  const slug = raw
+    .toLowerCase()
+    .trim()
+    .replace(/[^a-z0-9-]/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^-|-$/g, '')
+    .slice(0, 48);
+
+  if (!slug || slug.length < 2) {
+    throw new Error('Workspace slug must be at least 2 characters');
+  }
+
+  if (RESERVED_SLUGS.has(slug)) {
+    throw new Error('Workspace slug is reserved');
+  }
+
+  return slug;
+}
+
+export function ensureUniqueSlugCandidate(base: string, taken: boolean): string {
+  if (!taken) return base;
+  return `${base}-${Date.now().toString(36).slice(-4)}`;
+}

--- a/lib/workspace/start-workspace-trial.ts
+++ b/lib/workspace/start-workspace-trial.ts
@@ -1,0 +1,180 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { provisionWorkspace } from '@/lib/workspace/provision-workspace';
+import { provisionTrialWebsite } from '@/lib/tenant/provision-trial-website';
+import { tenantAdminUrl } from '@/lib/tenant/public-site-url';
+import { slugifyWorkspaceName, ensureUniqueSlugCandidate } from '@/lib/workspace/slug';
+import { TRIAL_DURATION_DAYS } from '@/lib/workspace/tier-limits';
+
+export type StartWorkspaceTrialInput = {
+  organizationName: string;
+  ownerEmail: string;
+  ownerName?: string;
+  industry?: string;
+  plan?: string;
+};
+
+export type StartWorkspaceTrialResult =
+  | {
+      ok: true;
+      workspaceId: string;
+      tenantId: string;
+      organizationId: string;
+      slug: string;
+      workspaceUrl: string;
+      publicPreviewUrl: string;
+      dashboardUrl: string;
+      trialEndsAt: string;
+      status: string;
+    }
+  | { ok: false; error: string; status?: number };
+
+function validateEmail(email: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+
+export async function startWorkspaceTrial(
+  input: StartWorkspaceTrialInput,
+): Promise<StartWorkspaceTrialResult> {
+  const organizationName = input.organizationName?.trim();
+  const email = input.ownerEmail?.trim().toLowerCase();
+
+  if (!organizationName || organizationName.length < 2 || organizationName.length > 100) {
+    return { ok: false, error: 'Organization name must be 2–100 characters', status: 400 };
+  }
+
+  if (!email || !validateEmail(email)) {
+    return { ok: false, error: 'Valid email is required', status: 400 };
+  }
+
+  const db = await requireAdminClient();
+
+  const { data: existingWorkspace } = await db
+    .from('customer_workspaces')
+    .select('id, slug, workspace_url')
+    .eq('owner_email', email)
+    .in('status', ['pending', 'provisioning', 'active'])
+    .maybeSingle();
+
+  if (existingWorkspace?.id) {
+    return {
+      ok: false,
+      error: 'A workspace already exists for this email',
+      status: 409,
+    };
+  }
+
+  let slug = slugifyWorkspaceName(organizationName);
+  const { data: slugRow } = await db
+    .from('customer_workspaces')
+    .select('id')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (slugRow?.id) {
+    slug = ensureUniqueSlugCandidate(slug, true);
+  }
+
+  const { data: orgSlugTaken } = await db
+    .from('organizations')
+    .select('id')
+    .eq('slug', slug)
+    .maybeSingle();
+
+  if (orgSlugTaken?.id) {
+    slug = ensureUniqueSlugCandidate(slug, true);
+  }
+
+  const trialEndsAt = new Date();
+  trialEndsAt.setDate(trialEndsAt.getDate() + TRIAL_DURATION_DAYS);
+
+  const provisioned = await provisionWorkspace({
+    displayName: organizationName,
+    slug,
+    plan: input.plan ?? 'builder',
+    contactEmail: email,
+    trialEndsAt: trialEndsAt.toISOString(),
+  });
+
+  if (!provisioned.ok) {
+    return { ok: false, error: provisioned.error, status: 500 };
+  }
+
+  const { error: licenseError } = await db.from('managed_licenses').insert({
+    organization_id: provisioned.organizationId,
+    status: 'active',
+    tier: 'trial',
+    plan_id: 'workspace-trial',
+    trial_started_at: new Date().toISOString(),
+    trial_ends_at: trialEndsAt.toISOString(),
+    expires_at: trialEndsAt.toISOString(),
+  });
+
+  if (licenseError) {
+    logger.error('[startWorkspaceTrial] managed_licenses insert failed', licenseError);
+  }
+
+  if (input.ownerName?.trim()) {
+    await db
+      .from('organizations')
+      .update({ contact_name: input.ownerName.trim() } as Record<string, unknown>)
+      .eq('id', provisioned.organizationId)
+      .then(() => {}, () => {});
+  }
+
+  const website = await provisionTrialWebsite({
+    organizationId: provisioned.organizationId,
+    organizationName,
+    subdomain: slug,
+    trialEndsAt: trialEndsAt.toISOString(),
+    contactEmail: email,
+    industry: input.industry?.trim() || 'Training Provider',
+    websiteMode: 'new_site',
+  });
+
+  if (!website.ok) {
+    logger.error('[startWorkspaceTrial] website provision failed', new Error(website.error));
+    await db
+      .from('customer_workspaces')
+      .update({
+        status: 'failed',
+        provision_error: website.error,
+        updated_at: new Date().toISOString(),
+      } as Record<string, unknown>)
+      .eq('id', provisioned.workspaceId);
+
+    return { ok: false, error: 'Failed to provision trial website', status: 500 };
+  }
+
+  await db
+    .from('customer_workspaces')
+    .update({
+      status: 'active',
+      provisioned_at: new Date().toISOString(),
+      workspace_url: website.publicUrl,
+      metadata: {
+        website_id: website.websiteId,
+        public_preview_url: website.publicUrl,
+        industry: input.industry ?? null,
+      },
+      updated_at: new Date().toISOString(),
+    } as Record<string, unknown>)
+    .eq('id', provisioned.workspaceId);
+
+  const dashboardUrl = tenantAdminUrl(slug, '/admin');
+
+  return {
+    ok: true,
+    workspaceId: provisioned.workspaceId,
+    tenantId: provisioned.tenantId,
+    organizationId: provisioned.organizationId,
+    slug,
+    workspaceUrl: website.publicUrl,
+    publicPreviewUrl: website.publicUrl,
+    dashboardUrl,
+    trialEndsAt: trialEndsAt.toISOString(),
+    status: 'active',
+  };
+}

--- a/lib/workspace/tier-limits.ts
+++ b/lib/workspace/tier-limits.ts
@@ -1,0 +1,68 @@
+/**
+ * Elevate Dev Cloud workspace subscription tiers.
+ */
+
+export type WorkspaceSubscriptionTier = 'builder' | 'pro' | 'agency' | 'starter';
+
+export type WorkspaceTierLimits = {
+  maxWorkspaces: number;
+  maxDatabaseGb: number;
+  customDomains: boolean;
+  teamAccess: boolean;
+  whiteLabel: boolean;
+  aiOperator: boolean;
+  aiAutopilot: boolean;
+};
+
+export const WORKSPACE_TIER_LIMITS: Record<'builder' | 'pro' | 'agency', WorkspaceTierLimits> = {
+  builder: {
+    maxWorkspaces: 1,
+    maxDatabaseGb: 1,
+    customDomains: false,
+    teamAccess: false,
+    whiteLabel: false,
+    aiOperator: false,
+    aiAutopilot: false,
+  },
+  pro: {
+    maxWorkspaces: 10,
+    maxDatabaseGb: 10,
+    customDomains: true,
+    teamAccess: true,
+    whiteLabel: false,
+    aiOperator: true,
+    aiAutopilot: false,
+  },
+  agency: {
+    maxWorkspaces: Number.POSITIVE_INFINITY,
+    maxDatabaseGb: 50,
+    customDomains: true,
+    teamAccess: true,
+    whiteLabel: true,
+    aiOperator: true,
+    aiAutopilot: true,
+  },
+};
+
+export const WORKSPACE_TIER_PRICING_USD_MONTHLY: Record<'builder' | 'pro' | 'agency', number> = {
+  builder: 49,
+  pro: 149,
+  agency: 499,
+};
+
+export const TRIAL_DURATION_DAYS = 14;
+
+/** Map API aliases (starter) to canonical tier. */
+export function normalizeWorkspaceTier(
+  plan: string | undefined | null,
+): 'builder' | 'pro' | 'agency' {
+  const raw = (plan ?? 'builder').toLowerCase().trim();
+  if (raw === 'starter' || raw === 'builder') return 'builder';
+  if (raw === 'pro' || raw === 'professional') return 'pro';
+  if (raw === 'agency') return 'agency';
+  return 'builder';
+}
+
+export function getWorkspaceTierLimits(tier: 'builder' | 'pro' | 'agency'): WorkspaceTierLimits {
+  return WORKSPACE_TIER_LIMITS[tier];
+}

--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -42,12 +42,16 @@ mkdirSync(exportRoot, { recursive: true });
 // Must match node_modules/@napi-rs/{canvas,canvas-linux-x64-gnu} layout
 copyPkg('@napi-rs/canvas', '@napi-rs/canvas');
 
-// pdf-parse does not export package.json subpath; resolve entry then dirname
-const pdfParseEntry = require.resolve('pdf-parse', { paths: [root] });
-copyDir(dirname(pdfParseEntry), 'pdf-parse');
+const pnpmDir = join(root, 'node_modules', '.pnpm');
+
+// pdf-parse v2 resolve() points at dist/.../index.cjs (no package.json export) — use pnpm store
+const pdfParseStore = readdirSync(pnpmDir).find((e) => e.startsWith('pdf-parse@'));
+if (!pdfParseStore) {
+  throw new Error('pdf-parse not found under node_modules/.pnpm');
+}
+copyDir(join(pnpmDir, pdfParseStore, 'node_modules', 'pdf-parse'), 'pdf-parse');
 
 // pdfjs-dist lives in pnpm store (not always hoisted to workspace root)
-const pnpmDir = join(root, 'node_modules', '.pnpm');
 const pdfjsStore = readdirSync(pnpmDir).find((e) => e.startsWith('pdfjs-dist@'));
 if (!pdfjsStore) {
   throw new Error('pdfjs-dist not found under node_modules/.pnpm');
@@ -70,6 +74,12 @@ if (canvasNative) {
 const canvasPkg = join(exportRoot, '@napi-rs', 'canvas', 'package.json');
 if (!existsSync(canvasPkg)) {
   console.error('[export-pdf] @napi-rs/canvas export failed');
+  process.exit(1);
+}
+
+const pdfParsePkg = join(exportRoot, 'pdf-parse', 'package.json');
+if (!existsSync(pdfParsePkg)) {
+  console.error('[export-pdf] pdf-parse export failed (missing package.json)');
   process.exit(1);
 }
 

--- a/supabase/migrations/20260709000001_workspace_provisioning_foundation.sql
+++ b/supabase/migrations/20260709000001_workspace_provisioning_foundation.sql
@@ -1,0 +1,296 @@
+-- Workspace provisioning foundation (Elevate Dev Cloud)
+-- Reuses tenants + organizations; adds customer_workspaces lifecycle.
+-- Does NOT replace is_platform_admin() — uses is_platform_owner_user() for new RLS only.
+-- Apply manually in Supabase SQL Editor.
+
+BEGIN;
+
+-- ── 1. Tenant classification ───────────────────────────────────────────────
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS is_platform_owner BOOLEAN NOT NULL DEFAULT false;
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS parent_tenant_id UUID REFERENCES public.tenants(id) ON DELETE SET NULL;
+
+ALTER TABLE public.tenants
+  ADD COLUMN IF NOT EXISTS type TEXT;
+
+CREATE INDEX IF NOT EXISTS idx_tenants_is_platform_owner
+  ON public.tenants(is_platform_owner)
+  WHERE is_platform_owner = true;
+
+CREATE INDEX IF NOT EXISTS idx_tenants_parent_tenant_id
+  ON public.tenants(parent_tenant_id)
+  WHERE parent_tenant_id IS NOT NULL;
+
+ALTER TABLE public.tenants DROP CONSTRAINT IF EXISTS tenants_type_check;
+ALTER TABLE public.tenants
+  ADD CONSTRAINT tenants_type_check
+  CHECK (
+    type IS NULL
+    OR type IN ('elevate', 'partner_provider', 'employer', 'workforce_agency', 'customer')
+  );
+
+CREATE UNIQUE INDEX IF NOT EXISTS tenants_single_platform_owner_idx
+  ON public.tenants ((true))
+  WHERE is_platform_owner = true;
+
+-- Backfill platform owner tenant (idempotent)
+DO $$
+DECLARE
+  v_owner_id UUID;
+BEGIN
+  SELECT id INTO v_owner_id
+  FROM public.tenants
+  WHERE is_platform_owner = true
+  ORDER BY created_at ASC
+  LIMIT 1;
+
+  IF v_owner_id IS NULL THEN
+    SELECT id INTO v_owner_id
+    FROM public.tenants
+    WHERE type = 'elevate'
+    ORDER BY created_at ASC
+    LIMIT 1;
+  END IF;
+
+  IF v_owner_id IS NULL THEN
+    SELECT id INTO v_owner_id
+    FROM public.tenants
+    ORDER BY created_at ASC
+    LIMIT 1;
+  END IF;
+
+  IF v_owner_id IS NOT NULL THEN
+    UPDATE public.tenants
+    SET is_platform_owner = true,
+        type = COALESCE(NULLIF(type, ''), 'elevate')
+    WHERE id = v_owner_id;
+
+    INSERT INTO public.platform_settings (key, value, updated_at)
+    VALUES ('PLATFORM_OWNER_TENANT_ID', v_owner_id::text, now())
+    ON CONFLICT (key) DO UPDATE
+      SET value = EXCLUDED.value,
+          updated_at = now();
+  END IF;
+END $$;
+
+-- ── 2. Customer workspaces ───────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.customer_workspaces (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL REFERENCES public.tenants(id) ON DELETE CASCADE,
+  organization_id UUID REFERENCES public.organizations(id) ON DELETE SET NULL,
+  slug TEXT NOT NULL,
+  display_name TEXT NOT NULL,
+  owner_email TEXT,
+  subscription_tier TEXT NOT NULL DEFAULT 'builder'
+    CHECK (subscription_tier IN ('builder', 'pro', 'agency', 'starter')),
+  status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (status IN ('pending', 'provisioning', 'active', 'suspended', 'failed', 'archived')),
+  template_slug TEXT NOT NULL DEFAULT 'workforce-platform-v1',
+  github_repo_url TEXT,
+  northflank_project_id TEXT,
+  northflank_service_id TEXT,
+  supabase_project_ref TEXT,
+  workspace_url TEXT,
+  trial_ends_at TIMESTAMPTZ,
+  provision_error TEXT,
+  provisioned_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  provisioned_at TIMESTAMPTZ,
+  CONSTRAINT customer_workspaces_slug_unique UNIQUE (slug)
+);
+
+CREATE INDEX IF NOT EXISTS customer_workspaces_tenant_id_idx
+  ON public.customer_workspaces(tenant_id);
+CREATE INDEX IF NOT EXISTS customer_workspaces_status_idx
+  ON public.customer_workspaces(status);
+CREATE INDEX IF NOT EXISTS customer_workspaces_owner_email_idx
+  ON public.customer_workspaces(owner_email)
+  WHERE owner_email IS NOT NULL;
+
+-- ── 3. Workspace deployments (Northflank / release history) ────────────────
+
+CREATE TABLE IF NOT EXISTS public.workspace_deployments (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES public.customer_workspaces(id) ON DELETE CASCADE,
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'building', 'deploying', 'live', 'failed', 'rolled_back')),
+  northflank_build_id TEXT,
+  northflank_deployment_id TEXT,
+  commit_ref TEXT,
+  error_message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  deployed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS workspace_deployments_workspace_id_idx
+  ON public.workspace_deployments(workspace_id);
+
+-- ── 4. Custom domains ────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.workspace_domains (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES public.customer_workspaces(id) ON DELETE CASCADE,
+  hostname TEXT NOT NULL,
+  is_primary BOOLEAN NOT NULL DEFAULT false,
+  ssl_status TEXT NOT NULL DEFAULT 'pending'
+    CHECK (ssl_status IN ('pending', 'active', 'failed')),
+  verification_token TEXT,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT workspace_domains_hostname_unique UNIQUE (hostname)
+);
+
+CREATE INDEX IF NOT EXISTS workspace_domains_workspace_id_idx
+  ON public.workspace_domains(workspace_id);
+
+-- ── 5. AI operator (foundation) ────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.operator_tasks (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID REFERENCES public.customer_workspaces(id) ON DELETE CASCADE,
+  tenant_id UUID REFERENCES public.tenants(id) ON DELETE CASCADE,
+  created_by UUID REFERENCES public.profiles(id) ON DELETE SET NULL,
+  task_type TEXT NOT NULL DEFAULT 'chat'
+    CHECK (task_type IN ('chat', 'build', 'test', 'deploy', 'fix', 'generate_site', 'generate_lms')),
+  status TEXT NOT NULL DEFAULT 'queued'
+    CHECK (status IN ('queued', 'running', 'completed', 'failed', 'canceled')),
+  prompt TEXT NOT NULL,
+  result_summary TEXT,
+  error_message TEXT,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS operator_tasks_workspace_id_idx
+  ON public.operator_tasks(workspace_id);
+
+CREATE TABLE IF NOT EXISTS public.operator_memory (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  workspace_id UUID NOT NULL REFERENCES public.customer_workspaces(id) ON DELETE CASCADE,
+  scope TEXT NOT NULL DEFAULT 'workspace',
+  key TEXT NOT NULL,
+  value JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  CONSTRAINT operator_memory_workspace_key_unique UNIQUE (workspace_id, scope, key)
+);
+
+-- ── 6. RLS ───────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.customer_workspaces ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_deployments ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.workspace_domains ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.operator_tasks ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.operator_memory ENABLE ROW LEVEL SECURITY;
+
+CREATE OR REPLACE FUNCTION public.get_platform_owner_tenant_id()
+RETURNS UUID
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT id
+  FROM public.tenants
+  WHERE is_platform_owner = true
+  ORDER BY created_at ASC
+  LIMIT 1;
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_platform_owner_user()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    INNER JOIN public.tenants t ON t.id = p.tenant_id
+    WHERE p.id = auth.uid()
+      AND t.is_platform_owner = true
+      AND p.role IN ('super_admin', 'admin', 'staff')
+  );
+$$;
+
+CREATE OR REPLACE FUNCTION public.is_platform_operator()
+RETURNS BOOLEAN
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = pg_catalog, public
+AS $$
+  SELECT EXISTS (
+    SELECT 1
+    FROM public.profiles p
+    INNER JOIN public.tenants t ON t.id = p.tenant_id
+    WHERE p.id = auth.uid()
+      AND t.is_platform_owner = true
+      AND p.role = 'super_admin'
+  );
+$$;
+
+-- Customer workspace: platform staff read/write; tenant members read own
+DROP POLICY IF EXISTS "customer_workspaces_platform_staff" ON public.customer_workspaces;
+CREATE POLICY "customer_workspaces_platform_staff" ON public.customer_workspaces
+  FOR ALL
+  USING (public.is_platform_owner_user())
+  WITH CHECK (public.is_platform_owner_user());
+
+DROP POLICY IF EXISTS "customer_workspaces_tenant_read" ON public.customer_workspaces;
+CREATE POLICY "customer_workspaces_tenant_read" ON public.customer_workspaces
+  FOR SELECT
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM public.profiles WHERE id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS "customer_workspaces_service_role" ON public.customer_workspaces;
+CREATE POLICY "customer_workspaces_service_role" ON public.customer_workspaces
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "workspace_deployments_service_role" ON public.workspace_deployments;
+CREATE POLICY "workspace_deployments_service_role" ON public.workspace_deployments
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "workspace_domains_service_role" ON public.workspace_domains;
+CREATE POLICY "workspace_domains_service_role" ON public.workspace_domains
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "operator_tasks_service_role" ON public.operator_tasks;
+CREATE POLICY "operator_tasks_service_role" ON public.operator_tasks
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+DROP POLICY IF EXISTS "operator_memory_service_role" ON public.operator_memory;
+CREATE POLICY "operator_memory_service_role" ON public.operator_memory
+  FOR ALL
+  USING (auth.role() = 'service_role')
+  WITH CHECK (auth.role() = 'service_role');
+
+GRANT SELECT ON public.customer_workspaces TO authenticated;
+GRANT ALL ON public.customer_workspaces TO service_role;
+GRANT ALL ON public.workspace_deployments TO service_role;
+GRANT ALL ON public.workspace_domains TO service_role;
+GRANT ALL ON public.operator_tasks TO service_role;
+GRANT ALL ON public.operator_memory TO service_role;
+
+COMMIT;

--- a/tests/unit/export-admin-pdf-deps.test.ts
+++ b/tests/unit/export-admin-pdf-deps.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { mkdtempSync } from 'node:fs';
+
+describe('export-admin-pdf-deps.mjs', () => {
+  it('exports pdf-parse with package.json at package root', () => {
+    const exportRoot = mkdtempSync(join(tmpdir(), 'pdf-export-'));
+    execSync('node scripts/export-admin-pdf-deps.mjs', {
+      cwd: process.cwd(),
+      env: { ...process.env, EXPORT_ROOT: exportRoot },
+      stdio: 'pipe',
+    });
+
+    expect(existsSync(join(exportRoot, 'pdf-node_modules', 'pdf-parse', 'package.json'))).toBe(
+      true,
+    );
+    expect(existsSync(join(exportRoot, 'pdf-node_modules', '@napi-rs', 'canvas', 'package.json'))).toBe(
+      true,
+    );
+  });
+});

--- a/tests/unit/workspace-slug.test.ts
+++ b/tests/unit/workspace-slug.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest';
+import {
+  slugifyWorkspaceName,
+  normalizeWorkspaceSlug,
+  ensureUniqueSlugCandidate,
+} from '@/lib/workspace/slug';
+import { normalizeWorkspaceTier } from '@/lib/workspace/tier-limits';
+
+describe('workspace slug helpers', () => {
+  it('slugifies organization names', () => {
+    expect(slugifyWorkspaceName('Acme Training Co.')).toBe('acme-training-co');
+  });
+
+  it('rejects reserved slugs', () => {
+    expect(() => normalizeWorkspaceSlug('admin')).toThrow(/reserved/i);
+  });
+
+  it('appends suffix when slug is taken', () => {
+    const next = ensureUniqueSlugCandidate('acme', true);
+    expect(next).toMatch(/^acme-[a-z0-9]+$/);
+  });
+});
+
+describe('normalizeWorkspaceTier', () => {
+  it('maps starter to builder', () => {
+    expect(normalizeWorkspaceTier('starter')).toBe('builder');
+  });
+
+  it('defaults unknown plans to builder', () => {
+    expect(normalizeWorkspaceTier('unknown')).toBe('builder');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Implements the **workspace provisioning foundation** for Elevate Dev Cloud and includes **Northflank Docker build fixes** from the same branch.

### Workspace provisioning (new)

Customers can start a 14-day trial without manual ops:

1. **`POST /api/workspaces/create`** — public, rate-limited
2. Creates **customer tenant** + **organization** + **`customer_workspaces`** row
3. Provisions **trial website** (`user_websites`) + **`managed_licenses`** trial record
4. Enqueues **`workspace_provision`** job (Northflank/GitHub phase 2)
5. **`/start-trial`** signup page

### API surface

| Route | Purpose |
|-------|---------|
| `POST /api/workspaces/create` | Self-service trial |
| `GET /api/workspaces/status` | Poll by `slug` or `workspaceId` |
| `POST /api/workspaces/deploy` | Admin: queue deploy (phase 2) |
| `DELETE /api/workspaces/delete` | Admin: archive workspace |
| `POST /api/subscriptions/{create,cancel,upgrade}` | Billing stubs → existing checkout |
| `POST /api/operator/chat` | Operator task queue (phase 2 AI) |
| `GET /api/operator/tasks` | List operator tasks |

### Database (apply manually)

`supabase/migrations/20260709000001_workspace_provisioning_foundation.sql`

- `customer_workspaces`, `workspace_deployments`, `workspace_domains`
- `operator_tasks`, `operator_memory`
- Platform owner tenant columns on `tenants`

**Does not** duplicate `organizations` / generic `subscriptions` tables — reuses existing schema.

### Northflank build fixes

- Full `pdf-parse` package export for LMS runtime
- Admin `transpilePackages: ['edge-tts']`

### Docs

`docs/platform-owner-tenant-model.md`

### Next phase

- Wire `workspace_provision` job handler → Northflank API + GitHub fork
- Stripe webhook → auto-provision on paid signup
- AI operator execution (build/test/deploy in sandbox)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add self-service workspace trial provisioning and fix Northflank PDF build
> - Adds `POST /api/workspaces/create` backed by [`startWorkspaceTrial`](https://github.com/elevate-for-humanity/Elevate-lms/pull/311/files#diff-b0121714d3712d49510fd116f3945cb75d5e304c093d4e700a1033fbbf753719), which provisions a 14-day trial workspace including tenant/org records, a managed license, and a trial website, then returns dashboard and public URLs.
> - Adds a [`/start-trial`](https://github.com/elevate-for-humanity/Elevate-lms/pull/311/files#diff-6b1278a04b4bade1cdca76838dd26bf54f1cdfba7abde504cddb603a8665b67a) public page with a signup form that posts to the new endpoint and displays the resulting workspace links.
> - Adds admin endpoints `POST /api/workspaces/deploy` (enqueue provision job), `DELETE /api/workspaces/delete` (soft-archive), and `GET /api/workspaces/status` (public status polling by id or slug).
> - Adds subscription lifecycle endpoints (`/api/subscriptions/create`, `/api/subscriptions/upgrade`, `/api/subscriptions/cancel`) and operator task endpoints (`/api/operator/chat`, `/api/operator/tasks`).
> - Adds a SQL migration establishing `customer_workspaces`, `workspace_deployments`, `operator_tasks`, and related tables with RLS policies.
> - Fixes Northflank Docker builds by correcting `pdf-parse` export logic in [`export-admin-pdf-deps.mjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/311/files#diff-6008e504749ec4e549578b5971e34032f88e4e8b024a078fb3f215409361abbe) and adding build-time assertions to fail early if the export is missing; transpiles `edge-tts` in the admin Next.js config.
> - Risk: `startWorkspaceTrial` silently marks the workspace as failed if website provisioning errors, rather than surfacing the error to the caller.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 4002035. 24 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->