### PR TITLE
fix: barber apprentice portal access for program_holder (timeclock, workbook, LMS)

### DIFF
--- a/app/apprentice/layout.tsx
+++ b/app/apprentice/layout.tsx
@@ -8,6 +8,7 @@ import {
   resolveApprenticeNavConfig,
 } from '@/components/portal/ApprenticeSubNav';
 import { resolveApprenticeProgramSlug } from '@/lib/portal/resolve-apprentice-program';
+import { canAccessApprenticeTools } from '@/lib/portal/apprentice-access';
 
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
@@ -25,8 +26,11 @@ export default async function Layout({ children }: { children: React.ReactNode }
     data: { user },
   } = await supabase.auth.getUser();
 
+  const headersList = await headers();
+  const pathname = headersList.get('x-pathname') ?? '/apprentice';
+
   if (!user) {
-    redirect('/login?redirect=/apprentice');
+    redirect(`/login?redirect=${encodeURIComponent(pathname)}`);
   }
 
   const { data: profile } = await supabase
@@ -35,12 +39,9 @@ export default async function Layout({ children }: { children: React.ReactNode }
     .eq('id', user.id)
     .maybeSingle();
 
-  const ALLOWED = ['student', 'admin', 'super_admin', 'staff', 'instructor'];
-  if (!profile?.role || !ALLOWED.includes(profile.role)) {
+  if (!canAccessApprenticeTools(profile?.role)) {
     redirect('/unauthorized');
   }
-
-  const pathname = (await headers()).get('x-pathname') ?? '';
   const isBillingExempt = BILLING_EXEMPT_PREFIXES.some((p) => pathname.startsWith(p));
 
   const db = await getAdminClient();

--- a/app/login/apprentice/ApprenticeLoginForm.tsx
+++ b/app/login/apprentice/ApprenticeLoginForm.tsx
@@ -5,7 +5,7 @@ import { Loader2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
 
-export default function ApprenticeLoginForm() {
+export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: string }) {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
   const [error, setError] = useState('');
@@ -40,11 +40,9 @@ export default function ApprenticeLoginForm() {
         .eq('id', data.user.id)
         .maybeSingle();
 
-      const dest = await resolveStudentHomePath(
-        supabase,
-        data.user.id,
-        profile?.portal_type,
-      );
+      const dest = redirectTo
+        ? redirectTo
+        : await resolveStudentHomePath(supabase, data.user.id, profile?.portal_type);
 
       window.location.href = dest;
     } catch (err: unknown) {

--- a/app/login/apprentice/page.tsx
+++ b/app/login/apprentice/page.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import { Scissors, GraduationCap } from 'lucide-react';
 import ApprenticeLoginForm from './ApprenticeLoginForm';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
 
 export const metadata: Metadata = {
   title: `Apprentice Login — ${PLATFORM_DEFAULTS.orgName}`,
@@ -13,12 +15,25 @@ export const metadata: Metadata = {
 
 export const dynamic = 'force-dynamic';
 
-export default async function ApprenticeLoginPage() {
+export default async function ApprenticeLoginPage({
+  searchParams,
+}: {
+  searchParams: Promise<{ redirect?: string; next?: string }>;
+}) {
+  const params = await searchParams;
+  const redirectTo = validateRedirect(params.redirect ?? params.next, '');
+
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
   if (user) {
-    redirect('/portal/apprentice');
+    const { data: profile } = await supabase
+      .from('profiles')
+      .select('portal_type')
+      .eq('id', user.id)
+      .maybeSingle();
+    const home = await resolveStudentHomePath(supabase, user.id, profile?.portal_type);
+    redirect(home);
   }
 
   return (
@@ -40,7 +55,7 @@ export default async function ApprenticeLoginPage() {
           </div>
         </div>
 
-        <ApprenticeLoginForm />
+        <ApprenticeLoginForm redirectTo={redirectTo || undefined} />
 
         <div className="mt-6 text-center space-y-2">
           <Link

--- a/app/portal/layout.tsx
+++ b/app/portal/layout.tsx
@@ -1,16 +1,19 @@
 import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
 import { createClient } from '@/lib/supabase/server';
+import { allowedRolesForPortalPath } from '@/lib/portal/apprentice-access';
 
 export const dynamic = 'force-dynamic';
-
-const ALLOWED_ROLES = ['student', 'admin', 'super_admin', 'staff', 'instructor'];
 
 export default async function PortalLayout({ children }: { children: React.ReactNode }) {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
+  const headersList = await headers();
+  const pathname = headersList.get('x-pathname') ?? '/portal';
+
   if (!user) {
-    redirect('/login?redirect=/portal');
+    redirect(`/login?redirect=${encodeURIComponent(pathname)}`);
   }
 
   const { data: profile } = await supabase
@@ -19,7 +22,8 @@ export default async function PortalLayout({ children }: { children: React.React
     .eq('id', user.id)
     .maybeSingle();
 
-  if (!profile?.role || !ALLOWED_ROLES.includes(profile.role)) {
+  const allowedRoles = allowedRolesForPortalPath(pathname);
+  if (!profile?.role || !allowedRoles.includes(profile.role)) {
     redirect('/unauthorized');
   }
 

--- a/components/apprenticeship/ApprenticeEnrollmentGate.tsx
+++ b/components/apprenticeship/ApprenticeEnrollmentGate.tsx
@@ -1,0 +1,46 @@
+import Link from 'next/link';
+import { AlertTriangle, ArrowRight } from 'lucide-react';
+
+type Props = {
+  programSlug: string;
+  label: string;
+  portalPath: string;
+};
+
+export function ApprenticeEnrollmentGate({ programSlug, label, portalPath }: Props) {
+  const applyHref = `/programs/${programSlug}/apply`;
+  const apprenticeLoginHref = `/login?redirect=${encodeURIComponent(portalPath)}`;
+
+  return (
+    <div className="min-h-[60vh] flex items-center justify-center bg-slate-50 px-4">
+      <div className="max-w-lg w-full bg-white rounded-2xl border border-slate-200 p-8 shadow-sm">
+        <div className="flex items-start gap-3 mb-4">
+          <AlertTriangle className="w-6 h-6 text-amber-500 shrink-0 mt-0.5" />
+          <div>
+            <h1 className="text-xl font-bold text-slate-900">No active {label} enrollment</h1>
+            <p className="text-sm text-slate-600 mt-2">
+              This dashboard is only available after you are enrolled in the {label} program. Apply
+              first, complete orientation and documents, then return here to track hours, RTI, and
+              billing.
+            </p>
+          </div>
+        </div>
+        <div className="flex flex-col sm:flex-row gap-3 mt-6">
+          <Link
+            href={applyHref}
+            className="inline-flex items-center justify-center gap-2 px-5 py-3 bg-slate-900 text-white rounded-lg font-semibold text-sm hover:bg-slate-800 transition"
+          >
+            Apply to {label}
+            <ArrowRight className="w-4 h-4" />
+          </Link>
+          <Link
+            href={apprenticeLoginHref}
+            className="inline-flex items-center justify-center px-5 py-3 border border-slate-300 text-slate-800 rounded-lg font-semibold text-sm hover:bg-slate-50 transition"
+          >
+            Sign in with another account
+          </Link>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/components/apprenticeship/ApprenticeshipProgramDashboard.tsx
+++ b/components/apprenticeship/ApprenticeshipProgramDashboard.tsx
@@ -1,11 +1,26 @@
 import { ApprenticePortalShell } from '@/components/portal/ApprenticePortalShell';
+import { ApprenticeEnrollmentGate } from '@/components/apprenticeship/ApprenticeEnrollmentGate';
 import type { ApprenticeshipDashboardData } from '@/lib/apprenticeship/load-apprenticeship-dashboard';
 
 export function ApprenticeshipProgramDashboard(props: ApprenticeshipDashboardData) {
-  const { extras, complianceLinks, rti, ...shellProps } = props;
+  const { extras, complianceLinks, rti, enrollment, billing, config, ...shellProps } = props;
+
+  if (!enrollment && !billing) {
+    return (
+      <ApprenticeEnrollmentGate
+        programSlug={config.programSlug}
+        label={config.label}
+        portalPath={config.portalPath}
+      />
+    );
+  }
+
   return (
     <ApprenticePortalShell
       {...shellProps}
+      config={config}
+      enrollment={enrollment}
+      billing={billing}
       brandSubtitle={extras.brandSubtitle}
       rti={rti}
       complianceLinks={complianceLinks}

--- a/lib/barber/branding.ts
+++ b/lib/barber/branding.ts
@@ -27,10 +27,10 @@ export const BARBER_LMS_COURSE_PATH = `/lms/courses/${BARBER_COURSE_ID}` as cons
 export const prestigeElevationBarberCoursePath = BARBER_LMS_COURSE_PATH;
 
 /**
- * Static workbook fallback — course landing with reading tab hint.
+ * Static workbook fallback when server cannot resolve first lesson id.
  * Prefer server-resolved `workbookHref` from resolveCourseEntryLinks() on dashboards.
  */
-export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF = BARBER_LMS_COURSE_PATH;
+export const PRESTIGE_ELEVATION_BARBER_WORKBOOK_HREF = `${BARBER_LMS_COURSE_PATH}?activity=reading`;
 
 export const PRESTIGE_BARBER_BRAND = {
   instituteName: 'Prestige Barber & Beauty Institute',

--- a/lib/portal/apprentice-access.ts
+++ b/lib/portal/apprentice-access.ts
@@ -1,0 +1,49 @@
+/**
+ * Apprenticeship portal access — keep in sync with proxy.ts PROTECTED_ROUTES
+ * for /portal/{barber,cosmetology,...} and /apprentice/.
+ */
+
+export const APPRENTICE_FIELD_PORTAL_ROLES = [
+  'student',
+  'partner',
+  'program_holder',
+  'admin',
+  'super_admin',
+  'staff',
+  'instructor',
+] as const;
+
+export const GENERAL_PORTAL_ROLES = [
+  'student',
+  'admin',
+  'super_admin',
+  'staff',
+  'instructor',
+] as const;
+
+const APPRENTICE_PORTAL_PATH_PREFIXES = [
+  '/portal/apprentice',
+  '/portal/barber',
+  '/portal/cosmetology',
+  '/portal/esthetician',
+  '/portal/nail-technician',
+  '/portal/culinary',
+  '/portal/electrical',
+  '/portal/plumbing',
+] as const;
+
+export function isApprenticeFieldPortalPath(pathname: string): boolean {
+  return APPRENTICE_PORTAL_PATH_PREFIXES.some(
+    (prefix) => pathname === prefix || pathname.startsWith(`${prefix}/`),
+  );
+}
+
+export function allowedRolesForPortalPath(pathname: string): readonly string[] {
+  return isApprenticeFieldPortalPath(pathname)
+    ? APPRENTICE_FIELD_PORTAL_ROLES
+    : GENERAL_PORTAL_ROLES;
+}
+
+export function canAccessApprenticeTools(role: string | null | undefined): boolean {
+  return !!role && (APPRENTICE_FIELD_PORTAL_ROLES as readonly string[]).includes(role);
+}

--- a/proxy.ts
+++ b/proxy.ts
@@ -105,7 +105,7 @@ const PROTECTED_ROUTES: Record<string, string[]> = {
   '/program-holder/':          ['program_holder', 'admin', 'super_admin'],
 
   // ── Grant clients ─────────────────────────────────────────────────────────
-  '/lms/':                     ['student', 'grant_client', 'admin', 'super_admin', 'staff', 'instructor'],
+  '/lms/':                     ['student', 'grant_client', 'partner', 'program_holder', 'admin', 'super_admin', 'staff', 'instructor'],
 
   // ── Sponsor (DOL apprenticeship) ──────────────────────────────────────────
   // sponsor shares /employer/dashboard — employer route already covers it

--- a/scripts/audit-apprentice-dashboards.mjs
+++ b/scripts/audit-apprentice-dashboards.mjs
@@ -1,0 +1,93 @@
+#!/usr/bin/env node
+/**
+ * Audit apprentice portal routes + data prerequisites for a user email.
+ *
+ *   pnpm tsx --env-file=.env.local scripts/audit-apprentice-dashboards.mjs [email]
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const email = process.argv[2] || 'elizabethpowell6262@gmail.com';
+const base = process.env.AUDIT_BASE_URL || 'http://localhost:3000';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) {
+  console.error('Missing Supabase env');
+  process.exit(1);
+}
+
+const db = createClient(url, key);
+
+const PORTALS = [
+  { slug: 'barber-apprenticeship', path: '/portal/barber' },
+  { slug: 'cosmetology-apprenticeship', path: '/portal/cosmetology' },
+  { slug: 'esthetician-apprenticeship', path: '/portal/esthetician' },
+  { slug: 'nail-technician-apprenticeship', path: '/portal/nail-technician' },
+  { slug: 'culinary-apprenticeship', path: '/portal/culinary' },
+  { slug: 'electrical', path: '/portal/electrical' },
+  { slug: 'plumbing', path: '/portal/plumbing' },
+];
+
+const APPRENTICE_TABS = [
+  '/apprentice/hours',
+  '/apprentice/timeclock',
+  '/apprentice/competencies',
+  '/apprentice/billing',
+  '/apprentice/handbook',
+  '/apprentice/documents',
+  '/apprentice/skills',
+  '/programs/barber-apprenticeship/orientation',
+  '/programs/barber-apprenticeship/documents',
+];
+
+const { data: profile } = await db.from('profiles').select('id,email,role').eq('email', email).maybeSingle();
+console.log(`\n=== Apprentice dashboard audit: ${email} ===\n`);
+if (!profile) {
+  console.error('No profile');
+  process.exit(1);
+}
+
+const userId = profile.id;
+const [pe, bs, ap, lp] = await Promise.all([
+  db.from('program_enrollments').select('program_slug,enrollment_state,orientation_completed_at,course_id').eq('user_id', userId),
+  db.from('barber_subscriptions').select('id,status,setup_fee_paid').eq('user_id', userId),
+  db.from('apprentices').select('id,shop_id,status').eq('user_id', userId).maybeSingle(),
+  db.from('lms_progress').select('course_id,status,progress_percent').eq('user_id', userId),
+]);
+
+console.log('Profile role:', profile.role);
+console.log('program_enrollments:', pe.data?.length ? pe.data : 'NONE');
+console.log('barber_subscriptions:', bs.data?.length ? bs.data : 'NONE');
+console.log('apprentices:', ap.data ?? 'NONE');
+console.log('lms_progress:', lp.data?.length ? lp.data : 'NONE');
+
+const courseId = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';
+const { count: lessonCount } = await db
+  .from('course_lessons')
+  .select('id', { count: 'exact', head: true })
+  .eq('course_id', courseId);
+console.log(`barber course lessons: ${lessonCount ?? 0}`);
+
+console.log(`\n--- HTTP probe (${base}) ---\n`);
+
+async function probe(path) {
+  const start = Date.now();
+  try {
+    const res = await fetch(`${base}${path}`, { redirect: 'manual' });
+    const ms = Date.now() - start;
+    const loc = res.headers.get('location');
+    const tag = res.status >= 300 && res.status < 400 ? `→ ${loc}` : '';
+    const ok = res.status === 200 || (res.status >= 300 && res.status < 400);
+    console.log(`${ok ? '✅' : '❌'} ${String(res.status).padStart(3)} ${ms}ms ${path} ${tag}`);
+    return ok;
+  } catch (e) {
+    console.log(`❌ ERR ${path} ${e.message}`);
+    return false;
+  }
+}
+
+for (const p of PORTALS) await probe(p.path);
+for (const p of APPRENTICE_TABS) await probe(p);
+await probe(`/lms/courses/${courseId}`);
+
+console.log('\nDone.\n');

--- a/scripts/seed-elizabeth-barber-student.mjs
+++ b/scripts/seed-elizabeth-barber-student.mjs
@@ -1,0 +1,172 @@
+#!/usr/bin/env node
+/**
+ * Idempotent: wire Elizabeth Greene as an active barber apprenticeship student
+ * for dashboard / E2E testing (founder account used as QA student).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/seed-elizabeth-barber-student.mjs
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const EMAIL = 'elizabethpowell6262@gmail.com';
+const PROGRAM_SLUG = 'barber-apprenticeship';
+const PROGRAM_ID = '5ff21fcb-1968-41fd-99d3-37d69a31bd5c';
+const COURSE_ID = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';
+const DEFAULT_SHOP_ID = '66833b02-ec3f-4a6e-a7e0-00268d3cf7ed';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key || key === 'placeholder') {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const db = createClient(url, key);
+const now = new Date().toISOString();
+
+const { data: profile, error: profileErr } = await db
+  .from('profiles')
+  .select('id, email, full_name, role')
+  .eq('email', EMAIL)
+  .maybeSingle();
+
+if (profileErr || !profile) {
+  console.error('Profile not found for', EMAIL, profileErr?.message);
+  process.exit(1);
+}
+
+const userId = profile.id;
+console.log('User:', userId, profile.full_name, `role=${profile.role}`);
+
+const { data: existingPe } = await db
+  .from('program_enrollments')
+  .select('id')
+  .eq('user_id', userId)
+  .eq('program_slug', PROGRAM_SLUG)
+  .maybeSingle();
+
+let enrollmentId = existingPe?.id;
+
+if (!enrollmentId) {
+  const { data: inserted, error } = await db
+    .from('program_enrollments')
+    .insert({
+      user_id: userId,
+      student_id: userId,
+      program_id: PROGRAM_ID,
+      program_slug: PROGRAM_SLUG,
+      course_id: COURSE_ID,
+      email: EMAIL,
+      full_name: profile.full_name ?? 'Elizabeth Greene',
+      status: 'active',
+      enrollment_state: 'active',
+      funding_source: 'self_pay',
+      payment_status: 'paid',
+      enrolled_at: now,
+      enrollment_confirmed_at: now,
+      orientation_completed_at: now,
+      documents_completed_at: now,
+      access_granted_at: now,
+      start_date: now,
+      program_holder_id: DEFAULT_SHOP_ID,
+      created_at: now,
+      updated_at: now,
+    })
+    .select('id')
+    .single();
+
+  if (error) {
+    console.error('program_enrollments insert failed:', error.message);
+    process.exit(1);
+  }
+  enrollmentId = inserted.id;
+  console.log('Created program_enrollments', enrollmentId);
+} else {
+  const { error } = await db
+    .from('program_enrollments')
+    .update({
+      status: 'active',
+      enrollment_state: 'active',
+      course_id: COURSE_ID,
+      orientation_completed_at: now,
+      documents_completed_at: now,
+      access_granted_at: now,
+      updated_at: now,
+    })
+    .eq('id', enrollmentId);
+  if (error) console.warn('program_enrollments update:', error.message);
+  else console.log('Updated program_enrollments', enrollmentId);
+}
+
+const { data: existingSub } = await db
+  .from('barber_subscriptions')
+  .select('id')
+  .eq('user_id', userId)
+  .maybeSingle();
+
+if (!existingSub) {
+  const { error } = await db.from('barber_subscriptions').insert({
+    user_id: userId,
+    enrollment_id: enrollmentId,
+    customer_email: EMAIL,
+    customer_name: profile.full_name ?? 'Elizabeth Greene',
+    status: 'active',
+    payment_status: 'active',
+    setup_fee_paid: true,
+    fully_paid: false,
+    weekly_payment_cents: 15103,
+    remaining_balance: 5000,
+    payment_model: 'weekly',
+    created_at: now,
+    updated_at: now,
+  });
+  if (error) console.warn('barber_subscriptions insert:', error.message);
+  else console.log('Created barber_subscriptions');
+} else {
+  await db
+    .from('barber_subscriptions')
+    .update({ status: 'active', setup_fee_paid: true, updated_at: now })
+    .eq('id', existingSub.id);
+  console.log('Updated barber_subscriptions', existingSub.id);
+}
+
+const { data: existingApprentice } = await db
+  .from('apprentices')
+  .select('id')
+  .eq('user_id', userId)
+  .maybeSingle();
+
+if (!existingApprentice) {
+  const { error } = await db.from('apprentices').insert({
+    user_id: userId,
+    shop_id: DEFAULT_SHOP_ID,
+    status: 'active',
+    start_date: now.split('T')[0],
+    created_at: now,
+    updated_at: now,
+  });
+  if (error) console.warn('apprentices insert:', error.message);
+  else console.log('Created apprentices row');
+} else {
+  await db
+    .from('apprentices')
+    .update({ shop_id: DEFAULT_SHOP_ID, status: 'active', updated_at: now })
+    .eq('id', existingApprentice.id);
+  console.log('Updated apprentices', existingApprentice.id);
+}
+
+await db.from('lms_progress').upsert(
+  {
+    user_id: userId,
+    course_id: COURSE_ID,
+    course_slug: 'barber-apprenticeship-v1',
+    status: 'in_progress',
+    progress_percent: 0,
+    started_at: now,
+    last_activity_at: now,
+  },
+  { onConflict: 'user_id,course_id' },
+);
+
+console.log('\n✅ Elizabeth barber student fixture ready');
+console.log('   Dashboard: https://www.elevateforhumanity.org/portal/barber');
+console.log('   LMS course:', `https://www.elevateforhumanity.org/lms/courses/${COURSE_ID}`);

--- a/tests/unit/apprentice-access.test.ts
+++ b/tests/unit/apprentice-access.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect } from 'vitest';
+import {
+  allowedRolesForPortalPath,
+  canAccessApprenticeTools,
+  isApprenticeFieldPortalPath,
+} from '@/lib/portal/apprentice-access';
+
+describe('apprentice portal access', () => {
+  it('treats barber portal as apprenticeship field portal', () => {
+    expect(isApprenticeFieldPortalPath('/portal/barber')).toBe(true);
+    expect(isApprenticeFieldPortalPath('/portal/healthcare')).toBe(false);
+  });
+
+  it('allows program_holder on barber portal', () => {
+    expect(allowedRolesForPortalPath('/portal/barber')).toContain('program_holder');
+  });
+
+  it('does not allow program_holder on healthcare portal', () => {
+    expect(allowedRolesForPortalPath('/portal/healthcare')).not.toContain('program_holder');
+  });
+
+  it('allows program_holder on apprentice tools', () => {
+    expect(canAccessApprenticeTools('program_holder')).toBe(true);
+    expect(canAccessApprenticeTools('employer')).toBe(false);
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes Elizabeth Greene (`program_holder`) and other apprenticeship users being sent to `/unauthorized` when opening the barber dashboard, timeclock, workbook, or LMS course — even though middleware already allowed them.

## Root cause

`app/portal/layout.tsx` and `app/apprentice/layout.tsx` only allowed `student` (+ staff roles). `program_holder` and `partner` were blocked at the layout layer after passing middleware.

`/lms/` middleware also excluded `program_holder`, blocking the Prestige Elevation workbook.

## Changes

- `lib/portal/apprentice-access.ts` — shared role lists aligned with `proxy.ts`
- Portal layout: path-aware roles (`program_holder` on `/portal/barber`, not `/portal/healthcare`)
- Apprentice layout: uses `canAccessApprenticeTools()`
- `proxy.ts`: add `program_holder` + `partner` to `/lms/`
- Apprentice login honors `?redirect=`
- Enrollment gate when no `program_enrollments` row
- Seed + audit scripts for Elizabeth barber QA

## Test plan

- [x] `pnpm test tests/unit/apprentice-access.test.ts` — 4/4
- [x] Elizabeth seed script — enrollment + subscription + apprentice row
- [x] Audit script — all apprentice routes redirect to login with preserved `?redirect=` (unauthenticated probe)

## After deploy

Sign in as `elizabethpowell6262@gmail.com` → `/portal/barber` → Timeclock, Workbook, Hours tabs should load (no `/unauthorized`).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix barber apprentice portal access for program_holder role across timeclock, workbook, and LMS
> - Adds a new [apprentice-access module](https://github.com/elevate-for-humanity/Elevate-lms/pull/327/files#diff-ab6102e42388aaf3390493b88615202c18fe96f72edf3e2bcc9795bf2e831826) exporting role lists and path helpers (`canAccessApprenticeTools`, `allowedRolesForPortalPath`) used to gate apprentice and portal routes.
> - Updates [app/apprentice/layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/327/files#diff-0473d66abc50e8ddd3b80d1e5578160fc623d9eb813b2dd1b6892ac1b1c03cdf) and [app/portal/layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/327/files#diff-6364adf7e0df8b23945b43f98a991032ad310b845077b5a6ecb0b730861532d4) to use these helpers instead of hardcoded role arrays, and redirects unauthenticated users back to their original path after login.
> - Adds `program_holder` and `partner` to the allowed roles for `/lms/` routes in [proxy.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/327/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775).
> - Renders an `ApprenticeEnrollmentGate` in the dashboard when a user has no active enrollment or billing data, offering apply and sign-in links.
> - Behavioral Change: portal access control is now path-dependent rather than using a single static role list.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 06f5268.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->