### PR TITLE
fix(admin): harden dashboard against ERR_DASHBOARD_LOAD

### DIFF
--- a/apps/admin/app/admin/dashboard/page.tsx
+++ b/apps/admin/app/admin/dashboard/page.tsx
@@ -8,7 +8,6 @@ import { logger } from '@/lib/logger';
 import DashboardLoading from './loading';
 
 export const dynamic = 'force-dynamic';
-export const revalidate = 60; // cache dashboard data for 60s — reduces DB load
 
 export const metadata: Metadata = {
   title: 'Admin Dashboard | Elevate For Humanity',

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -2,7 +2,6 @@
 // Operational command center layout — all data is real and DB-driven.
 
 import Link from "next/link";
-import Image from "next/image";
 import { AdminGreeting } from "@/components/admin/AdminGreeting";
 import {
   ArrowRight, AlertTriangle,
@@ -257,7 +256,7 @@ function TodaysPriorities({ data }: { data: AdminDashboardData }) {
       ) : (
         <div className="divide-y divide-slate-100">
           {items.map((item) => {
-            const s = SEVERITY_STYLES[item.severity];
+            const s = SEVERITY_STYLES[item.severity] ?? SEVERITY_STYLES.low;
             return (
               <Link key={item.id} href={item.href}
                 className={`flex items-center justify-between px-4 sm:px-6 py-3 sm:py-4 hover:brightness-95 group transition-all ${s.bg}`}>
@@ -322,13 +321,23 @@ function LearnersNeedingAttention({ learners }: { learners: InactiveLearner[] })
 }
 
 function ReviewQueues({ data }: { data: AdminDashboardData }) {
+  const counts = data.counts ?? {
+    pendingApplications: 0,
+    activeEnrollments: 0,
+    revenueThisMonthCents: 0,
+    certificatesIssued: 0,
+    pendingProgramHolders: 0,
+    pendingDocuments: 0,
+  };
+  const pendingWioaDocs = data.pendingWioaDocs ?? 0;
+  const pendingSubmissionsCount = data.pendingSubmissions?.length ?? 0;
   const queues = [
-    { label: "Applications awaiting review", count: data.counts.pendingApplications, context: data.counts.pendingApplications > 0 ? "Intake queue needs admin action" : "Queue is clear", href: "/admin/applications?status=submitted,pending,in_review,pending_admin_review", urgent: data.counts.pendingApplications > 0 },
-    { label: "WIOA documents awaiting review", count: data.pendingWioaDocs, context: data.pendingWioaDocs > 0 ? "Funding eligibility may be blocked" : "Queue is clear", href: "/admin/wioa/documents", urgent: data.pendingWioaDocs > 0 },
-    { label: "Lab submissions awaiting sign-off", count: data.pendingSubmissions?.length ?? 0, context: (data.pendingSubmissions?.length ?? 0) > 0 ? "Instructor action required" : "Queue is clear", href: "/admin/submissions", urgent: (data.pendingSubmissions?.length ?? 0) > 0 },
-    { label: "Program holders awaiting approval", count: data.counts.pendingProgramHolders, context: data.counts.pendingProgramHolders > 0 ? "Partner applications need review" : "Queue is clear", href: "/admin/program-holders", urgent: data.counts.pendingProgramHolders > 0 },
-    { label: "Program holder documents pending", count: data.counts.pendingDocuments, context: data.counts.pendingDocuments > 0 ? "Documents submitted, awaiting review" : "Queue is clear", href: "/admin/program-holder-documents", urgent: data.counts.pendingDocuments > 0 },
-    { label: "Certificates to issue", count: data.counts.certificatesIssued, context: "Completed learners awaiting credential", href: "/admin/certificates", urgent: false },
+    { label: "Applications awaiting review", count: counts.pendingApplications, context: counts.pendingApplications > 0 ? "Intake queue needs admin action" : "Queue is clear", href: "/admin/applications?status=submitted,pending,in_review,pending_admin_review", urgent: counts.pendingApplications > 0 },
+    { label: "WIOA documents awaiting review", count: pendingWioaDocs, context: pendingWioaDocs > 0 ? "Funding eligibility may be blocked" : "Queue is clear", href: "/admin/wioa/documents", urgent: pendingWioaDocs > 0 },
+    { label: "Lab submissions awaiting sign-off", count: pendingSubmissionsCount, context: pendingSubmissionsCount > 0 ? "Instructor action required" : "Queue is clear", href: "/admin/submissions", urgent: pendingSubmissionsCount > 0 },
+    { label: "Program holders awaiting approval", count: counts.pendingProgramHolders, context: counts.pendingProgramHolders > 0 ? "Partner applications need review" : "Queue is clear", href: "/admin/program-holders", urgent: counts.pendingProgramHolders > 0 },
+    { label: "Program holder documents pending", count: counts.pendingDocuments, context: counts.pendingDocuments > 0 ? "Documents submitted, awaiting review" : "Queue is clear", href: "/admin/program-holder-documents", urgent: counts.pendingDocuments > 0 },
+    { label: "Certificates to issue", count: counts.certificatesIssued, context: "Completed learners awaiting credential", href: "/admin/certificates", urgent: false },
   ];
   return (
     <div className="rounded-xl border border-slate-200 bg-white mb-6">
@@ -456,17 +465,10 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
 
   return (
     <div className="pb-16">
-      <div className="relative w-full h-32 sm:h-40 overflow-hidden rounded-2xl mb-6">
-        <Image
-          src="/images/pages/admin-dashboard-hero.webp"
-          alt=""
-          fill
-          className="object-cover"
-          sizes="(max-width: 768px) 100vw, 1200px"
-          loading="lazy"
-        />
-        <div className="absolute inset-x-0 bottom-0 h-20 bg-gradient-to-t from-white to-transparent" />
-      </div>
+      <div
+        className="relative w-full h-32 sm:h-40 overflow-hidden rounded-2xl mb-6 bg-slate-100 border border-slate-200"
+        aria-hidden="true"
+      />
 
       <div className="pt-2">
 
@@ -518,9 +520,9 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
         {/* Right (1/3): activity feed + recent applications               */}
         <div className="grid grid-cols-1 lg:grid-cols-3 gap-4 lg:gap-6 mt-6">
           <div className="lg:col-span-2 min-w-0 space-y-4">
-            <LearnersNeedingAttention learners={data.inactiveLearners} />
+            <LearnersNeedingAttention learners={data.inactiveLearners ?? []} />
             <ReviewQueues data={data} />
-            <CrmFollowUpQueue leads={data.staleLeads} />
+            <CrmFollowUpQueue leads={data.staleLeads ?? []} />
           </div>
           <div className="space-y-4">
             <EnrollmentFunnel data={data} />
@@ -585,11 +587,11 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
             sites={data.sitePreviewTargets ?? []}
             isSuperAdmin={data.isSuperAdmin === true}
             pendingApplications={data.recentApplications}
-            pendingApplicationsCount={data.counts.pendingApplications}
-            pendingProgramHolders={data.counts.pendingProgramHolders}
+            pendingApplicationsCount={data.counts?.pendingApplications ?? 0}
+            pendingProgramHolders={data.counts?.pendingProgramHolders ?? 0}
           />
           <SitePreviewPanelWrapperLazy sites={data.sitePreviewTargets ?? []} />
-          <SystemHealthPanel health={data.systemHealth} />
+          <SystemHealthPanel health={data.systemHealth ?? { stripeWebhookOk: false, stripeIssuingOk: false, buildEnvOk: false, staleJobs: 0, degraded: true, missingDocuments: 0, missingCertifications: 0, unresolvedFlags: 0, alerts: [] }} />
         </div>
 
       </div>

--- a/components/admin/dashboard/EnrollmentFunnel.tsx
+++ b/components/admin/dashboard/EnrollmentFunnel.tsx
@@ -22,9 +22,10 @@ function pct(num: number, denom: number) {
 }
 
 export function EnrollmentFunnel({ data }: Props) {
-  const applied   = data.kpis.find(k => k.label === 'Pending Applications')?.value ?? 0;
-  const active    = data.kpis.find(k => k.label === 'Active Enrollments')?.value ?? 0;
-  const certs     = data.kpis.find(k => k.label === 'Certificates Issued')?.value ?? 0;
+  const kpis = Array.isArray(data.kpis) ? data.kpis : [];
+  const applied   = kpis.find(k => k.label === 'Pending Applications')?.value ?? 0;
+  const active    = kpis.find(k => k.label === 'Active Enrollments')?.value ?? 0;
+  const certs     = kpis.find(k => k.label === 'Certificates Issued')?.value ?? 0;
   // Total ever enrolled = active + completed (certs) + withdrawn (not tracked separately yet)
   const enrolled  = active + certs;
 

--- a/components/admin/dashboard/KpiGrid.tsx
+++ b/components/admin/dashboard/KpiGrid.tsx
@@ -52,9 +52,11 @@ function useCountUp(target: number) {
 
 function KpiCard({ card }: { card: KPICard }) {
   const pos = card.delta >= 0;
-  const IconComponent = ICON_MAP[iconKeyFor(card.label)];
-  const isRevenue = card.label.toLowerCase().includes('revenue');
-  const animated = useCountUp(card.value);
+  const label = typeof card.label === 'string' ? card.label : 'Metric';
+  const deltaLabel = typeof card.deltaLabel === 'string' ? card.deltaLabel : '';
+  const IconComponent = ICON_MAP[iconKeyFor(label)] ?? Award;
+  const isRevenue = label.toLowerCase().includes('revenue');
+  const animated = useCountUp(typeof card.value === 'number' ? card.value : 0);
 
   return (
     <Link
@@ -80,7 +82,7 @@ function KpiCard({ card }: { card: KPICard }) {
         <div className="flex items-start justify-between gap-3">
           <div className="min-w-0">
             <p className="text-xs font-semibold uppercase tracking-wide text-slate-500 truncate mb-1">
-              {card.label}
+              {label}
             </p>
             <p className="text-3xl font-bold tracking-tight text-slate-900 tabular-nums">
               {isRevenue ? fmtCents(animated) : fmt(animated)}
@@ -99,7 +101,7 @@ function KpiCard({ card }: { card: KPICard }) {
         </div>
 
         <div className="mt-4 flex items-center gap-2 flex-wrap">
-          {card.delta !== 0 && card.deltaLabel.includes('%') && (
+          {card.delta !== 0 && deltaLabel.includes('%') && (
             <span
               className={[
                 'inline-flex items-center gap-1 rounded-full px-2.5 py-1 text-xs font-bold',
@@ -116,7 +118,7 @@ function KpiCard({ card }: { card: KPICard }) {
               {Math.abs(card.delta)}%
             </span>
           )}
-          <span className="text-xs text-slate-500">{card.deltaLabel}</span>
+          {deltaLabel ? <span className="text-xs text-slate-500">{deltaLabel}</span> : null}
         </div>
       </div>
 

--- a/components/admin/dashboard/OperationalAlerts.tsx
+++ b/components/admin/dashboard/OperationalAlerts.tsx
@@ -58,8 +58,12 @@ function AlertSection({ icon, title, count, viewAllHref, children }: AlertSectio
 }
 
 export function OperationalAlerts({ data }: { data: AdminDashboardData }) {
-  const { stalledApplications, noOutcomeEnrollments, missingFundingEnrollments, complianceAlerts } = data;
-  const openComplianceAlerts: any[] = Array.isArray(complianceAlerts) ? complianceAlerts : [];
+  const stalledApplications = Array.isArray(data.stalledApplications) ? data.stalledApplications : [];
+  const noOutcomeEnrollments = Array.isArray(data.noOutcomeEnrollments) ? data.noOutcomeEnrollments : [];
+  const missingFundingEnrollments = Array.isArray(data.missingFundingEnrollments)
+    ? data.missingFundingEnrollments
+    : [];
+  const openComplianceAlerts: any[] = Array.isArray(data.complianceAlerts) ? data.complianceAlerts : [];
 
   const totalAlerts =
     stalledApplications.length + noOutcomeEnrollments.length + missingFundingEnrollments.length + openComplianceAlerts.length;

--- a/lib/admin/normalize-dashboard-data.ts
+++ b/lib/admin/normalize-dashboard-data.ts
@@ -1,5 +1,11 @@
 import { getDegradedAdminDashboardData } from '@/lib/admin/degraded-dashboard-data';
-import type { AdminDashboardData, DashboardCounts } from '@/components/admin/dashboard/types';
+import type {
+  AdminDashboardData,
+  DashboardCounts,
+  KPICard,
+  OperationalCounts,
+} from '@/components/admin/dashboard/types';
+import type { PriorityItem } from '@/lib/admin/priority-score';
 
 function asArray<T>(value: T[] | null | undefined): T[] {
   return Array.isArray(value) ? value : [];
@@ -9,6 +15,60 @@ function asCount(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (Array.isArray(value)) return value.length;
   return fallback;
+}
+
+const PRIORITY_SEVERITIES = new Set<PriorityItem['severity']>([
+  'critical',
+  'high',
+  'medium',
+  'low',
+]);
+
+function normalizeKpis(kpis: KPICard[] | null | undefined): KPICard[] {
+  return asArray(kpis).map((kpi) => ({
+    label: typeof kpi.label === 'string' ? kpi.label : 'Metric',
+    value: asCount(kpi.value),
+    delta: asCount(kpi.delta),
+    deltaLabel: typeof kpi.deltaLabel === 'string' ? kpi.deltaLabel : '',
+    href: typeof kpi.href === 'string' ? kpi.href : '/admin/dashboard',
+    urgent: kpi.urgent === true,
+    sub: typeof kpi.sub === 'string' ? kpi.sub : undefined,
+  }));
+}
+
+function normalizePriorities(items: PriorityItem[] | null | undefined): PriorityItem[] {
+  return asArray(items).map((item) => ({
+    id: String(item.id ?? 'priority'),
+    type: item.type ?? 'system',
+    label: typeof item.label === 'string' ? item.label : 'Operational item',
+    href: typeof item.href === 'string' ? item.href : '/admin/operations',
+    score: asCount(item.score),
+    severity: PRIORITY_SEVERITIES.has(item.severity) ? item.severity : 'low',
+    context: typeof item.context === 'string' ? item.context : '',
+  }));
+}
+
+function normalizeOperational(
+  operational: Partial<OperationalCounts> | null | undefined,
+): OperationalCounts {
+  const base = getDegradedAdminDashboardData().operational;
+  const raw = operational ?? {};
+  return {
+    needsReview: asCount(raw.needsReview, base.needsReview),
+    needsReviewDetail:
+      typeof raw.needsReviewDetail === 'string' ? raw.needsReviewDetail : base.needsReviewDetail,
+    atRisk: asCount(raw.atRisk, base.atRisk),
+    complianceAlerts: asCount(raw.complianceAlerts, base.complianceAlerts),
+    complianceAlertsSeverity:
+      typeof raw.complianceAlertsSeverity === 'string' ? raw.complianceAlertsSeverity : null,
+    newToday: asCount(raw.newToday, base.newToday),
+    newTodayDetail:
+      typeof raw.newTodayDetail === 'string' ? raw.newTodayDetail : base.newTodayDetail,
+    newAppsToday: asCount(raw.newAppsToday, base.newAppsToday),
+    newLeadsToday: asCount(raw.newLeadsToday, base.newLeadsToday),
+    newEnrollmentsToday: asCount(raw.newEnrollmentsToday, base.newEnrollmentsToday),
+    revenueThisMonthCents: asCount(raw.revenueThisMonthCents, base.revenueThisMonthCents),
+  };
 }
 
 function normalizeCounts(
@@ -44,9 +104,9 @@ export function normalizeAdminDashboardData(
     revenueAllTimeCents: asCount(input.revenueAllTimeCents, fallback.revenueAllTimeCents),
     totalStudents: asCount(input.totalStudents, fallback.totalStudents),
     recentPayments: asArray(input.recentPayments),
-    operational: { ...fallback.operational, ...input.operational },
-    priorities: asArray(input.priorities),
-    kpis: asArray(input.kpis),
+    operational: normalizeOperational(input.operational),
+    priorities: normalizePriorities(input.priorities),
+    kpis: normalizeKpis(input.kpis),
     enrollmentTrend: asArray(input.enrollmentTrend),
     studentStatuses: asArray(input.studentStatuses),
     topPrograms: asArray(input.topPrograms),

--- a/tests/unit/normalize-dashboard-data.test.ts
+++ b/tests/unit/normalize-dashboard-data.test.ts
@@ -25,4 +25,52 @@ describe('normalizeAdminDashboardData', () => {
     expect(normalized.degradedSections).toContain('dashboard_data');
     expect(normalized.counts.pendingApplications).toBe(0);
   });
+
+  it('normalizes malformed KPI cards so render cannot throw on deltaLabel', () => {
+    const normalized = normalizeAdminDashboardData({
+      kpis: [
+        {
+          label: 'Active Enrollments',
+          value: 12,
+          delta: 5,
+          deltaLabel: undefined as unknown as string,
+          href: '/admin/students',
+        },
+      ],
+    });
+
+    expect(normalized.kpis[0].deltaLabel).toBe('');
+    expect(normalized.kpis[0].value).toBe(12);
+  });
+
+  it('coerces invalid priority severity to low', () => {
+    const normalized = normalizeAdminDashboardData({
+      priorities: [
+        {
+          id: 'p1',
+          type: 'application',
+          label: 'Review queue',
+          href: '/admin/applications',
+          score: 90,
+          severity: 'urgent' as 'critical',
+          context: '3 pending',
+        },
+      ],
+    });
+
+    expect(normalized.priorities[0].severity).toBe('low');
+  });
+
+  it('normalizes operational counters when partial payload omits fields', () => {
+    const normalized = normalizeAdminDashboardData({
+      operational: {
+        newAppsToday: undefined as unknown as number,
+        newLeadsToday: 2,
+      },
+    });
+
+    expect(normalized.operational.newAppsToday).toBe(0);
+    expect(normalized.operational.newLeadsToday).toBe(2);
+    expect(typeof normalized.operational.needsReviewDetail).toBe('string');
+  });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes admin dashboard `ERR_DASHBOARD_LOAD` by hardening the data normalization layer and render components so partial/malformed dashboard payloads never throw during render.

## Root cause

The dashboard page already catches data-load failures and falls back to degraded mode, but the **error boundary** still fired when client/server components accessed undefined fields (e.g. `card.deltaLabel.includes('%')`, missing `data.counts`, invalid priority severity).

## Changes

- **`lib/admin/normalize-dashboard-data.ts`**: `normalizeKpis`, `normalizePriorities`, `normalizeOperational` — guarantee complete, type-safe payload before render
- **`KpiGrid`**: safe `deltaLabel`, label, value, and icon fallback
- **`EnrollmentFunnel`**: guard `data.kpis` when array missing
- **`OperationalAlerts`**: safe array defaults for stalled/no-outcome/missing-funding lists
- **`DashboardShell`**: safe `counts` for review queues/Lizzy; severity fallback; remove broken hero image
- **`page.tsx`**: remove conflicting `revalidate` with `force-dynamic`
- **Tests**: 5 unit tests for malformed KPI/priority/operational payloads

## Verification

```bash
pnpm vitest run tests/unit/normalize-dashboard-data.test.ts
```

All 5 tests pass.

## Notes

- Dashboard should render in **degraded mode** (amber banner) when Supabase service role is missing — not hit the error boundary.
- If degraded banner persists in production, confirm `SUPABASE_SERVICE_ROLE_KEY` is set in Northflank.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden admin dashboard against ERR_DASHBOARD_LOAD by adding defensive defaults throughout
> - Adds three normalization helpers (`normalizeKpis`, `normalizePriorities`, `normalizeOperational`) in [`lib/admin/normalize-dashboard-data.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-8bec560e7d9088ea92319dda40d046b33a2108e633de6a641510d378f57b83c8) that coerce missing or malformed fields to safe defaults before the data reaches the UI.
> - Guards all render paths in [`DashboardShell.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-92df382a44bacb0fbe7c2d88a100ba8c11fdf3ae91cd3eb1f6d705aa953b4d92), [`EnrollmentFunnel.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-b614c1938714810afba05579d7f29472d2c41693a5f391c04d35817f1631736e), [`KpiGrid.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-1a6b684073a8cb0e7be0fa9fe3f482ae44a4468065763a1c8492dbb4afd87e28), and [`OperationalAlerts.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-233878a96b40b2d368628285fbd5090b5d5cfdba43daad879b292933c750b22f) against undefined arrays, counts, and severity values.
> - Replaces the hero `<Image>` in `AdminDashboardContent` with an `aria-hidden` decorative `div` to remove an additional load-time failure point.
> - Removes `export const revalidate = 60` from [`app/admin/dashboard/page.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/318/files#diff-110526a45502ef307993e4d22eecda7bc371e816c20643328cefe4dac5fc1b4b), leaving only `force-dynamic` rendering.
> - Behavioral Change: KPI cards, priority items, and operational alerts now silently fall back to zeros and empty states rather than throwing when source data is incomplete.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized a8720e7. 6 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->