### PR TITLE
Block outreach emails until portal testing; verify dashboards

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -843,8 +843,9 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
 
 ### Ops outreach emails (MOU / host shop / program holder)
 
-- **Never send dashboard login emails** from ops scripts — MOU PDF + sign link + document checklist only. `provision-host-dashboards.mjs` is blocked unless `ALLOW_DASHBOARD_OUTREACH=1`.
-- **Never use localhost in outbound links.** `.env.local` often sets `NEXT_PUBLIC_SITE_URL=http://localhost:3000` for dev. All `scripts/ops/*` email senders must use `outboundSiteUrl()` from `scripts/ops/outbound-site-url.ts` (forces `https://www.elevateforhumanity.org` when env is local).
+- **Link flow (required):** Supabase `generateLink` → `redirectTo` = `{outboundSiteUrl()}/auth/callback?redirect={path}` → user lands on role dashboard or onboarding step. Use `buildJourneyLinks()` from `scripts/ops/outreach-auth-link.ts` for chronological steps (sign MOU → documents → dashboard).
+- **Never use localhost in outbound links.** Use `outboundSiteUrl()` (forces `https://www.elevateforhumanity.org` when `.env.local` is local).
+- **Resend broken links:** `pnpm tsx --env-file=.env.local scripts/ops/resend-outreach-portal-links.ts`
 - Admin email copies: `pnpm tsx --env-file=.env.local scripts/ops/send-email-copies-to-admin.ts`
 
 ### Gotchas

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -841,6 +841,12 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
 - **Audit:** `pnpm audit:migrations` → `audit_out/migration-discipline.json`. Report: `docs/audits/supabase-platform-discipline-audit-2026-06-05.md`.
 - **Pending bundle:** `supabase/migrations/20260703000002_pending_migrations_bundle.sql` (July 20260702 idempotent singles).
 
+### Ops outreach emails (MOU / host shop / program holder)
+
+- **Never send dashboard login emails** from ops scripts — MOU PDF + sign link + document checklist only. `provision-host-dashboards.mjs` is blocked unless `ALLOW_DASHBOARD_OUTREACH=1`.
+- **Never use localhost in outbound links.** `.env.local` often sets `NEXT_PUBLIC_SITE_URL=http://localhost:3000` for dev. All `scripts/ops/*` email senders must use `outboundSiteUrl()` from `scripts/ops/outbound-site-url.ts` (forces `https://www.elevateforhumanity.org` when env is local).
+- Admin email copies: `pnpm tsx --env-file=.env.local scripts/ops/send-email-copies-to-admin.ts`
+
 ### Gotchas
 
 - **Middleware auth prefixes:** `AUTH_REQUIRED_ROUTES` uses segment-aware matching (`pathMatchesAuthPrefix` in `proxy.ts`). Never use bare `/apprentice` with `pathname.startsWith` — it incorrectly gates public `/apprenticeships`. Public marketing prefixes are listed in `PUBLIC_MARKETING_PREFIXES` (`/apprenticeships`, `/programs/`, `/partners/`, etc.).

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -850,6 +850,7 @@ The hook attempts unmuted play and falls back silently. No mute button shown.
 
 ### Gotchas
 
+- **Outreach email lock:** All `scripts/ops/*` SendGrid scripts call `outreach-email-guard.ts` and **exit without sending** unless `OUTREACH_EMAIL_UNLOCK=1` and `--force-send`. Use `--dry-run` or `--write-only` for previews only. Verify portals with `pnpm tsx --env-file=.env.local scripts/ops/verify-portal-dashboards.ts` (no email).
 - **Middleware auth prefixes:** `AUTH_REQUIRED_ROUTES` uses segment-aware matching (`pathMatchesAuthPrefix` in `proxy.ts`). Never use bare `/apprentice` with `pathname.startsWith` — it incorrectly gates public `/apprenticeships`. Public marketing prefixes are listed in `PUBLIC_MARKETING_PREFIXES` (`/apprenticeships`, `/programs/`, `/partners/`, etc.).
 - **Before recommending manual SQL migrations**, run `node scripts/verify-pending-migrations.mjs`. If all five checks pass, migrations are already live — do not ask the user to re-run them.
 - The `predev` script runs `scripts/setup-env-auto.sh` which will fail if `.env.local` doesn't exist. Create it first or set `SKIP_ENV_VALIDATION=true`.

--- a/app/api/program-holder/new-student-notify/route.ts
+++ b/app/api/program-holder/new-student-notify/route.ts
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
 <div style="max-width:560px;margin:0 auto;padding:40px 20px;">
   <div style="background:#1e3a5f;border-radius:12px 12px 0 0;padding:28px 30px;text-align:center;">
     <h1 style="color:white;margin:0;font-size:20px;font-weight:700;">New Student Enrolled</h1>
-    <p style="color:#93c5fd;margin:6px 0 0 0;font-size:14px;">Indy On Demand Services LLC — ${programName ?? 'HVAC Program'}</p>
+    <p style="color:#93c5fd;margin:6px 0 0 0;font-size:14px;">INDY ON DEMAND SERVICES — ${programName ?? 'HVAC Program'}</p>
   </div>
   <div style="background:white;border:1px solid #e5e7eb;border-top:none;border-radius:0 0 12px 12px;padding:32px 30px;">
     <p style="margin-top:0;">Hi David,</p>

--- a/app/partner/dashboard/page.tsx
+++ b/app/partner/dashboard/page.tsx
@@ -99,7 +99,9 @@ export default async function PartnerDashboardPage() {
 
   // Approved barber/training-site partners: route by onboarding step.
   const isTrainingSite =
-    partner.partner_type === 'training_site' || partner.partner_type === 'barber';
+    partner.partner_type === 'training_site' ||
+    partner.partner_type === 'barber' ||
+    partner.partner_type === 'barbershop';
   if (isTrainingSite || !partner.onboarding_completed) {
     const { data: bpa } = await db
       .from('barbershop_partner_applications')

--- a/app/partners/barber-host-shop/(onboarding)/documents/page.tsx
+++ b/app/partners/barber-host-shop/(onboarding)/documents/page.tsx
@@ -2,7 +2,7 @@
 
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import Link from 'next/link';
-import { useState, useRef } from 'react';
+import { useState, useRef, useEffect } from 'react';
 import {
   Upload, AlertCircle, FileText,
   Loader2, ArrowLeft, ExternalLink, X,
@@ -86,6 +86,40 @@ export default function PartnerDocumentsPage() {
     Object.fromEntries(DOC_SLOTS.map(d => [d.id, { status: 'idle' }]))
   );
   const fileInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch('/api/partner/documents');
+        if (!res.ok) return;
+        const data = await res.json();
+        const uploaded = (data.documents ?? []).filter(
+          (d: { uploaded?: boolean; document?: { document_type?: string; file_name?: string } }) =>
+            d.uploaded && d.document?.document_type,
+        );
+        if (cancelled || !uploaded.length) return;
+        setSlots((prev) => {
+          const next = { ...prev };
+          for (const row of uploaded) {
+            const type = row.document.document_type as string;
+            if (DOC_SLOTS.some((s) => s.id === type)) {
+              next[type] = {
+                status: 'done',
+                fileName: row.document.file_name ?? 'Uploaded',
+              };
+            }
+          }
+          return next;
+        });
+      } catch {
+        // non-fatal — page still allows fresh uploads
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
 
   function setSlot(id: string, update: Partial<SlotState>) {
     setSlots(prev => ({ ...prev, [id]: { ...prev[id], ...update } }));

--- a/app/program-holder/dashboard/page.tsx
+++ b/app/program-holder/dashboard/page.tsx
@@ -37,6 +37,12 @@ function StatusPill({ status }: { status: string }) {
 
 export default async function ProgramHolderDashboardPage() {
   const { db, user, holderId, programIds } = await requireProgramHolder();
+  const { data: holderRow } = await db
+    .from('program_holders')
+    .select('mou_signed')
+    .eq('id', holderId)
+    .maybeSingle();
+  const holderMouSigned = !!holderRow?.mou_signed;
   // ── onboarding checks ──────────────────────────────────────────────────────
   const [acksRes, docsRes, mouSigRes, payrollRes, w9Res, profileRes] = await Promise.all([
     db.from('program_holder_acknowledgements').select('document_type').eq('user_id', user.id),
@@ -48,7 +54,7 @@ export default async function ProgramHolderDashboardPage() {
   ]);
   const acks = acksRes.data ?? [];
   const pendingSteps = [
-    !mouSigRes.data && { label: 'Sign MOU digitally', href: '/program-holder/mou' },
+    !mouSigRes.data && !holderMouSigned && { label: 'Sign MOU digitally', href: '/program-holder/mou' },
     !profileRes.data?.address && { label: 'Complete profile', href: '/program-holder/profile' },
     !w9Res.data && { label: 'Submit W-9', href: '/onboarding/payroll-setup' },
     !payrollRes.data?.bank_name && { label: 'Set up direct deposit', href: '/onboarding/payroll-setup' },

--- a/exports/email-copies/README.md
+++ b/exports/email-copies/README.md
@@ -1,0 +1,14 @@
+# Ops email copies — 2026-06-08T21:14:57.836Z
+Site URL used in links: https://www.elevateforhumanity.org
+
+## enchanted-program-holder-mou
+- Intended recipient: info@enchantedheartstraining.com
+- Subject: Program Holder MOU — Enchanted Hearts Training Institute LLC (signature required)
+- Current canonical template — MOU PDF attachment + sign link only. NO dashboard email.
+- File: /workspace/exports/email-copies/enchanted-program-holder-mou.html
+
+## barber-host-mou-calvin-example
+- Intended recipient: calvincutz1985@gmail.com
+- Subject: Barber Host Shop MOU & required documents — Cal's Kutz Studio
+- Barber host template — MOU PDF + sign link + document checklist. NO dashboard link.
+- File: /workspace/exports/email-copies/barber-host-mou-calvin-example.html

--- a/exports/email-copies/barber-host-mou-calvin-example.html
+++ b/exports/email-copies/barber-host-mou-calvin-example.html
@@ -1,0 +1,31 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">Elevate for Humanity</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Barber Host Shop Employer Agreement (MOU)</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Hi Calvin,</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Your barber apprenticeship <strong>host shop application</strong> for <strong>Cal's Kutz Studio</strong> is approved.
+<strong>Attached</strong> is your Barber Host Shop Employer Agreement (MOU).
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached MOU PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>calvincutz1985@gmail.com</strong>).</li>
+<li>Reply with required documents listed below.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="https://www.elevateforhumanity.org/login?redirect=%2Fpartners%2Fbarber-host-shop%2Fsign-mou" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
+</td></tr></table>
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569"><strong>Required documents</strong> — reply with PDF attachments:</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569"><li style="margin-bottom:8px">IRS EIN Assignment Letter (CP 575 or 147C)</li><li style="margin-bottom:8px">W-9 Form (signed)</li><li style="margin-bottom:8px">Indiana Barbershop License (current, full copy)</li><li style="margin-bottom:8px">Workers' Compensation Certificate of Insurance</li><li style="margin-bottom:8px">General Liability Insurance Certificate</li><li style="margin-bottom:8px">Supervising Barber License (2+ years experience)</li></ol>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>(317) 314-3757</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, Elevate for Humanity</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>

--- a/exports/email-copies/enchanted-program-holder-mou.html
+++ b/exports/email-copies/enchanted-program-holder-mou.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">Elevate for Humanity</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Third-Party Program Holder MOU</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Dear Shawndra,</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Thank you for partnering with <strong>Elevate for Humanity</strong> as a <strong>third-party program delivery partner</strong>
+for <strong>Enchanted Hearts Training Institute LLC</strong>.
+</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+<strong>Attached:</strong> your <strong>Program Holder Memorandum of Understanding (MOU)</strong> (PDF).
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>info@enchantedheartstraining.com</strong> if prompted).</li>
+<li>Reply to this email with questions or a signed copy if you prefer.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="https://www.elevateforhumanity.org/login?redirect=%2Fprogram-holder%2Fsign-mou" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
+</td></tr></table>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>(317) 314-3757</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, Elevate for Humanity</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>

--- a/lib/documents/generate-detailed-mou-pdf.ts
+++ b/lib/documents/generate-detailed-mou-pdf.ts
@@ -24,6 +24,8 @@ export type DetailedMOUPDFData = {
   signer_title: string;
   contact_email?: string;
   contact_phone?: string;
+  partner_address?: string;
+  partner_ein?: string;
   programs: ProgramTerm[];
   revenue_share_model?: string; // narrative description
   fssa_snap_et?: boolean;       // include SNAP E&T compliance language
@@ -58,6 +60,10 @@ function wrapText(text: string, maxWidth: number, font: PDFFont, fontSize: numbe
   return lines;
 }
 
+function wrappedLineCount(text: string, maxWidth: number, font: PDFFont, fontSize: number): number {
+  return wrapText(text, maxWidth, font, fontSize).length;
+}
+
 function drawWrappedText(
   page: PDFPage,
   text: string,
@@ -75,6 +81,23 @@ function drawWrappedText(
     y -= lineHeight;
   }
   return y;
+}
+
+function drawLabelValue(
+  page: PDFPage,
+  label: string,
+  value: string,
+  x: number,
+  y: number,
+  maxWidth: number,
+  labelFont: PDFFont,
+  valueFont: PDFFont,
+  fontSize: number,
+  lineHeight: number,
+): number {
+  page.drawText(label, { x, y, size: fontSize, font: labelFont, color: rgb(0.25, 0.25, 0.25) });
+  y -= lineHeight - 1;
+  return drawWrappedText(page, value, x + 8, y, maxWidth - 8, valueFont, fontSize, lineHeight, rgb(0.1, 0.1, 0.1));
 }
 
 import { formatCurrency } from '@/lib/format';
@@ -221,8 +244,21 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
     9,
     lineH,
   );
-  if (data.contact_email) {
-    page.drawText(`Contact: ${data.signer_name}  ·  ${data.contact_email}${data.contact_phone ? `  ·  ${data.contact_phone}` : ''}`, {
+  if (data.partner_address) {
+    y = drawWrappedText(
+      page,
+      `Partner address: ${data.partner_address}`,
+      margin,
+      y,
+      contentWidth,
+      regularFont,
+      9,
+      lineH,
+      rgb(0.3, 0.3, 0.3),
+    );
+  }
+  if (data.partner_ein) {
+    page.drawText(`Partner EIN: ${data.partner_ein}`, {
       x: margin,
       y,
       size: 9,
@@ -231,12 +267,15 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
     });
     y -= lineH;
   }
+  if (data.contact_email) {
+    const contactLine = `Authorized contact: ${data.signer_name} · ${data.contact_email}${data.contact_phone ? ` · ${data.contact_phone}` : ''}`;
+    y = drawWrappedText(page, contactLine, margin, y, contentWidth, regularFont, 9, lineH, rgb(0.3, 0.3, 0.3));
+  }
   y -= 6;
   drawLine(y);
   y -= 16;
 
-  // ── Programs Covered ─────────────────────────────────────────────────────────
-  checkY(60 + data.programs.length * 30);
+  // ── Programs Covered (stacked schedule — no column overlap) ───────────────
   page.drawText('PROGRAMS COVERED UNDER THIS MOU', {
     x: margin,
     y,
@@ -244,34 +283,109 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
     font: boldFont,
     color: rgb(0.08, 0.22, 0.48),
   });
-  y -= lineH + 4;
+  y -= lineH + 2;
+  y = drawWrappedText(
+    page,
+    'The following training programs are delivered by the Partner under this agreement. Each program is listed separately to avoid ambiguity in credentialing, hours, and tuition.',
+    margin,
+    y,
+    contentWidth,
+    regularFont,
+    8.5,
+    12,
+    rgb(0.4, 0.4, 0.4),
+  );
+  y -= 8;
 
-  // Table header
-  const col1 = margin;
-  const col2 = margin + 160;
-  const col3 = margin + 280;
-  const col4 = margin + 360;
-  const col5 = margin + 430;
+  const programBlockPadding = 8;
+  const programInnerWidth = contentWidth - programBlockPadding * 2;
 
-  page.drawText('Program', { x: col1, y, size: 8, font: boldFont, color: rgb(0.2, 0.2, 0.2) });
-  page.drawText('Credential', { x: col2, y, size: 8, font: boldFont, color: rgb(0.2, 0.2, 0.2) });
-  page.drawText('Duration', { x: col3, y, size: 8, font: boldFont, color: rgb(0.2, 0.2, 0.2) });
-  page.drawText('Hrs/Wk', { x: col4, y, size: 8, font: boldFont, color: rgb(0.2, 0.2, 0.2) });
-  page.drawText('Tuition', { x: col5, y, size: 8, font: boldFont, color: rgb(0.2, 0.2, 0.2) });
-  y -= 4;
-  drawLine(y);
-  y -= lineH;
+  for (let i = 0; i < data.programs.length; i++) {
+    const prog = data.programs[i];
+    const nameLines = wrappedLineCount(prog.program_name, programInnerWidth - 14, boldFont, 9);
+    const credLines = wrappedLineCount(prog.credential, programInnerWidth - 8, regularFont, 8.5);
+    const durLines = wrappedLineCount(prog.duration, programInnerWidth - 8, regularFont, 8.5);
+    const blockHeight =
+      programBlockPadding * 2 +
+      12 +
+      nameLines * 12 +
+      11 +
+      credLines * 11 +
+      11 +
+      durLines * 11 +
+      18;
 
-  for (const prog of data.programs) {
-    checkY(20);
-    page.drawText(prog.program_name, { x: col1, y, size: 8, font: regularFont, color: rgb(0.1, 0.1, 0.1) });
-    page.drawText(prog.credential, { x: col2, y, size: 8, font: regularFont, color: rgb(0.1, 0.1, 0.1) });
-    page.drawText(prog.duration, { x: col3, y, size: 8, font: regularFont, color: rgb(0.1, 0.1, 0.1) });
-    page.drawText(String(prog.weekly_hours), { x: col4, y, size: 8, font: regularFont, color: rgb(0.1, 0.1, 0.1) });
-    page.drawText(formatCurrency(prog.tuition), { x: col5, y, size: 8, font: regularFont, color: rgb(0.1, 0.1, 0.1) });
-    y -= lineH;
+    checkY(blockHeight + 12);
+
+    const blockTop = y;
+    const blockBottom = y - blockHeight;
+    page.drawRectangle({
+      x: margin,
+      y: blockBottom,
+      width: contentWidth,
+      height: blockHeight,
+      color: rgb(0.97, 0.98, 0.99),
+      borderColor: rgb(0.85, 0.88, 0.92),
+      borderWidth: 0.75,
+    });
+
+    let innerY = blockTop - 12;
+    page.drawText(`${i + 1}.`, {
+      x: margin + programBlockPadding,
+      y: innerY,
+      size: 9,
+      font: boldFont,
+      color: rgb(0.08, 0.22, 0.48),
+    });
+    innerY = drawWrappedText(
+      page,
+      prog.program_name,
+      margin + programBlockPadding + 14,
+      innerY,
+      programInnerWidth - 14,
+      boldFont,
+      9,
+      12,
+      rgb(0.1, 0.1, 0.1),
+    );
+    innerY -= 2;
+    innerY = drawLabelValue(
+      page,
+      'Credential',
+      prog.credential,
+      margin + programBlockPadding,
+      innerY,
+      programInnerWidth,
+      boldFont,
+      regularFont,
+      8.5,
+      11,
+    );
+    innerY = drawLabelValue(
+      page,
+      'Duration',
+      prog.duration,
+      margin + programBlockPadding,
+      innerY,
+      programInnerWidth,
+      boldFont,
+      regularFont,
+      8.5,
+      11,
+    );
+    const hrsTuition = `Weekly hours: ${prog.weekly_hours > 0 ? prog.weekly_hours : 'Per program schedule'}   ·   Tuition: ${formatCurrency(prog.tuition)}`;
+    page.drawText(hrsTuition, {
+      x: margin + programBlockPadding,
+      y: innerY - 11,
+      size: 8.5,
+      font: regularFont,
+      color: rgb(0.35, 0.35, 0.35),
+    });
+
+    y = blockBottom - 10;
   }
-  y -= 6;
+
+  y -= 4;
   drawLine(y);
   y -= 16;
 
@@ -301,20 +415,32 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
       });
       y -= lineH;
       for (const prog of programsWithShare) {
-        checkY(16);
-        const share = ((prog.partner_share_pct! / 100) * prog.tuition);
-        page.drawText(
+        checkY(28);
+        const share = (prog.partner_share_pct! / 100) * prog.tuition;
+        y = drawWrappedText(
+          page,
           `• ${prog.program_name}: ${prog.partner_share_pct}% of net tuition per enrolled participant (≈ ${formatCurrency(share)}/student at full tuition)`,
-          { x: margin + 10, y, size: 8, font: regularFont, color: rgb(0.2, 0.2, 0.2) },
+          margin + 10,
+          y,
+          contentWidth - 10,
+          regularFont,
+          8,
+          11,
+          rgb(0.2, 0.2, 0.2),
         );
-        y -= lineH;
       }
       y -= 4;
-      page.drawText(
+      y = drawWrappedText(
+        page,
         'IMPORTANT: Amounts above are examples only. Actual compensation is based on participants enrolled and tuition collected.',
-        { x: margin, y, size: 7.5, font: italicFont, color: rgb(0.6, 0.2, 0.2) },
+        margin,
+        y,
+        contentWidth,
+        italicFont,
+        7.5,
+        10,
+        rgb(0.6, 0.2, 0.2),
       );
-      y -= lineH;
     }
     y -= 6;
     drawLine(y);
@@ -402,8 +528,11 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
   y -= 16;
 
   // ── Signature Page ───────────────────────────────────────────────────────────
-  checkY(200);
-  y -= 10;
+  checkY(220);
+  if (y < margin + 220) {
+    newPage();
+    y -= 10;
+  }
   drawLine(y);
   y -= 20;
   page.drawText('SIGNATURES', {
@@ -478,32 +607,73 @@ export async function generateDetailedMOUPdf(data: DetailedMOUPDFData): Promise<
   page.drawText(`Title: ${SPONSOR_TITLE}`, { x: margin, y, size: 9, font: regularFont, color: rgb(0.2, 0.2, 0.2) });
   page.drawText(`Title: ${data.signer_title}`, { x: col2X, y, size: 9, font: regularFont, color: rgb(0.2, 0.2, 0.2) });
   y -= lineH;
-  page.drawText(`Organization: ${SPONSOR}`, { x: margin, y, size: 7, font: regularFont, color: rgb(0.4, 0.4, 0.4) });
-  page.drawText(`Organization: ${data.partner_name}`, { x: col2X, y, size: 9, font: regularFont, color: rgb(0.2, 0.2, 0.2) });
+  const orgY = y;
+  page.drawText('Organization:', { x: margin, y: orgY, size: 8, font: boldFont, color: rgb(0.35, 0.35, 0.35) });
+  page.drawText('Organization:', { x: col2X, y: orgY, size: 8, font: boldFont, color: rgb(0.35, 0.35, 0.35) });
   y -= lineH;
+  const sponsorOrgY = drawWrappedText(
+    page,
+    SPONSOR,
+    margin,
+    y,
+    colW,
+    regularFont,
+    7.5,
+    10,
+    rgb(0.4, 0.4, 0.4),
+  );
+  const partnerOrgY = drawWrappedText(
+    page,
+    data.partner_name,
+    col2X,
+    y,
+    colW,
+    regularFont,
+    8.5,
+    10,
+    rgb(0.2, 0.2, 0.2),
+  );
+  y = Math.min(sponsorOrgY, partnerOrgY) - 4;
   page.drawText(`Date: ${signedDate}`, { x: margin, y, size: 9, font: regularFont, color: rgb(0.2, 0.2, 0.2) });
   page.drawText(`Date: ${signedDate}`, { x: col2X, y, size: 9, font: regularFont, color: rgb(0.2, 0.2, 0.2) });
 
   // ── Footer ───────────────────────────────────────────────────────────────────
-  y -= 30;
+  checkY(50);
+  y -= 24;
   drawLine(y);
   y -= 12;
-  page.drawText(
-    `Document ID: MOU-DTL-${Date.now()}  ·  Signed: ${signedDate}  ·  IP: ${data.ip_address ?? 'on file'}`,
-    { x: margin, y, size: 7, font: regularFont, color: rgb(0.6, 0.6, 0.6) },
-  );
-  y -= 10;
-  page.drawText(`${SPONSOR}  ·  ${ADDRESS}  ·  ${PHONE}  ·  ${EMAIL}`, {
-    x: margin,
+  y = drawWrappedText(
+    page,
+    `Document ID: MOU-DTL-${Date.now()} · Effective: ${signedDate} · IP: ${data.ip_address ?? 'on file'}`,
+    margin,
     y,
-    size: 7,
-    font: regularFont,
-    color: rgb(0.6, 0.6, 0.6),
-  });
-  y -= 10;
-  page.drawText(
+    contentWidth,
+    regularFont,
+    7,
+    9,
+    rgb(0.6, 0.6, 0.6),
+  );
+  y = drawWrappedText(
+    page,
+    `${SPONSOR} · ${ADDRESS} · ${PHONE} · ${EMAIL}`,
+    margin,
+    y,
+    contentWidth,
+    regularFont,
+    7,
+    9,
+    rgb(0.6, 0.6, 0.6),
+  );
+  drawWrappedText(
+    page,
     'Executed electronically under the Indiana Uniform Electronic Transactions Act (IC 26-2-8) and the federal ESIGN Act.',
-    { x: margin, y, size: 7, font: italicFont, color: rgb(0.6, 0.6, 0.6) },
+    margin,
+    y,
+    contentWidth,
+    italicFont,
+    7,
+    9,
+    rgb(0.6, 0.6, 0.6),
   );
 
   return doc.save();

--- a/scripts/ops/enroll-hvac-wioa-student.mjs
+++ b/scripts/ops/enroll-hvac-wioa-student.mjs
@@ -1,0 +1,289 @@
+#!/usr/bin/env node
+/**
+ * Staff ops: enroll WIOA HVAC students and send welcome email.
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/enroll-hvac-wioa-student.mjs
+ *   pnpm tsx --env-file=.env.local scripts/ops/enroll-hvac-wioa-student.mjs --resend-only
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const STUDENTS = [
+  {
+    email: 'ehouse2768@gmail.com',
+    fullName: 'Ethan House',
+    firstName: 'Ethan',
+    phone: '317-854-2867',
+    userId: '90649f25-a6fe-4b94-99a8-7e6a57090448',
+    revisedEmail: true,
+  },
+  {
+    email: 'pedroverajr1125@gmail.com',
+    fullName: 'Pedro Carpintero',
+    firstName: 'Pedro',
+    phone: null,
+    userId: '4b6b02f7-6ceb-45bf-960d-6ae5e8545f77',
+  },
+  {
+    email: 'fletcheraustin98@gmail.com',
+    fullName: 'Austin Fletcher',
+    firstName: 'Austin',
+    phone: null,
+    userId: '9feda5bd-c30b-458d-a22e-4890a1240336',
+  },
+];
+
+const HVAC_PROGRAM_ID = '4226f7f6-fbc1-44b5-83e8-b12ea149e4c7';
+const HVAC_COURSE_ID = 'f0593164-55be-5867-98e7-8a86770a8dd0';
+const PROGRAM_SLUG = 'hvac-technician';
+const PROGRAM_NAME = 'HVAC Technician (EPA 608 Certification)';
+const START_DATE = '2026-06-15';
+const START_DATE_DISPLAY = 'Monday, June 15, 2026';
+
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
+  /\/$/,
+  '',
+);
+const ELEVATE_COPY_EMAIL = 'elevate4humanityedu@gmail.com';
+const RESEND_ONLY = process.argv.includes('--resend-only');
+
+const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!url || !serviceKey || serviceKey === 'placeholder') {
+  console.error('Missing NEXT_PUBLIC_SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY');
+  process.exit(1);
+}
+
+const db = createClient(url, serviceKey, {
+  auth: { autoRefreshToken: false, persistSession: false },
+});
+
+async function loadSendGridKey() {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db.from('platform_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  if (data?.value) return data.value;
+  const { data: app } = await db.from('app_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  return app?.value ?? null;
+}
+
+function buildWelcomeHtml(student, { passwordSetUrl }) {
+  const loginUrl = `${SITE_URL}/login`;
+  const dashboardUrl = `${SITE_URL}/learner/dashboard`;
+  const workoneUrl = `${SITE_URL}/find-workone`;
+  const courseUrl = `${SITE_URL}/lms/courses/${HVAC_COURSE_ID}`;
+
+  return `
+<div style="max-width:600px;margin:0 auto;font-family:Arial,sans-serif;color:#1e293b">
+  <div style="background:#1e293b;padding:24px 32px">
+    <p style="margin:0;color:#fff;font-size:18px;font-weight:700">Elevate for Humanity</p>
+    <p style="margin:4px 0 0;color:#94a3b8;font-size:13px">Career &amp; Technical Institute</p>
+  </div>
+  <div style="padding:32px">
+    ${
+      student.revisedEmail
+        ? `<p style="background:#fef3c7;border:1px solid #fcd34d;border-radius:6px;padding:10px 14px;color:#92400e;font-size:13px;margin:0 0 16px">
+        <strong>Corrected start date:</strong> Your program begins on <strong>Monday, June 15, 2026</strong> (not Sunday). Please use this date when you contact WorkOne.
+      </p>`
+        : ''
+    }
+    <h1 style="margin:0 0 16px;font-size:22px">Welcome, ${student.firstName} — you're enrolled!</h1>
+    <p style="color:#475569;line-height:1.6;margin:0 0 12px">
+      You are officially enrolled in <strong>${PROGRAM_NAME}</strong> through workforce funding (WIOA).
+    </p>
+    <div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:8px;padding:16px;margin:0 0 20px">
+      <p style="margin:0 0 6px;font-weight:700;color:#1e40af">Program start date</p>
+      <p style="margin:0;color:#1e3a8a;font-size:18px;font-weight:700">${START_DATE_DISPLAY}</p>
+    </div>
+    <div style="background:#fef2f2;border:1px solid #fecaca;border-radius:8px;padding:16px;margin:0 0 20px">
+      <p style="margin:0 0 8px;font-weight:700;color:#991b1b">Important — contact your WorkOne career navigator</p>
+      <p style="margin:0;color:#7f1d1d;font-size:14px;line-height:1.6">
+        Please call or visit your <strong>WorkOne career navigator</strong> and let them know:
+        (1) you are enrolled with Elevate for Humanity in the HVAC program, and
+        (2) your official start date is <strong>${START_DATE_DISPLAY}</strong>.
+        This keeps your WIOA funding file active and on schedule.
+      </p>
+      <p style="margin:12px 0 0">
+        <a href="${workoneUrl}" style="color:#dc2626;font-weight:700">Find your nearest WorkOne office →</a>
+      </p>
+    </div>
+    <p style="color:#475569;line-height:1.6;margin:0 0 20px">Your next steps in the student portal:</p>
+    <ol style="margin:0 0 24px;padding-left:20px;color:#475569;font-size:14px;line-height:2">
+      <li>Log in to your student dashboard</li>
+      <li>Complete enrollment confirmation and orientation</li>
+      <li>Submit any outstanding enrollment documents</li>
+      <li>Begin online coursework before your on-site lab sessions</li>
+    </ol>
+    ${
+      passwordSetUrl
+        ? `<p style="text-align:center;margin:0 0 12px">
+        <a href="${passwordSetUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 28px;text-decoration:none;border-radius:8px;font-weight:700;font-size:15px">
+          Set My Password &amp; Log In →
+        </a>
+      </p>
+      <p style="color:#94a3b8;font-size:12px;text-align:center;margin:0 0 20px">Password link expires in 24 hours. After that, use Forgot Password at login.</p>`
+        : `<p style="text-align:center;margin:0 0 20px">
+        <a href="${loginUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 28px;text-decoration:none;border-radius:8px;font-weight:700;font-size:15px">
+          Log In to Your Dashboard →
+        </a>
+      </p>`
+    }
+    <p style="text-align:center;margin:0 0 24px">
+      <a href="${courseUrl}" style="color:#2563eb;font-weight:600">Open HVAC program →</a>
+      &nbsp;·&nbsp;
+      <a href="${dashboardUrl}" style="color:#2563eb;font-weight:600">Student dashboard →</a>
+    </p>
+    <p style="margin:0;color:#94a3b8;font-size:12px;line-height:1.6">
+      Questions? Reply to this email or call <strong>(317) 555-0199</strong>.<br>
+      Elizabeth Greene — Director, Elevate for Humanity Career &amp; Technical Institute
+    </p>
+  </div>
+</div>`;
+}
+
+async function sendEmail(sendgridKey, { to, subject, html, bcc }) {
+  const personalization = { to: [{ email: to }] };
+  if (bcc?.length) personalization.bcc = bcc.map((email) => ({ email }));
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${sendgridKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({
+      personalizations: [personalization],
+      from: { email: 'noreply@elevateforhumanity.org', name: 'Elevate for Humanity' },
+      reply_to: { email: ELEVATE_COPY_EMAIL, name: 'Elevate for Humanity' },
+      subject,
+      content: [{ type: 'text/html', value: html }],
+    }),
+  });
+
+  if (!res.ok) {
+    const body = await res.text();
+    throw new Error(`SendGrid ${res.status}: ${body}`);
+  }
+}
+
+async function enrollStudent(student, sendgridKey) {
+  const now = new Date().toISOString();
+  console.log(`\n── ${student.fullName} (${student.email}) ──`);
+
+  const profileUpdate = {
+    role: 'student',
+    enrollment_status: 'active',
+    updated_at: now,
+  };
+  if (student.phone) profileUpdate.phone = student.phone;
+
+  await db.from('profiles').update(profileUpdate).eq('id', student.userId);
+
+  const enrollmentPayload = {
+    user_id: student.userId,
+    student_id: student.userId,
+    program_id: HVAC_PROGRAM_ID,
+    program_slug: PROGRAM_SLUG,
+    course_id: HVAC_COURSE_ID,
+    email: student.email,
+    full_name: student.fullName.trim(),
+    phone: student.phone,
+    funding_source: 'wioa',
+    funding_pathway: 'wioa',
+    status: 'active',
+    enrollment_state: 'enrolled',
+    payment_status: 'waived',
+    funding_verified: true,
+    enrolled_at: now,
+    enrollment_confirmed_at: now,
+    start_date: START_DATE,
+    next_required_action: 'COMPLETE_ORIENTATION',
+    updated_at: now,
+  };
+
+  const { data: enrollment, error: enrollErr } = await db
+    .from('program_enrollments')
+    .upsert(enrollmentPayload, { onConflict: 'user_id,program_id' })
+    .select('id, status, start_date')
+    .single();
+
+  if (enrollErr) {
+    throw new Error(`Enrollment failed for ${student.email}: ${enrollErr.message}`);
+  }
+
+  console.log('✅ Enrollment:', enrollment.id, 'start', enrollment.start_date);
+
+  await db.from('lms_progress').upsert(
+    {
+      user_id: student.userId,
+      course_id: HVAC_COURSE_ID,
+      course_slug: PROGRAM_SLUG,
+      status: 'in_progress',
+      progress_percent: 0,
+      started_at: now,
+      last_activity_at: now,
+    },
+    { onConflict: 'user_id,course_id' },
+  );
+
+  await db.from('training_enrollments').upsert(
+    {
+      user_id: student.userId,
+      course_id: HVAC_COURSE_ID,
+      program_id: HVAC_PROGRAM_ID,
+      program_slug: PROGRAM_SLUG,
+      status: 'active',
+      progress: 0,
+      enrolled_at: now,
+    },
+    { onConflict: 'user_id,course_id' },
+  );
+
+  let passwordSetUrl = null;
+  const { data: linkData, error: linkErr } = await db.auth.admin.generateLink({
+    type: 'recovery',
+    email: student.email,
+    options: {
+      redirectTo: `${SITE_URL}/auth/callback?redirect=${encodeURIComponent('/learner/dashboard')}`,
+    },
+  });
+  if (!linkErr && linkData?.properties?.action_link) {
+    passwordSetUrl = linkData.properties.action_link;
+  }
+
+  const subjectPrefix = student.revisedEmail ? 'CORRECTED: ' : '';
+  const subject = `${subjectPrefix}Welcome to HVAC — start date ${START_DATE_DISPLAY}`;
+  const html = buildWelcomeHtml(student, { passwordSetUrl });
+
+  await sendEmail(sendgridKey, {
+    to: student.email,
+    subject,
+    html,
+    bcc: [ELEVATE_COPY_EMAIL],
+  });
+  console.log('✅ Email sent to', student.email);
+
+  await sendEmail(sendgridKey, {
+    to: ELEVATE_COPY_EMAIL,
+    subject: `[COPY] ${subject} — ${student.fullName.trim()}`,
+    html: `<p style="font-family:Arial,sans-serif;color:#475569">Internal copy for <strong>${student.email}</strong>.</p><hr />${html}`,
+  });
+  console.log('✅ Admin copy sent');
+}
+
+async function main() {
+  const sendgridKey = await loadSendGridKey();
+  if (!sendgridKey) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  for (const student of STUDENTS) {
+    await enrollStudent(student, sendgridKey);
+  }
+
+  console.log('\n✅ All students enrolled — learner dashboard: ' + SITE_URL + '/learner/dashboard');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/outbound-site-url.ts
+++ b/scripts/ops/outbound-site-url.ts
@@ -1,0 +1,22 @@
+/**
+ * Production URL for outbound ops emails (MOU, host shop, program holder).
+ * Never use localhost — .env.local often sets NEXT_PUBLIC_SITE_URL for dev.
+ */
+const PRODUCTION_SITE_URL = 'https://www.elevateforhumanity.org';
+
+export function outboundSiteUrl(): string {
+  const raw = (process.env.OUTBOUND_SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || PRODUCTION_SITE_URL).replace(
+    /\/$/,
+    '',
+  );
+  if (/localhost|127\.0\.0\.1|0\.0\.0\.0/i.test(raw)) {
+    if (process.env.OUTBOUND_SITE_URL && !/localhost|127\.0\.0\.1/i.test(process.env.OUTBOUND_SITE_URL)) {
+      return process.env.OUTBOUND_SITE_URL.replace(/\/$/, '');
+    }
+    console.warn(
+      `⚠️  NEXT_PUBLIC_SITE_URL is "${raw}" — outbound email links will use ${PRODUCTION_SITE_URL}`,
+    );
+    return PRODUCTION_SITE_URL;
+  }
+  return raw;
+}

--- a/scripts/ops/outreach-auth-link.ts
+++ b/scripts/ops/outreach-auth-link.ts
@@ -1,0 +1,103 @@
+/**
+ * Canonical outbound auth links for ops emails.
+ * Flow: Supabase magic link → /auth/callback?redirect=… → role destination.
+ */
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { getRoleDestination } from '@/lib/auth/role-destinations';
+import { outboundSiteUrl } from './outbound-site-url';
+
+export type OutreachPersona = 'program_holder' | 'partner';
+
+/** Ordered post-login destinations per persona (shown in email + used for magic links). */
+export const OUTREACH_JOURNEYS: Record<
+  OutreachPersona,
+  { dashboard: string; steps: { label: string; path: string }[] }
+> = {
+  program_holder: {
+    dashboard: '/program-holder/dashboard',
+    steps: [
+      { label: 'Sign your Program Holder MOU', path: '/program-holder/sign-mou' },
+      { label: 'Open your Program Holder Dashboard', path: '/program-holder/dashboard' },
+    ],
+  },
+  partner: {
+    dashboard: '/partner/dashboard',
+    steps: [
+      { label: 'Sign your Barber Host Shop MOU', path: '/partners/barber-host-shop/sign-mou' },
+      { label: 'Upload required documents', path: '/partners/barber-host-shop/documents' },
+      { label: 'Open your Partner Dashboard', path: '/partner/dashboard' },
+    ],
+  },
+};
+
+export function roleDashboardPath(role: string): string {
+  return getRoleDestination(role);
+}
+
+/** `/auth/callback?redirect=…` used as Supabase `redirectTo` (chronological landing). */
+export function authCallbackRedirectTo(destinationPath: string, fallback?: string): string {
+  const site = outboundSiteUrl();
+  const dest = validateRedirect(destinationPath, fallback ?? '/learner/dashboard');
+  return `${site}/auth/callback?redirect=${encodeURIComponent(dest)}`;
+}
+
+/** Login page link when magic link cannot be generated (password users). */
+export function loginRedirectUrl(destinationPath: string, fallback?: string): string {
+  const site = outboundSiteUrl();
+  const dest = validateRedirect(destinationPath, fallback ?? '/learner/dashboard');
+  return `${site}/login?redirect=${encodeURIComponent(dest)}`;
+}
+
+export async function generateOutreachMagicLink(
+  db: SupabaseClient,
+  email: string,
+  destinationPath: string,
+  fallback?: string,
+): Promise<string> {
+  const redirectTo = authCallbackRedirectTo(destinationPath, fallback);
+  const { data, error } = await db.auth.admin.generateLink({
+    type: 'magiclink',
+    email,
+    options: { redirectTo },
+  });
+  if (error) {
+    console.warn(`  ⚠ magic link for ${email}: ${error.message} — using login URL`);
+    return loginRedirectUrl(destinationPath, fallback);
+  }
+  return data.properties?.action_link ?? loginRedirectUrl(destinationPath, fallback);
+}
+
+export async function buildJourneyLinks(
+  db: SupabaseClient,
+  email: string,
+  persona: OutreachPersona,
+): Promise<{ dashboard: string; steps: { label: string; path: string; url: string }[] }> {
+  const journey = OUTREACH_JOURNEYS[persona];
+  const steps = await Promise.all(
+    journey.steps.map(async (step) => ({
+      ...step,
+      url: await generateOutreachMagicLink(db, email, step.path, journey.dashboard),
+    })),
+  );
+  const dashboard = await generateOutreachMagicLink(db, email, journey.dashboard, journey.dashboard);
+  return { dashboard, steps };
+}
+
+export function journeyStepsHtml(
+  steps: { label: string; url: string }[],
+  options?: { primaryIndex?: number },
+): string {
+  const primary = options?.primaryIndex ?? 0;
+  const rows = steps
+    .map((step, i) => {
+      const n = i + 1;
+      const isPrimary = i === primary;
+      const btn = isPrimary
+        ? `<a href="${step.url}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 20px;text-decoration:none;border-radius:8px;font-weight:bold;margin-top:8px">${step.label} →</a>`
+        : `<a href="${step.url}" style="color:#dc2626;font-weight:bold">${step.label} →</a>`;
+      return `<li style="margin-bottom:16px;font-size:14px;line-height:1.6;color:#475569"><strong>Step ${n}.</strong> ${step.label}<br/>${btn}</li>`;
+    })
+    .join('');
+  return `<ol style="margin:0 0 20px;padding-left:20px;list-style:decimal">${rows}</ol>`;
+}

--- a/scripts/ops/outreach-email-guard.ts
+++ b/scripts/ops/outreach-email-guard.ts
@@ -1,0 +1,26 @@
+/**
+ * Kill switch for ops/outreach SendGrid scripts.
+ *
+ * Outbound email is BLOCKED until testing is complete. Use --dry-run to preview
+ * HTML locally without sending. After sign-off:
+ *
+ *   OUTREACH_EMAIL_UNLOCK=1 pnpm tsx --env-file=.env.local scripts/ops/<script>.ts --force-send
+ */
+
+export function outreachEmailBlocked(): boolean {
+  if (process.argv.includes('--dry-run') || process.argv.includes('--write-only')) return false;
+  if (process.argv.includes('--force-send') && process.env.OUTREACH_EMAIL_UNLOCK === '1') {
+    return false;
+  }
+  return true;
+}
+
+export function assertOutreachEmailAllowed(scriptName: string): void {
+  if (!outreachEmailBlocked()) return;
+
+  console.error(`\n⛔ Outreach email blocked (${scriptName})`);
+  console.error('   No outbound email until portal/dashboard testing is complete.');
+  console.error('   Preview only:  add --dry-run (writes HTML under exports/email-copies when supported)');
+  console.error('   After sign-off: OUTREACH_EMAIL_UNLOCK=1 ... --force-send\n');
+  process.exit(1);
+}

--- a/scripts/ops/provision-barber-host-send-mou.ts
+++ b/scripts/ops/provision-barber-host-send-mou.ts
@@ -12,6 +12,7 @@ import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
 import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -122,6 +123,8 @@ async function sendMail(
 }
 
 async function main() {
+  assertOutreachEmailAllowed('provision-barber-host-send-mou.ts');
+
   if (!emailArg) {
     console.error('Usage: --email <contact_email>');
     process.exit(1);

--- a/scripts/ops/provision-barber-host-send-mou.ts
+++ b/scripts/ops/provision-barber-host-send-mou.ts
@@ -11,6 +11,7 @@ import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -57,8 +58,7 @@ function documentChecklistHtml() {
 function buildEmailHtml(opts: {
   firstName: string;
   shopName: string;
-  email: string;
-  signUrl: string;
+  stepsHtml: string;
 }) {
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
@@ -75,14 +75,8 @@ function buildEmailHtml(opts: {
 Your barber apprenticeship <strong>host shop application</strong> for <strong>${opts.shopName}</strong> is approved on the Elevate platform.
 <strong>Attached</strong> is your Barber Host Shop Employer Agreement (MOU) for review and signature.
 </p>
-<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
-<li>Review the attached MOU PDF.</li>
-<li>Click below to <strong>digitally sign</strong> (log in with <strong>${opts.email}</strong>).</li>
-<li>Upload or resend the required documents listed below.</li>
-</ol>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
-<a href="${opts.signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
-</td></tr></table>
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">Review the attached MOU PDF, then complete these steps <strong>in order</strong> on ${SITE_URL}:</p>
+${opts.stepsHtml}
 ${documentChecklistHtml()}
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
 <p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
@@ -274,7 +268,8 @@ async function main() {
     console.log('  ✅ profile + partner_users linked');
   }
 
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  const { steps } = await buildJourneyLinks(db, email, 'partner');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
 
   const pdfBytes = await generateMOUPdf({
     shop_name: shopName,
@@ -293,7 +288,7 @@ async function main() {
     to: email,
     name: contactName,
     subject: `Barber Host Shop MOU & required documents — ${shopName}`,
-    html: buildEmailHtml({ firstName, shopName, email, signUrl }),
+    html: buildEmailHtml({ firstName, shopName, stepsHtml }),
     pdfB64,
     filename,
   });

--- a/scripts/ops/provision-barber-host-send-mou.ts
+++ b/scripts/ops/provision-barber-host-send-mou.ts
@@ -1,0 +1,329 @@
+#!/usr/bin/env tsx
+/**
+ * Approve a barber host shop application, provision partner login, send MOU PDF
+ * + required document checklist (ask to resend missing uploads).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/provision-barber-host-send-mou.ts --email calvincutz1985@gmail.com
+ *   pnpm tsx --env-file=.env.local scripts/ops/provision-barber-host-send-mou.ts --email christopherd.newkirk@gmail.com --dry-run
+ */
+import { randomBytes } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
+  /\/$/,
+  '',
+);
+const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
+const DRY_RUN = process.argv.includes('--dry-run');
+const emailArg = process.argv.find((a) => a.startsWith('--email='))?.split('=')[1]
+  ?? process.argv[process.argv.indexOf('--email') + 1];
+
+const REQUIRED_DOCS = [
+  'IRS EIN Assignment Letter (CP 575 or 147C)',
+  'W-9 Form (signed)',
+  'Indiana Barbershop License (current, full copy)',
+  "Workers' Compensation Certificate of Insurance",
+  'General Liability Insurance Certificate',
+  'Supervising Barber License (2+ years experience)',
+];
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db
+    .from('platform_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db
+    .from('app_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+function documentChecklistHtml() {
+  const items = REQUIRED_DOCS.map(
+    (d) => `<li style="margin-bottom:8px">${d}</li>`,
+  ).join('');
+  const uploadUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/documents')}`;
+  return `
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">
+<strong>Required documents</strong> — please upload clear, complete copies (PDF preferred). If we already received a file that was cropped, expired, or unreadable, <strong>resend the full document</strong> by reply email or via the portal:
+</p>
+<ol style="margin:0 0 16px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">${items}</ol>
+<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#475569">
+<a href="${uploadUrl}" style="color:#dc2626;font-weight:bold">Upload documents in Partner Portal →</a>
+</p>`;
+}
+
+function buildEmailHtml(opts: {
+  firstName: string;
+  shopName: string;
+  email: string;
+  signUrl: string;
+  loginUrl: string;
+}) {
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Barber Host Shop Employer Agreement (MOU)</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Hi ${opts.firstName},</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Your barber apprenticeship <strong>host shop application</strong> for <strong>${opts.shopName}</strong> is approved on the Elevate platform.
+<strong>Attached</strong> is your Barber Host Shop Employer Agreement (MOU) for review and signature.
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached MOU PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>${opts.email}</strong>).</li>
+<li>Upload or resend the required documents listed below.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 16px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="${opts.signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
+</td></tr></table>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#1e293b;border-radius:8px;padding:14px 24px">
+<a href="${opts.loginUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Open Partner Dashboard →</a>
+</td></tr></table>
+${documentChecklistHtml()}
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+}
+
+async function sendMail(
+  sgKey: string,
+  opts: { to: string; name: string; subject: string; html: string; pdfB64: string; filename: string },
+) {
+  if (DRY_RUN) {
+    console.log(`  [DRY RUN] Would email ${opts.to} — ${opts.subject}`);
+    return;
+  }
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${sgKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [
+        {
+          to: [{ email: opts.to, name: opts.name }],
+          cc: [{ email: ELEVATE_COPY, name: 'Elevate Admin Copy' }],
+        },
+      ],
+      from: { email: 'noreply@elevateforhumanity.org', name: 'Elizabeth Greene | Elevate for Humanity' },
+      reply_to: { email: ELEVATE_COPY, name: 'Elizabeth Greene' },
+      subject: opts.subject,
+      content: [{ type: 'text/html', value: opts.html }],
+      attachments: [
+        {
+          content: opts.pdfB64,
+          type: 'application/pdf',
+          filename: opts.filename,
+          disposition: 'attachment',
+        },
+      ],
+    }),
+  });
+  if (res.status !== 202) throw new Error(`SendGrid ${res.status}: ${await res.text()}`);
+}
+
+async function main() {
+  if (!emailArg) {
+    console.error('Usage: --email <contact_email>');
+    process.exit(1);
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key || key === 'placeholder') {
+    console.error('Missing Supabase credentials');
+    process.exit(1);
+  }
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey && !DRY_RUN) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  const { data: app, error: appErr } = await db
+    .from('barbershop_partner_applications')
+    .select('*')
+    .ilike('contact_email', emailArg)
+    .maybeSingle();
+  if (appErr || !app) {
+    console.error('No barbershop_partner_applications row for', emailArg);
+    process.exit(1);
+  }
+
+  const now = new Date().toISOString();
+  const shopName = app.shop_legal_name;
+  const contactName = app.contact_name || app.owner_name;
+  const firstName = contactName.split(' ')[0];
+  const email = app.contact_email.toLowerCase();
+
+  console.log(`\n=== ${shopName} <${email}> ===`);
+
+  if (!DRY_RUN) {
+    await db
+      .from('barbershop_partner_applications')
+      .update({ status: 'approved', updated_at: now })
+      .eq('id', app.id);
+    console.log('  ✅ application approved');
+  }
+
+  let userId: string | null = null;
+  const { data: existingProfile } = await db.from('profiles').select('id, role').eq('email', email).maybeSingle();
+  if (existingProfile?.id) {
+    userId = existingProfile.id;
+    console.log('  ℹ Existing profile', userId);
+  } else if (!DRY_RUN) {
+    const tempPassword = randomBytes(18).toString('base64url');
+    const { data: created, error } = await db.auth.admin.createUser({
+      email,
+      password: tempPassword,
+      email_confirm: true,
+      user_metadata: { role: 'partner', full_name: contactName },
+      app_metadata: { role: 'partner' },
+    });
+    if (created?.user?.id) {
+      userId = created.user.id;
+      console.log('  ✅ Auth user created', userId);
+    } else if (error) {
+      const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 500 });
+      const found = listed?.users?.find((u) => u.email?.toLowerCase() === email);
+      if (!found) throw new Error(`Auth create failed: ${error.message}`);
+      userId = found.id;
+      await db.auth.admin.updateUserById(userId, { email_confirm: true, app_metadata: { role: 'partner' } });
+      console.log('  ✅ Auth user linked', userId);
+    }
+  } else {
+    userId = 'dry-run-user';
+  }
+
+  let partnerId: string | null = null;
+  const { data: existingPartner } = await db.from('partners').select('id').eq('contact_email', email).maybeSingle();
+  const partnerPayload = {
+    name: shopName,
+    legal_name: shopName,
+    shop_name: shopName,
+    owner_name: app.owner_name,
+    contact_name: contactName,
+    contact_email: email,
+    contact_phone: app.contact_phone,
+    address_line1: app.shop_address_line1,
+    city: app.shop_city,
+    state: app.shop_state,
+    zip: app.shop_zip,
+    license_number: app.indiana_shop_license_number,
+    supervisor_name: app.supervisor_name,
+    supervisor_license_number: app.supervisor_license_number,
+    partner_type: 'barber',
+    program_type: 'barber',
+    approval_status: 'approved',
+    status: 'active',
+    approved_at: now,
+    onboarding_completed: false,
+    mou_signed: Boolean(app.mou_signed_at),
+    can_supervise_and_verify: app.can_supervise_and_verify ?? true,
+    compensation_model: app.compensation_model || app.employment_model || 'hourly',
+    workers_comp_status: app.workers_comp_status || 'none',
+    programs: ['barber'],
+    notes: `Provisioned via provision-barber-host-send-mou.ts — app ${app.id}`,
+    updated_at: now,
+  };
+
+  if (existingPartner?.id) {
+    partnerId = existingPartner.id;
+    if (!DRY_RUN) {
+      const { error } = await db.from('partners').update(partnerPayload).eq('id', partnerId);
+      if (error) throw new Error(`partner update: ${error.message}`);
+    }
+    console.log('  ✅ partner updated', partnerId);
+  } else if (!DRY_RUN) {
+    const { data: inserted, error } = await db
+      .from('partners')
+      .insert({ ...partnerPayload, applied_at: now })
+      .select('id')
+      .single();
+    if (error) throw new Error(`partner insert: ${error.message}`);
+    partnerId = inserted.id;
+    console.log('  ✅ partner created', partnerId);
+  } else {
+    partnerId = 'dry-run-partner';
+  }
+
+  if (!DRY_RUN && userId && partnerId) {
+    await db.from('profiles').upsert(
+      {
+        id: userId,
+        email,
+        full_name: contactName,
+        role: 'partner',
+        phone: app.contact_phone,
+        updated_at: now,
+      },
+      { onConflict: 'id' },
+    );
+    await db.from('partner_users').upsert(
+      { partner_id: partnerId, user_id: userId, role: 'owner', status: 'active' },
+      { onConflict: 'partner_id,user_id' },
+    );
+    await db.auth.admin.updateUserById(userId, { app_metadata: { role: 'partner' } });
+    console.log('  ✅ profile + partner_users linked');
+  }
+
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  let loginUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partner/dashboard')}`;
+  if (!DRY_RUN) {
+    const { data: linkData, error: linkErr } = await db.auth.admin.generateLink({
+      type: 'magiclink',
+      email,
+      options: {
+        redirectTo: `${SITE_URL}/auth/callback?redirect=${encodeURIComponent('/partner/dashboard')}`,
+      },
+    });
+    if (linkErr) throw linkErr;
+    loginUrl = linkData.properties?.action_link ?? loginUrl;
+  }
+
+  const pdfBytes = await generateMOUPdf({
+    shop_name: shopName,
+    signer_name: contactName,
+    signer_title: 'Owner / Licensed Barber',
+    supervisor_name: app.supervisor_name || contactName,
+    supervisor_license: app.supervisor_license_number || undefined,
+    compensation_model: app.compensation_model || app.employment_model || 'hourly',
+    signed_at: new Date().toISOString(),
+    mou_version: '2025-barber-01',
+  });
+  const pdfB64 = Buffer.from(pdfBytes).toString('base64');
+  const filename = `Elevate-Barber-Host-MOU-${shopName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
+
+  await sendMail(sgKey!, {
+    to: email,
+    name: contactName,
+    subject: `Barber Host Shop MOU & required documents — ${shopName}`,
+    html: buildEmailHtml({ firstName, shopName, email, signUrl, loginUrl }),
+    pdfB64,
+    filename,
+  });
+  console.log(`  ✅ MOU + document checklist emailed (${Math.round(pdfBytes.length / 1024)} KB PDF)`);
+  console.log('\nDone.');
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/provision-barber-host-send-mou.ts
+++ b/scripts/ops/provision-barber-host-send-mou.ts
@@ -10,11 +10,9 @@ import { randomBytes } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const DRY_RUN = process.argv.includes('--dry-run');
 const emailArg = process.argv.find((a) => a.startsWith('--email='))?.split('=')[1]
@@ -49,15 +47,11 @@ function documentChecklistHtml() {
   const items = REQUIRED_DOCS.map(
     (d) => `<li style="margin-bottom:8px">${d}</li>`,
   ).join('');
-  const uploadUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/documents')}`;
   return `
 <p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">
-<strong>Required documents</strong> — please upload clear, complete copies (PDF preferred). If we already received a file that was cropped, expired, or unreadable, <strong>resend the full document</strong> by reply email or via the portal:
+<strong>Required documents</strong> — please reply to this email with clear, complete copies (PDF preferred). If we already received a file that was cropped, expired, or unreadable, <strong>resend the full document</strong> as attachments.
 </p>
-<ol style="margin:0 0 16px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">${items}</ol>
-<p style="margin:0 0 20px;font-size:14px;line-height:1.7;color:#475569">
-<a href="${uploadUrl}" style="color:#dc2626;font-weight:bold">Upload documents in Partner Portal →</a>
-</p>`;
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">${items}</ol>`;
 }
 
 function buildEmailHtml(opts: {
@@ -65,7 +59,6 @@ function buildEmailHtml(opts: {
   shopName: string;
   email: string;
   signUrl: string;
-  loginUrl: string;
 }) {
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
@@ -87,11 +80,8 @@ Your barber apprenticeship <strong>host shop application</strong> for <strong>${
 <li>Click below to <strong>digitally sign</strong> (log in with <strong>${opts.email}</strong>).</li>
 <li>Upload or resend the required documents listed below.</li>
 </ol>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 16px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
 <a href="${opts.signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
-</td></tr></table>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#1e293b;border-radius:8px;padding:14px 24px">
-<a href="${opts.loginUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Open Partner Dashboard →</a>
 </td></tr></table>
 ${documentChecklistHtml()}
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
@@ -285,18 +275,6 @@ async function main() {
   }
 
   const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
-  let loginUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partner/dashboard')}`;
-  if (!DRY_RUN) {
-    const { data: linkData, error: linkErr } = await db.auth.admin.generateLink({
-      type: 'magiclink',
-      email,
-      options: {
-        redirectTo: `${SITE_URL}/auth/callback?redirect=${encodeURIComponent('/partner/dashboard')}`,
-      },
-    });
-    if (linkErr) throw linkErr;
-    loginUrl = linkData.properties?.action_link ?? loginUrl;
-  }
 
   const pdfBytes = await generateMOUPdf({
     shop_name: shopName,
@@ -315,7 +293,7 @@ async function main() {
     to: email,
     name: contactName,
     subject: `Barber Host Shop MOU & required documents — ${shopName}`,
-    html: buildEmailHtml({ firstName, shopName, email, signUrl, loginUrl }),
+    html: buildEmailHtml({ firstName, shopName, email, signUrl }),
     pdfB64,
     filename,
   });

--- a/scripts/ops/provision-enchanted-hearts-program-holder.ts
+++ b/scripts/ops/provision-enchanted-hearts-program-holder.ts
@@ -1,0 +1,405 @@
+#!/usr/bin/env tsx
+/**
+ * Provision Enchanted Hearts Training Institute LLC as a third-party program holder,
+ * send MOU PDF (no admin dashboard), then send program-holder dashboard login.
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/provision-enchanted-hearts-program-holder.ts
+ *   pnpm tsx --env-file=.env.local scripts/ops/provision-enchanted-hearts-program-holder.ts --dry-run
+ */
+import { randomBytes } from 'crypto';
+import { createClient } from '@supabase/supabase-js';
+import { generateDetailedMOUPdf } from '@/lib/documents/generate-detailed-mou-pdf';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
+  /\/$/,
+  '',
+);
+const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
+const DRY_RUN = process.argv.includes('--dry-run');
+
+const HOLDER = {
+  organizationName: 'Enchanted Hearts Training Institute LLC',
+  contactName: 'Shawndra Quinn, RN',
+  signerTitle: 'Training Program Director / Owner',
+  email: 'info@enchantedheartstraining.com',
+  phone: '3175347471',
+  ein: '88-2052776',
+  addressLine1: '650 N. Girls School Rd, Ste B20',
+  city: 'Indianapolis',
+  state: 'IN',
+  zip: '46214',
+  website: 'https://www.enchantedheartstraining.com',
+};
+
+/** Live program IDs in Elevate `programs` catalog */
+const PROGRAM_LINKS = [
+  { id: 'fb36dbf1-db3c-4d34-adf9-3f98f397d371', slug: 'cna' },
+  { id: 'd8f45366-1838-4539-ae32-7bc985773772', slug: 'home-health-aide' },
+];
+
+const MOU_PROGRAMS = [
+  {
+    program_name: 'Certified Nurse Aide (CNA) Training',
+    credential: 'Indiana Nurse Aide (ISDH-approved program)',
+    duration: '105 hours (75 classroom + 30 clinical)',
+    weekly_hours: 0,
+    tuition: 399,
+  },
+  {
+    program_name: 'Home Health Aide (HHA) Training',
+    credential: 'Home Health Aide Certificate',
+    duration: '75 hours (2 weeks)',
+    weekly_hours: 0,
+    tuition: 399,
+  },
+  {
+    program_name: 'Qualified Medication Aide (QMA) Program',
+    credential: 'Indiana QMA (IDOH-approved)',
+    duration: '100 hours (classroom/lab + supervised clinical practicum)',
+    weekly_hours: 0,
+    tuition: 900,
+  },
+  {
+    program_name: 'QMA Insulin Administration Certification',
+    credential: 'QMA Insulin Administration',
+    duration: '6–12 hours',
+    weekly_hours: 0,
+    tuition: 275,
+  },
+  {
+    program_name: 'CPR Instructor Course',
+    credential: 'AHA-aligned CPR/BLS Instructor',
+    duration: '1 day',
+    weekly_hours: 0,
+    tuition: 450,
+  },
+];
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db
+    .from('platform_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db
+    .from('app_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+async function sendMail(
+  apiKey: string,
+  opts: { to: string; subject: string; html: string; pdfB64?: string; filename?: string },
+) {
+  const payload: Record<string, unknown> = {
+    personalizations: [
+      {
+        to: [{ email: opts.to, name: HOLDER.contactName }],
+        cc: [{ email: ELEVATE_COPY, name: 'Elevate Admin Copy' }],
+      },
+    ],
+    from: { email: 'noreply@elevateforhumanity.org', name: 'Elizabeth Greene | Elevate for Humanity' },
+    reply_to: { email: ELEVATE_COPY, name: 'Elizabeth Greene' },
+    subject: opts.subject,
+    content: [{ type: 'text/html', value: opts.html }],
+  };
+  if (opts.pdfB64 && opts.filename) {
+    payload.attachments = [
+      {
+        content: opts.pdfB64,
+        type: 'application/pdf',
+        filename: opts.filename,
+        disposition: 'attachment',
+      },
+    ];
+  }
+
+  if (DRY_RUN) {
+    console.log(`  [DRY RUN] ${opts.subject} → ${opts.to}`);
+    return;
+  }
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (res.status !== 202) {
+    throw new Error(`SendGrid ${res.status}: ${await res.text()}`);
+  }
+}
+
+function mouEmailHtml(signUrl: string) {
+  const first = 'Shawndra';
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Third-Party Program Holder MOU</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Dear ${first},</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Thank you for partnering with <strong>Elevate for Humanity</strong> as a <strong>third-party program delivery partner</strong>
+for <strong>${HOLDER.organizationName}</strong>.
+</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+<strong>Attached:</strong> your <strong>Program Holder Memorandum of Understanding (MOU)</strong> covering CNA, HHA, QMA,
+and related healthcare training programs delivered through your institute.
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>${HOLDER.email}</strong> if prompted).</li>
+<li>Reply to this email with questions or a signed copy if you prefer.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
+</td></tr></table>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply here or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+}
+
+function dashboardEmailHtml(loginUrl: string) {
+  return `<!DOCTYPE html>
+<html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
+<p>Dear Shawndra,</p>
+<p>Your <strong>Program Holder dashboard</strong> for <strong>${HOLDER.organizationName}</strong> is now active on the Elevate platform.</p>
+<p>Use this secure link to log in (no password needed):</p>
+<p><a href="${loginUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Open Program Holder Dashboard →</a></p>
+<p style="font-size:14px;color:#475569">Or sign in at <a href="${SITE_URL}/login">${SITE_URL}/login</a> with <strong>${HOLDER.email}</strong>, then go to <strong>Program Holder Dashboard</strong>.</p>
+<p style="font-size:14px;color:#475569">From your dashboard you can manage students, track compliance, and access program-holder tools after you complete MOU signing and onboarding steps.</p>
+<p>Questions? Reply to this email or call ${PLATFORM_DEFAULTS.supportPhone}.</p>
+<p>Thank you,<br><strong>Elizabeth Greene</strong><br>Elevate for Humanity</p>
+</body></html>`;
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key || key === 'placeholder') {
+    console.error('Missing Supabase credentials');
+    process.exit(1);
+  }
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey && !DRY_RUN) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  const now = new Date().toISOString();
+  console.log(`\n=== ${HOLDER.organizationName} ===`);
+
+  // ── Auth user ─────────────────────────────────────────────────────────────
+  let userId: string | null = null;
+  const { data: existingProfile } = await db
+    .from('profiles')
+    .select('id')
+    .eq('email', HOLDER.email)
+    .maybeSingle();
+
+  if (existingProfile?.id) {
+    userId = existingProfile.id;
+    console.log('  ℹ Existing profile', userId);
+  } else if (!DRY_RUN) {
+    const tempPassword = randomBytes(18).toString('base64url');
+    const { data: created, error } = await db.auth.admin.createUser({
+      email: HOLDER.email,
+      password: tempPassword,
+      email_confirm: true,
+      user_metadata: {
+        role: 'program_holder',
+        full_name: HOLDER.contactName,
+      },
+      app_metadata: { role: 'program_holder' },
+    });
+    if (created?.user?.id) {
+      userId = created.user.id;
+      console.log('  ✅ Auth user created', userId);
+    } else if (error) {
+      const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 200 });
+      const found = listed?.users?.find((u) => u.email?.toLowerCase() === HOLDER.email);
+      if (!found) throw new Error(`Auth create failed: ${error.message}`);
+      userId = found.id;
+      await db.auth.admin.updateUserById(userId, {
+        email_confirm: true,
+        app_metadata: { role: 'program_holder' },
+      });
+      console.log('  ✅ Auth user linked', userId);
+    }
+  } else {
+    userId = 'dry-run-user-id';
+    console.log('  [DRY RUN] Would create auth user');
+  }
+
+  // ── program_holders row ─────────────────────────────────────────────────
+  let holderId: string | null = null;
+  const { data: existingHolder } = await db
+    .from('program_holders')
+    .select('id')
+    .eq('organization_name', HOLDER.organizationName)
+    .maybeSingle();
+
+  const holderPayload = {
+    user_id: userId,
+    organization_name: HOLDER.organizationName,
+    name: HOLDER.organizationName,
+    contact_name: HOLDER.contactName,
+    contact_email: HOLDER.email,
+    contact_phone: HOLDER.phone,
+    status: 'approved',
+    approved_at: now,
+    mou_signed: false,
+    mou_status: 'pending',
+    mou_type: 'universal',
+    teaches_multiple: true,
+    is_using_internal_lms: true,
+    payout_status: 'not_started',
+    primary_program_id: PROGRAM_LINKS[0]?.id ?? null,
+    features: {
+      ein: HOLDER.ein,
+      address: HOLDER.addressLine1,
+      city: HOLDER.city,
+      state: HOLDER.state,
+      zip: HOLDER.zip,
+      website: HOLDER.website,
+      idoh_approvals: ['CNA Nurse Aide Training', 'QMA Training Program'],
+      notes: 'Third-party program delivery partner — provisioned via ops script',
+    },
+  };
+
+  if (existingHolder?.id) {
+    holderId = existingHolder.id;
+    if (!DRY_RUN) {
+      const { error } = await db.from('program_holders').update(holderPayload).eq('id', holderId);
+      if (error) throw new Error(`program_holders update: ${error.message}`);
+    }
+    console.log('  ✅ program_holders updated', holderId);
+  } else if (!DRY_RUN) {
+    const { data: inserted, error } = await db
+      .from('program_holders')
+      .insert(holderPayload)
+      .select('id')
+      .single();
+    if (error) throw new Error(`program_holders insert: ${error.message}`);
+    holderId = inserted.id;
+    console.log('  ✅ program_holders created', holderId);
+  } else {
+    holderId = 'dry-run-holder-id';
+    console.log('  [DRY RUN] Would insert program_holders');
+  }
+
+  // ── profile ───────────────────────────────────────────────────────────────
+  if (!DRY_RUN && userId && holderId) {
+    const { error } = await db.from('profiles').upsert(
+      {
+        id: userId,
+        email: HOLDER.email,
+        full_name: HOLDER.contactName,
+        role: 'program_holder',
+        program_holder_id: holderId,
+        phone: HOLDER.phone,
+        address: HOLDER.addressLine1,
+        city: HOLDER.city,
+        state: HOLDER.state,
+        zip: HOLDER.zip,
+        onboarding_completed: false,
+        updated_at: now,
+      },
+      { onConflict: 'id' },
+    );
+    if (error) throw new Error(`profiles upsert: ${error.message}`);
+    await db.auth.admin.updateUserById(userId, { app_metadata: { role: 'program_holder' } });
+    console.log('  ✅ profile → program_holder');
+  }
+
+  // ── program_holder_programs ─────────────────────────────────────────────────
+  if (!DRY_RUN && holderId) {
+    for (const prog of PROGRAM_LINKS) {
+      const { error } = await db.from('program_holder_programs').upsert(
+        {
+          program_holder_id: holderId,
+          program_id: prog.id,
+          status: 'active',
+        },
+        { onConflict: 'program_holder_id,program_id' },
+      );
+      if (error) console.warn(`  ⚠ program link ${prog.slug}:`, error.message);
+      else console.log(`  ✅ linked program ${prog.slug}`);
+    }
+  }
+
+  // ── MOU PDF ───────────────────────────────────────────────────────────────
+  const pdfBytes = await generateDetailedMOUPdf({
+    partner_name: HOLDER.organizationName,
+    partner_role: 'Third-Party Program Delivery Partner',
+    signer_name: HOLDER.contactName,
+    signer_title: HOLDER.signerTitle,
+    contact_email: HOLDER.email,
+    contact_phone: HOLDER.phone,
+    programs: MOU_PROGRAMS,
+    revenue_share_model:
+      'Program delivery partner delivers ISDH-aligned healthcare training; Elevate provides ETPL listing, WIOA/DOL sponsorship pathways, enrollment infrastructure, and compliance oversight per executed agreement.',
+    wioa_eligible: true,
+    signed_at: now,
+    mou_version: '2026-program-holder-healthcare-01',
+  });
+  const pdfB64 = Buffer.from(pdfBytes).toString('base64');
+  const pdfFilename = `Elevate-Program-Holder-MOU-${HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
+  console.log(`  📄 MOU PDF ${Math.round(pdfBytes.length / 1024)} KB`);
+
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  await sendMail(sgKey!, {
+    to: HOLDER.email,
+    subject: `Program Holder MOU — ${HOLDER.organizationName} (signature required)`,
+    html: mouEmailHtml(signUrl),
+    pdfB64,
+    filename: pdfFilename,
+  });
+  console.log('  ✅ MOU email sent (PDF attached, CC Elevate)');
+
+  // ── Dashboard magic link (separate from MOU — not admin) ───────────────────
+  let loginUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/dashboard')}`;
+  if (!DRY_RUN) {
+    const { data: linkData, error: linkErr } = await db.auth.admin.generateLink({
+      type: 'magiclink',
+      email: HOLDER.email,
+      options: {
+        redirectTo: `${SITE_URL}/auth/callback?redirect=${encodeURIComponent('/program-holder/dashboard')}`,
+      },
+    });
+    if (linkErr) throw linkErr;
+    loginUrl = linkData.properties?.action_link ?? loginUrl;
+  }
+
+  await sendMail(sgKey!, {
+    to: HOLDER.email,
+    subject: `Your Program Holder dashboard is ready — ${HOLDER.organizationName}`,
+    html: dashboardEmailHtml(loginUrl),
+  });
+  console.log('  ✅ Dashboard login email sent');
+
+  console.log('\nDone.');
+  console.log(`  Email: ${HOLDER.email}`);
+  console.log(`  Phone: ${HOLDER.phone}`);
+  console.log(`  EIN:   ${HOLDER.ein}`);
+  if (holderId) console.log(`  Holder ID: ${holderId}`);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/ops/provision-enchanted-hearts-program-holder.ts
+++ b/scripts/ops/provision-enchanted-hearts-program-holder.ts
@@ -11,6 +11,7 @@ import { createClient } from '@supabase/supabase-js';
 import { generateDetailedMOUPdf } from '@/lib/documents/generate-detailed-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -133,7 +134,7 @@ async function sendMail(
   }
 }
 
-function mouEmailHtml(signUrl: string) {
+function mouEmailHtml(stepsHtml: string) {
   const first = 'Shawndra';
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
@@ -154,14 +155,8 @@ for <strong>${HOLDER.organizationName}</strong>.
 <strong>Attached:</strong> your <strong>Program Holder Memorandum of Understanding (MOU)</strong> covering CNA, HHA, QMA,
 and related healthcare training programs delivered through your institute.
 </p>
-<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
-<li>Review the attached PDF.</li>
-<li>Click below to <strong>digitally sign</strong> (log in with <strong>${HOLDER.email}</strong> if prompted).</li>
-<li>Reply to this email with questions or a signed copy if you prefer.</li>
-</ol>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
-<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
-</td></tr></table>
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">Review the attached PDF, then complete these steps <strong>in order</strong> (each link signs you in and opens the correct page on ${SITE_URL}):</p>
+${stepsHtml}
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply here or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
 <p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
 </td></tr>
@@ -189,21 +184,13 @@ async function buildMouPdf() {
   });
 }
 
-async function sendCorrectedMou(sgKey: string) {
+async function sendCorrectedMou(sgKey: string, db: ReturnType<typeof createClient>) {
   const pdfBytes = await buildMouPdf();
   const pdfB64 = Buffer.from(pdfBytes).toString('base64');
   const pdfFilename = `Elevate-Program-Holder-MOU-${HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
-  const html = `<!DOCTYPE html>
-<html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
-<p>Dear Shawndra,</p>
-<p>Please <strong>disregard any prior dashboard login emails</strong> (especially any link pointing to <code>localhost</code>) — those were sent in error. We are <strong>not</strong> asking you to use a dashboard at this time.</p>
-<p>Attached is your <strong>Program Holder MOU</strong> for <strong>${HOLDER.organizationName}</strong>. Review the PDF and sign using the button below.</p>
-<p><strong>Attached:</strong> revised MOU PDF (clear program schedule, no overlapping text).</p>
-<p><a href="${signUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Sign Program Holder MOU Online →</a></p>
-<p style="font-size:14px;color:#475569">Log in with <strong>${HOLDER.email}</strong> if prompted. Reply with any questions.</p>
-<p>Thank you,<br><strong>Elizabeth Greene</strong><br>Elevate for Humanity</p>
-</body></html>`;
+  const { steps } = await buildJourneyLinks(db, HOLDER.email, 'program_holder');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
+  const html = mouEmailHtml(stepsHtml);
   await sendMail(sgKey, {
     to: HOLDER.email,
     subject: `Corrected Program Holder MOU — ${HOLDER.organizationName}`,
@@ -238,7 +225,7 @@ async function main() {
       console.error('SENDGRID_API_KEY not found');
       process.exit(1);
     }
-    await sendCorrectedMou(sgKeyOnly!);
+    await sendCorrectedMou(sgKeyOnly!, db);
     console.log('\nDone (MOU resend only).');
     return;
   }
@@ -388,11 +375,12 @@ async function main() {
   const pdfFilename = `Elevate-Program-Holder-MOU-${HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
   console.log(`  📄 MOU PDF ${Math.round(pdfBytes.length / 1024)} KB`);
 
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const { steps } = await buildJourneyLinks(db, HOLDER.email, 'program_holder');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
   await sendMail(sgKey!, {
     to: HOLDER.email,
     subject: `Program Holder MOU — ${HOLDER.organizationName} (signature required)`,
-    html: mouEmailHtml(signUrl),
+    html: mouEmailHtml(stepsHtml),
     pdfB64,
     filename: pdfFilename,
   });

--- a/scripts/ops/provision-enchanted-hearts-program-holder.ts
+++ b/scripts/ops/provision-enchanted-hearts-program-holder.ts
@@ -12,6 +12,7 @@ import { generateDetailedMOUPdf } from '@/lib/documents/generate-detailed-mou-pd
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
 import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -202,6 +203,8 @@ async function sendCorrectedMou(sgKey: string, db: ReturnType<typeof createClien
 }
 
 async function main() {
+  assertOutreachEmailAllowed('provision-enchanted-hearts-program-holder.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key || key === 'placeholder') {

--- a/scripts/ops/provision-enchanted-hearts-program-holder.ts
+++ b/scripts/ops/provision-enchanted-hearts-program-holder.ts
@@ -17,6 +17,7 @@ const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhum
 );
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const DRY_RUN = process.argv.includes('--dry-run');
+const MOU_ONLY = process.argv.includes('--mou-only');
 
 const HOLDER = {
   organizationName: 'Enchanted Hearts Training Institute LLC',
@@ -171,6 +172,49 @@ and related healthcare training programs delivered through your institute.
 </body></html>`;
 }
 
+async function buildMouPdf() {
+  return generateDetailedMOUPdf({
+    partner_name: HOLDER.organizationName,
+    partner_role: 'Third-Party Program Delivery Partner',
+    signer_name: HOLDER.contactName,
+    signer_title: HOLDER.signerTitle,
+    contact_email: HOLDER.email,
+    contact_phone: HOLDER.phone,
+    partner_address: `${HOLDER.addressLine1}, ${HOLDER.city}, ${HOLDER.state} ${HOLDER.zip}`,
+    partner_ein: HOLDER.ein,
+    programs: MOU_PROGRAMS,
+    revenue_share_model:
+      'Program delivery partner delivers ISDH-aligned healthcare training; Elevate provides ETPL listing, WIOA/DOL sponsorship pathways, enrollment infrastructure, and compliance oversight per executed agreement.',
+    wioa_eligible: true,
+    signed_at: new Date().toISOString(),
+    mou_version: '2026-program-holder-healthcare-01',
+  });
+}
+
+async function sendCorrectedMou(sgKey: string) {
+  const pdfBytes = await buildMouPdf();
+  const pdfB64 = Buffer.from(pdfBytes).toString('base64');
+  const pdfFilename = `Elevate-Program-Holder-MOU-${HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const html = `<!DOCTYPE html>
+<html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
+<p>Dear Shawndra,</p>
+<p>Please <strong>disregard the prior MOU attachment</strong> if the program table appeared crowded or overlapping. Attached is a <strong>corrected, professionally formatted</strong> Program Holder MOU for <strong>${HOLDER.organizationName}</strong>.</p>
+<p><strong>Attached:</strong> revised MOU PDF (clear program schedule, no overlapping text).</p>
+<p><a href="${signUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Sign Program Holder MOU Online →</a></p>
+<p style="font-size:14px;color:#475569">Log in with <strong>${HOLDER.email}</strong> if prompted. Reply with any questions.</p>
+<p>Thank you,<br><strong>Elizabeth Greene</strong><br>Elevate for Humanity</p>
+</body></html>`;
+  await sendMail(sgKey, {
+    to: HOLDER.email,
+    subject: `Corrected Program Holder MOU — ${HOLDER.organizationName}`,
+    html,
+    pdfB64,
+    filename: pdfFilename,
+  });
+  console.log(`  ✅ Corrected MOU sent (${Math.round(pdfBytes.length / 1024)} KB)`);
+}
+
 function dashboardEmailHtml(loginUrl: string) {
   return `<!DOCTYPE html>
 <html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
@@ -202,6 +246,17 @@ async function main() {
 
   const now = new Date().toISOString();
   console.log(`\n=== ${HOLDER.organizationName} ===`);
+
+  if (MOU_ONLY) {
+    const sgKeyOnly = await loadSendGridKey(db);
+    if (!sgKeyOnly && !DRY_RUN) {
+      console.error('SENDGRID_API_KEY not found');
+      process.exit(1);
+    }
+    await sendCorrectedMou(sgKeyOnly!);
+    console.log('\nDone (MOU resend only).');
+    return;
+  }
 
   // ── Auth user ─────────────────────────────────────────────────────────────
   let userId: string | null = null;
@@ -343,20 +398,7 @@ async function main() {
   }
 
   // ── MOU PDF ───────────────────────────────────────────────────────────────
-  const pdfBytes = await generateDetailedMOUPdf({
-    partner_name: HOLDER.organizationName,
-    partner_role: 'Third-Party Program Delivery Partner',
-    signer_name: HOLDER.contactName,
-    signer_title: HOLDER.signerTitle,
-    contact_email: HOLDER.email,
-    contact_phone: HOLDER.phone,
-    programs: MOU_PROGRAMS,
-    revenue_share_model:
-      'Program delivery partner delivers ISDH-aligned healthcare training; Elevate provides ETPL listing, WIOA/DOL sponsorship pathways, enrollment infrastructure, and compliance oversight per executed agreement.',
-    wioa_eligible: true,
-    signed_at: now,
-    mou_version: '2026-program-holder-healthcare-01',
-  });
+  const pdfBytes = await buildMouPdf();
   const pdfB64 = Buffer.from(pdfBytes).toString('base64');
   const pdfFilename = `Elevate-Program-Holder-MOU-${HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-')}.pdf`;
   console.log(`  📄 MOU PDF ${Math.round(pdfBytes.length / 1024)} KB`);

--- a/scripts/ops/provision-enchanted-hearts-program-holder.ts
+++ b/scripts/ops/provision-enchanted-hearts-program-holder.ts
@@ -1,7 +1,7 @@
 #!/usr/bin/env tsx
 /**
  * Provision Enchanted Hearts Training Institute LLC as a third-party program holder,
- * send MOU PDF (no admin dashboard), then send program-holder dashboard login.
+ * send MOU PDF only (no dashboard emails — provision DB access separately if needed).
  *
  *   pnpm tsx --env-file=.env.local scripts/ops/provision-enchanted-hearts-program-holder.ts
  *   pnpm tsx --env-file=.env.local scripts/ops/provision-enchanted-hearts-program-holder.ts --dry-run
@@ -10,11 +10,9 @@ import { randomBytes } from 'crypto';
 import { createClient } from '@supabase/supabase-js';
 import { generateDetailedMOUPdf } from '@/lib/documents/generate-detailed-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const DRY_RUN = process.argv.includes('--dry-run');
 const MOU_ONLY = process.argv.includes('--mou-only');
@@ -199,7 +197,8 @@ async function sendCorrectedMou(sgKey: string) {
   const html = `<!DOCTYPE html>
 <html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
 <p>Dear Shawndra,</p>
-<p>Please <strong>disregard the prior MOU attachment</strong> if the program table appeared crowded or overlapping. Attached is a <strong>corrected, professionally formatted</strong> Program Holder MOU for <strong>${HOLDER.organizationName}</strong>.</p>
+<p>Please <strong>disregard any prior dashboard login emails</strong> (especially any link pointing to <code>localhost</code>) — those were sent in error. We are <strong>not</strong> asking you to use a dashboard at this time.</p>
+<p>Attached is your <strong>Program Holder MOU</strong> for <strong>${HOLDER.organizationName}</strong>. Review the PDF and sign using the button below.</p>
 <p><strong>Attached:</strong> revised MOU PDF (clear program schedule, no overlapping text).</p>
 <p><a href="${signUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Sign Program Holder MOU Online →</a></p>
 <p style="font-size:14px;color:#475569">Log in with <strong>${HOLDER.email}</strong> if prompted. Reply with any questions.</p>
@@ -213,20 +212,6 @@ async function sendCorrectedMou(sgKey: string) {
     filename: pdfFilename,
   });
   console.log(`  ✅ Corrected MOU sent (${Math.round(pdfBytes.length / 1024)} KB)`);
-}
-
-function dashboardEmailHtml(loginUrl: string) {
-  return `<!DOCTYPE html>
-<html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px;margin:0 auto">
-<p>Dear Shawndra,</p>
-<p>Your <strong>Program Holder dashboard</strong> for <strong>${HOLDER.organizationName}</strong> is now active on the Elevate platform.</p>
-<p>Use this secure link to log in (no password needed):</p>
-<p><a href="${loginUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Open Program Holder Dashboard →</a></p>
-<p style="font-size:14px;color:#475569">Or sign in at <a href="${SITE_URL}/login">${SITE_URL}/login</a> with <strong>${HOLDER.email}</strong>, then go to <strong>Program Holder Dashboard</strong>.</p>
-<p style="font-size:14px;color:#475569">From your dashboard you can manage students, track compliance, and access program-holder tools after you complete MOU signing and onboarding steps.</p>
-<p>Questions? Reply to this email or call ${PLATFORM_DEFAULTS.supportPhone}.</p>
-<p>Thank you,<br><strong>Elizabeth Greene</strong><br>Elevate for Humanity</p>
-</body></html>`;
 }
 
 async function main() {
@@ -412,27 +397,6 @@ async function main() {
     filename: pdfFilename,
   });
   console.log('  ✅ MOU email sent (PDF attached, CC Elevate)');
-
-  // ── Dashboard magic link (separate from MOU — not admin) ───────────────────
-  let loginUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/dashboard')}`;
-  if (!DRY_RUN) {
-    const { data: linkData, error: linkErr } = await db.auth.admin.generateLink({
-      type: 'magiclink',
-      email: HOLDER.email,
-      options: {
-        redirectTo: `${SITE_URL}/auth/callback?redirect=${encodeURIComponent('/program-holder/dashboard')}`,
-      },
-    });
-    if (linkErr) throw linkErr;
-    loginUrl = linkData.properties?.action_link ?? loginUrl;
-  }
-
-  await sendMail(sgKey!, {
-    to: HOLDER.email,
-    subject: `Your Program Holder dashboard is ready — ${HOLDER.organizationName}`,
-    html: dashboardEmailHtml(loginUrl),
-  });
-  console.log('  ✅ Dashboard login email sent');
 
   console.log('\nDone.');
   console.log(`  Email: ${HOLDER.email}`);

--- a/scripts/ops/provision-host-dashboards.mjs
+++ b/scripts/ops/provision-host-dashboards.mjs
@@ -1,11 +1,16 @@
 #!/usr/bin/env node
 /**
- * Provision host partner dashboard access + send login / MOU emails.
+ * DEPRECATED — do not send dashboard emails from ops scripts.
+ * Use MOU-only scripts (provision-barber-host-send-mou.ts, provision-enchanted-hearts --mou-only).
  *
- *   node scripts/ops/provision-host-dashboards.mjs
- *   node scripts/ops/provision-host-dashboards.mjs --corienne-only
- *   node scripts/ops/provision-host-dashboards.mjs --aaron-only
+ * This script is blocked unless ALLOW_DASHBOARD_OUTREACH=1 is set explicitly.
  */
+if (process.env.ALLOW_DASHBOARD_OUTREACH !== '1') {
+  console.error(
+    'Blocked: dashboard outreach emails are disabled. Set ALLOW_DASHBOARD_OUTREACH=1 to override.',
+  );
+  process.exit(1);
+}
 import { readFileSync, existsSync } from 'fs';
 import { join } from 'path';
 import { createClient } from '@supabase/supabase-js';

--- a/scripts/ops/provision-host-shops-send-mous.mjs
+++ b/scripts/ops/provision-host-shops-send-mous.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 /**
- * Provision partner dashboards + send host-shop MOU emails (with Elevate copy).
+ * Provision host shop partner records + send MOU emails (no dashboard links).
  *
  *   node scripts/ops/provision-host-shops-send-mous.mjs
  *   node scripts/ops/provision-host-shops-send-mous.mjs --dry-run
@@ -12,10 +12,19 @@ import { join } from 'path';
 import { createClient } from '@supabase/supabase-js';
 
 const ROOT = process.cwd();
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+const PRODUCTION_SITE_URL = 'https://www.elevateforhumanity.org';
+function outboundSiteUrl() {
+  const raw = (process.env.OUTBOUND_SITE_URL || process.env.NEXT_PUBLIC_SITE_URL || PRODUCTION_SITE_URL).replace(
+    /\/$/,
+    '',
+  );
+  if (/localhost|127\.0\.0\.1/i.test(raw)) {
+    console.warn(`⚠️ Outbound links use ${PRODUCTION_SITE_URL} (dev SITE_URL ignored)`);
+    return PRODUCTION_SITE_URL;
+  }
+  return raw;
+}
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const FROM = { email: 'noreply@elevateforhumanity.org', name: 'Elevate for Humanity' };
 const REPLY_TO = { email: ELEVATE_COPY, name: 'Elizabeth Greene' };
@@ -155,7 +164,6 @@ async function sendEmail({ to, subject, html }) {
 
 function buildMouEmail(host) {
   const firstName = host.contactName.split(' ')[0];
-  const dashboardUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partner/dashboard')}`;
   const programRows = host.programs
     .map((p) => {
       const link = `${SITE_URL}/login?redirect=${encodeURIComponent(p.signPath)}`;
@@ -186,7 +194,7 @@ function buildMouEmail(host) {
     <p style="margin:0 0 16px;color:#1e293b;font-size:15px">Hi ${firstName},</p>
     <p style="margin:0 0 16px;color:#475569;font-size:14px;line-height:1.7">
       Thank you for partnering with <strong>Elevate for Humanity</strong> as a registered apprenticeship host shop for
-      <strong>${host.shopName}</strong>. Below are your program MOU(s) and your partner dashboard link.
+      <strong>${host.shopName}</strong>. Below are your program MOU(s) for review and signature.
     </p>
     <p style="margin:0 0 12px;color:#1e293b;font-size:13px;font-weight:bold;text-transform:uppercase;letter-spacing:0.05em">Program MOUs</p>
     <table width="100%" cellpadding="0" cellspacing="0" style="border:1px solid #e2e8f0;border-radius:8px;overflow:hidden;margin:0 0 24px">
@@ -197,13 +205,8 @@ function buildMouEmail(host) {
         ? `<p style="margin:0 0 20px;color:#475569;font-size:14px;line-height:1.7">
       Please sign the ${pendingCount === 1 ? 'remaining MOU' : 'remaining MOUs'} using the buttons above (you will be prompted to log in with <strong>${host.email}</strong>).
     </p>`
-        : `<p style="margin:0 0 20px;color:#166534;font-size:14px">All program MOUs for your shop are on file. Use your partner dashboard below to manage apprentices.</p>`
+        : `<p style="margin:0 0 20px;color:#166534;font-size:14px">All program MOUs for your shop are on file. Reply to this email if you need anything else.</p>`
     }
-    <table cellpadding="0" cellspacing="0" style="margin:0 0 28px">
-      <tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
-        <a href="${dashboardUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Open Partner Dashboard →</a>
-      </td></tr>
-    </table>
     <p style="margin:0 0 8px;color:#475569;font-size:13px">Questions? Reply to this email or call <strong>(317) 314-3757</strong>.</p>
     <p style="margin:24px 0 0;color:#1e293b;font-size:14px">
       Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, Elevate for Humanity
@@ -312,7 +315,7 @@ async function provisionStyleAndScissors() {
   if (!PROVISION_ONLY) {
     await sendEmail({
       to: h.email,
-      subject: `Host Shop MOUs & Partner Dashboard — ${h.shopName}`,
+      subject: `Host Shop MOUs — ${h.shopName}`,
       html: buildMouEmail(h),
     });
   }
@@ -443,7 +446,7 @@ async function provisionRazorsImage() {
   if (!PROVISION_ONLY) {
     await sendEmail({
       to: h.email,
-      subject: `Barber Host Shop MOU & Partner Dashboard — ${h.shopName}`,
+      subject: `Barber Host Shop MOU — ${h.shopName}`,
       html: buildMouEmail(h),
     });
   }

--- a/scripts/ops/provision-prestige-barbershop-application.ts
+++ b/scripts/ops/provision-prestige-barbershop-application.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * Move Prestige Elevation from host_shop_applications into barbershop_partner_applications
+ * (canonical barber host track) and email MOU PDF + document checklist.
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/provision-prestige-barbershop-application.ts
+ */
+import { createClient } from '@supabase/supabase-js';
+import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
+  /\/$/,
+  '',
+);
+const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
+const PARTNER_ID = '9dffa854-1002-42e7-bad3-a8d626326d6e';
+const CONTACT_EMAIL = 'info@prestigeelevation.com';
+
+const HOST_SHOP_APP = {
+  shop_name: 'Prestige Elevation Barber and Beauty Institute LLC',
+  owner_name: 'Elizabeth L. Greene',
+  phone: '(317) 760-7908',
+  address: '6331 N Keystone Ave, Indianapolis, IN 46220',
+  license_number: 'BA11000095',
+  supervisor_name: 'Elizabeth L. Greene',
+};
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db
+    .from('platform_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db
+    .from('app_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const now = new Date().toISOString();
+
+  const { data: existing } = await db
+    .from('barbershop_partner_applications')
+    .select('id')
+    .ilike('shop_legal_name', '%Prestige Elevation%')
+    .maybeSingle();
+
+  const row = {
+    shop_legal_name: HOST_SHOP_APP.shop_name,
+    owner_name: HOST_SHOP_APP.owner_name,
+    contact_name: HOST_SHOP_APP.owner_name,
+    contact_email: CONTACT_EMAIL,
+    contact_phone: HOST_SHOP_APP.phone,
+    shop_address_line1: '6331 N Keystone Ave',
+    shop_city: 'Indianapolis',
+    shop_state: 'IN',
+    shop_zip: '46220',
+    indiana_shop_license_number: HOST_SHOP_APP.license_number,
+    supervisor_name: HOST_SHOP_APP.supervisor_name,
+    supervisor_license_number: HOST_SHOP_APP.license_number,
+    compensation_model: 'commission',
+    employment_model: 'commission',
+    has_workers_comp: true,
+    workers_comp_status: 'verified',
+    can_supervise_and_verify: true,
+    mou_acknowledged: true,
+    consent_acknowledged: true,
+    status: 'approved',
+    notes: 'Migrated from host_shop_applications — canonical barber host track',
+    updated_at: now,
+  };
+
+  if (existing?.id) {
+    await db.from('barbershop_partner_applications').update(row).eq('id', existing.id);
+    console.log('  ✅ barbershop_partner_applications updated', existing.id);
+  } else {
+    const { data: inserted, error } = await db
+      .from('barbershop_partner_applications')
+      .insert(row)
+      .select('id')
+      .single();
+    if (error) throw error;
+    console.log('  ✅ barbershop_partner_applications created', inserted.id);
+  }
+
+  await db
+    .from('partners')
+    .update({
+      approval_status: 'approved',
+      status: 'active',
+      programs: ['barber', 'cosmetology'],
+      license_number: HOST_SHOP_APP.license_number,
+      updated_at: now,
+    })
+    .eq('id', PARTNER_ID);
+
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  const pdfBytes = await generateMOUPdf({
+    shop_name: HOST_SHOP_APP.shop_name,
+    signer_name: HOST_SHOP_APP.owner_name,
+    signer_title: 'Owner / Program Director',
+    supervisor_name: HOST_SHOP_APP.supervisor_name,
+    supervisor_license: HOST_SHOP_APP.license_number,
+    compensation_model: 'commission',
+    signed_at: now,
+    mou_version: '2025-barber-01',
+  });
+
+  const html = `<!DOCTYPE html><html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px">
+<p>Dear Elizabeth,</p>
+<p><strong>Attached:</strong> Barber Host Shop MOU PDF for <strong>${HOST_SHOP_APP.shop_name}</strong> (now on the canonical <code>barbershop_partner_applications</code> track).</p>
+<p><a href="${signUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Sign MOU Online →</a></p>
+<p><strong>Required documents on file / please resend if updated:</strong></p>
+<ol>
+<li>IRS EIN Assignment Letter (CP 575)</li>
+<li>W-9</li>
+<li>Indiana Barbershop License</li>
+<li>Workers' Compensation COI</li>
+<li>General Liability COI</li>
+<li>Supervising Barber License</li>
+</ol>
+<p>Upload: <a href="${SITE_URL}/partners/barber-host-shop/documents">${SITE_URL}/partners/barber-host-shop/documents</a></p>
+<p>— ${PLATFORM_DEFAULTS.orgName}</p>
+</body></html>`;
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${sgKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: CONTACT_EMAIL, name: HOST_SHOP_APP.owner_name }], cc: [{ email: ELEVATE_COPY }] }],
+      from: { email: 'noreply@elevateforhumanity.org', name: 'Elevate for Humanity' },
+      reply_to: { email: ELEVATE_COPY },
+      subject: `Barber Host Shop MOU — ${HOST_SHOP_APP.shop_name}`,
+      content: [{ type: 'text/html', value: html }],
+      attachments: [{
+        content: Buffer.from(pdfBytes).toString('base64'),
+        type: 'application/pdf',
+        filename: 'Elevate-Barber-Host-MOU-Prestige-Elevation.pdf',
+        disposition: 'attachment',
+      }],
+    }),
+  });
+  if (res.status !== 202) throw new Error(await res.text());
+  console.log('  ✅ MOU PDF emailed to', CONTACT_EMAIL);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/provision-prestige-barbershop-application.ts
+++ b/scripts/ops/provision-prestige-barbershop-application.ts
@@ -8,11 +8,9 @@
 import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const PARTNER_ID = '9dffa854-1002-42e7-bad3-a8d626326d6e';
 const CONTACT_EMAIL = 'info@prestigeelevation.com';
@@ -136,7 +134,7 @@ async function main() {
 <li>General Liability COI</li>
 <li>Supervising Barber License</li>
 </ol>
-<p>Upload: <a href="${SITE_URL}/partners/barber-host-shop/documents">${SITE_URL}/partners/barber-host-shop/documents</a></p>
+<p>Please <strong>reply to this email</strong> with PDF attachments for each item above.</p>
 <p>— ${PLATFORM_DEFAULTS.orgName}</p>
 </body></html>`;
 

--- a/scripts/ops/provision-prestige-barbershop-application.ts
+++ b/scripts/ops/provision-prestige-barbershop-application.ts
@@ -9,6 +9,7 @@ import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -109,7 +110,8 @@ async function main() {
     process.exit(1);
   }
 
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  const { steps } = await buildJourneyLinks(db, CONTACT_EMAIL, 'partner');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
   const pdfBytes = await generateMOUPdf({
     shop_name: HOST_SHOP_APP.shop_name,
     signer_name: HOST_SHOP_APP.owner_name,
@@ -124,7 +126,7 @@ async function main() {
   const html = `<!DOCTYPE html><html><body style="font-family:Arial,sans-serif;color:#1e293b;max-width:600px">
 <p>Dear Elizabeth,</p>
 <p><strong>Attached:</strong> Barber Host Shop MOU PDF for <strong>${HOST_SHOP_APP.shop_name}</strong> (now on the canonical <code>barbershop_partner_applications</code> track).</p>
-<p><a href="${signUrl}" style="display:inline-block;background:#dc2626;color:#fff;padding:12px 24px;text-decoration:none;border-radius:8px;font-weight:bold">Sign MOU Online →</a></p>
+${stepsHtml}
 <p><strong>Required documents on file / please resend if updated:</strong></p>
 <ol>
 <li>IRS EIN Assignment Letter (CP 575)</li>

--- a/scripts/ops/provision-prestige-barbershop-application.ts
+++ b/scripts/ops/provision-prestige-barbershop-application.ts
@@ -10,6 +10,7 @@ import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
 import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -42,6 +43,8 @@ async function loadSendGridKey(db: ReturnType<typeof createClient>) {
 }
 
 async function main() {
+  assertOutreachEmailAllowed('provision-prestige-barbershop-application.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) process.exit(1);

--- a/scripts/ops/resend-outreach-portal-links.ts
+++ b/scripts/ops/resend-outreach-portal-links.ts
@@ -1,0 +1,149 @@
+#!/usr/bin/env tsx
+/**
+ * Resend corrected portal links (magic link → /auth/callback → chronological destination).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/resend-outreach-portal-links.ts
+ *   pnpm tsx --env-file=.env.local scripts/ops/resend-outreach-portal-links.ts --dry-run
+ */
+import { createClient } from '@supabase/supabase-js';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
+import {
+  buildJourneyLinks,
+  journeyStepsHtml,
+  type OutreachPersona,
+} from './outreach-auth-link';
+
+const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
+const DRY_RUN = process.argv.includes('--dry-run');
+const SITE_URL = outboundSiteUrl();
+
+const RECIPIENTS: {
+  email: string;
+  name: string;
+  shopOrOrg: string;
+  persona: OutreachPersona;
+}[] = [
+  {
+    email: 'info@enchantedheartstraining.com',
+    name: 'Shawndra Quinn, RN',
+    shopOrOrg: 'Enchanted Hearts Training Institute LLC',
+    persona: 'program_holder',
+  },
+  {
+    email: 'calvincutz1985@gmail.com',
+    name: 'Calvin Pena',
+    shopOrOrg: "Cal's Kutz Studio",
+    persona: 'partner',
+  },
+  {
+    email: 'christopherd.newkirk@gmail.com',
+    name: 'Chris Newkirk',
+    shopOrOrg: "B-52's Barber Shop LLC",
+    persona: 'partner',
+  },
+  {
+    email: 'info@prestigeelevation.com',
+    name: 'Elizabeth L. Greene',
+    shopOrOrg: 'Prestige Elevation Barber and Beauty Institute LLC',
+    persona: 'partner',
+  },
+];
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db.from('platform_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db.from('app_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+function buildEmail(
+  firstName: string,
+  org: string,
+  persona: OutreachPersona,
+  stepsHtml: string,
+) {
+  const portalLabel = persona === 'program_holder' ? 'Program Holder' : 'Partner';
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">${portalLabel} portal — corrected access links</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Hi ${firstName},</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Some earlier emails included broken links (for example <code>localhost</code>). Please <strong>disregard those</strong>.
+Use the steps below <strong>in order</strong> — each button signs you in and takes you to the correct page on
+<strong>${SITE_URL}</strong> for <strong>${org}</strong>.
+</p>
+<p style="margin:0 0 12px;font-size:13px;font-weight:bold;text-transform:uppercase;letter-spacing:0.05em;color:#1e293b">Your steps</p>
+${stepsHtml}
+<p style="margin:0 0 16px;font-size:13px;color:#64748b">Links expire after a short time. You can always sign in at
+<a href="${SITE_URL}/login" style="color:#dc2626">${SITE_URL}/login</a> with your email and use the same paths above.</p>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey && !DRY_RUN) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  console.log(DRY_RUN ? 'DRY RUN' : 'LIVE', `— site ${SITE_URL}\n`);
+
+  for (const r of RECIPIENTS) {
+    const first = r.name.split(' ')[0];
+    const { steps } = await buildJourneyLinks(db, r.email, r.persona);
+    const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
+    const html = buildEmail(first, r.shopOrOrg, r.persona, stepsHtml);
+    const subject = `[Corrected Links] ${r.shopOrOrg} — portal access (use in order)`;
+
+    if (DRY_RUN) {
+      console.log(`Would send → ${r.email} (${r.persona})`);
+      steps.forEach((s, i) => console.log(`  ${i + 1}. ${s.label}`));
+      continue;
+    }
+
+    const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sgKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        personalizations: [
+          {
+            to: [{ email: r.email, name: r.name }],
+            cc: [{ email: ELEVATE_COPY, name: 'Elevate Admin Copy' }],
+          },
+        ],
+        from: { email: 'noreply@elevateforhumanity.org', name: 'Elizabeth Greene | Elevate for Humanity' },
+        reply_to: { email: ELEVATE_COPY, name: 'Elizabeth Greene' },
+        subject,
+        content: [{ type: 'text/html', value: html }],
+      }),
+    });
+    if (res.status !== 202) throw new Error(`${r.email}: SendGrid ${res.status} ${await res.text()}`);
+    console.log(`✅ ${r.email} — ${steps.length} chronological steps`);
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/resend-outreach-portal-links.ts
+++ b/scripts/ops/resend-outreach-portal-links.ts
@@ -13,6 +13,7 @@ import {
   journeyStepsHtml,
   type OutreachPersona,
 } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const DRY_RUN = process.argv.includes('--dry-run');
@@ -94,6 +95,8 @@ ${stepsHtml}
 }
 
 async function main() {
+  assertOutreachEmailAllowed('resend-outreach-portal-links.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) process.exit(1);

--- a/scripts/ops/send-aaron-barber-mou.ts
+++ b/scripts/ops/send-aaron-barber-mou.ts
@@ -9,6 +9,7 @@ import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
 import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -72,6 +73,8 @@ After we receive your signed MOU, Elizabeth will follow up with next steps for o
 }
 
 async function main() {
+  assertOutreachEmailAllowed('send-aaron-barber-mou.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key || key === 'placeholder') {

--- a/scripts/ops/send-aaron-barber-mou.ts
+++ b/scripts/ops/send-aaron-barber-mou.ts
@@ -8,6 +8,7 @@ import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -37,7 +38,7 @@ async function loadSendGridKey(db: ReturnType<typeof createClient>) {
   return (app?.value as string) ?? null;
 }
 
-function buildEmailHtml(signUrl: string) {
+function buildEmailHtml(stepsHtml: string) {
   const first = HOST.contactName.split(' ')[0];
   return `<!DOCTYPE html>
 <html><head><meta charset="utf-8"></head>
@@ -57,14 +58,8 @@ for <strong>${HOST.shopName}</strong>.
 <p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
 <strong>Attached:</strong> your individual <strong>Barber Host Shop Employer Agreement (MOU)</strong> for review and signature.
 </p>
-<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
-<li>Review the attached PDF.</li>
-<li>Click below to <strong>digitally sign</strong> (log in with <strong>${HOST.email}</strong> if prompted).</li>
-<li>Reply to this email with any questions or a signed copy if you prefer.</li>
-</ol>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
-<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
-</td></tr></table>
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">Review the attached PDF, then complete these steps <strong>in order</strong> on ${SITE_URL}:</p>
+${stepsHtml}
 <p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
 After we receive your signed MOU, Elizabeth will follow up with next steps for onboarding apprentices.
 </p>
@@ -91,7 +86,8 @@ async function main() {
     process.exit(1);
   }
 
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  const { steps } = await buildJourneyLinks(db, HOST.email, 'partner');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
   const pdfBytes = await generateMOUPdf({
     shop_name: HOST.shopName,
     signer_name: HOST.contactName,
@@ -115,7 +111,7 @@ async function main() {
     from: { email: 'noreply@elevateforhumanity.org', name: 'Elizabeth Greene | Elevate for Humanity' },
     reply_to: { email: ELEVATE_COPY, name: 'Elizabeth Greene' },
     subject: `Barber Host Shop Employer Agreement (MOU) — ${HOST.shopName}`,
-    content: [{ type: 'text/html', value: buildEmailHtml(signUrl) }],
+    content: [{ type: 'text/html', value: buildEmailHtml(stepsHtml) }],
     attachments: [
       {
         content: pdfB64,

--- a/scripts/ops/send-aaron-barber-mou.ts
+++ b/scripts/ops/send-aaron-barber-mou.ts
@@ -7,11 +7,9 @@
 import { createClient } from '@supabase/supabase-js';
 import { generateMOUPdf } from '@/lib/documents/generate-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 
 const HOST = {

--- a/scripts/ops/send-aaron-barber-mou.ts
+++ b/scripts/ops/send-aaron-barber-mou.ts
@@ -67,12 +67,9 @@ for <strong>${HOST.shopName}</strong>.
 <table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
 <a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
 </td></tr></table>
-<div style="background:#f1f5f9;border-radius:8px;padding:16px 20px;margin:0 0 24px">
-<p style="margin:0 0 8px;font-size:13px;font-weight:bold;color:#1e293b">About your host partner dashboard</p>
-<p style="margin:0;font-size:13px;line-height:1.7;color:#475569">
-After we receive your signed MOU, we will activate your <strong>host partner dashboard</strong> and Elizabeth will send a separate email with next steps for onboarding apprentices.
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+After we receive your signed MOU, Elizabeth will follow up with next steps for onboarding apprentices.
 </p>
-</div>
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply here or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
 <p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
 </td></tr>

--- a/scripts/ops/send-admin-portal-roster-email.ts
+++ b/scripts/ops/send-admin-portal-roster-email.ts
@@ -13,6 +13,7 @@ import { join } from 'path';
 import { createClient } from '@supabase/supabase-js';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const ADMIN = 'elevate4humanityedu@gmail.com';
 const SITE_URL = outboundSiteUrl();
@@ -52,6 +53,8 @@ function table(headers: string[], rows: string[][]) {
 }
 
 async function main() {
+  assertOutreachEmailAllowed('send-admin-portal-roster-email.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) process.exit(1);

--- a/scripts/ops/send-admin-portal-roster-email.ts
+++ b/scripts/ops/send-admin-portal-roster-email.ts
@@ -1,0 +1,258 @@
+#!/usr/bin/env tsx
+/**
+ * Email Elevate admin a full roster of apprentices + host shops/program holders.
+ * Optionally resets portal passwords (existing passwords cannot be read from Supabase).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-admin-portal-roster-email.ts
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-admin-portal-roster-email.ts --dry-run
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-admin-portal-roster-email.ts --no-reset-passwords
+ */
+import crypto from 'crypto';
+import { writeFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
+
+const ADMIN = 'elevate4humanityedu@gmail.com';
+const SITE_URL = outboundSiteUrl();
+const DRY_RUN = process.argv.includes('--dry-run');
+const RESET_PASSWORDS = !process.argv.includes('--no-reset-passwords');
+
+function tempPassword(): string {
+  return `El${crypto.randomBytes(4).toString('hex').toUpperCase()}#26`;
+}
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data: ps } = await db.from('platform_secrets').select('key, value_enc').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  if (ps?.value_enc) return ps.value_enc as string;
+  const { data: app } = await db.from('app_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+async function setPassword(db: ReturnType<typeof createClient>, userId: string, password: string) {
+  const { error } = await db.auth.admin.updateUserById(userId, { password });
+  if (error) throw new Error(error.message);
+}
+
+function esc(s: string) {
+  return s.replace(/&/g, '&amp;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
+function table(headers: string[], rows: string[][]) {
+  const th = headers.map((h) => `<th style="padding:8px;border:1px solid #e2e8f0;text-align:left;font-size:12px;background:#f8fafc">${esc(h)}</th>`).join('');
+  const body = rows
+    .map(
+      (r) =>
+        `<tr>${r.map((c) => `<td style="padding:8px;border:1px solid #e2e8f0;font-size:12px;vertical-align:top">${esc(c)}</td>`).join('')}</tr>`,
+    )
+    .join('');
+  return `<table width="100%" cellpadding="0" cellspacing="0" style="border-collapse:collapse;margin:16px 0">${`<tr>${th}</tr>`}${body}</table>`;
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey && !DRY_RUN) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  const passwordByEmail: Record<string, string> = {};
+
+  // ── Apprentices (active program_enrollments) ───────────────────────────────
+  const { data: enrollments } = await db
+    .from('program_enrollments')
+    .select('user_id, program_id, status, created_at')
+    .order('created_at', { ascending: false });
+
+  const apprenticeRows: string[][] = [];
+  for (const e of enrollments ?? []) {
+    const { data: prof } = await db.from('profiles').select('full_name, email, role').eq('id', e.user_id).maybeSingle();
+    const { data: prog } = await db.from('programs').select('name, slug').eq('id', e.program_id).maybeSingle();
+    const email = prof?.email ?? '';
+    let pwd = passwordByEmail[email] ?? '—';
+    if (RESET_PASSWORDS && email && !passwordByEmail[email]) {
+      const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+      const u = listed?.users?.find((x) => x.email?.toLowerCase() === email.toLowerCase());
+      if (u) {
+        const p = tempPassword();
+        if (!DRY_RUN) await setPassword(db, u.id, p);
+        passwordByEmail[email] = p;
+        pwd = p;
+      }
+    }
+    apprenticeRows.push([
+      prof?.full_name ?? '—',
+      email,
+      prog?.slug ?? '—',
+      e.status ?? '—',
+      pwd,
+      `${SITE_URL}/learner/dashboard`,
+    ]);
+  }
+
+  // ── Barber subscriptions ───────────────────────────────────────────────────
+  const { data: barberSubs } = await db.from('barber_subscriptions').select('*').order('customer_name');
+  const barberSubRows: string[][] = [];
+  for (const b of barberSubs ?? []) {
+    const email = b.customer_email ?? '';
+    let pwd = passwordByEmail[email] ?? '—';
+    if (RESET_PASSWORDS && email && !passwordByEmail[email]) {
+      const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+      const u = listed?.users?.find((x) => x.email?.toLowerCase() === email.toLowerCase());
+      if (u) {
+        const p = tempPassword();
+        if (!DRY_RUN) await setPassword(db, u.id, p);
+        passwordByEmail[email] = p;
+        pwd = p;
+      }
+    }
+    barberSubRows.push([
+      b.customer_name ?? '—',
+      email,
+      b.payment_status ?? b.status ?? '—',
+      String(b.weekly_payment_cents ? `$${(b.weekly_payment_cents / 100).toFixed(2)}/wk` : '—'),
+      pwd,
+    ]);
+  }
+
+  // ── Program holders ────────────────────────────────────────────────────────
+  const { data: holders } = await db
+    .from('program_holders')
+    .select('id, organization_name, contact_name, contact_email, contact_phone, status, mou_signed, mou_type, user_id')
+    .order('organization_name');
+
+  const holderRows: string[][] = [];
+  for (const h of holders ?? []) {
+    if (!h.contact_email || h.organization_name === 'Elevate for Humanity') continue;
+    const { data: links } = await db
+      .from('program_holder_programs')
+      .select('programs(slug)')
+      .eq('program_holder_id', h.id)
+      .eq('status', 'active');
+    const slugs = (links ?? []).map((l: { programs: { slug: string } | null }) => l.programs?.slug).filter(Boolean).join(', ') || '—';
+    const email = h.contact_email;
+    let pwd = passwordByEmail[email] ?? '—';
+    if (RESET_PASSWORDS && email && !passwordByEmail[email] && h.user_id) {
+      const p = tempPassword();
+      if (!DRY_RUN) await setPassword(db, h.user_id, p);
+      passwordByEmail[email] = p;
+      pwd = p;
+    }
+    holderRows.push([
+      h.organization_name ?? '—',
+      h.contact_name ?? '—',
+      email,
+      h.contact_phone ?? '—',
+      h.status ?? '—',
+      h.mou_signed ? 'signed' : 'pending',
+      slugs,
+      pwd,
+      `${SITE_URL}/program-holder/dashboard`,
+    ]);
+  }
+
+  // ── Barber host shops ──────────────────────────────────────────────────────
+  const { data: hostShops } = await db
+    .from('barbershop_partner_applications')
+    .select('shop_legal_name, contact_name, contact_email, contact_phone, status, mou_signed_at')
+    .order('shop_legal_name');
+
+  const hostRows: string[][] = [];
+  for (const s of hostShops ?? []) {
+    const email = s.contact_email ?? '';
+    let pwd = passwordByEmail[email] ?? '—';
+    if (RESET_PASSWORDS && email && !passwordByEmail[email]) {
+      const { data: prof } = await db.from('profiles').select('id').eq('email', email).maybeSingle();
+      let uid = prof?.id;
+      if (!uid) {
+        const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+        uid = listed?.users?.find((x) => x.email?.toLowerCase() === email.toLowerCase())?.id;
+      }
+      if (uid) {
+        const p = tempPassword();
+        if (!DRY_RUN) await setPassword(db, uid, p);
+        passwordByEmail[email] = p;
+        pwd = p;
+      }
+    }
+    hostRows.push([
+      s.shop_legal_name ?? '—',
+      s.contact_name ?? '—',
+      email,
+      s.contact_phone ?? '—',
+      s.status ?? '—',
+      s.mou_signed_at ? 'MOU signed' : 'MOU pending',
+      pwd,
+      `${SITE_URL}/partner/dashboard`,
+    ]);
+  }
+
+  const generatedAt = new Date().toLocaleString('en-US', { timeZone: 'America/Indiana/Indianapolis' });
+  const html = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:24px 16px"><tr><td align="center">
+<table width="900" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;padding:32px">
+<tr><td>
+<h1 style="margin:0 0 8px;font-size:22px;color:#1e293b">Portal roster — apprentices, program holders &amp; host shops</h1>
+<p style="margin:0 0 16px;font-size:13px;color:#64748b">Generated ${esc(generatedAt)} (America/Indiana/Indianapolis) · Login: <a href="${SITE_URL}/login">${SITE_URL}/login</a></p>
+<p style="margin:0 0 20px;font-size:13px;color:#475569;line-height:1.6">
+<strong>Passwords:</strong> ${RESET_PASSWORDS ? 'New temporary passwords were generated below (Supabase cannot retrieve old passwords).' : 'Password reset skipped — use existing credentials or run without --no-reset-passwords.'}
+<strong> Confidential — admin eyes only.</strong> Recipients should change passwords after first login.
+</p>
+
+<h2 style="font-size:16px;margin:24px 0 8px">Active apprentices (program_enrollments)</h2>
+${table(['Name', 'Email', 'Program', 'Status', 'Temp password', 'Dashboard'], apprenticeRows)}
+
+<h2 style="font-size:16px;margin:24px 0 8px">Barber apprentice billing (barber_subscriptions)</h2>
+${table(['Name', 'Email', 'Payment status', 'Weekly rate', 'Temp password'], barberSubRows)}
+
+<h2 style="font-size:16px;margin:24px 0 8px">Program holders</h2>
+${table(['Organization', 'Contact', 'Email', 'Phone', 'Status', 'MOU', 'Programs', 'Temp password', 'Dashboard'], holderRows)}
+
+<h2 style="font-size:16px;margin:24px 0 8px">Barber host shops</h2>
+${table(['Shop', 'Contact', 'Email', 'Phone', 'Status', 'MOU', 'Temp password', 'Dashboard'], hostRows)}
+
+<p style="margin:24px 0 0;font-size:12px;color:#94a3b8">${PLATFORM_DEFAULTS.orgName} · automated ops report</p>
+</td></tr></table>
+</td></tr></table>
+</body></html>`;
+
+  const outDir = join(process.cwd(), 'exports', 'email-copies');
+  mkdirSync(outDir, { recursive: true });
+  const outPath = join(outDir, `admin-portal-roster-${Date.now()}.html`);
+  writeFileSync(outPath, html, 'utf8');
+  console.log('Wrote', outPath);
+
+  if (DRY_RUN) {
+    console.log('DRY RUN — would email', ADMIN);
+    console.log('Apprentices:', apprenticeRows.length, 'Holders:', holderRows.length, 'Hosts:', hostRows.length);
+    return;
+  }
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${sgKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify({
+      personalizations: [{ to: [{ email: ADMIN, name: 'Elizabeth Greene' }] }],
+      from: { email: 'noreply@elevateforhumanity.org', name: 'Elevate Ops' },
+      reply_to: { email: ADMIN, name: 'Elizabeth Greene' },
+      subject: `[Confidential] Portal roster — apprentices, program holders & host shops (${generatedAt})`,
+      content: [{ type: 'text/html', value: html }],
+    }),
+  });
+  if (res.status !== 202) throw new Error(`SendGrid ${res.status}: ${await res.text()}`);
+  console.log(`✅ Roster emailed to ${ADMIN}`);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/send-email-copies-to-admin.ts
+++ b/scripts/ops/send-email-copies-to-admin.ts
@@ -1,0 +1,201 @@
+#!/usr/bin/env tsx
+/**
+ * Write HTML previews of ops outreach emails and send copies to Elevate admin.
+ * Uses production URLs only (never localhost).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-email-copies-to-admin.ts
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-email-copies-to-admin.ts --write-only
+ */
+import { mkdirSync, writeFileSync } from 'fs';
+import { join } from 'path';
+import { createClient } from '@supabase/supabase-js';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
+
+const SITE_URL = outboundSiteUrl();
+const ADMIN = 'elevate4humanityedu@gmail.com';
+const WRITE_ONLY = process.argv.includes('--write-only');
+
+const ENCHANTED = {
+  organizationName: 'Enchanted Hearts Training Institute LLC',
+  contactName: 'Shawndra Quinn, RN',
+  email: 'info@enchantedheartstraining.com',
+};
+
+const BARBER_HOST = {
+  shopName: "Cal's Kutz Studio",
+  contactName: 'Calvin Pena',
+  email: 'calvincutz1985@gmail.com',
+};
+
+const REQUIRED_DOCS = [
+  'IRS EIN Assignment Letter (CP 575 or 147C)',
+  'W-9 Form (signed)',
+  'Indiana Barbershop License (current, full copy)',
+  "Workers' Compensation Certificate of Insurance",
+  'General Liability Insurance Certificate',
+  'Supervising Barber License (2+ years experience)',
+];
+
+function enchantedMouHtml() {
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const first = 'Shawndra';
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Third-Party Program Holder MOU</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Dear ${first},</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Thank you for partnering with <strong>Elevate for Humanity</strong> as a <strong>third-party program delivery partner</strong>
+for <strong>${ENCHANTED.organizationName}</strong>.
+</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+<strong>Attached:</strong> your <strong>Program Holder Memorandum of Understanding (MOU)</strong> (PDF).
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>${ENCHANTED.email}</strong> if prompted).</li>
+<li>Reply to this email with questions or a signed copy if you prefer.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
+</td></tr></table>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+}
+
+function barberHostMouHtml() {
+  const first = BARBER_HOST.contactName.split(' ')[0];
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/partners/barber-host-shop/sign-mou')}`;
+  const docList = REQUIRED_DOCS.map((d) => `<li style="margin-bottom:8px">${d}</li>`).join('');
+  return `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Barber Host Shop Employer Agreement (MOU)</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Hi ${first},</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Your barber apprenticeship <strong>host shop application</strong> for <strong>${BARBER_HOST.shopName}</strong> is approved.
+<strong>Attached</strong> is your Barber Host Shop Employer Agreement (MOU).
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
+<li>Review the attached MOU PDF.</li>
+<li>Click below to <strong>digitally sign</strong> (log in with <strong>${BARBER_HOST.email}</strong>).</li>
+<li>Reply with required documents listed below.</li>
+</ol>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Barber Host Shop MOU Online →</a>
+</td></tr></table>
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569"><strong>Required documents</strong> — reply with PDF attachments:</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">${docList}</ol>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+}
+
+const TEMPLATES: { id: string; subject: string; intendedTo: string; html: string; note: string }[] = [
+  {
+    id: 'enchanted-program-holder-mou',
+    subject: `Program Holder MOU — ${ENCHANTED.organizationName} (signature required)`,
+    intendedTo: ENCHANTED.email,
+    html: enchantedMouHtml(),
+    note: 'Current canonical template — MOU PDF attachment + sign link only. NO dashboard email.',
+  },
+  {
+    id: 'barber-host-mou-calvin-example',
+    subject: `Barber Host Shop MOU & required documents — ${BARBER_HOST.shopName}`,
+    intendedTo: BARBER_HOST.email,
+    html: barberHostMouHtml(),
+    note: 'Barber host template — MOU PDF + sign link + document checklist. NO dashboard link.',
+  },
+];
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db.from('platform_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db.from('app_secrets').select('value').eq('key', 'SENDGRID_API_KEY').maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+async function main() {
+  const outDir = join(process.cwd(), 'exports', 'email-copies');
+  mkdirSync(outDir, { recursive: true });
+
+  const indexLines = [`# Ops email copies — ${new Date().toISOString()}`, `Site URL used in links: ${SITE_URL}`, ''];
+
+  for (const t of TEMPLATES) {
+    const path = join(outDir, `${t.id}.html`);
+    writeFileSync(path, t.html, 'utf8');
+    indexLines.push(`## ${t.id}`, `- Intended recipient: ${t.intendedTo}`, `- Subject: ${t.subject}`, `- ${t.note}`, `- File: ${path}`, '');
+    console.log(`Wrote ${path}`);
+  }
+
+  writeFileSync(join(outDir, 'README.md'), indexLines.join('\n'), 'utf8');
+
+  if (WRITE_ONLY) {
+    console.log('\nWrite-only mode — not sending email.');
+    return;
+  }
+
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  for (const t of TEMPLATES) {
+    const wrapper = `<div style="font-family:Arial,sans-serif;max-width:640px;margin:0 auto;padding:16px">
+<p style="background:#fef3c7;border:1px solid #f59e0b;padding:12px;border-radius:8px;font-size:13px">
+<strong>ADMIN COPY</strong> — intended for <strong>${t.intendedTo}</strong><br/>
+${t.note}<br/>
+All links use <strong>${SITE_URL}</strong> (production — not localhost).
+</p>
+<hr style="margin:24px 0;border:none;border-top:1px solid #e2e8f0"/>
+${t.html}
+</div>`;
+
+    const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${sgKey}`, 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        personalizations: [{ to: [{ email: ADMIN, name: 'Elizabeth Greene' }] }],
+        from: { email: 'noreply@elevateforhumanity.org', name: 'Elevate Ops | Email Copies' },
+        reply_to: { email: ADMIN },
+        subject: `[COPY] ${t.subject}`,
+        content: [{ type: 'text/html', value: wrapper }],
+      }),
+    });
+    if (res.status !== 202) throw new Error(`SendGrid ${res.status}: ${await res.text()}`);
+    console.log(`Sent copy to ${ADMIN}: ${t.subject}`);
+  }
+
+  console.log('\nDone. HTML files also in exports/email-copies/');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/send-email-copies-to-admin.ts
+++ b/scripts/ops/send-email-copies-to-admin.ts
@@ -11,6 +11,7 @@ import { join } from 'path';
 import { createClient } from '@supabase/supabase-js';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ADMIN = 'elevate4humanityedu@gmail.com';
@@ -155,6 +156,8 @@ async function main() {
     console.log('\nWrite-only mode — not sending email.');
     return;
   }
+
+  assertOutreachEmailAllowed('send-email-copies-to-admin.ts');
 
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;

--- a/scripts/ops/send-enchanted-hearts-mou-package.ts
+++ b/scripts/ops/send-enchanted-hearts-mou-package.ts
@@ -1,0 +1,282 @@
+#!/usr/bin/env tsx
+/**
+ * Send complete Program Holder MOU package to Enchanted Hearts:
+ *   - Apology + disregard prior MOU emails
+ *   - Part 1: Full workforce training MOU
+ *   - Part 2: Payment, refund, reporting addendum
+ *   - No dashboard emails (MOU + sign link only)
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/send-enchanted-hearts-mou-package.ts
+ */
+import { createClient } from '@supabase/supabase-js';
+import { generateProgramHolderWorkforceMOUPdf } from '@/lib/documents/generate-program-holder-workforce-mou-pdf';
+import { generateProgramHolderMOUPart2Pdf } from '@/lib/documents/generate-program-holder-mou-part2-pdf';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { outboundSiteUrl } from './outbound-site-url';
+
+const SITE_URL = outboundSiteUrl();
+const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
+
+const HOLDER = {
+  organizationName: 'Enchanted Hearts Training Institute LLC',
+  contactName: 'Shawndra Quinn, RN',
+  signerTitle: 'Training Program Director / Owner',
+  email: 'info@enchantedheartstraining.com',
+  phone: '3175347471',
+  ein: '88-2052776',
+  addressLine1: '650 N. Girls School Rd, Ste B20',
+  city: 'Indianapolis',
+  state: 'IN',
+  zip: '46214',
+  userId: '44f2d0cb-c966-401c-83e7-6e231fd6cb63',
+  holderId: 'ac01769d-c1d9-496c-981e-f7963e6d0f48',
+};
+
+const PROGRAMS = [
+  {
+    program_name: 'Certified Nurse Aide (CNA) Training',
+    credential: 'Indiana Nurse Aide (ISDH-approved program)',
+    duration: '105 hours (75 classroom + 30 clinical)',
+    weekly_hours: 0,
+    tuition: 399,
+  },
+  {
+    program_name: 'Home Health Aide (HHA) Training',
+    credential: 'Home Health Aide Certificate',
+    duration: '75 hours (2 weeks)',
+    weekly_hours: 0,
+    tuition: 399,
+  },
+  {
+    program_name: 'Qualified Medication Aide (QMA) Program',
+    credential: 'Indiana QMA (IDOH-approved)',
+    duration: '100 hours (classroom/lab + supervised clinical practicum)',
+    weekly_hours: 0,
+    tuition: 900,
+  },
+  {
+    program_name: 'QMA Insulin Administration Certification',
+    credential: 'QMA Insulin Administration',
+    duration: '6–12 hours',
+    weekly_hours: 0,
+    tuition: 275,
+  },
+  {
+    program_name: 'CPR Instructor Course',
+    credential: 'AHA-aligned CPR/BLS Instructor',
+    duration: '1 day',
+    weekly_hours: 0,
+    tuition: 450,
+  },
+];
+
+const PROGRAM_LINKS = [
+  { id: 'fb36dbf1-db3c-4d34-adf9-3f98f397d371', slug: 'cna' },
+  { id: 'd8f45366-1838-4539-ae32-7bc985773772', slug: 'home-health-aide' },
+];
+
+async function loadSendGridKey(db: ReturnType<typeof createClient>) {
+  if (process.env.SENDGRID_API_KEY) return process.env.SENDGRID_API_KEY;
+  const { data } = await db
+    .from('platform_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  if (data?.value) return data.value as string;
+  const { data: app } = await db
+    .from('app_secrets')
+    .select('value')
+    .eq('key', 'SENDGRID_API_KEY')
+    .maybeSingle();
+  return (app?.value as string) ?? null;
+}
+
+async function sendMail(
+  apiKey: string,
+  opts: {
+    to: string;
+    subject: string;
+    html: string;
+    attachments?: { content: string; filename: string }[];
+  },
+) {
+  const payload = {
+    personalizations: [
+      {
+        to: [{ email: opts.to, name: HOLDER.contactName }],
+        cc: [{ email: ELEVATE_COPY, name: 'Elevate Admin Copy' }],
+      },
+    ],
+    from: { email: 'noreply@elevateforhumanity.org', name: 'Elizabeth Greene | Elevate for Humanity' },
+    reply_to: { email: ELEVATE_COPY, name: 'Elizabeth Greene' },
+    subject: opts.subject,
+    content: [{ type: 'text/html', value: opts.html }],
+    attachments: opts.attachments?.map((a) => ({
+      content: a.content,
+      type: 'application/pdf',
+      filename: a.filename,
+      disposition: 'attachment',
+    })),
+  };
+
+  const res = await fetch('https://api.sendgrid.com/v3/mail/send', {
+    method: 'POST',
+    headers: { Authorization: `Bearer ${apiKey}`, 'Content-Type': 'application/json' },
+    body: JSON.stringify(payload),
+  });
+  if (res.status !== 202) throw new Error(`SendGrid ${res.status}: ${await res.text()}`);
+}
+
+async function ensureProvisioned(db: ReturnType<typeof createClient>) {
+  const now = new Date().toISOString();
+  await db.auth.admin.updateUserById(HOLDER.userId, {
+    email_confirm: true,
+    app_metadata: { role: 'program_holder' },
+  });
+  await db.from('profiles').upsert(
+    {
+      id: HOLDER.userId,
+      email: HOLDER.email,
+      full_name: HOLDER.contactName,
+      role: 'program_holder',
+      program_holder_id: HOLDER.holderId,
+      phone: HOLDER.phone,
+      address: HOLDER.addressLine1,
+      city: HOLDER.city,
+      state: HOLDER.state,
+      zip: HOLDER.zip,
+      updated_at: now,
+    },
+    { onConflict: 'id' },
+  );
+  await db
+    .from('program_holders')
+    .update({
+      status: 'approved',
+      approved_at: now,
+      contact_email: HOLDER.email,
+      contact_phone: HOLDER.phone,
+      updated_at: now,
+    })
+    .eq('id', HOLDER.holderId);
+  for (const prog of PROGRAM_LINKS) {
+    await db.from('program_holder_programs').upsert(
+      { program_holder_id: HOLDER.holderId, program_id: prog.id, status: 'active' },
+      { onConflict: 'program_holder_id,program_id' },
+    );
+  }
+  console.log('  ✅ Program holder provision confirmed');
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const sgKey = await loadSendGridKey(db);
+  if (!sgKey) {
+    console.error('SENDGRID_API_KEY not found');
+    process.exit(1);
+  }
+
+  console.log(`\n=== ${HOLDER.organizationName} — complete MOU package ===`);
+  await ensureProvisioned(db);
+
+  const signedAt = new Date().toISOString();
+  const common = {
+    organization_name: HOLDER.organizationName,
+    signer_name: HOLDER.contactName,
+    signer_title: HOLDER.signerTitle,
+    contact_email: HOLDER.email,
+    contact_phone: HOLDER.phone,
+    partner_address: `${HOLDER.addressLine1}, ${HOLDER.city}, ${HOLDER.state} ${HOLDER.zip}`,
+    partner_ein: HOLDER.ein,
+    signed_at: signedAt,
+    payout_share_pct: 33.33,
+  };
+
+  const part1 = await generateProgramHolderWorkforceMOUPdf({
+    ...common,
+    programs: PROGRAMS,
+    regulatory_approvals: [
+      'Indiana Nurse Aide Training Program (105-hour)',
+      'Qualified Medication Aide (QMA) Training Program',
+      'Approved clinical/practicum sites as listed with IDOH/ISDH',
+    ],
+    mou_version: '2026-workforce-part1-master',
+  });
+
+  const part2 = await generateProgramHolderMOUPart2Pdf({
+    organization_name: HOLDER.organizationName,
+    signer_name: HOLDER.contactName,
+    contact_email: HOLDER.email,
+    payout_share_pct: 33.33,
+    signed_at: signedAt,
+    mou_version: '2026-workforce-part2-payments',
+  });
+
+  console.log(`  📄 Part 1: ${Math.round(part1.length / 1024)} KB`);
+  console.log(`  📄 Part 2: ${Math.round(part2.length / 1024)} KB`);
+
+  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const orgSlug = HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-');
+
+  const mouHtml = `<!DOCTYPE html>
+<html><head><meta charset="utf-8"></head>
+<body style="margin:0;padding:0;background:#f8fafc;font-family:Arial,sans-serif;color:#1e293b">
+<table width="100%" cellpadding="0" cellspacing="0" style="padding:32px 16px"><tr><td align="center">
+<table width="600" cellpadding="0" cellspacing="0" style="background:#fff;border-radius:10px;overflow:hidden">
+<tr><td style="background:#1e293b;padding:24px 32px">
+<p style="margin:0;color:#fff;font-size:18px;font-weight:700">${PLATFORM_DEFAULTS.orgName}</p>
+<p style="margin:6px 0 0;color:#94a3b8;font-size:13px">Program Holder Agreement — Complete Package</p>
+</td></tr>
+<tr><td style="padding:32px">
+<p style="margin:0 0 16px;font-size:15px">Dear Shawndra,</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+We apologize for the confusion caused by our earlier MOU emails. Please <strong>disregard and delete all previous MOU attachments</strong> we sent — they are superseded by this message.
+</p>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Attached is the <strong>complete, correct Program Holder workforce training agreement</strong> for <strong>${HOLDER.organizationName}</strong>, in two parts:
+</p>
+<ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.8;color:#475569">
+<li><strong>Part 1 — Master Workforce Training MOU</strong> (programs, roles, compliance, signatures)</li>
+<li><strong>Part 2 — Payment, Refund &amp; Reporting Addendum</strong> (what you are entitled to, refund policy, reporting requirements, audits)</li>
+</ol>
+<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
+Please review both PDFs, then sign online using the button below (log in with <strong>${HOLDER.email}</strong>).
+</p>
+<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
+<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
+</td></tr></table>
+<p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
+<p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
+</td></tr>
+</table>
+</td></tr></table>
+</body></html>`;
+
+  await sendMail(sgKey, {
+    to: HOLDER.email,
+    subject: `Please Disregard Prior MOU — Complete Program Holder Agreement (Part 1 + Part 2) — ${HOLDER.organizationName}`,
+    html: mouHtml,
+    attachments: [
+      {
+        content: Buffer.from(part1).toString('base64'),
+        filename: `Elevate-MOU-Part-1-Master-Agreement-${orgSlug}.pdf`,
+      },
+      {
+        content: Buffer.from(part2).toString('base64'),
+        filename: `Elevate-MOU-Part-2-Payment-Refund-Reporting-${orgSlug}.pdf`,
+      },
+    ],
+  });
+  console.log('  ✅ Complete MOU package sent (Part 1 + Part 2, CC Elevate)');
+
+  console.log('\nDone.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/send-enchanted-hearts-mou-package.ts
+++ b/scripts/ops/send-enchanted-hearts-mou-package.ts
@@ -14,6 +14,7 @@ import { generateProgramHolderMOUPart2Pdf } from '@/lib/documents/generate-progr
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
 import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -170,6 +171,8 @@ async function ensureProvisioned(db: ReturnType<typeof createClient>) {
 }
 
 async function main() {
+  assertOutreachEmailAllowed('send-enchanted-hearts-mou-package.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key) process.exit(1);

--- a/scripts/ops/send-enchanted-hearts-mou-package.ts
+++ b/scripts/ops/send-enchanted-hearts-mou-package.ts
@@ -13,6 +13,7 @@ import { generateProgramHolderWorkforceMOUPdf } from '@/lib/documents/generate-p
 import { generateProgramHolderMOUPart2Pdf } from '@/lib/documents/generate-program-holder-mou-part2-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { outboundSiteUrl } from './outbound-site-url';
+import { buildJourneyLinks, journeyStepsHtml } from './outreach-auth-link';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -219,7 +220,8 @@ async function main() {
   console.log(`  📄 Part 1: ${Math.round(part1.length / 1024)} KB`);
   console.log(`  📄 Part 2: ${Math.round(part2.length / 1024)} KB`);
 
-  const signUrl = `${SITE_URL}/login?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const { steps } = await buildJourneyLinks(db, HOLDER.email, 'program_holder');
+  const stepsHtml = journeyStepsHtml(steps, { primaryIndex: 0 });
   const orgSlug = HOLDER.organizationName.replace(/[^a-zA-Z0-9]+/g, '-');
 
   const mouHtml = `<!DOCTYPE html>
@@ -243,12 +245,10 @@ Attached is the <strong>complete, correct Program Holder workforce training agre
 <li><strong>Part 1 — Master Workforce Training MOU</strong> (programs, roles, compliance, signatures)</li>
 <li><strong>Part 2 — Payment, Refund &amp; Reporting Addendum</strong> (what you are entitled to, refund policy, reporting requirements, audits)</li>
 </ol>
-<p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
-Please review both PDFs, then sign online using the button below (log in with <strong>${HOLDER.email}</strong>).
+<p style="margin:0 0 12px;font-size:14px;line-height:1.7;color:#475569">
+Please review both PDFs, then complete these steps <strong>in order</strong> (log in with <strong>${HOLDER.email}</strong>):
 </p>
-<table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
-<a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign Program Holder MOU Online →</a>
-</td></tr></table>
+${stepsHtml}
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply to this email or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
 <p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
 </td></tr>

--- a/scripts/ops/send-style-scissors-individual-mous.ts
+++ b/scripts/ops/send-style-scissors-individual-mous.ts
@@ -12,6 +12,7 @@ import { generateNailMOUPdf } from '@/lib/documents/generate-nail-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 import { outboundSiteUrl } from './outbound-site-url';
+import { assertOutreachEmailAllowed } from './outreach-email-guard';
 
 const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
@@ -133,6 +134,8 @@ async function sendWithAttachment(
 }
 
 async function main() {
+  assertOutreachEmailAllowed('send-style-scissors-individual-mous.ts');
+
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
   if (!url || !key || key === 'placeholder') {

--- a/scripts/ops/send-style-scissors-individual-mous.ts
+++ b/scripts/ops/send-style-scissors-individual-mous.ts
@@ -70,24 +70,17 @@ Attached is your <strong>individual ${programLabel} Host Shop Memorandum of Unde
 <strong>${HOST.shopName}</strong>. This is a separate employer agreement for this program only.
 </p>
 <p style="margin:0 0 16px;font-size:14px;line-height:1.7;color:#475569">
-<strong>How to sign (please do not use the partner dashboard for this step):</strong>
+<strong>How to sign:</strong>
 </p>
 <ol style="margin:0 0 20px;padding-left:20px;font-size:14px;line-height:1.7;color:#475569">
 <li>Review the attached PDF.</li>
-<li>Click below to open the <strong>digital signature page</strong> for this program only (log in with <strong>${HOST.email}</strong> if prompted).</li>
+<li>Click below to open the <strong>digital signature page</strong> for this program (log in with <strong>${HOST.email}</strong> if prompted).</li>
 <li>Sign with your finger, mouse, or stylus and submit — a signed copy is sent to Elevate automatically.</li>
 <li>You may also reply to this email with the signed PDF attached if you prefer.</li>
 </ol>
 <table cellpadding="0" cellspacing="0" style="margin:0 0 24px"><tr><td style="background:#dc2626;border-radius:8px;padding:14px 24px">
 <a href="${signUrl}" style="color:#fff;font-size:15px;font-weight:bold;text-decoration:none">Sign ${programLabel} MOU Online →</a>
 </td></tr></table>
-<div style="background:#f1f5f9;border-radius:8px;padding:16px 20px;margin:0 0 24px">
-<p style="margin:0 0 8px;font-size:13px;font-weight:bold;color:#1e293b">About your partner dashboard</p>
-<p style="margin:0;font-size:13px;line-height:1.7;color:#475569">
-Your partner dashboard is <strong>not active yet</strong>. Once we receive your signed MOU for this program, we will turn on dashboard access.
-You will sign the executed copy again inside the dashboard when Elizabeth sends your <strong>next-steps email</strong> with onboarding instructions.
-</p>
-</div>
 <p style="margin:0;font-size:13px;color:#475569">Questions? Reply here or call <strong>${PLATFORM_DEFAULTS.supportPhone}</strong>.</p>
 <p style="margin:24px 0 0;font-size:14px">Warm regards,<br><strong>Elizabeth Greene</strong><br>Founder &amp; CEO, ${PLATFORM_DEFAULTS.orgName}</p>
 </td></tr>

--- a/scripts/ops/send-style-scissors-individual-mous.ts
+++ b/scripts/ops/send-style-scissors-individual-mous.ts
@@ -11,10 +11,9 @@ import { generateCosmetologyMOUPdf } from '@/lib/documents/generate-cosmetology-
 import { generateNailMOUPdf } from '@/lib/documents/generate-nail-mou-pdf';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
-const SITE_URL = (process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org').replace(
-  /\/$/,
-  '',
-);
+import { outboundSiteUrl } from './outbound-site-url';
+
+const SITE_URL = outboundSiteUrl();
 const ELEVATE_COPY = 'elevate4humanityedu@gmail.com';
 const DRY_RUN = process.argv.includes('--dry-run');
 

--- a/scripts/ops/sync-program-holder-dashboards.ts
+++ b/scripts/ops/sync-program-holder-dashboards.ts
@@ -24,6 +24,11 @@ const HOLDER_PROGRAMS: Record<string, string[]> = {
     'entrepreneurship',
   ],
   'indyondemandservices@gmail.com': ['hvac-technician'],
+  'doreen.hawkins01@outlook.com': [
+    'peer-recovery-specialist',
+    'peer-support',
+    'life-coach-certification-wioa',
+  ],
   'amecosenterprise@gmail.com': [
     'it-help-desk',
     'data-analytics',
@@ -159,14 +164,20 @@ async function main() {
         .eq('user_id', h.user_id)
         .maybeSingle();
       if (sig) continue;
-      await db.from('mou_signatures').insert({
+      const { error: sigErr } = await db.from('mou_signatures').insert({
         user_id: h.user_id,
         program_holder_id: h.id,
         signed_at: h.mou_signed_at ?? new Date().toISOString(),
+        agreed_at: h.mou_signed_at ?? new Date().toISOString(),
         signer_name: h.contact_email,
-        document_type: 'program_holder_mou',
+        contact_email: h.contact_email,
+        signature_data: 'admin-backfill-mou-signed',
+        partner_type: 'program_holder',
+        agreed: true,
+        mou_version: 'admin-backfill',
       });
-      console.log(`✅ mou_signatures backfill: ${h.contact_email}`);
+      if (sigErr) console.warn(`  ⚠ mou_signatures backfill ${h.contact_email}:`, sigErr.message);
+      else console.log(`✅ mou_signatures backfill: ${h.contact_email}`);
     }
   }
 

--- a/scripts/ops/sync-program-holder-dashboards.ts
+++ b/scripts/ops/sync-program-holder-dashboards.ts
@@ -1,0 +1,179 @@
+#!/usr/bin/env tsx
+/**
+ * Link program_holder_programs rows so each holder's dashboard shows the right verticals.
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/sync-program-holder-dashboards.ts
+ *   pnpm tsx --env-file=.env.local scripts/ops/sync-program-holder-dashboards.ts --dry-run
+ */
+import { createClient } from '@supabase/supabase-js';
+
+const DRY_RUN = process.argv.includes('--dry-run');
+
+/** contact_email → program slugs they oversee */
+const HOLDER_PROGRAMS: Record<string, string[]> = {
+  'mesmerizedbybeautyl@yahoo.com': [
+    'esthetician-apprenticeship',
+    'nail-technician-apprenticeship',
+    'cosmetology-apprenticeship',
+  ],
+  'info@centerofdestiny.org': [
+    'business-startup',
+    'bookkeeping',
+    'tax-preparation',
+    'business-administration',
+    'entrepreneurship',
+  ],
+  'indyondemandservices@gmail.com': ['hvac-technician'],
+  'amecosenterprise@gmail.com': [
+    'it-help-desk',
+    'data-analytics',
+    'cybersecurity-analyst',
+    'network-administration',
+    'network-support-technician',
+    'web-development',
+    'software-development',
+    'graphic-design',
+    'bookkeeping',
+    'tax-preparation',
+    'office-administration',
+    'business-administration',
+    'entrepreneurship',
+    'project-management',
+    'cad-drafting',
+    'information-technology',
+  ],
+};
+
+const PRESTIGE_PARTNER = {
+  email: 'info@prestigeelevation.com',
+  partnerId: '9dffa854-1002-42e7-bad3-a8d626326d6e',
+  name: 'Elizabeth L. Greene',
+};
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) process.exit(1);
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+
+  const allSlugs = [...new Set(Object.values(HOLDER_PROGRAMS).flat())];
+  const { data: programs } = await db.from('programs').select('id, slug').in('slug', allSlugs);
+  const slugToId = Object.fromEntries((programs ?? []).map((p) => [p.slug, p.id]));
+  const missingSlugs = allSlugs.filter((s) => !slugToId[s]);
+  if (missingSlugs.length) console.warn('⚠ Missing program slugs:', missingSlugs.join(', '));
+
+  for (const [email, slugs] of Object.entries(HOLDER_PROGRAMS)) {
+    const { data: holder } = await db
+      .from('program_holders')
+      .select('id, organization_name')
+      .eq('contact_email', email)
+      .maybeSingle();
+    if (!holder) {
+      console.warn(`Skip ${email} — no program_holders row`);
+      continue;
+    }
+
+    const programIds = slugs.map((s) => slugToId[s]).filter(Boolean);
+    console.log(`\n${holder.organization_name} (${email}) → ${slugs.length} programs`);
+
+    if (!DRY_RUN) {
+      await db.from('program_holders').update({ teaches_multiple: slugs.length > 1 }).eq('id', holder.id);
+      if (programIds[0]) {
+        await db.from('program_holders').update({ primary_program_id: programIds[0] }).eq('id', holder.id);
+      }
+    }
+
+    for (const programId of programIds) {
+      const slug = programs?.find((p) => p.id === programId)?.slug ?? programId;
+      if (DRY_RUN) {
+        console.log(`  [dry-run] link ${slug}`);
+        continue;
+      }
+      const { error } = await db.from('program_holder_programs').upsert(
+        { program_holder_id: holder.id, program_id: programId, status: 'active' },
+        { onConflict: 'program_holder_id,program_id' },
+      );
+      if (error) console.warn(`  ⚠ ${slug}:`, error.message);
+      else console.log(`  ✅ ${slug}`);
+    }
+  }
+
+  // Prestige — barber host partner dashboard (Elizabeth Greene)
+  console.log('\n=== Prestige barber partner ===');
+  const { data: prestigeUser } = await db
+    .from('profiles')
+    .select('id, role')
+    .eq('email', PRESTIGE_PARTNER.email)
+    .maybeSingle();
+  let userId = prestigeUser?.id;
+  if (!userId) {
+    const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+    userId = listed?.users?.find((u) => u.email?.toLowerCase() === PRESTIGE_PARTNER.email)?.id;
+  }
+  if (!userId) {
+    console.warn('Prestige auth user not found');
+  } else if (!DRY_RUN) {
+    await db.from('profiles').upsert(
+      {
+        id: userId,
+        email: PRESTIGE_PARTNER.email,
+        full_name: PRESTIGE_PARTNER.name,
+        role: 'partner',
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'id' },
+    );
+    await db.auth.admin.updateUserById(userId, { app_metadata: { role: 'partner' }, email_confirm: true });
+    await db.from('partners').update({ partner_type: 'barber', type: 'barber' }).eq('id', PRESTIGE_PARTNER.partnerId);
+    const { data: existingPu } = await db
+      .from('partner_users')
+      .select('id')
+      .eq('user_id', userId)
+      .eq('partner_id', PRESTIGE_PARTNER.partnerId)
+      .maybeSingle();
+    if (!existingPu) {
+      await db.from('partner_users').insert({
+        user_id: userId,
+        partner_id: PRESTIGE_PARTNER.partnerId,
+        role: 'owner',
+        status: 'active',
+      });
+    }
+    console.log('✅ Prestige partner wired for', PRESTIGE_PARTNER.email);
+  } else {
+    console.log('[dry-run] Would wire Prestige partner');
+  }
+
+  // Backfill mou_signatures for holders with mou_signed but no digital row
+  if (!DRY_RUN) {
+    const { data: holders } = await db
+      .from('program_holders')
+      .select('id, user_id, contact_email, mou_signed, mou_signed_at')
+      .eq('mou_signed', true);
+    for (const h of holders ?? []) {
+      if (!h.user_id) continue;
+      const { data: sig } = await db
+        .from('mou_signatures')
+        .select('id')
+        .eq('user_id', h.user_id)
+        .maybeSingle();
+      if (sig) continue;
+      await db.from('mou_signatures').insert({
+        user_id: h.user_id,
+        program_holder_id: h.id,
+        signed_at: h.mou_signed_at ?? new Date().toISOString(),
+        signer_name: h.contact_email,
+        document_type: 'program_holder_mou',
+      });
+      console.log(`✅ mou_signatures backfill: ${h.contact_email}`);
+    }
+  }
+
+  console.log('\nDone.');
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});

--- a/scripts/ops/verify-portal-dashboards.ts
+++ b/scripts/ops/verify-portal-dashboards.ts
@@ -1,0 +1,167 @@
+#!/usr/bin/env tsx
+/**
+ * Read-only verification of program-holder and partner portal readiness (no email, no writes).
+ *
+ *   pnpm tsx --env-file=.env.local scripts/ops/verify-portal-dashboards.ts
+ */
+import { createClient } from '@supabase/supabase-js';
+import { outboundSiteUrl } from './outbound-site-url';
+
+const SITE = outboundSiteUrl();
+
+type Row = { label: string; ok: boolean; detail: string };
+
+const EXPECTED_HOLDERS: { email: string; minPrograms: number; org?: string }[] = [
+  { email: 'mesmerizedbybeautyl@yahoo.com', minPrograms: 3, org: 'Jozanna' },
+  { email: 'info@centerofdestiny.org', minPrograms: 4, org: 'Carlina' },
+  { email: 'indyondemandservices@gmail.com', minPrograms: 1, org: 'David / INDY ON DEMAND' },
+  { email: 'amecosenterprise@gmail.com', minPrograms: 10, org: 'Ameco' },
+  { email: 'doreen.hawkins01@outlook.com', minPrograms: 2, org: 'Doreen Hawkins' },
+  { email: 'info@enchantedheartstraining.com', minPrograms: 0, org: 'Shawndra (MOU may block)' },
+];
+
+const EXPECTED_PARTNERS: { email: string; label: string }[] = [
+  { email: 'info@prestigeelevation.com', label: 'Prestige / Elizabeth Greene barber' },
+  { email: 'calvincutz1985@gmail.com', label: 'Calvin barber host' },
+  { email: 'christopherd.newkirk@gmail.com', label: 'Chris barber host' },
+];
+
+function gateHolderDashboard(holder: {
+  status: string | null;
+  mou_signed: boolean | null;
+  approved_at: string | null;
+}): { canDashboard: boolean; blockers: string[] } {
+  const blockers: string[] = [];
+  if (!holder.approved_at) blockers.push('not approved');
+  if (!['approved', 'active'].includes(holder.status ?? '')) blockers.push(`status=${holder.status}`);
+  if (!holder.mou_signed) blockers.push('MOU unsigned');
+  return { canDashboard: blockers.length === 0, blockers };
+}
+
+async function main() {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY;
+  if (!url || !key) {
+    console.error('Missing Supabase env');
+    process.exit(1);
+  }
+
+  const db = createClient(url, key, { auth: { persistSession: false } });
+  const rows: Row[] = [];
+  let fail = 0;
+
+  console.log(`\nPortal verification (read-only) · ${SITE}\n`);
+
+  for (const exp of EXPECTED_HOLDERS) {
+    const { data: holder } = await db
+      .from('program_holders')
+      .select('id, organization_name, contact_email, status, mou_signed, approved_at, user_id')
+      .eq('contact_email', exp.email)
+      .maybeSingle();
+
+    if (!holder) {
+      rows.push({ label: exp.org ?? exp.email, ok: false, detail: 'no program_holders row' });
+      fail++;
+      continue;
+    }
+
+    const { count: progCount } = await db
+      .from('program_holder_programs')
+      .select('id', { count: 'exact', head: true })
+      .eq('program_holder_id', holder.id)
+      .eq('status', 'active');
+
+    const programsOk = (progCount ?? 0) >= exp.minPrograms;
+    const gate = gateHolderDashboard(holder);
+
+    let mouSigOk = true;
+    if (holder.mou_signed && holder.user_id) {
+      const { data: sig } = await db
+        .from('mou_signatures')
+        .select('id')
+        .eq('user_id', holder.user_id)
+        .maybeSingle();
+      mouSigOk = Boolean(sig);
+    }
+
+    const { data: prof } = await db
+      .from('profiles')
+      .select('role, program_holder_id')
+      .eq('email', exp.email)
+      .maybeSingle();
+
+    const roleOk = prof?.role === 'program_holder' && prof.program_holder_id === holder.id;
+    const ok = programsOk && mouSigOk && roleOk && (exp.minPrograms === 0 || programsOk);
+
+    const parts = [
+      `programs=${progCount ?? 0}${exp.minPrograms ? ` (need ≥${exp.minPrograms})` : ''}`,
+      gate.canDashboard ? 'dashboard=OK' : `dashboard=BLOCKED (${gate.blockers.join(', ')})`,
+      mouSigOk ? 'mou_sig=OK' : 'mou_sig=MISSING',
+      roleOk ? 'profile=OK' : `profile=bad role=${prof?.role ?? '?'}`,
+      `login ${SITE}/login`,
+    ];
+
+    if (!ok) fail++;
+    rows.push({ label: `${holder.organization_name} <${exp.email}>`, ok, detail: parts.join(' · ') });
+  }
+
+  for (const exp of EXPECTED_PARTNERS) {
+    const { data: prof } = await db.from('profiles').select('id, role').eq('email', exp.email).maybeSingle();
+    let userId = prof?.id;
+    if (!userId) {
+      const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+      userId = listed?.users?.find((u) => u.email?.toLowerCase() === exp.email)?.id;
+    }
+
+    const { data: pu } = userId
+      ? await db.from('partner_users').select('partner_id, status').eq('user_id', userId).maybeSingle()
+      : { data: null };
+
+    const { data: partner } = pu?.partner_id
+      ? await db.from('partners').select('partner_type, type, name').eq('id', pu.partner_id).maybeSingle()
+      : { data: null };
+
+    const { data: app } = await db
+      .from('barbershop_partner_applications')
+      .select('status, mou_signed_at')
+      .eq('contact_email', exp.email)
+      .maybeSingle();
+
+    const roleOk = prof?.role === 'partner';
+    const wired = Boolean(pu?.partner_id);
+    const barberType =
+      partner?.partner_type === 'barber' ||
+      partner?.partner_type === 'barbershop' ||
+      partner?.type === 'barber';
+
+    const ok = Boolean(userId) && roleOk && wired && barberType;
+    if (!ok) fail++;
+
+    rows.push({
+      label: exp.label,
+      ok,
+      detail: [
+        userId ? 'auth=OK' : 'auth=MISSING',
+        roleOk ? 'role=partner' : `role=${prof?.role ?? '?'}`,
+        wired ? `partner_users=${pu?.partner_id?.slice(0, 8)}…` : 'partner_users=MISSING',
+        barberType ? 'partner_type=barber' : `partner_type=${partner?.partner_type ?? '?'}`,
+        app ? `application=${app.status} mou=${app.mou_signed_at ? 'signed' : 'unsigned'}` : 'no barber application row',
+        `dashboard ${SITE}/partner/dashboard`,
+      ].join(' · '),
+    });
+  }
+
+  const w = Math.max(...rows.map((r) => r.label.length), 20);
+  for (const r of rows) {
+    const mark = r.ok ? '✅' : '❌';
+    console.log(`${mark} ${r.label.padEnd(w)}  ${r.detail}`);
+  }
+
+  console.log(`\n${fail ? `❌ ${fail} issue(s)` : '✅ All checks passed'} · no emails sent\n`);
+  process.exit(fail ? 1 : 0);
+}
+
+main().catch((e) => {
+  console.error(e);
+  process.exit(1);
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Stops all outbound ops/outreach email until portal and dashboard testing is complete, per product request.

## Changes

- **`scripts/ops/outreach-email-guard.ts`** — global kill switch; live sends require `OUTREACH_EMAIL_UNLOCK=1` and `--force-send`. `--dry-run` / `--write-only` still work for HTML previews.
- **All `scripts/ops/*` SendGrid scripts** wired to the guard.
- **`scripts/ops/verify-portal-dashboards.ts`** — read-only verification of program-holder and partner portal readiness (no email, no writes).
- **`scripts/ops/sync-program-holder-dashboards.ts`** — Doreen Hawkins program links; fixed `mou_signatures` backfill (removed invalid `document_type`, added `partner_type`, error logging).
- **AGENTS.md** — documents the email lock and verification command.

## Verification (no emails sent)

```
pnpm tsx --env-file=.env.local scripts/ops/verify-portal-dashboards.ts
# ✅ All checks passed
```

Program holders (Jozanna, Carlina, David, Ameco, Doreen) — dashboard gate OK, programs linked, mou_signatures present.

Partners (Prestige, Calvin, Chris) — auth + partner_users wired; MOU still unsigned (expected).

Shawndra (Enchanted Hearts) — correctly blocked at MOU until she signs.

## To send email after sign-off

```bash
OUTREACH_EMAIL_UNLOCK=1 pnpm tsx --env-file=.env.local scripts/ops/<script>.ts --force-send
```
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Block outreach emails behind a guard flag and add portal dashboard verification scripts
> - Adds [`outreach-email-guard.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/364/files#diff-989a94834ba0407263e92025272014da33ed04a3f593408eea5a181c41964168) which blocks all outbound emails by default; scripts exit unless `--dry-run`/`--write-only` is passed, or `--force-send` with `OUTREACH_EMAIL_UNLOCK=1`.
> - Adds [`verify-portal-dashboards.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/364/files#diff-3718f9977a08595db14bfec7fddfdef5f6af7bfdf41cf1bbc014ceb13a37de3e), a read-only audit script that checks program-holder and partner portal readiness and exits nonzero on failures.
> - Adds [`sync-program-holder-dashboards.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/364/files#diff-fa2e7120fd90db4f8d68c678c64fb7bbe3348aa7bd84fa369921104388387f4d) to synchronize `program_holder_programs`, fix `teaches_multiple`/`primary_program_id`, backfill missing `mou_signatures`, and wire a specific barber partner; supports `--dry-run`.
> - Adds and updates multiple one-off provisioning and MOU email scripts (Enchanted Hearts, Prestige Barbershop, Style & Scissors, Aaron Barber, HVAC/WIOA students) to use the new guard and `outboundSiteUrl()` helper, which forces a production URL and warns when a localhost URL is detected.
> - Fixes the program-holder dashboard to suppress the 'Sign MOU digitally' step when `mou_signed` is already true or a `mou_signatures` row exists.
> - Adds `barbershop` partner type to the onboarding routing check in the partner dashboard, and pre-populates uploaded document slots on the barber host shop documents page.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 01f225b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->