### PR TITLE
fix(build): Northflank LMS pdf-parse export and admin edge-tts transpile

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -85,7 +85,8 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
     && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
-    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json \
+    && test -f /export/pdf-node_modules/pdf-parse/package.json
 
 # Drop node_modules + marketing-only assets before runtime COPY (BuildKit ENOSPC).
 RUN node scripts/prune-admin-builder-disk.mjs

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -77,7 +77,8 @@ RUN test -n "$NEXT_PUBLIC_SUPABASE_URL" \
     && test -f /export/sharp-node_modules/sharp/package.json \
     && test -d /export/sharp-node_modules/@img/sharp-linux-x64 \
     && EXPORT_ROOT=/export node scripts/export-admin-pdf-deps.mjs \
-    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json
+    && test -f /export/pdf-node_modules/@napi-rs/canvas/package.json \
+    && test -f /export/pdf-node_modules/pdf-parse/package.json
 
 RUN node scripts/prune-lms-builder-disk.mjs
 

--- a/apps/admin/next.config.mjs
+++ b/apps/admin/next.config.mjs
@@ -30,6 +30,9 @@ const adminConfig = {
     parallelServerBuildTraces: false,
   },
 
+  // edge-tts ships index.ts as its entry (uncompiled TS) — same as root LMS config.
+  transpilePackages: ['edge-tts'],
+
   // Resolve @/* to repo root so shared lib/, components/, types/ work
   webpack(config) {
     config.resolve.alias['@'] = ROOT;
@@ -120,6 +123,7 @@ const adminConfig = {
     '@opentelemetry/resources',
     '@opentelemetry/semantic-conventions',
     'sharp',
+    // edge-tts: transpilePackages only (conflicts if also listed here)
     // ws — custom server.js only
     'ws',
     // Document OCR / extract admin APIs

--- a/scripts/export-admin-pdf-deps.mjs
+++ b/scripts/export-admin-pdf-deps.mjs
@@ -42,12 +42,16 @@ mkdirSync(exportRoot, { recursive: true });
 // Must match node_modules/@napi-rs/{canvas,canvas-linux-x64-gnu} layout
 copyPkg('@napi-rs/canvas', '@napi-rs/canvas');
 
-// pdf-parse does not export package.json subpath; resolve entry then dirname
-const pdfParseEntry = require.resolve('pdf-parse', { paths: [root] });
-copyDir(dirname(pdfParseEntry), 'pdf-parse');
+const pnpmDir = join(root, 'node_modules', '.pnpm');
+
+// pdf-parse v2 resolve() points at dist/.../index.cjs (no package.json export) — use pnpm store
+const pdfParseStore = readdirSync(pnpmDir).find((e) => e.startsWith('pdf-parse@'));
+if (!pdfParseStore) {
+  throw new Error('pdf-parse not found under node_modules/.pnpm');
+}
+copyDir(join(pnpmDir, pdfParseStore, 'node_modules', 'pdf-parse'), 'pdf-parse');
 
 // pdfjs-dist lives in pnpm store (not always hoisted to workspace root)
-const pnpmDir = join(root, 'node_modules', '.pnpm');
 const pdfjsStore = readdirSync(pnpmDir).find((e) => e.startsWith('pdfjs-dist@'));
 if (!pdfjsStore) {
   throw new Error('pdfjs-dist not found under node_modules/.pnpm');
@@ -70,6 +74,12 @@ if (canvasNative) {
 const canvasPkg = join(exportRoot, '@napi-rs', 'canvas', 'package.json');
 if (!existsSync(canvasPkg)) {
   console.error('[export-pdf] @napi-rs/canvas export failed');
+  process.exit(1);
+}
+
+const pdfParsePkg = join(exportRoot, 'pdf-parse', 'package.json');
+if (!existsSync(pdfParsePkg)) {
+  console.error('[export-pdf] pdf-parse export failed (missing package.json)');
   process.exit(1);
 }
 

--- a/tests/unit/export-admin-pdf-deps.test.ts
+++ b/tests/unit/export-admin-pdf-deps.test.ts
@@ -1,0 +1,24 @@
+import { describe, expect, it } from 'vitest';
+import { existsSync } from 'node:fs';
+import { join } from 'node:path';
+import { execSync } from 'node:child_process';
+import { tmpdir } from 'node:os';
+import { mkdtempSync } from 'node:fs';
+
+describe('export-admin-pdf-deps.mjs', () => {
+  it('exports pdf-parse with package.json at package root', () => {
+    const exportRoot = mkdtempSync(join(tmpdir(), 'pdf-export-'));
+    execSync('node scripts/export-admin-pdf-deps.mjs', {
+      cwd: process.cwd(),
+      env: { ...process.env, EXPORT_ROOT: exportRoot },
+      stdio: 'pipe',
+    });
+
+    expect(existsSync(join(exportRoot, 'pdf-node_modules', 'pdf-parse', 'package.json'))).toBe(
+      true,
+    );
+    expect(existsSync(join(exportRoot, 'pdf-node_modules', '@napi-rs', 'canvas', 'package.json'))).toBe(
+      true,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
Fixes failed Northflank admin and LMS Docker builds.

### Admin
- Add `transpilePackages: ['edge-tts']` to `apps/admin/next.config.mjs` — edge-tts ships uncompiled TypeScript and webpack fails on `export type`.

### LMS + Admin runtime
- Fix `scripts/export-admin-pdf-deps.mjs` to copy pdf-parse from pnpm store (v2 resolve points at dist without package.json).
- Add Dockerfile build-time checks for pdf-parse export.
- Unit test for export script.

Fixes deploy failures on runs 27069744932 (admin) and 27062840651 (LMS).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build, packaging, and config-only changes with no runtime auth or data-path changes; risk is limited to CI/Docker image correctness.
> 
> **Overview**
> Fixes **Northflank admin and LMS Docker builds** that were failing on `edge-tts` webpack transpilation and incomplete **`pdf-parse`** copies into runtime images.
> 
> **Admin Next build:** Adds `transpilePackages: ['edge-tts']` in `apps/admin/next.config.mjs` so webpack can compile the package’s TypeScript entry (mirrors the root LMS config). A comment notes `edge-tts` must not also appear in `serverExternalPackages`.
> 
> **PDF dependency export:** `scripts/export-admin-pdf-deps.mjs` now copies **`pdf-parse` from the pnpm store** (`node_modules/.pnpm/pdf-parse@*`) instead of `require.resolve`, because v2 resolves to `dist/.../index.cjs` without a proper package root. The script **fails fast** if `pdf-parse/package.json` is missing after export.
> 
> **Docker:** `Dockerfile.northflank-admin` and `Dockerfile.northflank-lms` add a build-time check that `/export/pdf-node_modules/pdf-parse/package.json` exists after running the export script.
> 
> **Tests:** New Vitest coverage runs the export script with a temp `EXPORT_ROOT` and asserts `pdf-parse` and `@napi-rs/canvas` land under `pdf-node_modules` with `package.json` at the package root.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 1dbbec991dab652f6805e05b534433a3ebfc1573. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix pdf-parse export and edge-tts transpilation in Northflank admin and LMS builds
> - Updates [scripts/export-admin-pdf-deps.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/315/files#diff-6008e504749ec4e549578b5971e34032f88e4e8b024a078fb3f215409361abbe) to locate `pdf-parse` from the pnpm store (under `node_modules/.pnpm`) rather than via `require.resolve`, and exits with an error if the package cannot be found or its `package.json` is missing after copy.
> - Adds `transpilePackages: ['edge-tts']` to [apps/admin/next.config.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/315/files#diff-e828c07fa656d38e17175d7af2758d0f906bfdd02a3005a99fefd6469eff345f) so Next.js transpiles the package, which ships as TypeScript source.
> - Adds build-time assertions in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/315/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) and [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/315/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e) that fail the image build if `pdf-parse/package.json` is missing from the export.
> - Adds a Vitest integration test in [tests/unit/export-admin-pdf-deps.test.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/315/files#diff-eb1927d9ef2024cba1fedcc2693926c265f21712e00970d987b09d23368cec5e) that runs the export script and asserts both `pdf-parse` and `@napi-rs/canvas` are present in the output.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dbbec9.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->