### PR TITLE
fix(home): move path picker and apply CTA under hero

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,7 +4,6 @@ import HomeHeroVideo from '@/components/ui/HomeHeroVideo';
 import heroBanners from '@/content/heroBanners';
 import { HomeWhyChoose } from '@/components/home/HomeWhyChoose';
 import { HomeFundingStrip } from '@/components/home/HomeFundingStrip';
-import { HomePrimaryPathways } from '@/components/home/HomePrimaryPathways';
 import { HomeHowItWorks } from '@/components/home/HomeHowItWorks';
 import { HomeCareerPathways } from '@/components/home/HomeCareerPathways';
 import { HomeApprenticeshipInfra } from '@/components/home/HomeApprenticeshipInfra';
@@ -103,7 +102,8 @@ export default async function HomePage() {
   return (
     <>
       <HomeHeroVideo banner={banner} />
-      <HomePrimaryPathways />
+      <HomeSegmentedCTA />
+      <HomeFinalCTA />
       <HomeFundingStrip />
       <HomeWhyChoose />
       <HomeHowItWorks />
@@ -112,8 +112,6 @@ export default async function HomePage() {
       <Suspense fallback={<OutcomesSkeleton />}>
         <HomeOutcomes />
       </Suspense>
-      <HomeSegmentedCTA />
-      <HomeFinalCTA />
     </>
   );
 }

--- a/components/home/HomeFinalCTA.tsx
+++ b/components/home/HomeFinalCTA.tsx
@@ -13,7 +13,7 @@ import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 export function HomeFinalCTA() {
   return (
     <section
-      className="relative bg-brand-red-700 py-16 px-4 overflow-hidden"
+      className="relative bg-brand-red-700 py-12 sm:py-14 px-4 overflow-hidden"
       aria-labelledby="final-cta-heading"
     >
       <div className="relative max-w-3xl mx-auto text-center">

--- a/components/home/HomeSegmentedCTA.tsx
+++ b/components/home/HomeSegmentedCTA.tsx
@@ -75,7 +75,7 @@ const SEGMENTS = [
 export function HomeSegmentedCTA() {
   return (
     <section
-      className="bg-white py-16 px-4 border-t border-slate-100"
+      className="bg-white py-12 sm:py-16 px-4 border-b border-slate-100"
       aria-labelledby="segments-heading"
     >
       <div className="max-w-6xl mx-auto">


### PR DESCRIPTION
Moves the **Find your path in 10 seconds** audience cards and **Ready to start** apply block directly below the hero video.

- `HomeSegmentedCTA` + `HomeFinalCTA` now render immediately after `HomeHeroVideo`
- Removed duplicate `HomePrimaryPathways` (same audience routing, simpler cards)
- Removed duplicate bottom placement of segmented/final CTAs
- Slight padding tweak on top sections

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Homepage layout and presentation only; no auth, data, or API changes.
> 
> **Overview**
> Reorders the homepage so **audience path cards** (`HomeSegmentedCTA`) and the **apply / eligibility block** (`HomeFinalCTA`) sit directly under the hero video instead of after most of the page content.
> 
> **`HomePrimaryPathways`** is dropped from the home route (no import or render), avoiding a second audience-routing block alongside the segmented CTA. The duplicate bottom placement of segmented + final CTAs is removed.
> 
> **`HomeSegmentedCTA`** and **`HomeFinalCTA`** get slightly tighter vertical padding for their new slot; segmented CTA uses a **bottom** border instead of a top one to separate from the hero.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f946b553fa3b833d48b5a591b83a87672e4e5a32. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move path picker and apply CTA to render immediately after hero video on homepage
> - Removes `HomePrimaryPathways` from the homepage and repositions `HomeSegmentedCTA` and `HomeFinalCTA` to render directly after `HomeHeroVideo` instead of near the bottom of the page.
> - Adjusts padding on both components to suit their new position, and swaps `HomeSegmentedCTA`'s top border for a bottom border.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f946b55.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->