### PR TITLE
fix(home): remove SNAP E&T from homepage funding strip

### DIFF
--- a/components/home/HomeFundingStrip.tsx
+++ b/components/home/HomeFundingStrip.tsx
@@ -9,7 +9,6 @@ import { ArrowRight } from 'lucide-react';
 const FUNDING_PATHS = [
   { label: 'WIOA', desc: 'Federal tuition', href: '/funding/wioa' },
   { label: 'Workforce Ready Grant', desc: 'Indiana state', href: '/funding/wrg' },
-  { label: 'SNAP E&T', desc: 'Training support', href: '/snap-et-partner' },
   { label: 'State funding hub', desc: 'WRG, JRI, WIOA', href: '/funding' },
   { label: 'Earn While You Learn', desc: 'Apprenticeship', href: '/programs/apprenticeships' },
 ];
@@ -45,7 +44,7 @@ export function HomeFundingStrip() {
             </Link>
           </div>
         </div>
-        <div className="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-5 gap-2">
+        <div className="grid grid-cols-2 sm:grid-cols-2 lg:grid-cols-4 gap-2">
           {FUNDING_PATHS.map((path) => (
             <Link
               key={path.label}

--- a/components/home/HomePrimaryPathways.tsx
+++ b/components/home/HomePrimaryPathways.tsx
@@ -17,7 +17,7 @@ const PATHWAYS = [
   },
   {
     headline: 'I Need Funding',
-    desc: 'WIOA, Workforce Ready Grant, FSSA IMPACT, and apprenticeship earn-while-you-learn.',
+    desc: 'WIOA, Workforce Ready Grant, and apprenticeship earn-while-you-learn.',
     href: '/funding',
     cta: 'Check Funding',
     icon: Landmark,


### PR DESCRIPTION
Remove SNAP E&T and FSSA IMPACT references from the homepage — Elevate is no longer working with those programs.

- **HomeFundingStrip**: removed SNAP E&T card; grid adjusted to 4 columns
- **HomePrimaryPathways**: funding pathway copy no longer mentions FSSA IMPACT

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy and layout-only homepage changes with no auth, data, or API impact.
> 
> **Overview**
> Removes discontinued program messaging from the homepage funding UI now that Elevate is no longer partnered on SNAP E&T / FSSA IMPACT.
> 
> **`HomeFundingStrip`** drops the SNAP E&T tile from `FUNDING_PATHS` and retunes the link grid from `sm:grid-cols-3` / `lg:grid-cols-5` to **2 / 4** columns so four tiles lay out cleanly.
> 
> **`HomePrimaryPathways`** shortens the “I Need Funding” card blurb by removing **FSSA IMPACT** from the listed options (WIOA, WRG, and apprenticeship remain).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a5f6381f39d61db5f809ba7edf3f450c717f9588. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove SNAP E&T tile from homepage funding strip
> - Removes the SNAP E&T entry from the `FUNDING_PATHS` constant in [`HomeFundingStrip.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/316/files#diff-637e5d77a547b178ebc6a319f6ee700a17ed0fe7f3d964dff5e5fd2207f18c84), so the tile and its link no longer render.
> - Adjusts the grid layout from 3/5 columns to 2/4 columns at `sm`/`lg` breakpoints to match the reduced tile count.
> - Removes 'FSSA IMPACT' from the 'I Need Funding' card description in [`HomePrimaryPathways.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/316/files#diff-38d73b2b54e4aab266fe454f5edf74be1a696c5800e8a25e9fc491d4d9730eb0).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a5f6381.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->