### PR TITLE
Step 2: dashboard-routes canonical + migration verify script

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -844,6 +844,7 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
 ### Gotchas
 
 - **Middleware auth prefixes:** `AUTH_REQUIRED_ROUTES` uses segment-aware matching (`pathMatchesAuthPrefix` in `proxy.ts`). Never use bare `/apprentice` with `pathname.startsWith` — it incorrectly gates public `/apprenticeships`. Public marketing prefixes are listed in `PUBLIC_MARKETING_PREFIXES` (`/apprenticeships`, `/programs/`, `/partners/`, etc.).
+- **Before recommending manual SQL migrations**, run `node scripts/verify-pending-migrations.mjs`. If all five checks pass, migrations are already live — do not ask the user to re-run them.
 - The `predev` script runs `scripts/setup-env-auto.sh` which will fail if `.env.local` doesn't exist. Create it first or set `SKIP_ENV_VALIDATION=true`.
 - Dev server logs `Failed to load from app_secrets` and `Failed to load from platform_secrets` with placeholder Supabase keys — this is expected and does not block the server.
 - Northflank Dockerfiles require real `NEXT_PUBLIC_SUPABASE_URL` and `NEXT_PUBLIC_SUPABASE_ANON_KEY` at build time. Runtime must also inject real keys via the `elevate-production-env` secret group. Admin `/api/health` returns 500 with `supabaseAnonKeyLooksPlaceholder` when the anon key is still a placeholder. URL must be `https://<ref>.supabase.co`, not `db.<ref>.supabase.co`.

--- a/config/dashboard-routes.ts
+++ b/config/dashboard-routes.ts
@@ -1,40 +1,18 @@
-import { UserRole } from '@/types/user';
+/**
+ * @deprecated Import getRoleDestination from '@/lib/auth/role-destinations' instead.
+ * Thin wrapper kept for UserMenu and legacy imports.
+ */
+import { getRoleDestination, ROLE_DESTINATIONS } from '@/lib/auth/role-destinations';
+import type { UserRole } from '@/types/user';
 
-export const DASHBOARD_ROUTES: Record<UserRole, string> = {
-  // Admin tier
-  super_admin: '/admin/dashboard',
-  admin: '/admin/dashboard',
-  org_admin: '/admin/dashboard',
-
-  // Staff / operations
-  staff: 'https://admin.elevateforhumanity.org/admin/staff-portal/dashboard',
-  instructor: 'https://admin.elevateforhumanity.org/admin/instructor/dashboard',
-
-  // Program holders / delegates
-  program_holder: '/program-holder/dashboard',
-  delegate: '/my-dashboard',
-
-  // Partners / sponsors
-  partner: '/partner/dashboard',
-  sponsor: '/employer/dashboard',
-
-  // Workforce oversight
-  workforce_board: '/workforce-board/dashboard',
-
-  // Employer
-  employer: '/employer/dashboard',
-
-  // Mentor
-  mentor: '/mentor/dashboard',
-
-  // Creator
-  creator: '/creator/products',
-
-  // Student
-  student: '/learner/dashboard',
-};
+/** @deprecated Use ROLE_DESTINATIONS from role-destinations.ts */
+export const DASHBOARD_ROUTES = ROLE_DESTINATIONS as Record<UserRole, string>;
 
 export function getDashboardUrl(role?: UserRole): string {
   if (!role) return '/unauthorized?reason=unknown_role';
-  return DASHBOARD_ROUTES[role] || '/unauthorized?reason=unknown_role';
+  const destination = getRoleDestination(role);
+  if (destination === '/learner/dashboard' && !(role in ROLE_DESTINATIONS)) {
+    return '/unauthorized?reason=unknown_role';
+  }
+  return destination;
 }

--- a/scripts/verify-pending-migrations.mjs
+++ b/scripts/verify-pending-migrations.mjs
@@ -1,0 +1,153 @@
+#!/usr/bin/env node
+/**
+ * Verify whether the five "pending" production migrations are already live.
+ * Run BEFORE telling anyone to paste SQL in the Dashboard.
+ *
+ * Usage:
+ *   node scripts/verify-pending-migrations.mjs
+ *
+ * Requires one of:
+ *   SUPABASE_MANAGEMENT_API_KEY + SUPABASE_PROJECT_REF
+ *   SUPABASE_DB_URL or SUPABASE_DB_PASSWORD + SUPABASE_PROJECT_REF
+ */
+
+import { config } from 'dotenv';
+import { dirname, join } from 'path';
+import { fileURLToPath } from 'url';
+
+const root = join(dirname(fileURLToPath(import.meta.url)), '..');
+config({ path: join(root, '.env.local') });
+
+const CHECKS = [
+  {
+    id: '20260702000009',
+    label: 'two_factor_auth normalized (is_enabled dropped)',
+    sql: `SELECT NOT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'two_factor_auth' AND column_name = 'is_enabled'
+    ) AS ok`,
+  },
+  {
+    id: '20260702000010',
+    label: 'onboarding_progress_user_step_unique',
+    sql: `SELECT EXISTS (
+      SELECT 1 FROM pg_constraint WHERE conname = 'onboarding_progress_user_step_unique'
+    ) AS ok`,
+  },
+  {
+    id: '20260702000011',
+    label: 'storage buckets (documents, course-videos, apprentice-uploads)',
+    sql: `SELECT (
+      SELECT count(*) FROM storage.buckets
+      WHERE id IN ('documents','course-videos','apprentice-uploads')
+    ) >= 3 AS ok`,
+  },
+  {
+    id: '20260702000012',
+    label: 'program_external_courses.elevate_fee_cents',
+    sql: `SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'program_external_courses'
+        AND column_name = 'elevate_fee_cents'
+    ) AS ok`,
+  },
+  {
+    id: '20260702000015',
+    label: 'user_app_subscriptions.app_slug (store trials)',
+    sql: `SELECT EXISTS (
+      SELECT 1 FROM information_schema.columns
+      WHERE table_schema = 'public' AND table_name = 'user_app_subscriptions'
+        AND column_name = 'app_slug'
+    ) AS ok`,
+  },
+];
+
+async function runViaMgmtApi(sql) {
+  const key = process.env.SUPABASE_MANAGEMENT_API_KEY;
+  const ref = process.env.SUPABASE_PROJECT_REF;
+  if (!key || !ref) return null;
+
+  const res = await fetch(`https://api.supabase.com/v1/projects/${ref}/database/query`, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: sql }),
+    signal: AbortSignal.timeout(20000),
+  });
+  const body = await res.json().catch(() => ({}));
+  if (!res.ok) throw new Error(body?.message ?? `HTTP ${res.status}`);
+  return body;
+}
+
+async function runViaPg(sql) {
+  const { default: pg } = await import('pg');
+  let connStr = process.env.SUPABASE_DB_URL;
+  if (!connStr) {
+    const password = process.env.SUPABASE_DB_PASSWORD;
+    const ref = process.env.SUPABASE_PROJECT_REF;
+    if (password && ref) {
+      connStr = `postgresql://postgres.${ref}:${encodeURIComponent(password)}@aws-0-us-east-1.pooler.supabase.com:6543/postgres`;
+    }
+  }
+  if (!connStr) return null;
+
+  const client = new pg.Client({
+    connectionString: connStr,
+    ssl: { rejectUnauthorized: false },
+  });
+  await client.connect();
+  try {
+    const { rows } = await client.query(sql);
+    return rows;
+  } finally {
+    await client.end();
+  }
+}
+
+async function query(sql) {
+  const mgmt = await runViaMgmtApi(sql).catch((e) => {
+    throw new Error(`Management API: ${e.message}`);
+  });
+  if (mgmt !== null) return mgmt;
+
+  const pgRows = await runViaPg(sql);
+  if (pgRows !== null) return pgRows;
+
+  console.error('❌ Cannot verify live DB — set SUPABASE_MANAGEMENT_API_KEY or SUPABASE_DB_PASSWORD.');
+  console.error('   Without credentials, assume migrations may already be applied (check Dashboard).');
+  process.exit(2);
+}
+
+async function main() {
+  console.log('Pending migration verification (live Supabase)\n');
+  let allOk = true;
+  let needRun = [];
+
+  for (const check of CHECKS) {
+    const rows = await query(check.sql);
+    const ok = Boolean(rows?.[0]?.ok);
+    const icon = ok ? '✅' : '❌';
+    console.log(`${icon} ${check.id} — ${check.label}`);
+    if (!ok) {
+      allOk = false;
+      needRun.push(check.id);
+    }
+  }
+
+  console.log('');
+  if (allOk) {
+    console.log('✅ All five checks passed — do NOT re-run migration SQL (already live).');
+    process.exit(0);
+  }
+
+  console.log('⚠️  Missing:', needRun.join(', '));
+  console.log('   Apply only the matching files under supabase/migrations/ in Supabase SQL Editor.');
+  process.exit(1);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/tests/unit/dashboard-routes.test.ts
+++ b/tests/unit/dashboard-routes.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it } from 'vitest';
+import { getDashboardUrl } from '@/config/dashboard-routes';
+import { getRoleDestination } from '@/lib/auth/role-destinations';
+
+describe('getDashboardUrl', () => {
+  it('matches canonical role destinations for known roles', () => {
+    expect(getDashboardUrl('partner')).toBe(getRoleDestination('partner'));
+    expect(getDashboardUrl('program_holder')).toBe(getRoleDestination('program_holder'));
+    expect(getDashboardUrl('delegate')).toBe('/learner/dashboard');
+  });
+
+  it('returns unauthorized for missing or unknown roles', () => {
+    expect(getDashboardUrl(undefined)).toBe('/unauthorized?reason=unknown_role');
+    expect(getDashboardUrl('not_a_real_role' as 'student')).toBe(
+      '/unauthorized?reason=unknown_role',
+    );
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Step 2 of production readiness (isolated)

No nav, no admin nav, no DB migrations.

### Changes
- `config/dashboard-routes.ts` — delegate to `role-destinations` (single source of truth)
- `scripts/verify-pending-migrations.mjs` — probe live DB before recommending SQL
- `AGENTS.md` — require verify script before telling anyone to run migrations
- `tests/unit/dashboard-routes.test.ts`

### Depends on
Merge **after** or in parallel with #335 (no file overlap).

### Remaining steps
3. Admin DEFAULT_NAV sync
4. Smoke/audit scripts
5. Views migration (v2 + security_invoker)
6. Codex Northflank diagnostics
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-1e06be16-77cd-4869-8d56-15bf910dc4c6"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add migration verify script and canonicalize `getDashboardUrl` to use `getRoleDestination`
> - [config/dashboard-routes.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/336/files#diff-5d182d772165d58bbb378d37388ac38f5e31a4abfa23b7e20bfb7fe044f9085e) now delegates role resolution to `getRoleDestination` from `@/lib/auth/role-destinations`; `DASHBOARD_ROUTES` becomes a deprecated alias for `ROLE_DESTINATIONS`.
> - `getDashboardUrl` returns `/unauthorized?reason=unknown_role` for roles not present in `ROLE_DESTINATIONS` that would otherwise silently fall through to `/learner/dashboard`.
> - [scripts/verify-pending-migrations.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/336/files#diff-fdcf0d622d070801f19f1feb5b72d1255bf015535c76f8825db91ef0aff88c3f) is a new CLI tool that checks five specific migration IDs against the database via Supabase Management API or direct Postgres, exiting 0 (all applied), 1 (some missing), or 2 (credentials unavailable).
> - [AGENTS.md](https://github.com/elevate-for-humanity/Elevate-lms/pull/336/files#diff-a54ff182c7e8acf56acfd6e4b9c3ff41e2c41a31c9b211b2deb9df75d9a478f9) adds a note to run the verify script before recommending manual SQL migrations.
> - Behavioral Change: unknown roles that previously resolved to `/learner/dashboard` now return `/unauthorized?reason=unknown_role`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ba3e401.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->