### PR TITLE
fix(login): site header on login pages, apprentice hero, rate-limit messaging

### DIFF
--- a/app/login/apprentice/ApprenticeLoginForm.tsx
+++ b/app/login/apprentice/ApprenticeLoginForm.tsx
@@ -4,6 +4,8 @@ import { useState } from 'react';
 import { Loader2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
+import { mapAuthError } from '@/lib/auth/map-auth-error';
+import { hydrateBrowserSupabaseConfig } from '@/lib/supabase/public-config';
 
 export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: string }) {
   const [email, setEmail] = useState('');
@@ -17,6 +19,12 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
     setLoading(true);
 
     try {
+      const hydrated = await hydrateBrowserSupabaseConfig();
+      if (!hydrated) {
+        setError(mapAuthError('site configuration'));
+        return;
+      }
+
       const supabase = createClient();
 
       const { data, error: authError } = await supabase.auth.signInWithPassword({
@@ -25,7 +33,7 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
       });
 
       if (authError) {
-        setError(authError.message || 'Invalid credentials');
+        setError(mapAuthError(authError.message));
         return;
       }
 
@@ -47,7 +55,7 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
       window.location.href = dest;
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Login failed';
-      setError(msg);
+      setError(mapAuthError(msg));
     } finally {
       setLoading(false);
     }
@@ -56,13 +64,16 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
       {error && (
-        <div className="bg-red-500/10 border border-red-500/30 rounded-lg px-4 py-3 text-sm text-red-300">
+        <div
+          className="bg-brand-red-50 border border-brand-red-200 rounded-lg px-4 py-3 text-sm text-brand-red-800"
+          role="alert"
+        >
           {error}
         </div>
       )}
 
       <div>
-        <label htmlFor="apprentice-email" className="block text-sm font-medium text-slate-200 mb-1">
+        <label htmlFor="apprentice-email" className="block text-sm font-medium text-slate-800 mb-1">
           Email
         </label>
         <input
@@ -72,13 +83,13 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
           required
           value={email}
           onChange={(e) => setEmail(e.target.value)}
-          className="w-full px-4 py-2.5 rounded-lg bg-slate-800 border border-slate-600 text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className="w-full px-4 py-2.5 rounded-lg bg-white border border-slate-300 text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-500"
           placeholder="you@example.com"
         />
       </div>
 
       <div>
-        <label htmlFor="apprentice-password" className="block text-sm font-medium text-slate-200 mb-1">
+        <label htmlFor="apprentice-password" className="block text-sm font-medium text-slate-800 mb-1">
           Password
         </label>
         <input
@@ -88,14 +99,14 @@ export default function ApprenticeLoginForm({ redirectTo }: { redirectTo?: strin
           required
           value={password}
           onChange={(e) => setPassword(e.target.value)}
-          className="w-full px-4 py-2.5 rounded-lg bg-slate-800 border border-slate-600 text-white placeholder:text-slate-500 focus:outline-none focus:ring-2 focus:ring-amber-500"
+          className="w-full px-4 py-2.5 rounded-lg bg-white border border-slate-300 text-slate-900 placeholder:text-slate-400 focus:outline-none focus:ring-2 focus:ring-amber-500"
         />
       </div>
 
       <button
         type="submit"
         disabled={loading}
-        className="w-full py-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-slate-900 font-semibold transition disabled:opacity-60 flex items-center justify-center gap-2"
+        className="w-full py-3 rounded-lg bg-amber-500 hover:bg-amber-600 text-white font-semibold transition disabled:opacity-60 flex items-center justify-center gap-2"
       >
         {loading ? <Loader2 className="w-5 h-5 animate-spin" /> : null}
         Sign In

--- a/app/login/apprentice/page.tsx
+++ b/app/login/apprentice/page.tsx
@@ -1,8 +1,9 @@
 import { Metadata } from 'next';
 import { redirect } from 'next/navigation';
-import { createClient } from '@/lib/supabase/server';
+import Image from 'next/image';
 import Link from 'next/link';
-import { Scissors, GraduationCap } from 'lucide-react';
+import { GraduationCap, Scissors } from 'lucide-react';
+import { createClient } from '@/lib/supabase/server';
 import ApprenticeLoginForm from './ApprenticeLoginForm';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
@@ -10,7 +11,8 @@ import { validateRedirect } from '@/lib/auth/validate-redirect';
 
 export const metadata: Metadata = {
   title: `Apprentice Login — ${PLATFORM_DEFAULTS.orgName}`,
-  description: 'Sign in to your apprenticeship portal. Track hours, competencies, and training progress.',
+  description:
+    'Sign in to your apprenticeship portal. Track hours, competencies, timeclock, and training progress.',
 };
 
 export const dynamic = 'force-dynamic';
@@ -24,7 +26,9 @@ export default async function ApprenticeLoginPage({
   const redirectTo = validateRedirect(params.redirect ?? params.next, '');
 
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
 
   if (user) {
     const { data: profile } = await supabase
@@ -33,45 +37,55 @@ export default async function ApprenticeLoginPage({
       .eq('id', user.id)
       .maybeSingle();
     const home = await resolveStudentHomePath(supabase, user.id, profile?.portal_type);
-    redirect(home);
+    redirect(redirectTo || home);
   }
 
   return (
-    <div className="min-h-screen bg-slate-900 flex flex-col items-center justify-center px-4">
-      <div className="w-full max-w-sm">
-        <div className="text-center mb-8">
-          <div className="w-14 h-14 bg-amber-500 rounded-2xl flex items-center justify-center mx-auto mb-4">
-            <Scissors className="w-7 h-7 text-white" />
-          </div>
-          <h1 className="text-2xl font-bold text-white">Apprentice Portal</h1>
-          <p className="text-slate-400 text-sm mt-1">
-            Registered Apprenticeship Program
-          </p>
-          <div className="flex items-center justify-center gap-2 mt-3">
-            <GraduationCap aria-label="graduationcap" className="w-4 h-4 text-amber-400" />
-            <span className="text-xs text-amber-400 font-medium uppercase tracking-widest">
-              DOL Registered
-            </span>
+    <>
+      <section className="relative h-[200px] w-full overflow-hidden">
+        <Image
+          src="/images/beauty/hero-program-barber.webp"
+          alt="Barber and beauty apprenticeship training"
+          fill
+          className="object-cover"
+          priority
+          sizes="100vw"
+        />
+      </section>
+
+      <section className="py-10 px-4">
+        <div className="max-w-md mx-auto">
+          <div className="bg-white rounded-xl shadow-lg border border-slate-200 p-8">
+            <div className="text-center mb-6">
+              <div className="w-12 h-12 bg-amber-500 rounded-xl flex items-center justify-center mx-auto mb-3">
+                <Scissors className="w-6 h-6 text-white" aria-hidden />
+              </div>
+              <h1 className="text-2xl font-bold text-slate-900">Apprentice Portal</h1>
+              <p className="text-slate-600 text-sm mt-1">Registered Apprenticeship Program</p>
+              <div className="flex items-center justify-center gap-2 mt-2">
+                <GraduationCap className="w-4 h-4 text-amber-600" aria-hidden />
+                <span className="text-xs text-amber-700 font-semibold uppercase tracking-widest">
+                  DOL Registered
+                </span>
+              </div>
+            </div>
+
+            <ApprenticeLoginForm redirectTo={redirectTo || undefined} />
+
+            <div className="mt-6 text-center space-y-2 text-sm">
+              <Link href="/login" className="text-slate-500 hover:text-slate-800 block">
+                Not an apprentice? Sign in as a different role →
+              </Link>
+              <p className="text-slate-500">
+                Need help?{' '}
+                <Link href="/contact" className="text-brand-blue-600 hover:underline font-medium">
+                  Contact support
+                </Link>
+              </p>
+            </div>
           </div>
         </div>
-
-        <ApprenticeLoginForm redirectTo={redirectTo || undefined} />
-
-        <div className="mt-6 text-center space-y-2">
-          <Link
-            href="/login"
-            className="text-xs text-slate-500 hover:text-slate-300 transition"
-          >
-            Not an apprentice? Sign in as a different role →
-          </Link>
-          <p className="text-xs text-slate-600">
-            Need help?{' '}
-            <Link href="/contact" className="text-amber-400 hover:underline">
-              Contact support
-            </Link>
-          </p>
-        </div>
-      </div>
-    </div>
+      </section>
+    </>
   );
 }

--- a/app/login/layout.tsx
+++ b/app/login/layout.tsx
@@ -15,11 +15,7 @@ export const metadata: Metadata = {
 };
 
 export default function LoginLayout({ children }: { children: React.ReactNode }) {
-  // MarketingChromeGuard hides header/footer on /login via data-app-route.
-  // This layout provides the dark centered shell for the auth form.
-  return (
-    <div className="min-h-screen bg-slate-950 flex items-center justify-center px-4">
-      {children}
-    </div>
-  );
+  // Marketing Header from PublicLayout stays visible (see lib/layout/app-routes.ts).
+  // pt-[60px] clears the fixed site header.
+  return <div className="min-h-screen bg-slate-50 pt-[60px]">{children}</div>;
 }

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -15,6 +15,7 @@ import { getRoleDestination } from '@/lib/auth/role-destinations';
 import { resolvePortalForUser } from '@/lib/portal/router';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { hydrateBrowserSupabaseConfig } from '@/lib/supabase/public-config';
+import { mapAuthError } from '@/lib/auth/map-auth-error';
 
 function LoginForm() {
   const [email, setEmail] = useState('');
@@ -59,9 +60,7 @@ function LoginForm() {
     try {
       const hydrated = await hydrateBrowserSupabaseConfig();
       if (!hydrated) {
-        setError(
-          'Sign-in is temporarily unavailable (site configuration). Please try again later or contact support.',
-        );
+        setError(mapAuthError('site configuration'));
         setLoading(false);
         return;
       }
@@ -149,12 +148,8 @@ function LoginForm() {
       window.location.href = dest;
     } catch (err: any) {
       // Supabase error objects have non-enumerable properties — extract explicitly
-      let msg = err?.message || err?.error_description || err?.msg || 'Invalid email or password';
-      if (msg === 'Supabase not configured') {
-        msg =
-          'Sign-in is temporarily unavailable (site configuration). Please try again later or contact support.';
-      }
-      setError(msg);
+      const raw = err?.message || err?.error_description || err?.msg || 'Invalid email or password';
+      setError(mapAuthError(raw));
     } finally {
       setLoading(false);
     }

--- a/components/admin/dashboard/DashboardShell.tsx
+++ b/components/admin/dashboard/DashboardShell.tsx
@@ -52,7 +52,28 @@ const DEGRADED_LABELS: Record<string, string> = {
   recent_students: "Recent students",
   enrollments_by_program: "Enrollment breakdown",
 };
-function DegradedBanner({ sections }: { sections: string[] }) {
+function DegradedBanner({
+  sections,
+  dashboardUnavailable,
+}: {
+  sections: string[];
+  dashboardUnavailable?: boolean;
+}) {
+  if (dashboardUnavailable) {
+    return (
+      <div className="flex items-start gap-3 rounded-xl border border-rose-200 bg-rose-50 px-5 py-4 text-sm text-rose-900 mb-6">
+        <AlertTriangle className="mt-0.5 h-4 w-4 shrink-0 text-rose-600" />
+        <div>
+          <span className="font-semibold">Live dashboard data could not be loaded.</span>{' '}
+          Counts below may show zero until Supabase reconnects. Use{' '}
+          <Link href="/admin/operations" className="underline font-medium">
+            Operations
+          </Link>{' '}
+          or hard-refresh. If this persists, verify admin deploy SHA matches main.
+        </div>
+      </div>
+    );
+  }
   if (!sections.length) return null;
   return (
     <div className="flex items-start gap-3 rounded-xl border border-amber-200 bg-amber-50 px-5 py-4 text-sm text-amber-800 mb-6">
@@ -500,7 +521,10 @@ export function AdminDashboardContent({ data }: { data: AdminDashboardData }) {
           <Link href="/admin/dev-studio" className="flex-shrink-0 inline-flex items-center gap-2 px-3 sm:px-4 py-2 bg-white border border-slate-200 text-slate-700 text-xs sm:text-sm font-semibold rounded-xl hover:bg-slate-50 transition-colors">Dev Studio</Link>
         </div>
 
-        <DegradedBanner sections={data.degradedSections ?? []} />
+        <DegradedBanner
+          sections={(data.degradedSections ?? []).filter((s) => s !== 'dashboard_data')}
+          dashboardUnavailable={(data.degradedSections ?? []).includes('dashboard_data')}
+        />
 
         <AdminCategoryLanding />
 

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -45,9 +45,16 @@ export default function Header() {
             <SearchModal />
             <LanguageSwitcher compact={true} />
             <Link
-              href="/login"
+              href="/portals"
               prefetch={false}
               className="text-slate-600 font-semibold text-[13px] hover:text-slate-900 transition-colors px-2.5 py-1.5 rounded-md hover:bg-slate-50 whitespace-nowrap"
+            >
+              Portals
+            </Link>
+            <Link
+              href="/login"
+              prefetch={false}
+              className="text-slate-600 font-semibold text-[13px] hover:text-slate-900 transition-colors px-2.5 py-1.5 rounded-md hover:bg-slate-50 whitespace-nowrap hidden xl:inline"
             >
               Sign In
             </Link>

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -273,12 +273,20 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
                     Get Started
                   </Link>
                   <Link
-                    href="/login"
+                    href="/portals"
                     prefetch={false}
                     onClick={closeMenu}
                     className="block w-full text-center py-3 border border-slate-300 text-slate-800 rounded-lg font-semibold hover:bg-slate-50"
                   >
-                    Sign In
+                    Portals
+                  </Link>
+                  <Link
+                    href="/login"
+                    prefetch={false}
+                    onClick={closeMenu}
+                    className="block w-full text-center py-2.5 text-slate-600 font-medium text-sm hover:underline"
+                  >
+                    Sign in (all roles)
                   </Link>
                   <Link
                     href="/apply"

--- a/lib/auth/map-auth-error.ts
+++ b/lib/auth/map-auth-error.ts
@@ -1,0 +1,27 @@
+/**
+ * User-facing auth errors — map Supabase / network messages to actionable copy.
+ */
+export function mapAuthError(message: string | undefined | null): string {
+  const raw = (message ?? '').trim();
+  const lower = raw.toLowerCase();
+
+  if (!raw) return 'Sign-in failed. Please try again.';
+
+  if (lower.includes('rate limit') || lower.includes('too many requests')) {
+    return 'Too many sign-in attempts. Please wait 10–15 minutes and try again, or contact support if this continues.';
+  }
+
+  if (lower.includes('invalid login credentials') || lower.includes('invalid email or password')) {
+    return 'Invalid email or password. Check your credentials or reset your password.';
+  }
+
+  if (lower.includes('email not confirmed')) {
+    return 'Please confirm your email before signing in. Check your inbox for the verification link.';
+  }
+
+  if (lower.includes('supabase not configured') || lower.includes('site configuration')) {
+    return 'Sign-in is temporarily unavailable. Please try again later or contact support.';
+  }
+
+  return raw;
+}

--- a/lib/layout/app-routes.ts
+++ b/lib/layout/app-routes.ts
@@ -29,7 +29,6 @@ export const APP_ROUTE_PREFIXES = [
   '/case-manager',
   '/workforce-board',
   '/admin-login',
-  '/login',
   '/signup',
   '/reset-password',
   '/verify',

--- a/tests/unit/map-auth-error.test.ts
+++ b/tests/unit/map-auth-error.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from 'vitest';
+import { mapAuthError } from '@/lib/auth/map-auth-error';
+
+describe('mapAuthError', () => {
+  it('maps Supabase rate limit to actionable copy', () => {
+    expect(mapAuthError('Request rate limit reached')).toContain('Too many sign-in attempts');
+  });
+
+  it('maps invalid credentials', () => {
+    expect(mapAuthError('Invalid login credentials')).toContain('Invalid email or password');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Fixes user-reported issues

### Apprentice login (`/login/apprentice`)
- **Site header + full nav now visible** (removed `/login` from chrome-suppression list)
- Hero image + white card layout (matches main `/login` — no more isolated dark fullscreen)
- **Rate limit:** maps Supabase `Request rate limit reached` to actionable copy (wait 10–15 min)
- Hydrates Supabase config before sign-in (same as main login)

### Public header
- **Portals** link prominent (desktop + mobile) → `/portals` hub with Apprentice, Employer, Partner, etc.
- Portals dropdown already lists all role logins in `lib/navigation.ts`

### Admin dashboard
- **Rose banner** when `dashboard_data` degraded — explains zeros are not real KPIs, not silent fake template

## Not in this PR (tracked in SYSTEM_INTEGRITY_AUDIT)
- 180 orphan admin routes (internal shells)
- Full homepage chronological re-template of every page
- Store trial migration apply in Supabase
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix login page layout to show site header, add apprentice hero, and improve auth error messages
> - Removes `/login` from [`APP_ROUTE_PREFIXES`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-de223490a7f69ac5ef57b3bd42571a2d3f476a9fc2f4d20dcca3bff046107e0e) and reworks [`LoginLayout`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-718387fd26d74b77e1fdf9cc995cb9cce0824f0057888859638d2a65bbd6ca5f) so the marketing header and footer remain visible on all `/login` routes, with top padding to clear the fixed header.
> - Reworks the [`ApprenticeLoginPage`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-3759982a00a61130222305121166aa08aaf5164d6318c315dd5e65d4df39cad9) to render a hero image section and a white card layout, replacing the previous dark centered shell.
> - Adds [`mapAuthError`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-b5684393ed067bced6bc2d656f8fdebc80cc982760b8a3b967003302b80e57d3), a utility that maps raw Supabase and network error strings to user-friendly messages for rate limiting, invalid credentials, unconfirmed email, and config failures; both login forms now use it.
> - Adds a 'Portals' link to [`Header`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-ab1fe96a19fb5a4115ecc8932848cfad8d945af1a39528b95ecf35d3e7f1caca) (desktop) and [`HeaderMobileMenu`](https://github.com/elevate-for-humanity/Elevate-lms/pull/333/files#diff-87be3332ef07c1677edd45f68793b6c4b53f5e8d91feaf1fb1a3c7fcd445a047) (mobile), where it replaces the primary 'Sign In' CTA with a secondary 'Sign in (all roles)' text link.
> - Behavioral Change: The marketing header is now visible on all `/login` routes; previously these pages suppressed it.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized cfd9ea3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->