### PR TITLE
fix(ops): PR #336 review — migration verify PG fallback + getDashboardUrl

### DIFF
--- a/config/dashboard-routes.ts
+++ b/config/dashboard-routes.ts
@@ -8,11 +8,11 @@ import type { UserRole } from '@/types/user';
 /** @deprecated Use ROLE_DESTINATIONS from role-destinations.ts */
 export const DASHBOARD_ROUTES = ROLE_DESTINATIONS as Record<UserRole, string>;
 
+/** @deprecated Use getRoleDestination() from '@/lib/auth/role-destinations' */
 export function getDashboardUrl(role?: UserRole): string {
   if (!role) return '/unauthorized?reason=unknown_role';
-  const destination = getRoleDestination(role);
-  if (destination === '/learner/dashboard' && !(role in ROLE_DESTINATIONS)) {
+  if (!(role in ROLE_DESTINATIONS)) {
     return '/unauthorized?reason=unknown_role';
   }
-  return destination;
+  return getRoleDestination(role);
 }

--- a/scripts/verify-pending-migrations.mjs
+++ b/scripts/verify-pending-migrations.mjs
@@ -108,7 +108,8 @@ async function runViaPg(sql) {
 
 async function query(sql) {
   const mgmt = await runViaMgmtApi(sql).catch((e) => {
-    throw new Error(`Management API: ${e.message}`);
+    console.warn(`Management API failed, trying PG: ${e.message}`);
+    return null;
   });
   if (mgmt !== null) return mgmt;
 

--- a/tests/unit/dashboard-routes.test.ts
+++ b/tests/unit/dashboard-routes.test.ts
@@ -6,6 +6,7 @@ describe('getDashboardUrl', () => {
   it('matches canonical role destinations for known roles', () => {
     expect(getDashboardUrl('partner')).toBe(getRoleDestination('partner'));
     expect(getDashboardUrl('program_holder')).toBe(getRoleDestination('program_holder'));
+    // delegate intentionally maps to learner dashboard until a dedicated portal ships
     expect(getDashboardUrl('delegate')).toBe('/learner/dashboard');
   });
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Context

Supersedes and unblocks **#336**. The scoped files (`dashboard-routes.ts`, `verify-pending-migrations.mjs`, `dashboard-routes.test.ts`, `AGENTS.md`) are **already on `main`** via #334/#337 — this PR only lands the **Devin code review fixes**.

Closes review items on #336:
- [x] Management API errors no longer block Postgres fallback
- [x] `getDashboardUrl` checks `role in ROLE_DESTINATIONS` directly (not coupled to fallback string)
- [x] `@deprecated` on `getDashboardUrl`
- [x] Delegate test comment (temporary until delegate portal ships)

## Changes

### `scripts/verify-pending-migrations.mjs`
Management API transient failures (timeout, 500) now warn and fall through to `SUPABASE_DB_URL` / pooler PG path instead of exiting.

### `config/dashboard-routes.ts`
```ts
if (!(role in ROLE_DESTINATIONS)) return '/unauthorized?reason=unknown_role';
return getRoleDestination(role);
```

## Action on #336

**Close #336** after merging this PR — content is duplicated on `main`; auto-merge was blocked on review + a11y gate.

## Tests

`pnpm test tests/unit/dashboard-routes.test.ts` — pass
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix `getDashboardUrl` unknown-role handling and add PG fallback in migration verify script
> - [`getDashboardUrl`](https://github.com/elevate-for-humanity/Elevate-lms/pull/355/files#diff-5d182d772165d58bbb378d37388ac38f5e31a4abfa23b7e20bfb7fe044f9085e) now rejects any role absent from `ROLE_DESTINATIONS` with `/unauthorized?reason=unknown_role` unconditionally, removing the prior guard that only rejected when the destination happened to equal `/learner/dashboard`.
> - [`query`](https://github.com/elevate-for-humanity/Elevate-lms/pull/355/files#diff-fdcf0d622d070801f19f1feb5b72d1255bf015535c76f8825db91ef0aff88c3f) in the migration verify script no longer throws immediately on Management API failure; it logs a warning and falls back to direct PG execution instead.
> - Behavioral Change: roles that previously passed the old `getDashboardUrl` guard (destination ≠ `/learner/dashboard`) now receive an unauthorized redirect.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 6eaf61f.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->