### PR TITLE
fix: preserve post-login redirect through auth flows

### DIFF
--- a/app/api/auth/resend-magic-link/route.ts
+++ b/app/api/auth/resend-magic-link/route.ts
@@ -19,6 +19,7 @@ import { sendEmail } from '@/lib/email';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
 
 const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || PLATFORM_DEFAULTS.siteUrl;
 const LOGO_URL = `${SITE_URL}/images/Elevate_for_Humanity_logo_81bf0fab.jpg`;
@@ -36,18 +37,13 @@ export async function POST(request: NextRequest) {
   try {
     const body = await request.json();
     email = (body.email ?? '').trim().toLowerCase();
-    redirectPath = (body.redirect ?? body.next ?? '/learner/dashboard').trim();
+    redirectPath = validateRedirect(body.redirect ?? body.next, '/learner/dashboard');
   } catch {
     return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
   }
 
   if (!email || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email)) {
     return NextResponse.json({ error: 'Valid email required' }, { status: 400 });
-  }
-
-  // Sanitize redirect path — must be a relative path on this domain.
-  if (!redirectPath.startsWith('/') || redirectPath.includes('//') || redirectPath.length > 200) {
-    redirectPath = '/learner/dashboard';
   }
 
   try {

--- a/app/api/auth/send-magic-link/route.ts
+++ b/app/api/auth/send-magic-link/route.ts
@@ -3,6 +3,7 @@ import { getAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError } from '@/lib/api/safe-error';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 // PUBLIC ROUTE: unauthenticated users need this to sign in
@@ -21,7 +22,7 @@ export async function POST(req: Request) {
   const siteUrl = process.env.NEXT_PUBLIC_SITE_URL || PLATFORM_DEFAULTS.siteUrl;
   // Always route through /auth/callback so the session is established correctly
   // and role-based destination routing runs. Never redirect directly to a page.
-  const destination = redirectTo || getRoleDestination('student');
+  const destination = validateRedirect(redirectTo, getRoleDestination('student'));
   const finalRedirect = `${siteUrl}/auth/callback?redirect=${encodeURIComponent(destination)}`;
 
   // generateLink fails with "User not found" for unknown emails — use that as

--- a/app/auth/callback/route.ts
+++ b/app/auth/callback/route.ts
@@ -3,7 +3,7 @@ import { createClient } from '@/lib/supabase/server';
 import { NextResponse } from 'next/server';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
 import { resolvePostLoginDestination } from '@/lib/auth/role-redirects';
-import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { readRedirectParam, resolveRedirectLocation, validateRedirect } from '@/lib/auth/validate-redirect';
 import { reconcilePreAuthRows } from '@/lib/pre-auth-tables';
 import { resolvePortalForUser } from '@/lib/portal/router';
 
@@ -13,9 +13,7 @@ export async function GET(request: Request) {
   const error = requestUrl.searchParams.get('error');
   const errorDescription = requestUrl.searchParams.get('error_description');
   const type = requestUrl.searchParams.get('type');
-  const redirectParam =
-    requestUrl.searchParams.get('redirect') ??
-    requestUrl.searchParams.get('next');
+  const redirectParam = readRedirectParam(requestUrl.searchParams);
   const redirectTarget = validateRedirect(redirectParam, '/learner/dashboard');
 
   // Password reset flow — exchange code then send to reset form
@@ -158,7 +156,7 @@ export async function GET(request: Request) {
         return NextResponse.redirect(new URL(destination, requestUrl.origin));
       }
 
-      return NextResponse.redirect(new URL(redirectTarget, requestUrl.origin));
+      return NextResponse.redirect(resolveRedirectLocation(redirectTarget, requestUrl.origin));
     } catch (err) {
       logger.error('Auth callback exception:', err);
       return NextResponse.redirect(new URL('/login?error=auth_failed', requestUrl.origin));

--- a/app/auth/confirm/route.ts
+++ b/app/auth/confirm/route.ts
@@ -3,7 +3,7 @@ import { requireAdminClient } from '@/lib/supabase/admin';
 import { NextResponse } from 'next/server';
 import type { NextRequest } from 'next/server';
 import type { EmailOtpType } from '@supabase/supabase-js';
-import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { readRedirectParam, resolveRedirectLocation, validateRedirect } from '@/lib/auth/validate-redirect';
 import { logger } from '@/lib/logger';
 
 /**
@@ -16,7 +16,7 @@ export async function GET(request: NextRequest) {
   const { searchParams } = new URL(request.url);
   const token_hash = searchParams.get('token_hash');
   const type = searchParams.get('type') as EmailOtpType | null;
-  const next = validateRedirect(searchParams.get('next'), '/');
+  const next = validateRedirect(readRedirectParam(searchParams), '/');
 
   if (token_hash && type) {
     const supabase = await createClient();
@@ -200,7 +200,7 @@ export async function GET(request: NextRequest) {
       const CANONICAL = process.env.NEXT_PUBLIC_SITE_URL
         ? process.env.NEXT_PUBLIC_SITE_URL
         : new URL(request.url).origin;
-      return NextResponse.redirect(new URL(redirectTo, CANONICAL));
+      return NextResponse.redirect(resolveRedirectLocation(redirectTo, CANONICAL));
     }
 
     // verifyOtp failed — token expired or already used. This is expected user

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -10,7 +10,7 @@ import { useRouter } from 'next/navigation';
 import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
 import Link from 'next/link';
 import Image from 'next/image';
-import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { readRedirectParam, validateRedirect } from '@/lib/auth/validate-redirect';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { hydrateBrowserSupabaseConfig } from '@/lib/supabase/public-config';
@@ -36,7 +36,7 @@ function LoginForm() {
   const router = useRouter();
   const searchParams = useSafeSearchParams();
   // Support both 'next' and 'redirect' params for backward compatibility
-  const rawNext = searchParams.get('next') || searchParams.get('redirect') || '';
+  const rawNext = readRedirectParam(searchParams) || '';
   const next = validateRedirect(rawNext, '');
   const reason = searchParams.get('reason');
 
@@ -189,7 +189,9 @@ function LoginForm() {
     setLinkError('');
     try {
       const redirectTo = next
-        ? `${window.location.origin}${next}`
+        ? next.startsWith('https://')
+          ? next
+          : `${window.location.origin}${next}`
         : `${window.location.origin}/learner/dashboard`;
       const res = await fetch('/api/auth/send-magic-link', {
         method: 'POST',

--- a/apps/admin/app/admin/layout.tsx
+++ b/apps/admin/app/admin/layout.tsx
@@ -114,7 +114,11 @@ export default async function AdminLayout({ children }: { children: React.ReactN
   const {
     data: { user },
   } = await supabase.auth.getUser();
-  if (!user) redirect('/login');
+  if (!user) {
+    const headersList = await headers();
+    const pathname = headersList.get('x-pathname') || '/admin/dashboard';
+    redirect(`/login?redirect=${encodeURIComponent(pathname)}`);
+  }
 
   const db = await getAdminClient();
   const effectiveDb = db ?? (supabase as unknown as Awaited<ReturnType<typeof getAdminClient>>);

--- a/apps/admin/app/login/LoginForm.tsx
+++ b/apps/admin/app/login/LoginForm.tsx
@@ -3,14 +3,10 @@
 import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
 
-function getSafeRedirect(raw: string | null): string {
-  if (!raw) return '/admin/dashboard';
-  // Allow same-origin paths only
-  if (!raw.startsWith('/') || raw.startsWith('//') || raw.includes('://')) {
-    return '/admin/dashboard';
-  }
-  return raw;
+function getSafeRedirect(raw: string | null | undefined): string {
+  return validateRedirect(raw, '/admin/dashboard');
 }
 
 export default function AdminLoginForm({ redirectTo, initialError }: { redirectTo?: string; initialError?: string }) {

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -1,5 +1,6 @@
 import { NextResponse, type NextRequest } from 'next/server';
 import { checkAdminIP } from '@/lib/api/admin-ip-guard';
+import { buildLoginUrl, buildReturnPath } from '@/lib/auth/validate-redirect';
 
 const CANONICAL_ADMIN_HOST = 'admin.elevateforhumanity.org';
 
@@ -92,10 +93,8 @@ export async function middleware(req: NextRequest) {
   );
 
   if (!hasSession) {
-    const loginUrl = new URL('/login', req.url);
-    if (pathname.startsWith('/') && !pathname.startsWith('//') && !pathname.includes('://')) {
-      loginUrl.searchParams.set('redirect', pathname);
-    }
+    const returnPath = buildReturnPath(pathname, search);
+    const loginUrl = buildLoginUrl(req.url, returnPath);
     return NextResponse.redirect(loginUrl);
   }
 

--- a/components/auth/AuthRedirectHandler.tsx
+++ b/components/auth/AuthRedirectHandler.tsx
@@ -22,7 +22,7 @@ import { useEffect } from 'react';
 import { useRouter } from 'next/navigation';
 import { createBrowserClient } from '@/lib/supabase/client';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
-import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { readRedirectParam, validateRedirect } from '@/lib/auth/validate-redirect';
 
 export default function AuthRedirectHandler() {
   const router = useRouter();
@@ -44,7 +44,7 @@ export default function AuthRedirectHandler() {
     // Magic links are generated with redirect_to=${PLATFORM_DEFAULTS.siteUrl}?next=/apprentice
     // Supabase preserves query params on the base URL even when it strips the path.
     const searchParams = new URLSearchParams(window.location.search);
-    const next = searchParams.get('next');
+    const next = validateRedirect(readRedirectParam(searchParams), '');
 
     // If the user landed on a payment/checkout page via magic link, keep them
     // there after auth — do not redirect to their role destination.
@@ -73,7 +73,7 @@ export default function AuthRedirectHandler() {
       // If the landing page is a payment/checkout page, stay on it after auth.
       // Otherwise route by role, using cached portal_type for students.
       let destination: string;
-      if (next && next.startsWith('/')) {
+      if (next) {
         destination = next;
       } else if (isPaymentPage) {
         // Stay on the current payment page — preserve search params, drop the hash

--- a/lib/auth/validate-redirect.ts
+++ b/lib/auth/validate-redirect.ts
@@ -10,9 +10,37 @@ import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 const TRUSTED_HOSTS = [
   PLATFORM_DEFAULTS.canonicalDomain,
-  PLATFORM_DEFAULTS.canonicalDomain,
+  'elevateforhumanity.org',
   'admin.elevateforhumanity.org',
 ];
+
+/** Pathname + query (and hash) for post-login return URLs. */
+export function buildReturnPath(pathname: string, search = '', hash = ''): string {
+  const path = pathname.startsWith('/') ? pathname : `/${pathname}`;
+  return `${path}${search}${hash}`;
+}
+
+/** Read canonical ?redirect= with legacy ?next= fallback. */
+export function readRedirectParam(
+  searchParams: Pick<URLSearchParams, 'get'>,
+): string | null {
+  return searchParams.get('redirect') ?? searchParams.get('next');
+}
+
+/** Build /login?redirect=… with proper encoding (preserves nested query strings). */
+export function buildLoginUrl(base: string | URL, returnPath: string): URL {
+  const loginUrl = new URL('/login', base);
+  loginUrl.searchParams.set('redirect', returnPath);
+  return loginUrl;
+}
+
+/** Resolve a validated redirect target to an absolute URL for server redirects. */
+export function resolveRedirectLocation(target: string, origin: string): URL {
+  if (target.startsWith('https://')) {
+    return new URL(target);
+  }
+  return new URL(target, origin);
+}
 
 export function validateRedirect(url: string | null | undefined, fallback: string = '/'): string {
   if (!url || typeof url !== 'string') return fallback;

--- a/proxy.ts
+++ b/proxy.ts
@@ -3,6 +3,7 @@ import type { NextRequest } from 'next/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { checkAdminIPAsync } from '@/lib/api/admin-ip-guard';
 import { getSecuritySettings } from '@/lib/admin/security-settings';
+import { buildLoginUrl, buildReturnPath } from '@/lib/auth/validate-redirect';
 import { withSupabaseAuthCookieDomain } from '@/lib/supabase/auth-cookie-domain';
 import {
   rewriteCustomDomainRequest,
@@ -713,8 +714,7 @@ export async function middleware(request: NextRequest) {
   if (!supabaseUrl || !supabaseKey) {
     // Supabase not configured — fail closed: redirect to login rather than
     // allowing unauthenticated access to protected routes
-    const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('redirect', pathname);
+    const loginUrl = buildLoginUrl(request.url, buildReturnPath(pathname, search));
     return NextResponse.redirect(loginUrl, { status: 307 });
   }
 
@@ -745,8 +745,7 @@ export async function middleware(request: NextRequest) {
 
   // Not authenticated - redirect to login with return URL
   if (!user) {
-    const loginUrl = new URL('/login', request.url);
-    loginUrl.searchParams.set('redirect', pathname);
+    const loginUrl = buildLoginUrl(request.url, buildReturnPath(pathname, search));
     return NextResponse.redirect(loginUrl, { status: 307 });
   }
 
@@ -778,7 +777,7 @@ export async function middleware(request: NextRequest) {
       // is a no-op and the session cookie remains valid. The login page detects
       // ?reason=idle and calls supabase.auth.signOut() client-side where the
       // cookie write actually takes effect.
-      const idleUrl = new URL('/login', request.url);
+      const idleUrl = buildLoginUrl(request.url, buildReturnPath(pathname, search));
       idleUrl.searchParams.set('reason', 'idle');
       const idleResponse = NextResponse.redirect(idleUrl, { status: 307 });
       idleResponse.cookies.delete(ACTIVITY_COOKIE);

--- a/tests/unit/validate-redirect.test.ts
+++ b/tests/unit/validate-redirect.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import {
+  buildLoginUrl,
+  buildReturnPath,
+  readRedirectParam,
+  resolveRedirectLocation,
+  validateRedirect,
+} from '@/lib/auth/validate-redirect';
+
+describe('buildReturnPath', () => {
+  it('joins pathname and search', () => {
+    expect(buildReturnPath('/lms/courses/abc', '?activity=reading')).toBe(
+      '/lms/courses/abc?activity=reading',
+    );
+  });
+
+  it('normalizes missing leading slash', () => {
+    expect(buildReturnPath('portal/barber', '?tab=hours')).toBe('/portal/barber?tab=hours');
+  });
+});
+
+describe('buildLoginUrl', () => {
+  it('encodes nested query strings in redirect param', () => {
+    const url = buildLoginUrl('https://www.elevateforhumanity.org', '/lms/courses/x?activity=reading');
+    expect(url.pathname).toBe('/login');
+    expect(url.searchParams.get('redirect')).toBe('/lms/courses/x?activity=reading');
+    expect(url.toString()).toContain('redirect=%2Flms%2Fcourses%2Fx%3Factivity%3Dreading');
+  });
+});
+
+describe('readRedirectParam', () => {
+  it('prefers redirect over next', () => {
+    const params = new URLSearchParams('next=/old&redirect=/new');
+    expect(readRedirectParam(params)).toBe('/new');
+  });
+
+  it('falls back to next', () => {
+    const params = new URLSearchParams('next=/legacy');
+    expect(readRedirectParam(params)).toBe('/legacy');
+  });
+});
+
+describe('validateRedirect', () => {
+  it('allows same-origin paths with query strings', () => {
+    expect(validateRedirect('/portal/barber?tab=hours', '/')).toBe('/portal/barber?tab=hours');
+  });
+
+  it('allows trusted admin subdomain URLs', () => {
+    const admin = 'https://admin.elevateforhumanity.org/admin/instructor/dashboard';
+    expect(validateRedirect(admin, '/')).toBe(admin);
+  });
+
+  it('blocks external open redirects', () => {
+    expect(validateRedirect('https://evil.com/phish', '/safe')).toBe('/safe');
+    expect(validateRedirect('//evil.com', '/safe')).toBe('/safe');
+  });
+});
+
+describe('resolveRedirectLocation', () => {
+  it('preserves absolute trusted URLs', () => {
+    const target = 'https://admin.elevateforhumanity.org/admin/dashboard';
+    expect(resolveRedirectLocation(target, 'https://www.elevateforhumanity.org').href).toBe(target);
+  });
+
+  it('resolves relative paths against origin', () => {
+    expect(
+      resolveRedirectLocation('/portal/barber', 'https://www.elevateforhumanity.org').href,
+    ).toBe('https://www.elevateforhumanity.org/portal/barber');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes **redirects not passing** after login — the `?redirect=` destination was being dropped or truncated across middleware and auth handlers.

## Root causes

1. **Middleware** (`proxy.ts`, `apps/admin/middleware.ts`) only stored `pathname` in `?redirect=`, dropping query strings (e.g. `/lms/courses/[id]?activity=reading`).
2. **Idle timeout** sent users to `/login?reason=idle` without preserving where they were headed.
3. **`auth/confirm`** only read legacy `?next=`, not canonical `?redirect=`.
4. **Magic-link hash handler** (`AuthRedirectHandler`) had the same `next`-only gap and rejected cross-subdomain admin URLs.
5. **Magic-link email** client code prefixed `https://` onto already-absolute admin URLs, producing invalid destinations.

## Changes

- Added shared helpers in `lib/auth/validate-redirect.ts`:
  - `buildReturnPath`, `buildLoginUrl`, `readRedirectParam`, `resolveRedirectLocation`
- Middleware + admin middleware use `buildLoginUrl` with full path + query
- Unified `?redirect=` / `?next=` across login, callback, confirm, magic-link routes
- Admin layout login redirect preserves `x-pathname`
- 10 unit tests in `tests/unit/validate-redirect.test.ts`

## Test plan

- [x] `pnpm test tests/unit/validate-redirect.test.ts` — 10/10 pass
- [x] Pre-push typecheck + redirect conflict scan — clean
- [ ] Manual: visit `/portal/barber` logged out → login → lands on barber portal
- [ ] Manual: visit `/lms/courses/[id]?activity=reading` logged out → login → lands with `?activity=reading`
- [ ] Manual: portals nav instructor link (admin subdomain) → login on www → lands on admin instructor dashboard

## Note for Elizabeth / barber walkthrough

Elizabeth (`program_holder`) will still route to `/program-holder/dashboard` **unless** she signs in via a link with `?redirect=/portal/barber`. After this fix, middleware will preserve that redirect through the full login flow.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Preserve post-login redirect targets through auth and magic-link flows
> - Adds centralized helpers (`buildReturnPath`, `buildLoginUrl`, `readRedirectParam`, `resolveRedirectLocation`) in [`lib/auth/validate-redirect.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/326/files#diff-ac5bb5723f5ed7be1beac532a91d0bd72a947590cc925eba81ae308951f244d3) to encode, read, and resolve redirect parameters consistently.
> - Updates middleware ([`proxy.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/326/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775), [`apps/admin/middleware.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/326/files#diff-8c77ff212195bfeb17b57db46023e4b8b4bbe1c813474969ceec48e54da86ebb)) and layout ([`apps/admin/app/admin/layout.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/326/files#diff-9921d5216c5ab74c5c43248564262bdd36f10017d6471a7805d85154acd9a1d0)) to attach the full original path and query string as an encoded `redirect` param when bouncing unauthenticated users to login.
> - Replaces ad-hoc redirect sanitization in magic-link routes, auth callback, and confirm routes with `validateRedirect`, which accepts trusted absolute HTTPS URLs (including `elevateforhumanity.org`) and falls back to role-based defaults for invalid values.
> - Behavioral Change: `redirect` query param now takes precedence over `next` everywhere; absolute HTTPS URLs to trusted hosts are preserved rather than forced to same-origin.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 77132aa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->