### PR TITLE
fix(admin): address dashboard normalizer review feedback (PR #318)

### DIFF
--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -526,7 +526,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           </div>
           <div className="space-y-4">
             <EnrollmentFunnel data={data} />
-            <RecentActivity items={data.recentActivity} />
+            <RecentActivity items={data.recentActivity ?? []} />
             {(data.recentApplications?.length ?? 0) > 0 && (
               <div className="rounded-xl border border-slate-200 bg-white overflow-hidden">
                 <div className="px-4 py-3 border-b border-slate-100 flex items-center justify-between">
@@ -542,7 +542,7 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
               </div>
             )}
             <RecentPaymentsPanel payments={data.recentPayments} />
-            <RecentStudentsPanel students={data.recentStudents} />
+            <RecentStudentsPanel students={data.recentStudents ?? []} />
           </div>
         </div>
 

--- a/lib/admin/normalize-dashboard-data.ts
+++ b/lib/admin/normalize-dashboard-data.ts
@@ -11,6 +11,10 @@ function asArray<T>(value: T[] | null | undefined): T[] {
   return Array.isArray(value) ? value : [];
 }
 
+function asObjectArray<T extends object>(value: T[] | null | undefined): T[] {
+  return asArray(value).filter((item): item is T => item != null && typeof item === 'object');
+}
+
 function asCount(value: unknown, fallback = 0): number {
   if (typeof value === 'number' && Number.isFinite(value)) return value;
   if (Array.isArray(value)) return value.length;
@@ -25,7 +29,7 @@ const PRIORITY_SEVERITIES = new Set<PriorityItem['severity']>([
 ]);
 
 function normalizeKpis(kpis: KPICard[] | null | undefined): KPICard[] {
-  return asArray(kpis).map((kpi) => ({
+  return asObjectArray(kpis).map((kpi) => ({
     label: typeof kpi.label === 'string' ? kpi.label : 'Metric',
     value: asCount(kpi.value),
     delta: asCount(kpi.delta),
@@ -37,7 +41,7 @@ function normalizeKpis(kpis: KPICard[] | null | undefined): KPICard[] {
 }
 
 function normalizePriorities(items: PriorityItem[] | null | undefined): PriorityItem[] {
-  return asArray(items).map((item) => ({
+  return asObjectArray(items).map((item) => ({
     id: String(item.id ?? 'priority'),
     type: item.type ?? 'system',
     label: typeof item.label === 'string' ? item.label : 'Operational item',

--- a/tests/unit/normalize-dashboard-data.test.ts
+++ b/tests/unit/normalize-dashboard-data.test.ts
@@ -61,6 +61,40 @@ describe('normalizeAdminDashboardData', () => {
     expect(normalized.priorities[0].severity).toBe('low');
   });
 
+  it('skips null KPI entries without throwing', () => {
+    const normalized = normalizeAdminDashboardData({
+      kpis: [
+        null,
+        { label: 'Applications', value: 3, delta: 0, deltaLabel: '', href: '/admin/applications' },
+        undefined,
+      ] as unknown as import('@/components/admin/dashboard/types').KPICard[],
+    });
+
+    expect(normalized.kpis).toHaveLength(1);
+    expect(normalized.kpis[0].label).toBe('Applications');
+  });
+
+  it('skips null priority entries without throwing', () => {
+    const normalized = normalizeAdminDashboardData({
+      priorities: [
+        null,
+        {
+          id: 'p2',
+          type: 'application',
+          label: 'Queue',
+          href: '/admin/applications',
+          score: 10,
+          severity: 'high',
+          context: '',
+        },
+        undefined,
+      ] as unknown as import('@/lib/admin/priority-score').PriorityItem[],
+    });
+
+    expect(normalized.priorities).toHaveLength(1);
+    expect(normalized.priorities[0].severity).toBe('high');
+  });
+
   it('normalizes operational counters when partial payload omits fields', () => {
     const normalized = normalizeAdminDashboardData({
       operational: {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up to merged PR #318 — addresses Macroscope review feedback.

## Changes

- **`normalizeKpis` / `normalizePriorities`**: filter out `null` and non-object array elements via `asObjectArray()` before mapping, preserving the "never throws" guarantee
- **`DashboardShell`**: pass `data.recentStudents ?? []` and `data.recentActivity ?? []` to child panels (consistent with `inactiveLearners` / `staleLeads` guards)
- **Tests**: two new cases for null KPI and priority entries

## Verification

```bash
pnpm vitest run tests/unit/normalize-dashboard-data.test.ts
```

7/7 tests pass.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix null/undefined handling in dashboard data normalizers and child components
> - Adds `asObjectArray` helper in [`normalize-dashboard-data.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/319/files#diff-8bec560e7d9088ea92319dda40d046b33a2108e633de6a641510d378f57b83c8) that filters out null/undefined/non-object entries before mapping, replacing bare `asArray` calls in `normalizeKpis` and `normalizePriorities`.
> - Adds `?? []` fallbacks in [`DashboardShell.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/319/files#diff-92df382a44bacb0fbe7c2d88a100ba8c11fdf3ae91cd3eb1f6d705aa953b4d92) so `RecentActivity` and `RecentStudentsPanel` always receive arrays.
> - Adds unit tests covering null/undefined entries in `kpis` and `priorities` arrays.
> - Behavioral Change: `normalizeKpis` and `normalizePriorities` may now return shorter arrays when inputs contain null/undefined/non-object entries.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 62c4a33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->