### PR TITLE
Fix student enrollment flow, nav routing, and program pages

### DIFF
--- a/app/api/enrollment/complete-orientation/route.ts
+++ b/app/api/enrollment/complete-orientation/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { canCompleteOrientation, normalizeEnrollmentState } from '@/lib/enrollment/enrollment-flow';
 
 async function _POST(req: Request) {
   try {
@@ -22,13 +23,12 @@ async function _POST(req: Request) {
     const { program, enrollmentId } = await req.json();
     const now = new Date().toISOString();
 
-    // Resolve target enrollment — prefer explicit id, fall back to most recent pending
     let targetId: string | null = enrollmentId ?? null;
 
     if (!targetId) {
       const { data: pending } = await supabase
         .from('program_enrollments')
-        .select('id')
+        .select('id, enrollment_state')
         .eq('user_id', user.id)
         .is('orientation_completed_at', null)
         .order('enrolled_at', { ascending: false })
@@ -41,13 +41,24 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'No pending enrollment found' }, { status: 404 });
     }
 
-    // Single scoped update — ownership re-checked on write
+    const { data: row } = await supabase
+      .from('program_enrollments')
+      .select('enrollment_state')
+      .eq('id', targetId)
+      .eq('user_id', user.id)
+      .maybeSingle();
+
+    if (!row || !canCompleteOrientation(normalizeEnrollmentState(row.enrollment_state))) {
+      return NextResponse.json({ error: 'Cannot complete orientation from current state' }, { status: 400 });
+    }
+
     const { error: peError } = await supabase
       .from('program_enrollments')
       .update({
         orientation_completed_at: now,
-        status: 'orientation_complete',
-        enrollment_state: 'orientation_complete',
+        status: 'active',
+        enrollment_state: 'enrolled',
+        next_required_action: 'DOCUMENTS',
         updated_at: now,
       })
       .eq('id', targetId)
@@ -56,17 +67,6 @@ async function _POST(req: Request) {
     if (peError) {
       logger.error('[complete-orientation] program_enrollments update failed', peError);
       return NextResponse.json({ error: 'Failed to complete orientation' }, { status: 500 });
-    }
-
-    // Update training_enrollments — scoped to user + not yet completed
-    const { error: teError } = await supabase
-      .from('program_enrollments')
-      .update({ orientation_completed_at: now, updated_at: now })
-      .eq('user_id', user.id)
-      .is('orientation_completed_at', null);
-
-    if (teError) {
-      logger.warn('[complete-orientation] training_enrollments update failed (non-fatal)', teError);
     }
 
     return NextResponse.json({ success: true, program, enrollmentId: targetId });

--- a/app/api/enrollment/documents/complete/route.ts
+++ b/app/api/enrollment/documents/complete/route.ts
@@ -3,6 +3,7 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { canSubmitDocuments, hasLmsAccess, normalizeEnrollmentState } from '@/lib/enrollment/enrollment-flow';
 
 async function _POST(req: Request) {
   try {
@@ -40,16 +41,17 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
 
-    // Orientation gate — single source of truth is enrollments.enrollment_state.
-    // profiles.orientation_completed is a denormalized cache; do not gate on it here.
-    if (enrollment.enrollment_state !== 'orientation_complete') {
-      if (enrollment.enrollment_state === 'active') {
-        return NextResponse.json({
-          success: true,
-          message: 'Documents already submitted',
-          redirect: '/dashboard',
-        });
-      }
+    const state = normalizeEnrollmentState(enrollment.enrollment_state);
+
+    if (hasLmsAccess(state)) {
+      return NextResponse.json({
+        success: true,
+        message: 'Documents already submitted',
+        redirect: '/learner/dashboard',
+      });
+    }
+
+    if (!canSubmitDocuments(state)) {
       return NextResponse.json(
         {
           error: 'Cannot submit documents from current state',
@@ -165,7 +167,7 @@ async function _POST(req: Request) {
     return NextResponse.json({
       success: true,
       message: 'Documents submitted. Enrollment activated.',
-      redirect: '/dashboard',
+      redirect: '/learner/dashboard',
     });
   } catch (err) {
     logger.error('Documents complete error:', err);

--- a/app/api/enrollment/orientation/complete/route.ts
+++ b/app/api/enrollment/orientation/complete/route.ts
@@ -3,6 +3,11 @@ import { NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
+import {
+  canCompleteOrientation,
+  hasLmsAccess,
+  normalizeEnrollmentState,
+} from '@/lib/enrollment/enrollment-flow';
 
 async function _POST(req: Request) {
   try {
@@ -25,7 +30,6 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'Missing enrollment_id' }, { status: 400 });
     }
 
-    // Verify ownership and current state
     const { data: enrollment, error: fetchError } = await supabase
       .from('program_enrollments')
       .select('id, user_id, enrollment_state')
@@ -40,19 +44,17 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'Unauthorized' }, { status: 403 });
     }
 
-    // Check state allows transition
-    if (enrollment.enrollment_state !== 'confirmed') {
-      if (
-        enrollment.enrollment_state === 'orientation_complete' ||
-        enrollment.enrollment_state === 'documents_complete' ||
-        enrollment.enrollment_state === 'active'
-      ) {
-        return NextResponse.json({
-          success: true,
-          message: 'Orientation already completed',
-          redirect: '/enrollment/documents',
-        });
-      }
+    const state = normalizeEnrollmentState(enrollment.enrollment_state);
+
+    if (state === 'enrolled' || hasLmsAccess(state)) {
+      return NextResponse.json({
+        success: true,
+        message: 'Orientation already completed',
+        redirect: hasLmsAccess(state) ? '/learner/dashboard' : '/enrollment/documents',
+      });
+    }
+
+    if (!canCompleteOrientation(state)) {
       return NextResponse.json(
         {
           error: 'Cannot complete orientation from current state',
@@ -62,11 +64,10 @@ async function _POST(req: Request) {
       );
     }
 
-    // Advance state
     const { error: updateError } = await supabase
       .from('program_enrollments')
       .update({
-        enrollment_state: 'orientation_complete',
+        enrollment_state: 'enrolled',
         orientation_completed_at: new Date().toISOString(),
         next_required_action: 'DOCUMENTS',
       })

--- a/app/api/enrollment/submit-documents/route.ts
+++ b/app/api/enrollment/submit-documents/route.ts
@@ -5,6 +5,7 @@ import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { success, failure } from '@/lib/api/safe-handler';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { PRE_DOCUMENTS_STATES } from '@/lib/enrollment/enrollment-flow';
 
 async function _POST(req: Request) {
   try {
@@ -28,16 +29,12 @@ async function _POST(req: Request) {
     let targetId: string | null = enrollmentId ?? null;
 
     if (!targetId) {
-      // Find the most recent enrollment that hasn't had documents submitted yet.
-      // 'orientation_complete' is the canonical pre-documents state.
-      // 'onboarding' and 'orientation' are earlier states that may also be valid
-      // if the student skipped the orientation step (legacy flows).
       const { data: pending } = await supabase
         .from('program_enrollments')
         .select('id')
         .eq('user_id', user.id)
         .is('documents_submitted_at', null)
-        .in('enrollment_state', ['orientation_complete', 'onboarding', 'orientation', 'enrolled'])
+        .in('enrollment_state', [...PRE_DOCUMENTS_STATES])
         .order('enrolled_at', { ascending: false })
         .limit(1)
         .maybeSingle();

--- a/app/api/onboarding/complete-step/route.ts
+++ b/app/api/onboarding/complete-step/route.ts
@@ -72,17 +72,15 @@ export async function POST(req: Request) {
     if (step === 'orientation') {
       profileUpdates.orientation_completed = true;
       profileUpdates.orientation_completed_at = now;
-      // Canonical gate: advance enrollment_state so document gate reads one source of truth.
-      // Only advance if currently in 'confirmed' state — do not overwrite later states.
       await supabase
         .from('program_enrollments')
         .update({
-          enrollment_state: 'orientation_complete',
+          enrollment_state: 'enrolled',
           orientation_completed_at: now,
           next_required_action: 'DOCUMENTS',
         })
         .eq('user_id', user.id)
-        .eq('enrollment_state', 'confirmed');
+        .in('enrollment_state', ['orientation', 'onboarding']);
     }
     if (step === 'handbook') {
       profileUpdates.handbook_acknowledged_at = now;

--- a/app/enrollment/confirmed/page.tsx
+++ b/app/enrollment/confirmed/page.tsx
@@ -7,12 +7,18 @@ import { createClient } from '@/lib/supabase/client';
 import { Calendar, Building2, Award, ArrowRight } from 'lucide-react';
 import Link from 'next/link';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import {
+  canShowConfirmedPage,
+  getEnrollmentRoute,
+  hasLmsAccess,
+  normalizeEnrollmentState,
+} from '@/lib/enrollment/enrollment-flow';
 
 interface EnrollmentData {
   id: string;
   program_name: string;
   enrollment_state: string;
-  enrollment_confirmed_at: string;
+  enrollment_confirmed_at: string | null;
   start_date?: string;
 }
 
@@ -63,25 +69,28 @@ function EnrollmentConfirmedContent() {
         return;
       }
 
-      // Redirect based on state
-      if (data.enrollment_state === 'orientation_complete') {
-        router.push('/enrollment/documents');
+      const state = normalizeEnrollmentState(data.enrollment_state) ?? data.enrollment_state;
+
+      if (hasLmsAccess(state)) {
+        router.push('/learner/dashboard');
         return;
       }
-      if (data.enrollment_state === 'documents_complete' || data.enrollment_state === 'active') {
-        router.push('/dashboard');
+
+      const targetRoute = getEnrollmentRoute(state);
+      if (targetRoute !== '/enrollment/confirmed' && targetRoute !== '/programs') {
+        router.push(targetRoute);
         return;
       }
-      // Accept both 'approved' and 'confirmed' — approved students confirm here
-      if (data.enrollment_state !== 'confirmed' && data.enrollment_state !== 'approved') {
+
+      if (!canShowConfirmedPage(state)) {
         router.push('/programs');
         return;
       }
 
       setEnrollment({
         id: data.id,
-        program_name: (data.training_programs as any)?.name || 'Your Program',
-        enrollment_state: data.enrollment_state,
+        program_name: (data.training_programs as { name?: string } | null)?.name || 'Your Program',
+        enrollment_state: state,
         enrollment_confirmed_at: data.enrollment_confirmed_at,
       });
       setLoading(false);
@@ -100,7 +109,13 @@ function EnrollmentConfirmedContent() {
 
   if (!enrollment) return null;
 
-  const isApproved = enrollment.enrollment_state === 'approved';
+  const normalizedState = normalizeEnrollmentState(enrollment.enrollment_state);
+  const needsConfirm = normalizedState === 'onboarding';
+  const awaitingReview =
+    normalizedState === 'applied' ||
+    normalizedState === 'waitlisted' ||
+    normalizedState === 'pending_funding_verification';
+  const needsPayment = normalizedState === 'payment_required';
 
   async function handleConfirm() {
     setConfirming(true);
@@ -109,7 +124,7 @@ function EnrollmentConfirmedContent() {
       const { error } = await supabase
         .from('program_enrollments')
         .update({
-          enrollment_state: 'confirmed',
+          enrollment_state: 'orientation',
           enrollment_confirmed_at: new Date().toISOString(),
           next_required_action: 'COMPLETE_ORIENTATION',
         })
@@ -133,23 +148,32 @@ function EnrollmentConfirmedContent() {
   return (
     <div className="min-h-screen bg-white py-12 px-4">
       <div className="max-w-2xl mx-auto">
-        {/* Header */}
         <div className="text-center mb-8">
           <div className="inline-flex items-center justify-center w-20 h-20 bg-brand-green-100 rounded-full mb-4">
             <Award aria-label="award" className="w-10 h-10 text-brand-green-600" />
           </div>
           <h1 className="text-3xl font-bold text-slate-900">
-            {isApproved ? 'Confirm Your Enrollment' : 'Enrollment Confirmed'}
+            {needsConfirm
+              ? 'Confirm Your Enrollment'
+              : awaitingReview
+                ? 'Application Received'
+                : needsPayment
+                  ? 'Payment Required'
+                  : 'Enrollment Confirmed'}
           </h1>
-          {isApproved && (
+          {needsConfirm && (
             <p className="text-slate-700 mt-2">
-              Your application has been approved. Review the details below and confirm to begin
-              onboarding.
+              Your enrollment is ready. Review the details below and confirm to begin onboarding.
+            </p>
+          )}
+          {awaitingReview && (
+            <p className="text-slate-700 mt-2">
+              We received your application. Our team will notify you when you can continue to
+              orientation.
             </p>
           )}
         </div>
 
-        {/* Enrollment Details Card */}
         <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 mb-6">
           <div className="space-y-4">
             <div className="flex items-start gap-3">
@@ -165,14 +189,17 @@ function EnrollmentConfirmedContent() {
               <div>
                 <p className="text-sm text-slate-700">Status</p>
                 <p
-                  className={`font-semibold ${isApproved ? 'text-amber-600' : 'text-brand-green-600'}`}
+                  className={`font-semibold ${needsConfirm || needsPayment ? 'text-amber-600' : 'text-brand-green-600'}`}
                 >
-                  {isApproved ? 'Approved — Awaiting Confirmation' : 'Confirmed'}
+                  {needsConfirm && 'Ready — Awaiting Confirmation'}
+                  {awaitingReview && 'Under Review'}
+                  {needsPayment && 'Payment Required'}
+                  {!needsConfirm && !awaitingReview && !needsPayment && 'Confirmed'}
                 </p>
               </div>
             </div>
 
-            {!isApproved && (
+            {!needsConfirm && !awaitingReview && (
               <div className="flex items-start gap-3">
                 <Calendar className="w-5 h-5 text-brand-blue-600 mt-0.5" />
                 <div>
@@ -194,8 +221,7 @@ function EnrollmentConfirmedContent() {
           </div>
         </div>
 
-        {/* CTA Button */}
-        {isApproved ? (
+        {needsConfirm ? (
           <button
             onClick={handleConfirm}
             disabled={confirming}
@@ -203,6 +229,20 @@ function EnrollmentConfirmedContent() {
           >
             {confirming ? 'Confirming...' : 'Confirm Enrollment & Start Onboarding'}
           </button>
+        ) : needsPayment ? (
+          <Link
+            href="/apply"
+            className="flex items-center justify-center gap-2 w-full bg-brand-blue-600 hover:bg-brand-blue-700 text-white text-center font-semibold py-4 px-6 rounded-lg transition-colors"
+          >
+            Complete Payment <ArrowRight className="w-5 h-5" />
+          </Link>
+        ) : awaitingReview ? (
+          <Link
+            href="/learner/dashboard"
+            className="flex items-center justify-center gap-2 w-full bg-slate-100 hover:bg-slate-200 text-slate-900 text-center font-semibold py-4 px-6 rounded-lg transition-colors"
+          >
+            Go to Dashboard <ArrowRight className="w-5 h-5" />
+          </Link>
         ) : (
           <Link
             href="/enrollment/orientation"
@@ -212,7 +252,6 @@ function EnrollmentConfirmedContent() {
           </Link>
         )}
 
-        {/* Helper Text */}
         <p className="text-center text-sm text-slate-700 mt-4">
           This program is sponsor-managed. Orientation and required documents must be completed
           before course access is unlocked.
@@ -223,7 +262,5 @@ function EnrollmentConfirmedContent() {
 }
 
 export default function EnrollmentConfirmedPage() {
-  return (
-          <EnrollmentConfirmedContent />
-  );
+  return <EnrollmentConfirmedContent />;
 }

--- a/app/enrollment/documents/page.tsx
+++ b/app/enrollment/documents/page.tsx
@@ -5,6 +5,12 @@ import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { Upload, FileText, AlertCircle, X } from 'lucide-react';
 import DocumentAIPrefillPanel from '@/components/documents/DocumentAIPrefillPanel';
+import {
+  canSubmitDocuments,
+  getEnrollmentRoute,
+  hasLmsAccess,
+  normalizeEnrollmentState,
+} from '@/lib/enrollment/enrollment-flow';
 
 interface RequiredDocument {
   id: string;
@@ -65,17 +71,21 @@ export default function DocumentsPage() {
         return;
       }
 
-      // Redirect based on state
-      if (data.enrollment_state === 'applied' || data.enrollment_state === 'approved') {
-        router.push('/enrollment/confirmed');
+      const state = normalizeEnrollmentState(data.enrollment_state) ?? data.enrollment_state;
+
+      if (hasLmsAccess(state)) {
+        router.push('/learner/dashboard');
         return;
       }
-      if (data.enrollment_state === 'confirmed') {
-        router.push('/enrollment/orientation');
+
+      const targetRoute = getEnrollmentRoute(state);
+      if (targetRoute !== '/enrollment/documents' && targetRoute !== '/programs') {
+        router.push(targetRoute);
         return;
       }
-      if (data.enrollment_state === 'documents_complete' || data.enrollment_state === 'active') {
-        router.push('/dashboard');
+
+      if (!canSubmitDocuments(state)) {
+        router.push('/programs');
         return;
       }
 

--- a/app/enrollment/orientation/page.tsx
+++ b/app/enrollment/orientation/page.tsx
@@ -5,6 +5,12 @@ import { useRouter } from 'next/navigation';
 import { createClient } from '@/lib/supabase/client';
 import { ArrowRight, Play, Pause, Volume2, VolumeX } from 'lucide-react';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import {
+  canCompleteOrientation,
+  getEnrollmentRoute,
+  hasLmsAccess,
+  normalizeEnrollmentState,
+} from '@/lib/enrollment/enrollment-flow';
 
 export default function EnrollmentOrientationPage() {
   const router = useRouter();
@@ -44,12 +50,21 @@ export default function EnrollmentOrientationPage() {
         return;
       }
 
-      if (data.enrollment_state === 'orientation_complete') {
-        router.push('/enrollment/documents');
+      const state = normalizeEnrollmentState(data.enrollment_state) ?? data.enrollment_state;
+
+      if (hasLmsAccess(state)) {
+        router.push('/learner/dashboard');
         return;
       }
-      if (data.enrollment_state === 'documents_complete' || data.enrollment_state === 'active') {
-        router.push('/learner/dashboard');
+
+      const targetRoute = getEnrollmentRoute(state);
+      if (targetRoute !== '/enrollment/orientation' && targetRoute !== '/programs') {
+        router.push(targetRoute);
+        return;
+      }
+
+      if (!canCompleteOrientation(state)) {
+        router.push('/programs');
         return;
       }
 

--- a/app/learner/dashboard/page.tsx
+++ b/app/learner/dashboard/page.tsx
@@ -27,6 +27,7 @@ import {
   ScrollText,
 } from 'lucide-react';
 import { logger } from '@/lib/logger';
+import { getOnboardingBannerCopy } from '@/lib/enrollment/enrollment-flow';
 import HeroVideo from '@/components/marketing/HeroVideo';
 import heroBanners from '@/content/heroBanners';
 import BillingCard, { type BillingSummary } from '@/components/learner/BillingCard';
@@ -72,7 +73,7 @@ export default async function LearnerDashboardPage({ searchParams }: Props) {
       .select('program_slug')
       .eq('user_id', user.id)
       .in('program_slug', Object.keys(APPRENTICESHIP_SLUG_TO_PORTAL))
-      .in('enrollment_state', ['active', 'confirmed', 'orientation_complete', 'documents_complete'])
+      .in('enrollment_state', ['active', 'enrolled', 'orientation', 'onboarding'])
       .order('enrolled_at', { ascending: false })
       .limit(1)
       .maybeSingle();
@@ -431,47 +432,26 @@ export default async function LearnerDashboardPage({ searchParams }: Props) {
         </div>
 
         {/* Onboarding Banner — shown when student has a pending program enrollment */}
-        {pendingOnboarding && (
+        {pendingOnboarding && (() => {
+          const banner = getOnboardingBannerCopy(pendingOnboarding.enrollment_state);
+          return (
           <div className="mb-8 bg-amber-50 border border-amber-200 rounded-xl p-6">
             <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
               <div>
                 <h2 className="text-lg font-bold text-amber-900 mb-1">Complete Your Onboarding</h2>
-                <p className="text-amber-800 text-sm">
-                  {pendingOnboarding.enrollment_state === 'approved' &&
-                    'Confirm your enrollment to proceed to orientation.'}
-                  {pendingOnboarding.enrollment_state === 'confirmed' &&
-                    'Complete your orientation to unlock document upload.'}
-                  {pendingOnboarding.enrollment_state === 'orientation_complete' &&
-                    'Upload your required documents to activate your enrollment.'}
-                  {pendingOnboarding.enrollment_state === 'documents_complete' &&
-                    "Your documents are being reviewed. You'll be activated shortly."}
-                  {pendingOnboarding.enrollment_state === 'applied' &&
-                    "Your application is being reviewed. We'll notify you when it's approved."}
-                </p>
+                <p className="text-amber-800 text-sm">{banner.message}</p>
               </div>
               <Link
-                href={
-                  pendingOnboarding.enrollment_state === 'approved'
-                    ? '/enrollment/confirmed'
-                    : pendingOnboarding.enrollment_state === 'confirmed'
-                      ? '/enrollment/orientation'
-                      : pendingOnboarding.enrollment_state === 'orientation_complete'
-                        ? '/enrollment/documents'
-                        : '/enrollment/confirmed'
-                }
+                href={banner.href}
                 className="inline-flex items-center gap-2 bg-amber-600 hover:bg-amber-700 text-white font-semibold px-5 py-2.5 rounded-lg text-sm transition-colors whitespace-nowrap"
               >
-                {pendingOnboarding.enrollment_state === 'approved' && 'Confirm Enrollment'}
-                {pendingOnboarding.enrollment_state === 'confirmed' && 'Start Orientation'}
-                {pendingOnboarding.enrollment_state === 'orientation_complete' &&
-                  'Upload Documents'}
-                {pendingOnboarding.enrollment_state === 'documents_complete' && 'View Status'}
-                {pendingOnboarding.enrollment_state === 'applied' && 'View Status'}
+                {banner.cta}
                 <ChevronRight className="w-4 h-4" />
               </Link>
             </div>
           </div>
-        )}
+          );
+        })()}
 
         {/* Stats Grid */}
         <div className="grid grid-cols-1 md:grid-cols-4 gap-6 mb-8">

--- a/lib/enrollment-service.ts
+++ b/lib/enrollment-service.ts
@@ -83,8 +83,8 @@ export async function createOrUpdateEnrollment(
     stripePaymentIntentId,
     status,
     paymentStatus,
-    enrollmentState = 'confirmed',
-    nextRequiredAction = 'ORIENTATION',
+    enrollmentState = 'onboarding',
+    nextRequiredAction = 'CONFIRM_ENROLLMENT',
     email,
     fullName,
   } = input;

--- a/lib/enrollment/enrollment-flow.ts
+++ b/lib/enrollment/enrollment-flow.ts
@@ -1,0 +1,196 @@
+/**
+ * Canonical enrollment flow — DB-valid `enrollment_state` values only.
+ *
+ * Constraint source: supabase/migrations/20260501000010_enrollment_state_and_followup.sql
+ *
+ * Student self-serve path:
+ *   applied / waitlisted / funding gates → confirm → orientation → documents → active (LMS)
+ */
+
+/** States allowed by the live DB CHECK constraint. */
+export const VALID_ENROLLMENT_STATES = [
+  'applied',
+  'waitlisted',
+  'onboarding',
+  'orientation',
+  'enrolled',
+  'active',
+  'pending_funding_verification',
+  'payment_required',
+  'suspended',
+  'revoked',
+  'withdrawn',
+  'completed',
+  'graduated',
+  'placed',
+  'follow_up_6mo',
+  'follow_up_12mo',
+] as const;
+
+export type ValidEnrollmentState = (typeof VALID_ENROLLMENT_STATES)[number];
+
+/** Legacy values still present in old rows — normalize on read. */
+const LEGACY_STATE_MAP: Record<string, ValidEnrollmentState> = {
+  approved: 'onboarding',
+  confirmed: 'onboarding',
+  orientation_complete: 'enrolled',
+  documents_complete: 'active',
+  paid: 'onboarding',
+};
+
+export function normalizeEnrollmentState(
+  state: string | null | undefined,
+): ValidEnrollmentState | null {
+  if (!state) return null;
+  if ((VALID_ENROLLMENT_STATES as readonly string[]).includes(state)) {
+    return state as ValidEnrollmentState;
+  }
+  return LEGACY_STATE_MAP[state] ?? null;
+}
+
+/** States that grant /lms access (proxy gate). */
+export const LMS_ACCESS_STATES: readonly ValidEnrollmentState[] = ['active'];
+
+/** Terminal — student cannot proceed; show /unauthorized. */
+export const TERMINAL_ENROLLMENT_STATES: readonly ValidEnrollmentState[] = [
+  'suspended',
+  'revoked',
+  'withdrawn',
+  'completed',
+  'graduated',
+  'placed',
+  'follow_up_6mo',
+  'follow_up_12mo',
+];
+
+/** Shown on learner dashboard onboarding banner. */
+export const PENDING_ONBOARDING_STATES: readonly ValidEnrollmentState[] = [
+  'applied',
+  'waitlisted',
+  'pending_funding_verification',
+  'payment_required',
+  'onboarding',
+  'orientation',
+  'enrolled',
+];
+
+/** States eligible for document submission APIs. */
+export const PRE_DOCUMENTS_STATES: readonly ValidEnrollmentState[] = [
+  'enrolled',
+  'orientation',
+  'onboarding',
+];
+
+/** Route for a student based on canonical enrollment_state. */
+export function getEnrollmentRoute(state: string | null | undefined): string {
+  const normalized = normalizeEnrollmentState(state);
+  if (!normalized) return '/programs';
+
+  if (LMS_ACCESS_STATES.includes(normalized)) {
+    return '/learner/dashboard';
+  }
+  if (TERMINAL_ENROLLMENT_STATES.includes(normalized)) {
+    return '/unauthorized';
+  }
+
+  switch (normalized) {
+    case 'orientation':
+      return '/enrollment/orientation';
+    case 'enrolled':
+      return '/enrollment/documents';
+    case 'onboarding':
+    case 'applied':
+    case 'waitlisted':
+    case 'pending_funding_verification':
+    case 'payment_required':
+      return '/enrollment/confirmed';
+    default:
+      return '/programs';
+  }
+}
+
+export function hasLmsAccess(state: string | null | undefined): boolean {
+  const normalized = normalizeEnrollmentState(state);
+  return normalized !== null && LMS_ACCESS_STATES.includes(normalized);
+}
+
+export function isTerminalEnrollmentState(state: string | null | undefined): boolean {
+  const normalized = normalizeEnrollmentState(state);
+  return normalized !== null && TERMINAL_ENROLLMENT_STATES.includes(normalized);
+}
+
+export function canShowConfirmedPage(state: string | null | undefined): boolean {
+  const normalized = normalizeEnrollmentState(state);
+  if (!normalized) return false;
+  return (
+    normalized === 'onboarding' ||
+    normalized === 'applied' ||
+    normalized === 'waitlisted' ||
+    normalized === 'pending_funding_verification' ||
+    normalized === 'payment_required'
+  );
+}
+
+export function canCompleteOrientation(state: string | null | undefined): boolean {
+  const normalized = normalizeEnrollmentState(state);
+  return normalized === 'orientation' || normalized === 'onboarding';
+}
+
+export function canSubmitDocuments(state: string | null | undefined): boolean {
+  const normalized = normalizeEnrollmentState(state);
+  return normalized === 'enrolled' || normalized === 'orientation';
+}
+
+export function getOnboardingBannerCopy(state: string | null | undefined): {
+  message: string;
+  href: string;
+  cta: string;
+} {
+  const normalized = normalizeEnrollmentState(state) ?? 'applied';
+
+  switch (normalized) {
+    case 'applied':
+    case 'waitlisted':
+      return {
+        message: "Your application is being reviewed. We'll notify you when it's approved.",
+        href: '/enrollment/confirmed',
+        cta: 'View Status',
+      };
+    case 'pending_funding_verification':
+      return {
+        message: 'Your funding is being verified. This usually takes 1–3 business days.',
+        href: '/enrollment/confirmed',
+        cta: 'View Status',
+      };
+    case 'payment_required':
+      return {
+        message: 'Complete payment to activate your enrollment.',
+        href: '/enrollment/confirmed',
+        cta: 'Complete Payment',
+      };
+    case 'onboarding':
+      return {
+        message: 'Confirm your enrollment to proceed to orientation.',
+        href: '/enrollment/confirmed',
+        cta: 'Confirm Enrollment',
+      };
+    case 'orientation':
+      return {
+        message: 'Complete your orientation to unlock document upload.',
+        href: '/enrollment/orientation',
+        cta: 'Start Orientation',
+      };
+    case 'enrolled':
+      return {
+        message: 'Upload your required documents to activate your enrollment.',
+        href: '/enrollment/documents',
+        cta: 'Upload Documents',
+      };
+    default:
+      return {
+        message: 'Complete your onboarding steps to access your program.',
+        href: '/enrollment/confirmed',
+        cta: 'Continue',
+      };
+  }
+}

--- a/lib/enrollment/state-machine.ts
+++ b/lib/enrollment/state-machine.ts
@@ -57,7 +57,7 @@ export function getActionRoute(action: EnrollmentAction, programSlug?: string | 
     case 'wait_for_approval':
       return '/lms/dashboard';
     case 'complete_onboarding':
-      return '/lms/onboarding';
+      return '/enrollment/orientation';
     case 'complete_payment':
       return slug ? `/apply/${slug}/payment` : '/lms/dashboard';
     case 'wait_for_funding_verification':

--- a/lib/learner/dashboard-loader.ts
+++ b/lib/learner/dashboard-loader.ts
@@ -19,11 +19,13 @@ import { createClient } from '@/lib/supabase/server';
 import { requireRole } from '@/lib/auth/require-role';
 import { logger } from '@/lib/logger';
 
+import { PENDING_ONBOARDING_STATES } from '@/lib/enrollment/enrollment-flow';
+
 const ACCESS_STATES = [
   'active',
   'in_progress',
   'enrolled',
-  'confirmed',
+  'onboarding',
   'pending_funding_verification',
 ];
 
@@ -560,13 +562,7 @@ export async function loadLearnerDashboard(): Promise<LearnerDashboardData> {
     .from('program_enrollments')
     .select('id, enrollment_state, next_required_action, full_name, program_id, program_slug')
     .eq('user_id', user.id)
-    .in('enrollment_state', [
-      'applied',
-      'approved',
-      'confirmed',
-      'orientation_complete',
-      'documents_complete',
-    ])
+    .in('enrollment_state', [...PENDING_ONBOARDING_STATES])
     .order('enrolled_at', { ascending: false })
     .limit(1)
     .maybeSingle();

--- a/lib/stripe/handlers/checkout-session-completed.ts
+++ b/lib/stripe/handlers/checkout-session-completed.ts
@@ -100,7 +100,7 @@ export const handleCheckoutSessionCompleted: StripeEventHandler = async (
           .update({
             status: 'active',
             payment_status: 'paid',
-            enrollment_state: 'confirmed',
+            enrollment_state: 'onboarding',
             enrollment_confirmed_at: now,
             stripe_checkout_session_id: session.id,
             amount_paid_cents: amountPaidCents,

--- a/proxy.ts
+++ b/proxy.ts
@@ -864,31 +864,32 @@ export async function middleware(request: NextRequest) {
   if (needsEnrollment && !isGitpodPreview && enrollmentResult.data) {
     const state = enrollmentResult.data.enrollment_state;
 
-    // States that grant LMS access. 'enrolled' and 'active' are the two live
-    // states the submit-documents flow produces. Legacy rows may have 'active'
-    // only — both are treated as equivalent here.
-    const LMS_ACCESS_STATES = new Set(['active', 'enrolled']);
+    // Canonical enrollment routing — see lib/enrollment/enrollment-flow.ts
+    const LMS_ACCESS_STATES = new Set(['active']);
 
-    // States that are terminal (suspended, revoked, etc.) — do not loop into
-    // the enrollment flow, send to /unauthorized so the student sees a clear message.
     const TERMINAL_STATES = new Set([
       'suspended', 'revoked', 'withdrawn', 'completed',
       'graduated', 'placed', 'follow_up_6mo', 'follow_up_12mo',
     ]);
 
-    if (!LMS_ACCESS_STATES.has(state)) {
-      if (TERMINAL_STATES.has(state)) {
+    // Legacy rows may still carry removed state strings — normalize before routing.
+    const LEGACY_STATE_MAP: Record<string, string> = {
+      approved: 'onboarding',
+      confirmed: 'onboarding',
+      orientation_complete: 'enrolled',
+      documents_complete: 'active',
+    };
+    const normalizedState = LEGACY_STATE_MAP[state] ?? state;
+
+    if (!LMS_ACCESS_STATES.has(normalizedState)) {
+      if (TERMINAL_STATES.has(normalizedState)) {
         return NextResponse.redirect(new URL('/unauthorized', request.url), { status: 307 });
       }
-      // In-progress enrollment states — route to the appropriate enrollment step.
-      // 'onboarding' and 'orientation' map to the orientation step.
-      // 'pending_funding_verification' and 'payment_required' map to confirmed (waiting).
-      // 'applied' and 'waitlisted' also map to confirmed (earliest state).
       let redirectPath = '/enrollment/confirmed';
-      if (state === 'orientation' || state === 'onboarding') {
+      if (normalizedState === 'orientation') {
         redirectPath = '/enrollment/orientation';
-      } else if (state === 'pending_funding_verification' || state === 'payment_required') {
-        redirectPath = '/enrollment/confirmed';
+      } else if (normalizedState === 'enrolled') {
+        redirectPath = '/enrollment/documents';
       }
       return NextResponse.redirect(new URL(redirectPath, request.url), { status: 307 });
     }

--- a/tests/unit/enrollment-flow.test.ts
+++ b/tests/unit/enrollment-flow.test.ts
@@ -1,238 +1,40 @@
-/**
- * Unit tests for enrollment flow logic
- */
+import { describe, it, expect } from 'vitest';
+import {
+  normalizeEnrollmentState,
+  getEnrollmentRoute,
+  hasLmsAccess,
+  canShowConfirmedPage,
+  canCompleteOrientation,
+  canSubmitDocuments,
+} from '@/lib/enrollment/enrollment-flow';
 
-import { describe, it, expect, vi, beforeEach } from 'vitest';
-
-// Mock the enrollment data structures and validation
-interface EnrollmentData {
-  userId: string;
-  courseId: string;
-  programId?: string;
-  paymentStatus?: 'pending' | 'completed' | 'failed';
-}
-
-interface EnrollmentResult {
-  success: boolean;
-  enrollmentId?: string;
-  error?: string;
-  courseAccessUrl?: string;
-}
-
-// Validation functions extracted from enrollment logic
-function validateEnrollmentData(data: Partial<EnrollmentData>): {
-  valid: boolean;
-  errors: string[];
-} {
-  const errors: string[] = [];
-
-  if (!data.userId || typeof data.userId !== 'string') {
-    errors.push('userId is required and must be a string');
-  }
-
-  if (!data.courseId || typeof data.courseId !== 'string') {
-    errors.push('courseId is required and must be a string');
-  }
-
-  if (
-    data.userId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data.userId)
-  ) {
-    errors.push('userId must be a valid UUID');
-  }
-
-  if (
-    data.courseId &&
-    !/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(data.courseId)
-  ) {
-    errors.push('courseId must be a valid UUID');
-  }
-
-  if (data.paymentStatus && !['pending', 'completed', 'failed'].includes(data.paymentStatus)) {
-    errors.push('paymentStatus must be pending, completed, or failed');
-  }
-
-  return { valid: errors.length === 0, errors };
-}
-
-function checkPrerequisites(completedCourseIds: string[], requiredPrereqs: string[]): boolean {
-  if (!requiredPrereqs || requiredPrereqs.length === 0) return true;
-  return requiredPrereqs.every((prereq) => completedCourseIds.includes(prereq));
-}
-
-function isAlreadyEnrolled(existingEnrollments: { courseId: string }[], courseId: string): boolean {
-  return existingEnrollments.some((e) => e.courseId === courseId);
-}
-
-function generateCourseAccessUrl(courseId: string): string {
-  return `/student/courses/${courseId}`;
-}
-
-describe('Enrollment Flow', () => {
-  describe('validateEnrollmentData', () => {
-    it('should validate correct enrollment data', () => {
-      const data: EnrollmentData = {
-        userId: '123e4567-e89b-12d3-a456-426614174000',
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-        paymentStatus: 'pending',
-      };
-
-      const result = validateEnrollmentData(data);
-      expect(result.valid).toBe(true);
-      expect(result.errors).toHaveLength(0);
-    });
-
-    it('should reject missing userId', () => {
-      const data = {
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-      };
-
-      const result = validateEnrollmentData(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain('userId is required and must be a string');
-    });
-
-    it('should reject missing courseId', () => {
-      const data = {
-        userId: '123e4567-e89b-12d3-a456-426614174000',
-      };
-
-      const result = validateEnrollmentData(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain('courseId is required and must be a string');
-    });
-
-    it('should reject invalid UUID format for userId', () => {
-      const data = {
-        userId: 'not-a-uuid',
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-      };
-
-      const result = validateEnrollmentData(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain('userId must be a valid UUID');
-    });
-
-    it('should reject invalid paymentStatus', () => {
-      const data = {
-        userId: '123e4567-e89b-12d3-a456-426614174000',
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-        paymentStatus: 'invalid' as any,
-      };
-
-      const result = validateEnrollmentData(data);
-      expect(result.valid).toBe(false);
-      expect(result.errors).toContain('paymentStatus must be pending, completed, or failed');
-    });
+describe('enrollment-flow', () => {
+  it('normalizes legacy states to DB-valid values', () => {
+    expect(normalizeEnrollmentState('confirmed')).toBe('onboarding');
+    expect(normalizeEnrollmentState('orientation_complete')).toBe('enrolled');
+    expect(normalizeEnrollmentState('documents_complete')).toBe('active');
+    expect(normalizeEnrollmentState('applied')).toBe('applied');
   });
 
-  describe('checkPrerequisites', () => {
-    it('should pass when no prerequisites required', () => {
-      const completed: string[] = [];
-      const required: string[] = [];
-
-      expect(checkPrerequisites(completed, required)).toBe(true);
-    });
-
-    it('should pass when all prerequisites completed', () => {
-      const completed = ['course-1', 'course-2', 'course-3'];
-      const required = ['course-1', 'course-2'];
-
-      expect(checkPrerequisites(completed, required)).toBe(true);
-    });
-
-    it('should fail when prerequisites not met', () => {
-      const completed = ['course-1'];
-      const required = ['course-1', 'course-2'];
-
-      expect(checkPrerequisites(completed, required)).toBe(false);
-    });
-
-    it('should fail when no courses completed but prerequisites required', () => {
-      const completed: string[] = [];
-      const required = ['course-1'];
-
-      expect(checkPrerequisites(completed, required)).toBe(false);
-    });
+  it('routes students through confirm → orientation → documents → dashboard', () => {
+    expect(getEnrollmentRoute('onboarding')).toBe('/enrollment/confirmed');
+    expect(getEnrollmentRoute('orientation')).toBe('/enrollment/orientation');
+    expect(getEnrollmentRoute('enrolled')).toBe('/enrollment/documents');
+    expect(getEnrollmentRoute('active')).toBe('/learner/dashboard');
   });
 
-  describe('isAlreadyEnrolled', () => {
-    it('should return false when not enrolled', () => {
-      const enrollments = [{ courseId: 'course-1' }, { courseId: 'course-2' }];
-
-      expect(isAlreadyEnrolled(enrollments, 'course-3')).toBe(false);
-    });
-
-    it('should return true when already enrolled', () => {
-      const enrollments = [{ courseId: 'course-1' }, { courseId: 'course-2' }];
-
-      expect(isAlreadyEnrolled(enrollments, 'course-2')).toBe(true);
-    });
-
-    it('should return false when no existing enrollments', () => {
-      const enrollments: { courseId: string }[] = [];
-
-      expect(isAlreadyEnrolled(enrollments, 'course-1')).toBe(false);
-    });
+  it('only grants LMS access in active state', () => {
+    expect(hasLmsAccess('active')).toBe(true);
+    expect(hasLmsAccess('enrolled')).toBe(false);
+    expect(hasLmsAccess('orientation_complete')).toBe(false);
   });
 
-  describe('generateCourseAccessUrl', () => {
-    it('should generate correct URL format', () => {
-      const courseId = '123e4567-e89b-12d3-a456-426614174001';
-      const url = generateCourseAccessUrl(courseId);
-
-      expect(url).toBe('/student/courses/123e4567-e89b-12d3-a456-426614174001');
-    });
-
-    it('should handle different course IDs', () => {
-      expect(generateCourseAccessUrl('abc')).toBe('/student/courses/abc');
-      expect(generateCourseAccessUrl('test-course')).toBe('/student/courses/test-course');
-    });
-  });
-
-  describe('Enrollment Flow Integration', () => {
-    it('should complete full validation flow for valid data', () => {
-      const enrollmentData: EnrollmentData = {
-        userId: '123e4567-e89b-12d3-a456-426614174000',
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-        paymentStatus: 'completed',
-      };
-
-      // Step 1: Validate input
-      const validation = validateEnrollmentData(enrollmentData);
-      expect(validation.valid).toBe(true);
-
-      // Step 2: Check not already enrolled
-      const existingEnrollments: { courseId: string }[] = [];
-      expect(isAlreadyEnrolled(existingEnrollments, enrollmentData.courseId)).toBe(false);
-
-      // Step 3: Check prerequisites
-      const completedCourses: string[] = [];
-      const prerequisites: string[] = [];
-      expect(checkPrerequisites(completedCourses, prerequisites)).toBe(true);
-
-      // Step 4: Generate access URL
-      const accessUrl = generateCourseAccessUrl(enrollmentData.courseId);
-      expect(accessUrl).toContain(enrollmentData.courseId);
-    });
-
-    it('should fail flow when already enrolled', () => {
-      const enrollmentData: EnrollmentData = {
-        userId: '123e4567-e89b-12d3-a456-426614174000',
-        courseId: '123e4567-e89b-12d3-a456-426614174001',
-        paymentStatus: 'pending',
-      };
-
-      const existingEnrollments = [{ courseId: enrollmentData.courseId }];
-
-      expect(isAlreadyEnrolled(existingEnrollments, enrollmentData.courseId)).toBe(true);
-    });
-
-    it('should fail flow when prerequisites not met', () => {
-      const completedCourses = ['intro-course'];
-      const prerequisites = ['intro-course', 'intermediate-course'];
-
-      expect(checkPrerequisites(completedCourses, prerequisites)).toBe(false);
-    });
+  it('gates each enrollment step correctly', () => {
+    expect(canShowConfirmedPage('applied')).toBe(true);
+    expect(canShowConfirmedPage('orientation')).toBe(false);
+    expect(canCompleteOrientation('orientation')).toBe(true);
+    expect(canCompleteOrientation('enrolled')).toBe(false);
+    expect(canSubmitDocuments('enrolled')).toBe(true);
+    expect(canSubmitDocuments('onboarding')).toBe(false);
   });
 });

--- a/tests/unit/student-portal-access.test.ts
+++ b/tests/unit/student-portal-access.test.ts
@@ -73,11 +73,16 @@ describe('proxy.ts enrollment gate — enrollment_state values', () => {
   const src = read('proxy.ts');
 
   it('passes students with enrollment_state = active', () => {
-    expect(src).toContain("LMS_ACCESS_STATES = new Set(['active', 'enrolled'])");
+    expect(src).toContain("LMS_ACCESS_STATES = new Set(['active'])");
   });
 
-  it('passes students with enrollment_state = enrolled', () => {
-    expect(src).toContain("'enrolled'");
+  it('routes enrolled state to documents before LMS access', () => {
+    const enrollmentGateBlock = src.slice(
+      src.indexOf('LMS_ACCESS_STATES'),
+      src.indexOf('if (needsPartner)'),
+    );
+    expect(enrollmentGateBlock).toContain("normalizedState === 'enrolled'");
+    expect(enrollmentGateBlock).toContain('/enrollment/documents');
   });
 
   it('does not reference the removed documents_complete state as an access state', () => {
@@ -91,10 +96,10 @@ describe('proxy.ts enrollment gate — enrollment_state values', () => {
   });
 
   it('sends terminal states to /unauthorized, not enrollment flow', () => {
-    expect(src).toContain("TERMINAL_STATES.has(state)");
+    expect(src).toContain('TERMINAL_STATES.has(normalizedState)');
     const terminalBlock = src.slice(
-      src.indexOf('TERMINAL_STATES.has(state)'),
-      src.indexOf('In-progress enrollment states'),
+      src.indexOf('TERMINAL_STATES.has(normalizedState)'),
+      src.indexOf('let redirectPath'),
     );
     expect(terminalBlock).toContain('/unauthorized');
   });
@@ -118,13 +123,13 @@ describe('proxy.ts enrollment gate — enrollment_state values', () => {
     expect(enrollmentGateBlock).not.toMatch(/state === ['"]orientation_complete['"]/);
   });
 
-  it('routes onboarding/orientation states to /enrollment/orientation', () => {
-    expect(src).toContain("state === 'orientation' || state === 'onboarding'");
-    const routingBlock = src.slice(
-      src.indexOf("state === 'orientation' || state === 'onboarding'"),
-      src.indexOf('return NextResponse.redirect(new URL(redirectPath'),
+  it('routes orientation state to /enrollment/orientation', () => {
+    const enrollmentGateBlock = src.slice(
+      src.indexOf('LMS_ACCESS_STATES'),
+      src.indexOf('if (needsPartner)'),
     );
-    expect(routingBlock).toContain('/enrollment/orientation');
+    expect(enrollmentGateBlock).toContain("normalizedState === 'orientation'");
+    expect(enrollmentGateBlock).toContain('/enrollment/orientation');
   });
 });
 
@@ -151,8 +156,9 @@ describe('submit-documents route — auto-grants LMS access', () => {
     expect(src).not.toContain("'confirmed'");
   });
 
-  it('looks for orientation_complete as the pre-documents state', () => {
-    expect(src).toContain("'orientation_complete'");
+  it('uses canonical PRE_DOCUMENTS_STATES from enrollment-flow', () => {
+    expect(src).toContain('PRE_DOCUMENTS_STATES');
+    expect(src).not.toContain("'orientation_complete'");
   });
 });
 
@@ -183,13 +189,9 @@ describe('documents/complete route — auto-grants LMS access', () => {
 // ---------------------------------------------------------------------------
 
 describe('enrollment state contract', () => {
-  it('DB-valid states used in proxy.ts access check match known valid states', () => {
-    // These are the states from migration 20260501000010 that mean "enrolled and active"
-    const DB_ACTIVE_STATES = ['active', 'enrolled'];
+  it('DB-valid LMS access state is active only', () => {
     const proxySrc = read('proxy.ts');
-    for (const state of DB_ACTIVE_STATES) {
-      expect(proxySrc).toContain(`'${state}'`);
-    }
+    expect(proxySrc).toContain("LMS_ACCESS_STATES = new Set(['active'])");
   });
 
   it('DB-valid terminal states are all handled in proxy.ts', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes the student program application/enrollment pipeline so all writes and redirects use **DB-valid** `enrollment_state` values (migration `20260501000010`). Students were getting stuck or bounced to `/programs` because code still used removed states (`confirmed`, `orientation_complete`, `documents_complete`, `approved`).

## Enrollment flow (canonical)

```
applied / waitlisted / funding gates → /enrollment/confirmed
  → confirm → orientation
  → complete orientation → enrolled
  → submit documents → active (+ access_granted_at)
```

- New module: `lib/enrollment/enrollment-flow.ts` — state normalization, routing, and step gates
- Fixed pages: `app/enrollment/{confirmed,orientation,documents}`
- Fixed APIs: orientation/complete, complete-orientation, documents/complete, submit-documents, onboarding/complete-step
- Fixed writers: `enrollment-service` default state, Stripe checkout handler
- Fixed `proxy.ts` LMS gate: only `active` grants `/lms` access; `enrolled` → documents; legacy states normalized on read
- Learner dashboard onboarding banner uses canonical copy/routes

## Also in this branch

- Slimmer homepage, categorized mobile nav, program BNPL/calculator, redirect fixes in `next.config.mjs`

## Tests

- `tests/unit/enrollment-flow.test.ts` (new)
- `tests/unit/student-portal-access.test.ts` (updated)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix student enrollment flow by normalizing enrollment states and routing across pages and middleware
> - Introduces [enrollment-flow.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/351/files#diff-108f304581b59c701824a984b53673671a68e9ce66c008897d711c9228ff5f62) with canonical state definitions, normalization of legacy states (e.g. `approved`→`onboarding`, `orientation_complete`→`enrolled`), and helpers like `canCompleteOrientation`, `canSubmitDocuments`, `hasLmsAccess`, and `getEnrollmentRoute`.
> - Enrollment pages (`confirmed`, `orientation`, `documents`) now validate state via these helpers and redirect to the correct step rather than relying on ad-hoc checks.
> - API routes (`complete-orientation`, `documents/complete`, `orientation/complete`) now gate actions on normalized state and transition enrollments to `enrolled`/`active` instead of legacy states like `orientation_complete`.
> - Middleware in [proxy.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/351/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775) normalizes legacy states, restricts LMS access to only `active`, and routes `orientation` and `enrolled` states to their respective enrollment pages.
> - Default enrollment state in [enrollment-service.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/351/files#diff-06501dc23e4781c85ccee6a9c5222ff9546c03925fc524d0393114584463cda9) and post-checkout handling now use `onboarding` instead of `confirmed`.
> - Behavioral Change: Any enrollment in a legacy state (`approved`, `confirmed`, `orientation_complete`, `documents_complete`) will be silently normalized at runtime; existing rows with those states must be compatible with the normalization map.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 89c66ea.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->