### PR TITLE
fix(dashboard): wire apprentice dashboards to LMS course and workbook

### DIFF
--- a/components/apprenticeship/RtiCourseCard.tsx
+++ b/components/apprenticeship/RtiCourseCard.tsx
@@ -42,13 +42,21 @@ export function RtiCourseCard({ config, rti }: Props) {
             </div>
             <p className="text-xs text-slate-500 mt-1">{Math.round(rti.progressPercent)}% through RTI</p>
           </div>
-          <Link
-            href={`/lms/courses/${rti.courseId}`}
-            className={`inline-flex items-center justify-center gap-2 ${config.accentBg} text-white text-sm font-semibold px-4 py-2.5 rounded-lg hover:opacity-90 transition shrink-0`}
-          >
-            <Play className="w-4 h-4" />
-            {rti.completedLessonCount > 0 ? 'Continue training' : 'Start RTI lessons'}
-          </Link>
+          <div className="flex flex-col sm:flex-row gap-2 shrink-0">
+            <Link
+              href={rti.continueHref}
+              className={`inline-flex items-center justify-center gap-2 ${config.accentBg} text-white text-sm font-semibold px-4 py-2.5 rounded-lg hover:opacity-90 transition`}
+            >
+              <Play className="w-4 h-4" />
+              {rti.completedLessonCount > 0 ? 'Continue training' : 'Start RTI lessons'}
+            </Link>
+            <Link
+              href={rti.workbookHref}
+              className="inline-flex items-center justify-center gap-2 border border-slate-200 text-slate-800 text-sm font-semibold px-4 py-2.5 rounded-lg hover:bg-slate-50 transition"
+            >
+              Open workbook
+            </Link>
+          </div>
         </div>
       </div>
     </div>

--- a/components/portal/ApprenticePortalShell.tsx
+++ b/components/portal/ApprenticePortalShell.tsx
@@ -21,6 +21,8 @@ import {
   Droplets,
 } from 'lucide-react';
 import { PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL } from '@/lib/barber/branding';
+import { RtiCourseCard } from '@/components/apprenticeship/RtiCourseCard';
+import type { RtiTrainingSummary } from '@/lib/apprenticeship/load-apprenticeship-dashboard';
 import {
   BARBER_STUDENT_APP_HOME,
   BARBER_STUDENT_APP_SHORT_LABEL,
@@ -165,6 +167,7 @@ interface Props {
   transferHoursVerified?: number | null;
   hoursRemainingDisplay?: number;
   apprentice?: unknown;
+  rti?: RtiTrainingSummary | null;
 }
 
 export function ApprenticePortalShell({
@@ -178,6 +181,7 @@ export function ApprenticePortalShell({
   transferHoursClaimed = 0,
   transferHoursVerified = null,
   hoursRemainingDisplay,
+  rti = null,
 }: Props) {
   const ProgramIcon = config.icon;
 
@@ -223,12 +227,15 @@ export function ApprenticePortalShell({
 
   const orientationHref = apprenticeshipOrientationPath(config.programSlug);
   const documentsHref = apprenticeshipDocumentsPath(config.programSlug);
-  const lmsCourseHref = apprenticeshipLmsCoursePath(config.programSlug);
+  const lmsCourseHref =
+    rti?.courseHref ?? apprenticeshipLmsCoursePath(config.programSlug);
+  const continueCourseHref = rti?.continueHref ?? lmsCourseHref;
   const rtiCourseLabel =
     apprenticeshipRtiLabel(config.programSlug) ?? 'Online Course';
   const rtiCourseLabelShort =
     apprenticeshipRtiLabel(config.programSlug, true) ?? 'Online Course';
-  const workbookHref = apprenticeshipWorkbookHref(config.programSlug);
+  const workbookHref =
+    rti?.workbookHref ?? apprenticeshipWorkbookHref(config.programSlug);
   const isBarberApprentice = config.programSlug === 'barber-apprenticeship';
 
   const onboardingItems = [
@@ -251,8 +258,8 @@ export function ApprenticePortalShell({
 
   const navTabs = [
     { id: 'dashboard', label: 'Dashboard', href: config.portalPath },
-    ...(lmsCourseHref
-      ? [{ id: 'course', label: rtiCourseLabelShort, href: lmsCourseHref }]
+    ...(continueCourseHref
+      ? [{ id: 'course', label: rtiCourseLabelShort, href: continueCourseHref }]
       : []),
     { id: 'hours', label: 'Hours', href: '/apprentice/hours' },
     { id: 'timeclock', label: 'Timeclock', href: '/apprentice/timeclock' },
@@ -321,6 +328,8 @@ export function ApprenticePortalShell({
           </div>
         </div>
       </nav>
+
+      <RtiCourseCard config={config} rti={rti} />
 
       <main className="max-w-6xl mx-auto px-4 sm:px-6 py-6 space-y-6">
         {/* Payment alert — no subscription at all */}
@@ -530,9 +539,9 @@ export function ApprenticePortalShell({
                   <p className="text-xs text-white/80">Start or end your shift</p>
                 </div>
               </Link>
-              {lmsCourseHref && (
+              {continueCourseHref && (
                 <Link
-                  href={lmsCourseHref}
+                  href={continueCourseHref}
                   className={`flex items-center gap-3 p-3 rounded-lg border-2 border-slate-200 hover:border-slate-300 bg-white transition`}
                 >
                   <BookOpen className={`w-5 h-5 ${config.accentText}`} />
@@ -637,9 +646,9 @@ export function ApprenticePortalShell({
             <p className="font-semibold text-sm text-slate-900">Skills Checklist</p>
             <p className="text-xs text-slate-500 mt-0.5">Track competency mastery</p>
           </Link>
-          {lmsCourseHref ? (
+          {continueCourseHref ? (
             <Link
-              href={lmsCourseHref}
+              href={continueCourseHref}
               className="bg-white rounded-xl border border-slate-200 p-4 hover:shadow-sm hover:border-slate-300 transition"
             >
               <BookOpen className={`w-5 h-5 ${config.accentText} mb-2`} />

--- a/lib/apprenticeship/load-apprenticeship-dashboard.ts
+++ b/lib/apprenticeship/load-apprenticeship-dashboard.ts
@@ -1,6 +1,7 @@
 import 'server-only';
 
 import { createClient } from '@/lib/supabase/server';
+import { getAdminClient } from '@/lib/supabase/admin';
 import { loadApprenticePortalData } from '@/lib/portal/load-apprentice-portal';
 import { resolveCourseIdFromDb } from '@/lib/course-builder/program-resolver';
 import {
@@ -8,10 +9,16 @@ import {
   getProgramDashboardExtras,
   type ProgramDashboardExtras,
 } from '@/lib/apprenticeship/program-dashboard-extras';
+import { ensureBarberLmsEnrollment } from '@/lib/barber/ensure-lms-enrollment';
+import { BARBER_PROGRAM_SLUG } from '@/lib/barber/constants';
+import { resolveCourseEntryLinks } from '@/lib/lms/resolve-course-entry-links';
 
 export interface RtiTrainingSummary {
   courseId: string;
   courseTitle: string;
+  courseHref: string;
+  workbookHref: string;
+  continueHref: string;
   progressPercent: number;
   status: string | null;
   publishedLessonCount: number;
@@ -45,7 +52,15 @@ export async function loadApprenticeshipDashboard(
     return { ...base, extras, complianceLinks, rti: null };
   }
 
-  const [{ data: course }, { data: lmsProgress }, lessonCountRes, completedRes] = await Promise.all([
+  if (programSlug === BARBER_PROGRAM_SLUG && base.enrollment) {
+    const adminDb = await getAdminClient();
+    await ensureBarberLmsEnrollment(adminDb ?? supabase, user.id, {
+      grantAccess: Boolean(base.enrollment.orientation_completed_at),
+    });
+  }
+
+  const [{ data: course }, { data: lmsProgress }, lessonCountRes, completedRes, entryLinks] =
+    await Promise.all([
     supabase.from('courses').select('id, title').eq('id', courseId).maybeSingle(),
     supabase
       .from('lms_progress')
@@ -56,14 +71,14 @@ export async function loadApprenticeshipDashboard(
     supabase
       .from('course_lessons')
       .select('id', { count: 'exact', head: true })
-      .eq('course_id', courseId)
-      .eq('status', 'published'),
+      .eq('course_id', courseId),
     supabase
       .from('lesson_progress')
       .select('lesson_id', { count: 'exact', head: true })
       .eq('user_id', user.id)
       .eq('course_id', courseId)
       .eq('completed', true),
+    resolveCourseEntryLinks(supabase, courseId, user.id),
   ]);
 
   const publishedLessonCount = lessonCountRes.count ?? 0;
@@ -76,6 +91,9 @@ export async function loadApprenticeshipDashboard(
   const rti: RtiTrainingSummary = {
     courseId,
     courseTitle: course?.title ?? extras.rtiCourseTitle ?? base.config.label,
+    courseHref: entryLinks.courseHref,
+    workbookHref: entryLinks.workbookHref,
+    continueHref: entryLinks.continueHref,
     progressPercent: lmsProgress?.progress_percent ?? progressFromRows,
     status: lmsProgress?.status ?? (completedLessonCount > 0 ? 'in_progress' : null),
     publishedLessonCount,

--- a/lib/barber/branding.ts
+++ b/lib/barber/branding.ts
@@ -3,7 +3,7 @@
  * Do not use third-party curriculum vendor names in learner UI.
  */
 
-import { BARBER_COURSE_ID } from '@/lib/barber/pricing';
+import { BARBER_COURSE_ID } from '@/lib/barber/constants';
 
 export const PRESTIGE_ELEVATION_BARBER_CURRICULUM =
   'Prestige Elevation Barber Curriculum';
@@ -14,9 +14,27 @@ export const PRESTIGE_ELEVATION_BARBER_CURRICULUM_SHORT = 'Prestige Elevation Co
 /** Printable / offline companion materials */
 export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_LABEL = 'Prestige Elevation Workbook';
 
-/** Canonical LMS path for Prestige Elevation RTI course */
-export const prestigeElevationBarberCoursePath = `/lms/courses/${BARBER_COURSE_ID}`;
+export const BARBER_CURRICULUM_COVER =
+  '/images/prestige-elevation/barber-curriculum-workbook-cover.svg';
 
-/** Primary workbook entry — opens Prestige Elevation RTI reading materials in LMS */
-export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF =
-  `${prestigeElevationBarberCoursePath}?activity=reading`;
+export const BARBER_ORIENTATION_VIDEO =
+  '/videos/barber-lessons/barber-apprenticeship-orientation.mp4';
+
+/** Canonical LMS path for Prestige Elevation RTI course */
+export const BARBER_LMS_COURSE_PATH = `/lms/courses/${BARBER_COURSE_ID}` as const;
+
+/** @deprecated Use BARBER_LMS_COURSE_PATH */
+export const prestigeElevationBarberCoursePath = BARBER_LMS_COURSE_PATH;
+
+/**
+ * Static workbook fallback — course landing with reading tab hint.
+ * Prefer server-resolved `workbookHref` from resolveCourseEntryLinks() on dashboards.
+ */
+export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF = BARBER_LMS_COURSE_PATH;
+
+export const PRESTIGE_BARBER_BRAND = {
+  instituteName: 'Prestige Barber & Beauty Institute',
+  curriculumName: 'Prestige Elevation™ Barbering RTI',
+  tagline: 'Elevate Your Future',
+  motto: 'Learn. Practice. Master. Elevate.',
+} as const;

--- a/lib/barber/load-barber-dashboard.ts
+++ b/lib/barber/load-barber-dashboard.ts
@@ -119,7 +119,7 @@ export async function loadBarberDashboardData(): Promise<BarberDashboardData> {
       .select('id', { count: 'exact', head: true })
       .eq('user_id', user.id)
       .eq('course_id', BARBER_COURSE_ID)
-      .eq('status', 'completed');
+      .eq('completed', true);
     rtiLessonsCompleted = count ?? 0;
   }
   const rtiLessonsTotal = lessonIds.length > 0 ? lessonIds.length : 50;

--- a/lib/enrollment/gate.ts
+++ b/lib/enrollment/gate.ts
@@ -1,6 +1,6 @@
 import { createClient } from '@/lib/supabase/server';
 import { redirect } from 'next/navigation';
-import { BARBER_LMS_COURSE_PATH } from '@/lib/barber/branding';
+import { apprenticeshipLmsCoursePath } from '@/lib/portal/program-portal-paths';
 
 export type EnrollmentState =
   | 'applied'
@@ -50,11 +50,12 @@ export function getNextRequiredAction(enrollment: {
     };
   }
 
-  // 3. Start first course
+  // 3. Open RTI course on Elevate LMS
+  const lmsPath = apprenticeshipLmsCoursePath(programSlug);
   return {
-    label: 'Begin Course 1',
-    href: '/apprentice/courses/1',
-    description: 'Start your first course module',
+    label: lmsPath ? 'Open RTI course' : 'Open training',
+    href: lmsPath ?? '/lms/courses',
+    description: 'Continue your related technical instruction on Elevate LMS',
   };
 }
 

--- a/lib/lms/resolve-course-entry-links.ts
+++ b/lib/lms/resolve-course-entry-links.ts
@@ -1,0 +1,71 @@
+import 'server-only';
+
+import type { SupabaseClient } from '@/lib/supabase';
+
+export type CourseEntryLinks = {
+  courseHref: string;
+  /** First published lesson reading tab, or course home when no lessons exist */
+  workbookHref: string;
+  /** Next incomplete lesson, or first lesson, or course home */
+  continueHref: string;
+  firstLessonId: string | null;
+};
+
+/**
+ * Resolve LMS URLs for apprenticeship dashboards.
+ * Workbook opens the first lesson's reading activity (not course-level ?activity=).
+ */
+export async function resolveCourseEntryLinks(
+  db: SupabaseClient,
+  courseId: string,
+  userId?: string | null,
+): Promise<CourseEntryLinks> {
+  const courseHref = `/lms/courses/${courseId}`;
+
+  const { data: lessons } = await db
+    .from('course_lessons')
+    .select('id, order_index')
+    .eq('course_id', courseId)
+    .order('order_index', { ascending: true });
+
+  const published =
+    lessons?.filter((row) => row.id) ?? [];
+
+  const firstLesson = published[0] ?? null;
+  const firstLessonId = firstLesson?.id ?? null;
+
+  const workbookHref = firstLessonId
+    ? `/lms/courses/${courseId}/lessons/${firstLessonId}?activity=reading`
+    : courseHref;
+
+  let continueHref = courseHref;
+
+  if (firstLessonId) {
+    continueHref = `/lms/courses/${courseId}/lessons/${firstLessonId}`;
+
+    if (userId && published.length > 0) {
+      const lessonIds = published.map((l) => l.id);
+      const { data: progress } = await db
+        .from('lesson_progress')
+        .select('lesson_id, completed')
+        .eq('user_id', userId)
+        .eq('course_id', courseId)
+        .in('lesson_id', lessonIds);
+
+      const completedIds = new Set(
+        (progress ?? []).filter((p) => p.completed).map((p) => p.lesson_id),
+      );
+      const nextLesson = published.find((l) => !completedIds.has(l.id)) ?? firstLesson;
+      if (nextLesson?.id) {
+        continueHref = `/lms/courses/${courseId}/lessons/${nextLesson.id}`;
+      }
+    }
+  }
+
+  return {
+    courseHref,
+    workbookHref,
+    continueHref,
+    firstLessonId,
+  };
+}

--- a/tests/unit/enrollment-gate-lms.test.ts
+++ b/tests/unit/enrollment-gate-lms.test.ts
@@ -1,0 +1,17 @@
+import { describe, expect, it } from 'vitest';
+import { getNextRequiredAction } from '@/lib/enrollment/gate';
+import { BARBER_COURSE_ID } from '@/lib/barber/constants';
+
+describe('getNextRequiredAction', () => {
+  it('routes barber apprentices to the Prestige Elevation LMS course', () => {
+    const action = getNextRequiredAction({
+      status: 'active',
+      orientation_completed_at: '2026-01-01T00:00:00Z',
+      documents_submitted_at: '2026-01-02T00:00:00Z',
+      program_slug: 'barber-apprenticeship',
+    });
+
+    expect(action.href).toBe(`/lms/courses/${BARBER_COURSE_ID}`);
+    expect(action.href).not.toContain('/apprentice/courses/');
+  });
+});

--- a/tests/unit/resolve-course-entry-links.test.ts
+++ b/tests/unit/resolve-course-entry-links.test.ts
@@ -1,0 +1,69 @@
+import { describe, expect, it } from 'vitest';
+import { resolveCourseEntryLinks } from '@/lib/lms/resolve-course-entry-links';
+
+function mockDb(
+  lessons: { id: string; order_index: number }[],
+  progress: { lesson_id: string; completed: boolean }[] = [],
+) {
+  return {
+    from(table: string) {
+      if (table === 'course_lessons') {
+        return {
+          select: () => ({
+            eq: () => ({
+              order: async () => ({ data: lessons, error: null }),
+            }),
+          }),
+        };
+      }
+      if (table === 'lesson_progress') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                in: async () => ({ data: progress, error: null }),
+              }),
+            }),
+          }),
+        };
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  } as never;
+}
+
+describe('resolveCourseEntryLinks', () => {
+  it('links workbook to first lesson reading tab', async () => {
+    const courseId = 'course-1';
+    const links = await resolveCourseEntryLinks(
+      mockDb([
+        { id: 'lesson-a', order_index: 1 },
+        { id: 'lesson-b', order_index: 2 },
+      ]),
+      courseId,
+    );
+
+    expect(links.courseHref).toBe(`/lms/courses/${courseId}`);
+    expect(links.workbookHref).toBe(
+      `/lms/courses/${courseId}/lessons/lesson-a?activity=reading`,
+    );
+    expect(links.continueHref).toBe(`/lms/courses/${courseId}/lessons/lesson-a`);
+  });
+
+  it('continues at next incomplete lesson for learner', async () => {
+    const courseId = 'course-1';
+    const links = await resolveCourseEntryLinks(
+      mockDb(
+        [
+          { id: 'lesson-a', order_index: 1 },
+          { id: 'lesson-b', order_index: 2 },
+        ],
+        [{ lesson_id: 'lesson-a', completed: true }],
+      ),
+      courseId,
+      'user-1',
+    );
+
+    expect(links.continueHref).toBe(`/lms/courses/${courseId}/lessons/lesson-b`);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Apprentice dashboards (`/portal/barber`, etc.) now resolve **real LMS URLs** instead of broken stubs.

### Fixes
- **Course links** → `/lms/courses/{barberCourseId}` (Prestige Elevation RTI)
- **Workbook links** → first published lesson reading tab: `/lms/courses/{id}/lessons/{lessonId}?activity=reading`
- **Continue training** → next incomplete lesson (or first lesson)
- **`RtiCourseCard`** rendered on dashboard with progress + Continue / Open workbook CTAs
- **Enrollment gate** no longer sends learners to `/apprentice/courses/1`
- **`lesson_progress`** query uses `completed=true` (not invalid `status` column)
- **Barber branding** exports restored (`BARBER_LMS_COURSE_PATH`, cover image, brand constants)
- **`ensureBarberLmsEnrollment`** runs on barber dashboard load so `lms_progress` exists

### Tests
- `tests/unit/resolve-course-entry-links.test.ts`
- `tests/unit/enrollment-gate-lms.test.ts`
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Wire apprentice dashboards to LMS course and workbook deep links
> - Adds `resolveCourseEntryLinks` utility in [resolve-course-entry-links.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/314/files#diff-326353b78be1e841ecbd52d4f49b94218e6692ff557649fbf2b0a20df4bd2520) to compute per-learner `courseHref`, `workbookHref`, and `continueHref` by querying lesson order and progress.
> - Surfaces these links in `loadApprenticeshipDashboard` and passes them through `RtiTrainingSummary` to `ApprenticePortalShell` and `RtiCourseCard`, replacing hard-coded course root hrefs with per-learner next-lesson links.
> - Ensures barber LMS enrollment at dashboard load time and routes the post-orientation action to the program-specific LMS course path instead of `/apprentice/courses/1`.
> - Fixes completed lesson count in `loadBarberDashboardData` to use the boolean `completed` field instead of a `status` string comparison.
> - Behavioral Change: lesson count in `loadApprenticeshipDashboard` now includes all lessons regardless of `status = 'published'`.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized e0be00b. 7 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->