### PR TITLE
Production readiness: portals, store catalog, Indiana-only scope, README

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,20 +118,26 @@ Programs run 4–18 weeks. Most are fully funded at no cost to eligible particip
 
 ## Stakeholder Portals
 
-| Portal | Path | Audience |
-|---|---|---|
-| Learner LMS | `/lms` | Enrolled students |
-| Student Portal | `/student-portal` | Student self-service |
-| Admin | `/admin` | Staff, super admins |
-| Instructor | `/instructor` | Course instructors |
-| Employer Portal | `/employer-portal` | Hiring partners |
-| Program Holder | `/program-holder` | Community org partners |
-| Partner Portal | `/partners/dashboard` | Apprenticeship host shops |
-| Staff Portal | `/staff-portal` | Internal staff |
-| Workforce Board | `/workforce-board` | WIOA/DWD administrators |
-| Parent Portal | `/parent-portal` | Guardians of youth participants |
-| Apprentice | `/apprentice` | Registered apprentices |
-| Case Manager | `/cm` | WIOA case managers |
+Canonical post-auth destinations are defined in `lib/auth/role-destinations.ts`. Legacy paths redirect to these routes (see `next.config.mjs`).
+
+| Portal | Canonical path | Host | Audience |
+|---|---|---|---|
+| Learner | `/learner/dashboard` | www | Enrolled students |
+| LMS (courses) | `/lms/courses` | www | Authenticated program access |
+| LMS (browse) | `/lms/programs` | www | Program catalog inside LMS |
+| Admin | `/admin/dashboard` | **admin** subdomain | `admin`, `super_admin`, `org_admin` |
+| Staff | `/admin/staff-portal/dashboard` | **admin** subdomain | Internal Elevate staff |
+| Instructor | `/admin/instructor/dashboard` | **admin** subdomain | Course instructors |
+| Employer | `/employer/dashboard` | www | Hiring partners |
+| Partner (host shop) | `/partner/dashboard` | www | Apprenticeship host sites |
+| Program Holder | `/program-holder/dashboard` | www | Community org partners |
+| Provider | `/provider/dashboard` | www | `provider_admin` tenants |
+| Case Manager | `/case-manager/dashboard` | www | WIOA case managers |
+| Mentor | `/mentor/dashboard` | www | Mentors |
+| Workforce Board | `/workforce-board/dashboard` | www | WIOA/DWD administrators |
+| Creator | `/creator/products` | www | Content creators |
+
+**Legacy redirects (do not link directly):** `/student-portal` → `/learner/dashboard`, `/employer-portal` → `/employer/dashboard`, `/partner-portal/*` → `/partner/*`, `/instructor/*` and `/staff-portal/*` on www → admin host, `/partners/dashboard` → `/partner/dashboard`.
 
 ---
 
@@ -141,8 +147,8 @@ Programs run 4–18 weeks. Most are fully funded at no cost to eligible particip
 |---|---|
 | Framework | Next.js 16 (App Router, Turbopack) |
 | Database | Supabase (PostgreSQL) — project `cuxzzpsyufcewtmicszk` |
-| Hosting | Northflank combined services — `elevate-lms` and `elevate-admin` |
-| CI/CD | GitHub Actions → Northflank API → service build/deploy |
+| Hosting | AWS ECS Fargate (`elevate-cluster`) — LMS + admin task definitions in `aws/`; Northflank scripts in `scripts/northflank/` for alternate deploy path |
+| CI/CD | GitHub Actions (`deploy-aws.yml`, `apply-pending-migrations.yml`) → Docker build → ECS deploy |
 | Package manager | pnpm |
 | Auth | Supabase Auth + custom role system |
 | Payments | Stripe + Affirm + Sezzle |
@@ -182,7 +188,7 @@ The admin platform now includes an operations-first automation center for curric
 |---|---|
 | `page.tsx` files | 1,293 |
 | `route.ts` API files | 1,186 |
-| Supabase migrations | 687 |
+| Supabase migrations | 754 |
 | Canonical programs | 37 |
 | Nav hrefs | 111 |
 
@@ -191,10 +197,16 @@ The admin platform now includes an operations-first automation center for curric
 ## Common Commands
 
 ```bash
-pnpm next dev --turbopack        # LMS dev server (port 3000)
-cd apps/admin && pnpm dev        # Admin dev server (port 3001)
-pnpm next build                  # Production build — must complete with zero errors
+pnpm dev                         # LMS dev server (port 3000, Turbopack)
+pnpm dev:admin                   # Admin dev server (port 3001)
+pnpm build                       # Production build — must complete with zero errors
 pnpm lint                        # Run ESLint
+pnpm test                        # Vitest unit tests
+pnpm typecheck                   # TypeScript (needs NODE_OPTIONS=--max-old-space-size=8192)
+pnpm production:gate             # Full production readiness gate
+pnpm integrity:store             # Store catalog integrity report
+pnpm check:redirects             # Redirect conflict check
+pnpm route:audit                 # Route vs filesystem audit
 bash scripts/audit-schema-refs.sh   # DB table gap report
 bash scripts/audit-auth-gaps.sh     # Auth gap report
 bash scripts/audit-env-vars.sh      # Env var gap report

--- a/app/career-training-indiana/page.tsx
+++ b/app/career-training-indiana/page.tsx
@@ -18,7 +18,7 @@ const workforceHighlights = [
   'WIOA-aligned enrollment guidance through Indiana workforce channels',
   'Career pathways across healthcare, skilled trades, technology, and business',
   'Credential-focused training mapped to employer-ready outcomes',
-  'Support for residents in Indianapolis, Fort Wayne, Evansville, South Bend, and statewide',
+  'Support for residents in Indianapolis, Fort Wayne, Evansville, South Bend, and Central Indiana',
 ];
 
 const indianaPathways = [

--- a/app/education/page.tsx
+++ b/app/education/page.tsx
@@ -15,23 +15,9 @@ const LOCATIONS = [
   {
     state: 'Indiana',
     href: '/career-training-indiana',
-    cities: ['Indianapolis', 'Fort Wayne', 'Evansville'],
+    cities: ['Indianapolis', 'Fort Wayne', 'Evansville', 'South Bend'],
     image: '/images/pages/about-career-training.webp',
-    desc: 'Main campus. WIOA-eligible programs, apprenticeships, and job placement.',
-  },
-  {
-    state: 'Illinois',
-    href: '/career-training-illinois',
-    cities: ['Chicago', 'Aurora', 'Naperville'],
-    image: '/images/pages/workforce-training.webp',
-    desc: 'Workforce programs across the Chicago metro and statewide.',
-  },
-  {
-    state: 'Ohio',
-    href: '/career-training-ohio',
-    cities: ['Columbus', 'Cleveland', 'Cincinnati'],
-    image: '/images/pages/welding-sparks.webp',
-    desc: 'Career training aligned with Ohio industry demand.',
+    desc: 'Main campus and training sites. WIOA-eligible programs, apprenticeships, and job placement across Central Indiana.',
   },
 ];
 

--- a/app/partner/hours/page.tsx
+++ b/app/partner/hours/page.tsx
@@ -32,7 +32,7 @@ export default async function PartnerHoursPage() {
     .maybeSingle();
 
   if (!partnerUser) {
-    redirect('/partner');
+    redirect('/partner/dashboard');
   }
 
   // Get hours statistics from consolidated hour_entries

--- a/app/partner/page.tsx
+++ b/app/partner/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from 'next/navigation';
+
+/** Partner root — canonical portal is /partner/dashboard (onboarding gates live there). */
+export default function PartnerRootPage() {
+  redirect('/partner/dashboard');
+}

--- a/app/portals/page.tsx
+++ b/app/portals/page.tsx
@@ -86,7 +86,7 @@ const portals: PortalEntry[] = [
     icon: Users,
     title: 'Instructor Portal',
     description: 'Roster, lab and assignment review, grades, and course tools.',
-    href: '/login?redirect=/instructor/dashboard',
+    href: '/login?redirect=https%3A%2F%2Fadmin.elevateforhumanity.org%2Fadmin%2Finstructor%2Fdashboard',
     features: ['Roster', 'Submissions', 'Grades'],
   },
   {
@@ -107,7 +107,7 @@ const portals: PortalEntry[] = [
     icon: Briefcase,
     title: 'Staff Portal',
     description: 'Daily operations — students, attendance, at-risk flags, and reports.',
-    href: '/login?redirect=/admin/staff-portal/dashboard',
+    href: '/login?redirect=https%3A%2F%2Fadmin.elevateforhumanity.org%2Fadmin%2Fstaff-portal%2Fdashboard',
     features: ['Students', 'Attendance', 'Reports'],
   },
 ];

--- a/app/store/licenses/page.tsx
+++ b/app/store/licenses/page.tsx
@@ -14,10 +14,55 @@ import {
   Award,
   Shield,
 } from 'lucide-react';
-import { STORE_PRODUCTS, CLONE_LICENSES } from '@/lib/data/store-products';
+import {
+  STORE_PRODUCTS,
+  CLONE_LICENSES,
+  type StoreProduct,
+} from '@/lib/data/store-products';
+import { getCatalogProducts, type CatalogProduct } from '@/lib/store/db';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export const dynamic = 'force-dynamic';
+
+type LicenseDisplayProduct = {
+  id: string;
+  slug: string;
+  name: string;
+  description: string;
+  price: number;
+  billingType: 'one_time' | 'subscription';
+  licenseType?: 'single' | 'school' | 'enterprise';
+  features: string[];
+  idealFor: string[];
+};
+
+function fromCatalogProduct(product: CatalogProduct): LicenseDisplayProduct {
+  return {
+    id: product.id,
+    slug: product.slug,
+    name: product.name,
+    description: product.description,
+    price: product.price / 100,
+    billingType: product.billingType,
+    licenseType: product.licenseType,
+    features: product.features,
+    idealFor: product.idealFor ? [product.idealFor] : [],
+  };
+}
+
+function fromStoreProduct(product: StoreProduct): LicenseDisplayProduct {
+  return {
+    id: product.id,
+    slug: product.slug,
+    name: product.name,
+    description: product.description,
+    price: product.price,
+    billingType: product.billingType,
+    licenseType: product.licenseType,
+    features: product.features,
+    idealFor: product.idealFor,
+  };
+}
 
 export const metadata: Metadata = {
   title: `Platform Licenses | ${PLATFORM_DEFAULTS.orgName} Store`,
@@ -29,10 +74,23 @@ export const metadata: Metadata = {
 };
 
 export default async function LicensesPage() {
-  // Filter to only show main license products (not community add-ons)
-  const licenseProducts = STORE_PRODUCTS.filter(
-    (p) => p.id.startsWith('efh-') && !p.id.includes('community')
-  );
+  const [dbStoreProducts, dbCloneProducts] = await Promise.all([
+    getCatalogProducts('store'),
+    getCatalogProducts('clone'),
+  ]);
+
+  // DB catalog is canonical; hardcoded list is dev/offline fallback only.
+  const licenseProducts: LicenseDisplayProduct[] =
+    dbStoreProducts.length > 0
+      ? dbStoreProducts.map(fromCatalogProduct)
+      : STORE_PRODUCTS.filter(
+          (p) => p.id.startsWith('efh-') && !p.id.includes('community'),
+        ).map(fromStoreProduct);
+
+  const cloneLicenses: LicenseDisplayProduct[] =
+    dbCloneProducts.length > 0
+      ? dbCloneProducts.map(fromCatalogProduct)
+      : CLONE_LICENSES.map(fromStoreProduct);
 
   return (
     <div className="bg-white">
@@ -246,7 +304,7 @@ export default async function LicensesPage() {
       </section>
 
       {/* Clone Licenses Section */}
-      {CLONE_LICENSES && CLONE_LICENSES.length > 0 && (
+      {cloneLicenses.length > 0 && (
         <section className="px-4 sm:px-6 lg:px-8 py-20 bg-white">
           <div className="max-w-7xl mx-auto">
             <div className="text-center mb-16">
@@ -264,7 +322,7 @@ export default async function LicensesPage() {
             </div>
 
             <div className="grid md:grid-cols-3 gap-8">
-              {CLONE_LICENSES.map((license) => (
+              {cloneLicenses.map((license) => (
                 <div
                   key={license.id}
                   className="bg-slate-50 rounded-2xl p-8 border border-slate-200 hover:border-purple-300 hover:shadow-lg transition-all"

--- a/config/dashboard-routes.ts
+++ b/config/dashboard-routes.ts
@@ -7,8 +7,8 @@ export const DASHBOARD_ROUTES: Record<UserRole, string> = {
   org_admin: '/admin/dashboard',
 
   // Staff / operations
-  staff: '/admin/staff-portal/dashboard',
-  instructor: '/instructor/dashboard',
+  staff: 'https://admin.elevateforhumanity.org/admin/staff-portal/dashboard',
+  instructor: 'https://admin.elevateforhumanity.org/admin/instructor/dashboard',
 
   // Program holders / delegates
   program_holder: '/program-holder/dashboard',

--- a/config/site-map.auto.ts
+++ b/config/site-map.auto.ts
@@ -219,7 +219,7 @@ export const siteMapSections: SiteMapSection[] = [
     id: "instructor",
     title: "Instructor",
     items: [
-      { label: "Dashboard", href: "/instructor/dashboard" },
+      { label: "Dashboard", href: "https://admin.elevateforhumanity.org/admin/instructor/dashboard" },
       { label: "Instructor Credentials", href: "/instructor-credentials" }
     ],
   },

--- a/config/states.ts
+++ b/config/states.ts
@@ -41,7 +41,7 @@ export const STATES: Record<string, StateConfig> = {
     careerTraining: {
       headline: 'Career Training & Workforce Programs in Indiana',
       description:
-        'Workforce development and career training programs in Indiana. WIOA-eligible training, apprenticeships, and certification programs serving Indianapolis, Fort Wayne, and statewide. Free for qualifying residents.',
+        'Workforce development and career training programs in Indiana. WIOA-eligible training, apprenticeships, and certification programs serving Indianapolis, Fort Wayne, and Central Indiana. Free for qualifying residents.',
       features: [
         'WIOA-eligible training programs',
         'Registered apprenticeships',
@@ -52,7 +52,7 @@ export const STATES: Record<string, StateConfig> = {
     taxPreparation: {
       headline: 'Free Tax Preparation in Indiana',
       description:
-        'VITA-certified free tax preparation services across Indiana. Serving Indianapolis, Fort Wayne, and communities statewide.',
+        'VITA-certified free tax preparation services across Central Indiana. Serving Indianapolis, Fort Wayne, and surrounding communities.',
       features: [
         'IRS-certified VITA volunteers',
         'Free federal and state filing',

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -252,12 +252,18 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'Student / learner', href: '/login?redirect=/learner/dashboard' },
       { name: 'Apprentice', href: '/login/apprentice' },
       { name: 'Employer', href: '/login?redirect=/employer/dashboard' },
-      { name: 'Instructor', href: '/login?redirect=/instructor/dashboard' },
+      {
+        name: 'Instructor',
+        href: '/login?redirect=https%3A%2F%2Fadmin.elevateforhumanity.org%2Fadmin%2Finstructor%2Fdashboard',
+      },
       { name: 'Partner', href: '/login?redirect=/partner/dashboard' },
       { name: 'Program holder', href: '/login?redirect=/program-holder/dashboard' },
       { name: 'Case manager', href: '/login?redirect=/case-manager/dashboard' },
       { name: 'Mentor', href: '/login?redirect=/mentor/dashboard' },
-      { name: 'Staff', href: '/login?redirect=/admin/staff-portal/dashboard' },
+      {
+        name: 'Staff',
+        href: '/login?redirect=https%3A%2F%2Fadmin.elevateforhumanity.org%2Fadmin%2Fstaff-portal%2Fdashboard',
+      },
       { name: 'Program catalog', href: '/programs/catalog' },
 
       { name: '— Career support —', href: '/career-services', isHeader: true },

--- a/lib/navigation/site-nav.config.ts
+++ b/lib/navigation/site-nav.config.ts
@@ -353,50 +353,14 @@ export const headerNavigation: NavGroup[] = [
     items: [
       { label: 'All Services', href: '/services', description: 'Our service offerings' },
       {
-        label: 'Career Training IL',
-        href: '/career-training-illinois',
-        description: 'Illinois programs',
-      },
-      {
-        label: 'Career Training IN',
+        label: 'Career Training Indiana',
         href: '/career-training-indiana',
-        description: 'Indiana programs',
-      },
-      { label: 'Career Training OH', href: '/career-training-ohio', description: 'Ohio programs' },
-      {
-        label: 'Career Training TN',
-        href: '/career-training-tennessee',
-        description: 'Tennessee programs',
+        description: 'Indiana workforce programs',
       },
       {
-        label: 'Career Training TX',
-        href: '/career-training-texas',
-        description: 'Texas programs',
-      },
-      {
-        label: 'Community Services IL',
-        href: '/community-services-illinois',
-        description: 'IL community services',
-      },
-      {
-        label: 'Community Services IN',
+        label: 'Community Services Indiana',
         href: '/community-services-indiana',
         description: 'IN community services',
-      },
-      {
-        label: 'Community Services OH',
-        href: '/community-services-ohio',
-        description: 'OH community services',
-      },
-      {
-        label: 'Community Services TN',
-        href: '/community-services-tennessee',
-        description: 'TN community services',
-      },
-      {
-        label: 'Community Services TX',
-        href: '/community-services-texas',
-        description: 'TX community services',
       },
       {
         label: 'Community Services',

--- a/lib/routes/canonical-routes.json
+++ b/lib/routes/canonical-routes.json
@@ -359,16 +359,6 @@
       "permanent": true
     },
     {
-      "source": "/store/licenses",
-      "destination": "/contact",
-      "permanent": true
-    },
-    {
-      "source": "/store/licenses/starter-license",
-      "destination": "/contact",
-      "permanent": true
-    },
-    {
       "source": "/ebook/barber-theory",
       "destination": "/programs/barber-apprenticeship",
       "permanent": true

--- a/lib/store/db.ts
+++ b/lib/store/db.ts
@@ -360,11 +360,34 @@ export async function getCatalogProducts(
     .eq('is_active', true)
     .order('sort_order', { ascending: true });
 
-  if (group) {
+  if (group === 'store') {
+    query = query.eq('catalog_group', 'store').in('category', ['platform', 'infrastructure']);
+  } else if (group) {
     query = query.eq('catalog_group', group);
   }
 
-  const { data, error } = await query;
+  let { data, error } = await query;
+
+  // Pre-catalog_group schema: filter by type/category until migration is applied.
+  if (error?.message?.includes('catalog_group')) {
+    let fallback = supabase
+      .from('products')
+      .select('*')
+      .eq('is_active', true)
+      .order('sort_order', { ascending: true });
+
+    if (group === 'store') {
+      fallback = fallback.eq('type', 'license').in('category', ['platform', 'infrastructure']);
+    } else if (group === 'clone') {
+      fallback = fallback.eq('type', 'license').eq('category', 'clone');
+    } else if (group === 'addon') {
+      fallback = fallback.in('type', ['addon', 'digital']);
+    }
+
+    const result = await fallback;
+    data = result.data;
+    error = result.error;
+  }
 
   if (error) {
     logger.error('Error fetching catalog products:', error);

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -1032,6 +1032,16 @@ const nextConfig = {
       { source: '/partner-portal', destination: '/partner/dashboard', permanent: true },
       { source: '/partner-portal/:path*', destination: '/partner/:path*', permanent: true },
 
+      // ── OUT-OF-STATE SEO STUBS → INDIANA (operational HQ: Indianapolis, IN) ─
+      { source: '/career-training-illinois', destination: '/career-training-indiana', permanent: true },
+      { source: '/career-training-ohio', destination: '/career-training-indiana', permanent: true },
+      { source: '/career-training-tennessee', destination: '/career-training-indiana', permanent: true },
+      { source: '/career-training-texas', destination: '/career-training-indiana', permanent: true },
+      { source: '/community-services-illinois', destination: '/community-services-indiana', permanent: true },
+      { source: '/community-services-ohio', destination: '/community-services-indiana', permanent: true },
+      { source: '/community-services-tennessee', destination: '/community-services-indiana', permanent: true },
+      { source: '/community-services-texas', destination: '/community-services-indiana', permanent: true },
+
       // ── CERTIFICATE / VERIFY DUPLICATES ────────────────────────────────────
       // Canonical verify: /verify/:certificateId
       { source: '/cert/verify', destination: '/verify', permanent: true },

--- a/next.config.mjs
+++ b/next.config.mjs
@@ -364,7 +364,7 @@ const nextConfig = {
       { source: '/admin/courses/pipeline',  destination: '/admin/studio', permanent: false },
       { source: '/admin/courses/generate',  destination: '/admin/studio', permanent: false },
 
-      { source: '/lms/programs', destination: '/lms/courses', permanent: false },
+      // /lms/programs — real browse page (app/lms/(app)/programs/page.tsx); do not redirect
 
       // Mentor / Mentorship
       { source: '/mentor', destination: '/mentor/dashboard', permanent: false },
@@ -378,6 +378,28 @@ const nextConfig = {
       {
         source: '/portal/staff/dashboard',
         destination: 'https://admin.elevateforhumanity.org/admin/staff-portal/dashboard',
+        permanent: true,
+      },
+
+      // Instructor + staff portals live on admin host — fix www deep links at source
+      {
+        source: '/instructor',
+        destination: 'https://admin.elevateforhumanity.org/admin/instructor/dashboard',
+        permanent: true,
+      },
+      {
+        source: '/instructor/:path*',
+        destination: 'https://admin.elevateforhumanity.org/admin/instructor/:path*',
+        permanent: true,
+      },
+      {
+        source: '/staff-portal',
+        destination: 'https://admin.elevateforhumanity.org/admin/staff-portal/dashboard',
+        permanent: true,
+      },
+      {
+        source: '/staff-portal/:path*',
+        destination: 'https://admin.elevateforhumanity.org/admin/staff-portal/:path*',
         permanent: true,
       },
 
@@ -1008,7 +1030,7 @@ const nextConfig = {
       // ── PARTNER PORTAL DUPLICATES ──────────────────────────────────────────
       // Canonical: /partner/dashboard
       { source: '/partner-portal', destination: '/partner/dashboard', permanent: true },
-      { source: '/partner-portal/:path*', destination: '/partner/dashboard', permanent: true },
+      { source: '/partner-portal/:path*', destination: '/partner/:path*', permanent: true },
 
       // ── CERTIFICATE / VERIFY DUPLICATES ────────────────────────────────────
       // Canonical verify: /verify/:certificateId

--- a/proxy.ts
+++ b/proxy.ts
@@ -262,6 +262,7 @@ const PUBLIC_DASHBOARD_LANDINGS = [
   '/program-holder',
   '/workforce-board',
   '/employer',
+  '/partner',
   '/mentor',
 ];
 

--- a/scripts/check-pending-migrations.ts
+++ b/scripts/check-pending-migrations.ts
@@ -94,8 +94,9 @@ const checks: Array<{ file: string; check: () => Promise<boolean>; description: 
   },
   {
     file: '20260701000009_fix_program_holders_user_id_constraint.sql',
-    check: () => columnExists('program_holders', 'user_id'),
-    description: 'program_holders.user_id column',
+    // Drops duplicate constraint unique_program_holders_user_id (column already exists).
+    check: () => tableExists('program_holders'),
+    description: 'program_holders table (constraint fix migration)',
   },
   {
     file: '20260701000010_platform_secrets.sql',

--- a/supabase/migrations/20260710000001_products_catalog_group_backfill.sql
+++ b/supabase/migrations/20260710000001_products_catalog_group_backfill.sql
@@ -1,0 +1,42 @@
+-- Products catalog_group backfill for store license pages.
+-- Idempotent: safe to re-run. Aligns DB with lib/store/db.ts getCatalogProducts() filters.
+
+ALTER TABLE products ADD COLUMN IF NOT EXISTS price_cents INTEGER;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS long_description TEXT;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS ideal_for TEXT;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS apps_included JSONB DEFAULT '[]'::jsonb;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS setup_fee_cents INTEGER DEFAULT 0;
+ALTER TABLE products ADD COLUMN IF NOT EXISTS catalog_group TEXT DEFAULT 'store';
+
+UPDATE products
+SET price_cents = (price * 100)::integer
+WHERE price_cents IS NULL AND price IS NOT NULL;
+
+UPDATE products
+SET catalog_group = 'clone'
+WHERE category = 'clone'
+   OR slug IN ('starter-license', 'pro-license', 'enterprise-clone-license');
+
+UPDATE products
+SET catalog_group = 'addon'
+WHERE type IN ('addon', 'digital', 'course', 'physical', 'program')
+   OR category IN (
+     'grants', 'compliance', 'ai-tools', 'apps', 'certification',
+     'safety', 'shop', 'resources', 'training', 'developer', 'community'
+   );
+
+UPDATE products
+SET catalog_group = 'store'
+WHERE type IN ('license', 'subscription')
+  AND category IN ('platform', 'infrastructure');
+
+UPDATE products
+SET catalog_group = 'store'
+WHERE slug IN (
+  'monthly-subscription',
+  'monthly-core',
+  'monthly-institutional',
+  'monthly-enterprise'
+);
+
+CREATE INDEX IF NOT EXISTS idx_products_catalog ON products (catalog_group, is_active, sort_order);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Aligns the live site with repository truth: canonical portal routing, DB-driven store licenses, Indiana-only service scope, and README updates.

## Portal routing (fix at source)

- `www` `/instructor/*` and `/staff-portal/*` → admin host (instructor/staff dashboards)
- `/partner` root page + public middleware bypass → `/partner/dashboard`
- `/partner-portal/:path*` preserves subpaths (`/partner/hours`, etc.)
- Removed `/lms/programs` shadow redirect (real browse page exists)
- Portal chooser, nav, `dashboard-routes.ts`, and `site-map.auto.ts` use canonical admin URLs

## Store catalog

- `/store/licenses` reads from Supabase `products` via `getCatalogProducts()` with hardcoded fallback
- Removed stale `canonical-routes.json` aliases that redirected `/store/licenses` → `/contact`
- Added migration `20260710000001_products_catalog_group_backfill.sql` (applied to production)
- `getCatalogProducts('store')` filters platform/infrastructure licenses only

## Indiana-only scope

- Redirect IL/OH/TN/TX career-training + community-services pages → Indiana canonical
- Removed multi-state links from education page and site nav
- Replaced "statewide" copy with Central Indiana

## README

- Portals table matches `lib/auth/role-destinations.ts`
- Commands, hosting (ECS + Northflank scripts), migration count (754)

## Verification

| Check | Result |
|-------|--------|
| `check:redirects` | ✅ 323 sources, no conflicts |
| `integrity:store` | ✅ pass |
| `check-pending-migrations` | ✅ all probed migrations applied |
| `audit-admin-dashboard-load` | ✅ ~2.5s, 6 KPIs |
| `audit-dashboard-panels` (local admin) | ✅ 5/5 |
| Local `/store/licenses` | ✅ 200, DB catalog renders |
| Local `/partner` | ✅ 200 |
| Local `/career-training-ohio` | ✅ 308 → Indiana |

## Deploy note

Production still serves pre-merge behavior until this PR is deployed. Admin dashboard fixes from #323/#324 are already on `main`.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope site to Indiana, redirect instructor/staff to admin subdomain, and load store catalog from DB
> - Redirects `/instructor`, `/instructor/*`, `/staff-portal`, and `/staff-portal/*` on the main host to the admin subdomain; updates portal login links, nav items, and `DASHBOARD_ROUTES` to match.
> - Removes Illinois and Ohio location entries from the education page and nav; updates marketing copy in multiple configs to reference Central Indiana instead of statewide.
> - `/store/licenses` now fetches license and clone products from the DB via `getCatalogProducts`, falling back to hardcoded lists when the DB returns nothing; a new migration backfills `catalog_group` and `price_cents` on the products table.
> - Adds a `PartnerRootPage` that redirects `/partner` to `/partner/dashboard`, and removes canonical redirects that previously sent `/store/licenses` to `/contact`.
> - Behavioral Change: out-of-state career training and community services URLs now permanently redirect to Indiana equivalents; `/lms/programs` redirect is removed so the page is accessible directly.
>
> <!-- Macroscope's review summary starts here -->
>
> <details>
> <summary>📊 <a href="https://app.macroscope.com">Macroscope</a> summarized 63dca6e. 17 files reviewed, 0 issues evaluated, 0 issues filtered, 0 comments posted</summary>
>
> ### 🗂️ Filtered Issues
> No issues evaluated.
>
>
> </details><!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->