### PR TITLE
fix: barber LMS crash and portal routes (missing merge)

### DIFF
--- a/app/lms/(app)/courses/[courseId]/page.tsx
+++ b/app/lms/(app)/courses/[courseId]/page.tsx
@@ -30,6 +30,8 @@ import {
 } from 'lucide-react';
 import { CourseModuleAccordion } from '@/components/lms/CourseModuleAccordion';
 import { CourseReviewsPanel } from '@/components/lms/CourseReviewsPanel';
+import { BARBER_COURSE_ID } from '@/lib/barber/constants';
+import { BARBER_CURRICULUM_COVER } from '@/lib/barber/branding';
 
 export const dynamic = 'force-dynamic';
 

--- a/app/lms/(app)/courses/page.tsx
+++ b/app/lms/(app)/courses/page.tsx
@@ -6,6 +6,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Clock, Users, BookOpen } from 'lucide-react';
 import { LMS_HEROES } from '@/lib/lms/image-map';
+import { BARBER_COURSE_ID } from '@/lib/barber/constants';
+import { BARBER_CURRICULUM_COVER } from '@/lib/barber/branding';
 
 export const metadata: Metadata = {
   title: 'My Programs | LMS',

--- a/app/lms/(app)/layout.tsx
+++ b/app/lms/(app)/layout.tsx
@@ -57,9 +57,10 @@ export default async function LmsAppLayout({ children }: { children: ReactNode }
     redirect(getUnauthorizedRedirect(profile.role));
   }
 
-  // Gate LMS access — students must have admin-granted access before entering the LMS.
+  // Gate LMS access — learners (student, partner, program_holder) need granted access.
   // access_granted_at is set by admin via /admin/enrollments grant-access action.
-  if (profile?.role === 'student' && db) {
+  const isLearnerRole = ['student', 'partner', 'program_holder'].includes(profile?.role ?? '');
+  if (isLearnerRole && db) {
     const enrollment = await resolveLatestEnrollment({
       client: db,
       userId: user.id,

--- a/components/apprenticeship/ApprenticeshipProgramDashboard.tsx
+++ b/components/apprenticeship/ApprenticeshipProgramDashboard.tsx
@@ -21,9 +21,7 @@ export function ApprenticeshipProgramDashboard(props: ApprenticeshipDashboardDat
       config={config}
       enrollment={enrollment}
       billing={billing}
-      brandSubtitle={extras.brandSubtitle}
       rti={rti}
-      complianceLinks={complianceLinks}
     />
   );
 }

--- a/lib/auth/lms-routes.ts
+++ b/lib/auth/lms-routes.ts
@@ -3,7 +3,14 @@
  * Defines which roles can access which routes
  */
 
-export type LMSRole = 'student' | 'instructor' | 'staff' | 'admin' | 'super_admin';
+export type LMSRole =
+  | 'student'
+  | 'partner'
+  | 'program_holder'
+  | 'instructor'
+  | 'staff'
+  | 'admin'
+  | 'super_admin';
 
 interface RouteConfig {
   path: string;
@@ -29,11 +36,11 @@ export const LMS_PROTECTED_ROUTES: RouteConfig[] = [
   // Student routes (most LMS pages)
   {
     path: '/lms/dashboard',
-    allowedRoles: ['student', 'instructor', 'staff', 'admin', 'super_admin'],
+    allowedRoles: ['student', 'partner', 'program_holder', 'instructor', 'staff', 'admin', 'super_admin'],
   },
   {
     path: '/lms/courses',
-    allowedRoles: ['student', 'instructor', 'staff', 'admin', 'super_admin'],
+    allowedRoles: ['student', 'partner', 'program_holder', 'instructor', 'staff', 'admin', 'super_admin'],
   },
   {
     path: '/lms/assignments',

--- a/lib/layout/app-routes.ts
+++ b/lib/layout/app-routes.ts
@@ -12,6 +12,9 @@
  */
 export const APP_ROUTE_PREFIXES = [
   '/lms',
+  '/portal',
+  '/portals',
+  '/apprentice',
   '/learner',
   '/admin',
   '/admin/instructor',

--- a/scripts/fix-barber-lms-progress.mjs
+++ b/scripts/fix-barber-lms-progress.mjs
@@ -1,0 +1,34 @@
+#!/usr/bin/env node
+/** Upsert lms_progress for barber students missing it. */
+import { createClient } from '@supabase/supabase-js';
+
+const emails = process.argv.slice(2);
+if (!emails.length) {
+  console.error('Usage: fix-barber-lms-progress.mjs email [email...]');
+  process.exit(1);
+}
+
+const db = createClient(process.env.NEXT_PUBLIC_SUPABASE_URL, process.env.SUPABASE_SERVICE_ROLE_KEY);
+const COURSE_ID = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';
+const now = new Date().toISOString();
+
+for (const email of emails) {
+  const { data: profile } = await db.from('profiles').select('id,full_name').eq('email', email).maybeSingle();
+  if (!profile) {
+    console.log(email, '— no profile');
+    continue;
+  }
+  const { error } = await db.from('lms_progress').upsert(
+    {
+      user_id: profile.id,
+      course_id: COURSE_ID,
+      course_slug: 'barber-apprenticeship-v1',
+      status: 'in_progress',
+      progress_percent: 0,
+      started_at: now,
+      last_activity_at: now,
+    },
+    { onConflict: 'user_id,course_id' },
+  );
+  console.log(email, profile.full_name, error ? error.message : 'lms_progress ok');
+}

--- a/scripts/verify-elizabeth-barber-ready.mjs
+++ b/scripts/verify-elizabeth-barber-ready.mjs
@@ -1,0 +1,107 @@
+#!/usr/bin/env node
+/**
+ * Verify barber apprentice portal prerequisites for a student email.
+ *   pnpm tsx --env-file=.env.local scripts/verify-elizabeth-barber-ready.mjs [email]
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const EMAIL = process.argv[2] || 'elizabethpowell6262@gmail.com';
+const COURSE_ID = '3fb5ce19-1cde-434c-a8c6-f138d7d7aa17';
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !key) process.exit(1);
+
+const db = createClient(url, key);
+
+const { data: profile } = await db.from('profiles').select('id,role,email,full_name').eq('email', EMAIL).maybeSingle();
+if (!profile) {
+  console.log(JSON.stringify({ ok: false, blockers: ['no profile for email'], email: EMAIL }, null, 2));
+  process.exit(1);
+}
+
+const userId = profile.id;
+
+const { data: apRes } = await db
+  .from('apprentices')
+  .select('id,shop_id,status')
+  .eq('user_id', userId)
+  .maybeSingle();
+
+const shopId = apRes?.shop_id ?? null;
+
+const [lessonsRes, courseRes, peRes, sitesRes, shopRes, progressRes, lmsRes, firstLesson] =
+  await Promise.all([
+    db.from('course_lessons').select('id', { count: 'exact', head: true }).eq('course_id', COURSE_ID),
+    db.from('courses').select('id,title,status').eq('id', COURSE_ID).maybeSingle(),
+    db
+      .from('program_enrollments')
+      .select('enrollment_state,orientation_completed_at,course_id,access_granted_at')
+      .eq('user_id', userId)
+      .eq('program_slug', 'barber-apprenticeship')
+      .maybeSingle(),
+    shopId
+      ? db
+          .from('apprentice_sites')
+          .select('id,name,is_active,latitude,longitude,radius_meters')
+          .eq('shop_id', shopId)
+          .eq('is_active', true)
+      : Promise.resolve({ data: [] }),
+    shopId ? db.from('shops').select('id,name').eq('id', shopId).maybeSingle() : Promise.resolve({ data: null }),
+    db
+      .from('lesson_progress')
+      .select('id', { count: 'exact', head: true })
+      .eq('user_id', userId)
+      .eq('course_id', COURSE_ID)
+      .eq('completed', true),
+    db
+      .from('lms_progress')
+      .select('status,progress_percent')
+      .eq('user_id', userId)
+      .eq('course_id', COURSE_ID)
+      .maybeSingle(),
+    db
+      .from('course_lessons')
+      .select('id,title,order_index')
+      .eq('course_id', COURSE_ID)
+      .order('order_index', { ascending: true })
+      .limit(1)
+      .maybeSingle(),
+  ]);
+
+const workbookHref = firstLesson.data
+  ? `/lms/courses/${COURSE_ID}/lessons/${firstLesson.data.id}?activity=reading`
+  : `/lms/courses/${COURSE_ID}`;
+
+const blockers = [];
+if (!peRes.data) blockers.push('missing program_enrollments');
+if (!apRes) blockers.push('missing apprentices row');
+if (!apRes?.shop_id) blockers.push('apprentice has no shop_id');
+if ((sitesRes.data?.length ?? 0) === 0) blockers.push('no active apprentice_sites for shop');
+if ((lessonsRes.count ?? 0) === 0) blockers.push('barber course has no lessons');
+if (courseRes.data?.status !== 'published') blockers.push(`course status=${courseRes.data?.status}`);
+if (!lmsRes.data) blockers.push('missing lms_progress');
+
+console.log(
+  JSON.stringify(
+    {
+      ok: blockers.length === 0,
+      blockers,
+      profile,
+      course: courseRes.data,
+      publishedLessons: lessonsRes.count,
+      workbookHref,
+      firstLesson: firstLesson.data?.title,
+      enrollment: peRes.data,
+      apprentice: apRes,
+      shop: shopRes.data,
+      clockInSites: sitesRes.data,
+      lmsProgress: lmsRes.data,
+      completedLessons: progressRes.count,
+    },
+    null,
+    2,
+  ),
+);
+
+process.exit(blockers.length === 0 ? 0 : 1);

--- a/tests/unit/lms-barber-imports.test.ts
+++ b/tests/unit/lms-barber-imports.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+describe('barber LMS course pages', () => {
+  it('import barber constants used in course detail page', () => {
+    const src = readFileSync(
+      join(process.cwd(), 'app/lms/(app)/courses/[courseId]/page.tsx'),
+      'utf8',
+    );
+    expect(src).toContain("from '@/lib/barber/constants'");
+    expect(src).toContain("from '@/lib/barber/branding'");
+    expect(src).toMatch(/BARBER_COURSE_ID/);
+    expect(src).toMatch(/BARBER_CURRICULUM_COVER/);
+  });
+
+  it('import barber constants used in courses list page', () => {
+    const src = readFileSync(join(process.cwd(), 'app/lms/(app)/courses/page.tsx'), 'utf8');
+    expect(src).toContain("from '@/lib/barber/constants'");
+    expect(src).toContain("from '@/lib/barber/branding'");
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Completes work that was left on branch `cursor/fix-barber-lms-portal-errors-c4c6` but **never merged to main**.

## Problem

`app/lms/(app)/courses/page.tsx` and `app/lms/(app)/courses/[courseId]/page.tsx` referenced `BARBER_COURSE_ID` and `BARBER_CURRICULUM_COVER` without imports → **ReferenceError** at runtime when barber students open LMS programs.

## Changes

- Add missing barber constant imports on LMS course pages
- `program_holder` / `partner` LMS layout access (pairs with #327)
- `/portal`, `/portals`, `/apprentice` in `APP_ROUTE_PREFIXES`
- Remove invalid props on `ApprenticeshipProgramDashboard`
- Unit test: `tests/unit/lms-barber-imports.test.ts`
- Ops scripts: `verify-elizabeth-barber-ready.mjs`, `fix-barber-lms-progress.mjs`

## Verification (live DB)

All four barber apprentices pass `verify-elizabeth-barber-ready.mjs`:
- Elizabeth Greene (`elizabethpowell6262@gmail.com`) — Prestige Elevation
- Natalia Roa (`natataroa@gmail.com`) — Kountry Kutz
- Jordan White (`jbwhite888@icloud.com`) — Kountry Kutz
- Mercedes Wellington (`msanqin@gmail.com`) — Prestige Elevation

No account named "Natolia" exists; closest match is **Natalia Roa**.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix barber LMS crash and extend portal route suppression for partner roles
> - Extends LMS access gate in [layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/329/files#diff-ede21e7fc0ebddc2ea98fc83c66108ff44031fec6aa3e5ad223a8cff518cbed0) and route config in [lms-routes.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/329/files#diff-c1147c5919705b983a6127932ee81550f18e549e266f7e2beb12af9a4880fb89) to include `partner` and `program_holder` roles alongside `student` for `/lms/dashboard` and `/lms/courses`.
> - Adds `/portal`, `/portals`, and `/apprentice` prefixes to `APP_ROUTE_PREFIXES` in [app-routes.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/329/files#diff-de223490a7f69ac5ef57b3bd42571a2d3f476a9fc2f4d20dcca3bff046107e0e) so marketing header/footer is suppressed on those routes.
> - Adds barber-specific imports (`BARBER_COURSE_ID`, `BARBER_CURRICULUM_COVER`) to the course detail and courses list pages, with unit tests asserting their presence.
> - Adds two utility scripts: [fix-barber-lms-progress.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/329/files#diff-4d2cf477f58271dd8d1e2b4c1bb2a7b545b3c9ac57c03435d48592464cabd3c0) to upsert `lms_progress` records and [verify-elizabeth-barber-ready.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/329/files#diff-15aa51c27aeec8710a98b99d56feb547e30cd5556fc981f90836b9e708cc280e) to verify apprentice portal prerequisites.
> - Behavioral Change: `partner` and `program_holder` users are now subject to the barber subscription suspension check previously applied only to `student`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e64ea6e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->