### PR TITLE
fix(admin): JobBoardPanel API on admin host + Lizzy panel isolation

### DIFF
--- a/apps/admin/app/api/jobs/government-feed/route.ts
+++ b/apps/admin/app/api/jobs/government-feed/route.ts
@@ -1,0 +1,10 @@
+/**
+ * Admin app route — JobBoardPanel on admin.elevateforhumanity.org calls this path.
+ * Re-exports the LMS handler via relative path (@/ alias would recurse into this file).
+ */
+export {
+  GET,
+  POST,
+  runtime,
+  dynamic,
+} from '../../../../../../app/api/jobs/government-feed/route';

--- a/components/admin/dashboard/LizzyWorkspace.tsx
+++ b/components/admin/dashboard/LizzyWorkspace.tsx
@@ -15,6 +15,7 @@ import {
   Zap,
 } from 'lucide-react';
 import type { RecentApplication } from './types';
+import { DashboardPanelErrorBoundary } from './DashboardPanelErrorBoundary';
 
 interface WorkflowButton {
   key: string;
@@ -121,7 +122,9 @@ export function LizzyWorkspace({
 
       {/* Northflank deploy — always visible */}
       <div className="shrink-0 max-h-[220px] overflow-hidden border-b border-[#3c3c3c]">
-        <DeployPanel workflowButtons={config?.workflowButtons} />
+        <DashboardPanelErrorBoundary name="Deploy">
+          <DeployPanel workflowButtons={config?.workflowButtons} />
+        </DashboardPanelErrorBoundary>
       </div>
 
       <div className="flex shrink-0 flex-wrap items-center gap-1 border-b border-[#3c3c3c] bg-[#252526] px-2 py-1.5">
@@ -153,30 +156,32 @@ export function LizzyWorkspace({
       </div>
 
       <div className="min-h-0 flex-1 overflow-hidden">
-        {panel === 'command' && <UnifiedEllieChat embedded />}
-        {panel === 'upload' && <LizzyUploadPanel />}
-        {panel === 'files' && <LizzyFilesPanel />}
-        {panel === 'ops' && (
-          <LizzyOperationsPanel
-            pendingApplications={pendingApplications}
-            pendingCount={pendingApplicationsCount}
-            pendingProgramHolders={pendingProgramHolders}
-          />
-        )}
-        {panel === 'health' && (
-          <div className="flex h-full flex-col overflow-hidden">
-            <div className="min-h-0 flex-1 overflow-auto">
-              <EnvironmentHealthPanel />
+        <DashboardPanelErrorBoundary name={`Lizzy ${panel}`}>
+          {panel === 'command' && <UnifiedEllieChat embedded />}
+          {panel === 'upload' && <LizzyUploadPanel />}
+          {panel === 'files' && <LizzyFilesPanel />}
+          {panel === 'ops' && (
+            <LizzyOperationsPanel
+              pendingApplications={pendingApplications}
+              pendingCount={pendingApplicationsCount}
+              pendingProgramHolders={pendingProgramHolders}
+            />
+          )}
+          {panel === 'health' && (
+            <div className="flex h-full flex-col overflow-hidden">
+              <div className="min-h-0 flex-1 overflow-auto">
+                <EnvironmentHealthPanel />
+              </div>
+              <div className="h-1/2 min-h-[200px] border-t border-[#3c3c3c]">
+                <ServicesPanel />
+              </div>
             </div>
-            <div className="h-1/2 min-h-[200px] border-t border-[#3c3c3c]">
-              <ServicesPanel />
-            </div>
-          </div>
-        )}
-        {panel === 'errors' && <LizzyErrorsPanel />}
-        {panel === 'video' && <LizzyVideoPanel />}
-        {panel === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <LizzyErrorsPanel />)}
-        {panel === 'workflows' && <WorkflowsOpsPanel />}
+          )}
+          {panel === 'errors' && <LizzyErrorsPanel />}
+          {panel === 'video' && <LizzyVideoPanel />}
+          {panel === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <LizzyErrorsPanel />)}
+          {panel === 'workflows' && <WorkflowsOpsPanel />}
+        </DashboardPanelErrorBoundary>
       </div>
     </div>
   );

--- a/scripts/audit-dashboard-panels.mjs
+++ b/scripts/audit-dashboard-panels.mjs
@@ -1,0 +1,71 @@
+#!/usr/bin/env node
+/**
+ * Audit lazy dashboard panel API dependencies.
+ * Usage: node scripts/audit-dashboard-panels.mjs [baseUrl]
+ * Default baseUrl: http://localhost:3001 (admin dev server)
+ */
+const base = (process.argv[2] || process.env.ADMIN_BASE_URL || 'http://localhost:3001').replace(
+  /\/$/,
+  '',
+);
+
+const panels = [
+  {
+    panel: 'PublishWebsitePanel',
+    method: 'GET',
+    path: '/api/admin/publish-website',
+    expectUnauth: [307, 401, 403],
+  },
+  {
+    panel: 'ProgramIntegrityPanel',
+    method: 'GET',
+    path: '/api/admin/program-integrity?limit=12&min=60',
+    expectUnauth: [307, 401, 403],
+  },
+  {
+    panel: 'JobBoardPanel',
+    method: 'GET',
+    path: '/api/jobs/government-feed',
+    expectUnauth: [200, 307, 401, 403],
+    note: 'Must exist on admin host (not 404)',
+  },
+  {
+    panel: 'LizzyContainer',
+    method: 'GET',
+    path: '/api/admin/devstudio/config',
+    expectUnauth: [307, 401, 403],
+  },
+  {
+    panel: 'LizzyWorkspace health',
+    method: 'GET',
+    path: '/api/devstudio/health',
+    expectUnauth: [200, 307, 401, 403],
+  },
+];
+
+async function probe({ panel, method, path, expectUnauth, note }) {
+  const url = `${base}${path}`;
+  const t0 = Date.now();
+  try {
+    const res = await fetch(url, { method, redirect: 'manual' });
+    const ms = Date.now() - t0;
+    const ok =
+      expectUnauth.includes(res.status) ||
+      (res.status === 404 && panel === 'JobBoardPanel' ? false : res.ok);
+    const flag = ok ? 'ok ' : 'FAIL';
+    console.log(
+      `${String(ms).padStart(5)}ms  ${flag}  ${panel.padEnd(22)}  ${res.status}  ${path}${note ? `  (${note})` : ''}`,
+    );
+    return ok;
+  } catch (e) {
+    console.log(`${String(Date.now() - t0).padStart(5)}ms  ERR   ${panel.padEnd(22)}  ${e.message}`);
+    return false;
+  }
+}
+
+console.log(`Dashboard panel API audit — ${base}\n`);
+let passed = 0;
+for (const p of panels) {
+  if (await probe(p)) passed++;
+}
+console.log(`\n${passed}/${panels.length} panels reachable (unauthenticated probe)`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Follow-up panel audit after merging #323 (ERR_DASHBOARD_LOAD fixes).

## Panel audit findings

| Panel | API / behavior | Before | After |
|-------|----------------|--------|-------|
| PublishWebsitePanel | `GET /api/admin/publish-website` | OK (auth-gated) | OK |
| ProgramIntegrityPanel | `GET /api/admin/program-integrity` | OK | OK |
| **JobBoardPanel** | `GET /api/jobs/government-feed` | **404 on admin host** | **200** |
| LizzyContainer | `GET /api/admin/devstudio/config` | OK | OK |
| LizzyWorkspace | `GET /api/devstudio/health` | OK | OK |
| Site preview | iframes only | OK | OK |

**Root cause:** `JobBoardPanel` called `/api/jobs/government-feed` on `admin.elevateforhumanity.org`, but that route only existed on the www LMS app.

## Changes

- Add `apps/admin/app/api/jobs/government-feed/route.ts` re-exporting the shared LMS handler
- `scripts/audit-dashboard-panels.mjs` — run `node scripts/audit-dashboard-panels.mjs [adminBaseUrl]`
- Wrap Lizzy deploy + tab content in `DashboardPanelErrorBoundary`

## Verify

```bash
node scripts/audit-dashboard-panels.mjs http://localhost:3001
# Expect 5/5 panels reachable
```

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix JobBoardPanel API on admin host and isolate Lizzy panels with error boundaries
> - Adds an admin app re-export at [`apps/admin/app/api/jobs/government-feed/route.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/324/files#diff-b87eb1cfbd8cceac4d9d97188cbe3c63b1d3c1fb2b822619516740248f16b5e7) so the government feed API is reachable on the admin host.
> - Wraps the Deploy panel and the active Lizzy panel in `DashboardPanelErrorBoundary` in [`LizzyWorkspace.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/324/files#diff-05f8958a9d355a36d3477b043f22691d78c4d2d526fe304f346475d0ed1c0e7d), isolating panel crashes from the rest of the dashboard.
> - Adds [`scripts/audit-dashboard-panels.mjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/324/files#diff-b3167939e79d565167aa3b91a5f59cc05465ca19cb29739ec3dd0445ad9c87cf), a CLI script that probes dashboard API endpoints and reports reachability, status codes, and latency without authentication.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6daa64c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->