### PR TITLE
feat(barber): add Mercedes to apprentice billing at $151.03/wk

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -937,4 +937,4 @@ Elevate is **not** a customer workspace — it is the **platform owner tenant** 
 - **Barber apprenticeship** events may also use `/api/barber/webhook` with `STRIPE_WEBHOOK_SECRET_BARBER` — keep both endpoints’ secrets in Northflank if both are registered.
 - Handler tries all configured `STRIPE_WEBHOOK_SECRET*` env vars (`lib/stripe/construct-webhook-event.ts`) so a mismatched secondary endpoint secret does not cause repeated 400s.
 - After fixing webhook secrets, redeploy LMS and **Enable** the endpoint in Stripe Dashboard. `GET /api/webhooks/stripe` returns `{ ok: true }` for smoke checks.
-- **Jordan / Natalia weekly billing (manual):** `POST /api/admin/stripe-apprentice-payments` (admin auth) or `pnpm tsx scripts/run-apprentice-stripe-billing.ts` with live `STRIPE_SECRET_KEY`. Defaults to customers `cus_UGFxoJKjtlNoy8` and `cus_UTVa6pmsYlWBsp`.
+- **Barber apprentice weekly billing (manual):** `POST /api/admin/stripe-apprentice-payments` (admin auth) or `pnpm tsx scripts/run-apprentice-stripe-billing.ts` with live `STRIPE_SECRET_KEY`. Defaults to Jordan (`cus_UGFxoJKjtlNoy8`), Natalia (`cus_UTVa6pmsYlWBsp`), and Mercedes (`cus_UG4BIa05facQez`, $151.03/wk).

--- a/lib/barber/apprentice-stripe-billing.ts
+++ b/lib/barber/apprentice-stripe-billing.ts
@@ -24,6 +24,15 @@ export const BARBER_APPRENTICE_STRIPE_CUSTOMERS = {
     downPaymentCents: 60_000,
     paymentTermWeeks: 29,
   },
+  cus_UG4BIa05facQez: {
+    name: 'Mercedes Wellington',
+    email: 'msanqin@gmail.com',
+    enrollmentId: '0320f78d-40df-4fb4-b5b9-3bed858e975b',
+    weeklyRateCents: 15103,
+    startDate: '2026-05-18',
+    downPaymentCents: 60_000,
+    paymentTermWeeks: 29,
+  },
 } as const;
 
 export type ApprenticeBillingAction = 'ensure_subscription' | 'pay_open_invoices';
@@ -39,7 +48,7 @@ export interface ApprenticeBillingResult {
 }
 
 export interface RunApprenticeBillingOptions {
-  /** Defaults to Jordan + Natalia only. */
+  /** Defaults to Jordan, Natalia, and Mercedes. */
   customerIds?: string[];
   actions?: ApprenticeBillingAction[];
 }
@@ -49,7 +58,7 @@ function resolveCustomerIds(customerIds?: string[]): string[] {
   const requested =
     customerIds?.length ?
       customerIds
-    : ['cus_UGFxoJKjtlNoy8', 'cus_UTVa6pmsYlWBsp'];
+    : ['cus_UGFxoJKjtlNoy8', 'cus_UTVa6pmsYlWBsp', 'cus_UG4BIa05facQez'];
   const invalid = requested.filter((id) => !allowed.includes(id));
   if (invalid.length) {
     throw new Error(`Unknown customer id(s): ${invalid.join(', ')}`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds Mercedes Wellington to the canonical barber apprentice Stripe billing registry at **$151.03/week** (`15103` cents), matching her `barber_subscriptions.weekly_payment_cents` and Natalia's plan tier.

## Changes

- `lib/barber/apprentice-stripe-billing.ts`: register `cus_UG4BIa05facQez` with enrollment `0320f78d-40df-4fb4-b5b9-3bed858e975b`, $600 down, 29-week term
- Default billing run now includes Jordan, Natalia, and Mercedes
- `AGENTS.md`: updated manual billing docs

## Ops (already applied live)

- Corrected `barber_payments` ledger entry from $153.00 → **$151.03** for today's Mercedes payment
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Mercedes Wellington to barber apprentice billing at $151.03/wk
> Adds a new customer entry for Mercedes Wellington (`cus_UG4BIa05facQez`) to `BARBER_APPRENTICE_STRIPE_CUSTOMERS` in [apprentice-stripe-billing.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/320/files#diff-e6e88d394db5e4e82d115e68e8c4f4a4ed8954931461bc6a16836a91fd8b4cfc) with a $600 down payment, 29-week term, and start date of 2026-05-18. The `resolveCustomerIds` default list is updated to include Mercedes alongside Jordan and Natalia, so callers omitting `customerIds` will now bill three customers instead of two.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 662bc1b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->