### PR TITLE
Fix host shop MOU on application pages

### DIFF
--- a/app/api/partners/barber-host-shop/my-application/route.ts
+++ b/app/api/partners/barber-host-shop/my-application/route.ts
@@ -44,7 +44,7 @@ export async function GET(req: NextRequest) {
   const { data: bpa } = await db
     .from('barbershop_partner_applications')
     .select(
-      'id, shop_legal_name, shop_dba_name, owner_name, contact_name, contact_email, contact_phone, shop_address_line1, shop_city, shop_state, shop_zip, indiana_shop_license_number, supervisor_name, supervisor_license_number, status, mou_signed_at',
+      'id, shop_legal_name, shop_dba_name, owner_name, contact_name, contact_email, contact_phone, shop_address_line1, shop_city, shop_state, shop_zip, indiana_shop_license_number, supervisor_name, supervisor_license_number, compensation_model, status, mou_signed_at',
     )
     .eq('contact_email', user.email ?? '')
     .order('created_at', { ascending: false })
@@ -58,8 +58,11 @@ export async function GET(req: NextRequest) {
     name: bpa.shop_dba_name || bpa.shop_legal_name,
     shop_name: bpa.shop_dba_name || bpa.shop_legal_name,
     shopName: bpa.shop_dba_name || bpa.shop_legal_name,
+    owner_name: bpa.owner_name,
     contact_name: bpa.contact_name,
     contact_email: bpa.contact_email,
+    supervisor_name: bpa.supervisor_name,
+    supervisor_license_number: bpa.supervisor_license_number,
     status: bpa.status,
     mou_signed: !!bpa.mou_signed_at,
   });

--- a/app/api/partners/cosmetology-host-shop/my-application/route.ts
+++ b/app/api/partners/cosmetology-host-shop/my-application/route.ts
@@ -35,5 +35,10 @@ export async function GET(req: NextRequest) {
   if (error) return safeError('Failed to load application', 500);
   if (!data) return NextResponse.json(null, { status: 200 });
 
-  return NextResponse.json(data);
+  return NextResponse.json({
+    ...data,
+    shop_name: data.name,
+    salon_legal_name: data.legal_name ?? data.name,
+    salon_name: data.name,
+  });
 }

--- a/app/partners/barber-host-shop/(onboarding)/sign-mou/page.tsx
+++ b/app/partners/barber-host-shop/(onboarding)/sign-mou/page.tsx
@@ -10,146 +10,9 @@ import {
 } from 'lucide-react';
 import { InstitutionalHeader } from '@/components/documents/InstitutionalHeader';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { getHostShopMouSections } from '@/lib/partners/host-shop-mou-sections';
 
-// MOU content sections for display
-// IMPORTANT: This is a USDOL Registered Apprenticeship worksite agreement.
-// It governs a barbershop hosting an apprentice as a paid employee under federal DOL rules.
-// It is NOT a Training Network Partner Agreement and does NOT contain tier structure,
-// revenue sharing, non-replication, or program ownership language from the general MOU.
-// Those documents are separate. This agreement covers only the apprenticeship worksite relationship.
-const MOU_SECTIONS = [
-  {
-    title: '1. Parties and Purpose',
-    content: `This Memorandum of Understanding ("MOU") is entered into between 2Exclusive LLC-S d/b/a ${PLATFORM_DEFAULTS.orgName} Career & Technical Institute ("Sponsor") and the barbershop identified at execution ("Worksite Partner" or "Shop").
-
-This MOU establishes the terms under which the Shop will serve as a worksite for the Indiana Barber Host Shop Program, RAPIDS Program ID: 2025-IN-132301, a USDOL Registered Apprenticeship sponsored by ${PLATFORM_DEFAULTS.orgName}.
-
-WHAT THIS AGREEMENT IS: This is a worksite hosting agreement for a federally registered apprenticeship program. The Shop is hosting an apprentice employee and providing on-the-job training under federal Department of Labor oversight.
-
-WHAT THIS AGREEMENT IS NOT: This MOU does not make the Shop a Training Network Partner, a co-owner of Elevate programs, a revenue-sharing partner, or a program delivery site for any Elevate training program other than the barber host shop. The Shop has no ownership rights, governance authority, or decision-making authority over Elevate's programs, curriculum, credentials, or brand.`,
-  },
-  {
-    title: '2. Program Structure — Non-Negotiable Federal Requirements',
-    content: `The Indiana Barber Host Shop Program is a USDOL Registered Apprenticeship. Its structure is set by federal law and the registered program standards. These terms are not negotiable.
-
-Program requirements:
-• 2,000 hours of on-the-job training (OJT) at the worksite, supervised by a licensed barber
-• Related Technical Instruction (RTI) coordinated by the Sponsor (Elevate)
-• Progressive skill development tracked through competency assessments per the registered standards
-• Apprentice must be registered with USDOL/RAPIDS before OJT hours begin
-• All OJT hours must be documented and submitted to the Sponsor monthly
-
-The Sponsor maintains sole authority over: RTI curriculum and delivery; competency assessment standards; RAPIDS registration and reporting; completion certificate issuance; program standards and modifications.`,
-  },
-  {
-    title: '3. Sponsor Responsibilities',
-    content: `${PLATFORM_DEFAULTS.orgName} agrees to:
-
-• Maintain USDOL/RAPIDS registration and all required federal reporting
-• Develop, deliver, and update all Related Technical Instruction (RTI)
-• Maintain official apprentice records and program documentation
-• Issue completion certificates upon successful program completion
-• Screen and refer qualified apprentice candidates to the Shop
-• Provide the Shop with competency checklists and OJT tracking tools
-• Conduct periodic worksite visits to verify program compliance
-• Serve as the point of contact with Indiana DWD and USDOL for all program matters`,
-  },
-  {
-    title: '4. Worksite Partner Responsibilities — Non-Negotiable',
-    content: `These responsibilities are required by federal apprenticeship law and USDOL program standards. They are not optional and are not subject to modification.
-
-The Shop agrees to:
-
-SUPERVISION: Provide direct, on-site supervision of the apprentice by a currently licensed Indiana barber at all times during OJT hours. The supervising barber must hold an active Indiana barber license. No exceptions.
-
-EMPLOYMENT: The apprentice is a paid employee of the Shop — not a volunteer, intern, or independent contractor. The Shop is the employer of record for the apprentice during OJT. The Shop is responsible for payroll, withholding, workers' compensation, and all employer obligations under Indiana and federal law.
-
-WAGES: Pay the apprentice according to the agreed progressive wage schedule (see Section 5). Failure to pay the apprentice as agreed is grounds for immediate termination of this MOU and will be reported to USDOL.
-
-HOURS TRACKING: Accurately track and submit OJT hours to the Sponsor monthly using the provided tracking forms. Falsifying OJT hours is a federal offense.
-
-SAFETY: Maintain a safe workplace that complies with all OSHA standards and Indiana workplace safety requirements. Report any workplace injury involving the apprentice to the Sponsor within 24 hours.
-
-INSURANCE: Carry workers' compensation insurance covering the apprentice. Provide proof of coverage to the Sponsor before the apprentice begins OJT.
-
-LICENSES: Maintain all required business licenses, health permits, and barbershop operating licenses throughout the term of this MOU. Notify the Sponsor immediately if any license lapses.
-
-NONDISCRIMINATION: Comply with all federal nondiscrimination requirements under WIOA Section 188, Title VI of the Civil Rights Act, the ADA, and all applicable equal opportunity laws. The apprenticeship program is open to all qualified individuals regardless of race, color, religion, sex, national origin, age, or disability.`,
-  },
-  {
-    title: '5. Apprentice Compensation — Federal Minimum Standards',
-    content: `Apprentice compensation is governed by federal apprenticeship standards and Indiana minimum wage law. These minimums are not negotiable.
-
-The apprentice is a paid employee. Compensation on a sole commission basis is prohibited under federal apprenticeship rules.
-
-Approved compensation models:
-• HOURLY: $10.00–$15.00/hr recommended. Must meet Indiana minimum wage ($7.25/hr) at all times.
-• HYBRID: $8.00–$10.00/hr base wage PLUS 15%–25% commission on services performed. Base wage must meet Indiana minimum wage at all times.
-
-Progressive wage increases are required as the apprentice advances through the program. The wage schedule is set in the registered program standards and must be followed.
-
-Apprentices retain 100% of tips. Tips may not be counted toward the minimum wage requirement.
-
-The Shop is responsible for all payroll taxes, withholding, and employer contributions for the apprentice.`,
-  },
-  {
-    title: '6. Term and Termination — 30-Day Notice Right',
-    content: `This MOU is effective from the date signed and continues until the apprentice completes the program, withdraws, or the agreement is terminated.
-
-YOUR RIGHT TO EXIT: Either party — the Shop or the Sponsor — may terminate this MOU at any time for any reason by providing 30 days written notice. Send written notice (email is acceptable) to your assigned Elevate coordinator and copy elevate4humanityedu@gmail.com. You do not need to provide a reason. You do not need the other party's permission. This right is non-negotiable and cannot be waived.
-
-During the 30-day notice period: the apprentice continues their OJT and the Shop continues its obligations under this MOU. The Sponsor will work with the Shop and the apprentice on a transition plan.
-
-IMMEDIATE TERMINATION BY SPONSOR (no notice required): The Sponsor may terminate this MOU immediately — without the 30-day notice period — if the Shop:
-• Fails to pay the apprentice as agreed
-• Violates any workplace safety or OSHA requirement
-• Loses any required business license or insurance
-• Falsifies OJT hours or program records
-• Engages in misconduct affecting the apprentice's safety or welfare
-• Violates federal nondiscrimination requirements
-
-After termination: the Shop must submit all outstanding OJT hour records to the Sponsor within 10 business days. The apprentice's program records remain with the Sponsor.`,
-  },
-  {
-    title: '7. Confidentiality and Non-Disclosure',
-    content: `Both parties agree to maintain confidentiality of apprentice personally identifiable information (PII) in compliance with applicable privacy laws.
-
-The Shop may not disclose apprentice PII (name, contact information, wage information, program records) to any third party without written apprentice consent and Sponsor authorization, except as required for program administration or by law.
-
-The Shop also receives access to Elevate's operational procedures, program materials, and business information through this collaboration. This information is confidential. The Shop may not disclose or use Elevate's confidential information for any purpose other than fulfilling its obligations under this MOU.
-
-A full Non-Disclosure Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/nda and is incorporated by reference into this MOU.`,
-  },
-  {
-    title: '8. Non-Compete and Non-Replication',
-    content: `The Shop receives access to Elevate's registered apprenticeship program structure, curriculum relationships, RAPIDS registration, and credential pathways through this collaboration. This access is provided to support the apprentice — not to enable the Shop to replicate the program independently.
-
-During the term of this MOU and for three (3) years following termination, the Shop agrees not to:
-• Use Elevate's program structure, RAPIDS registration, or DWD relationships to independently register or operate a competing USDOL Registered Apprenticeship program in barbering
-• Solicit or redirect Elevate apprentice candidates, instructors, or credential partners into a competing program derived from the Elevate apprenticeship model
-• Represent to any funding agency, employer, or student that the Shop independently operates the Indiana Barber Host Shop Program
-
-These restrictions do not prevent the Shop from: operating as a barbershop, employing licensed barbers, hiring apprentices through other registered programs, or participating in training programs that are not substantially similar to the Elevate apprenticeship model.
-
-A full Non-Compete Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/non-compete and is incorporated by reference into this MOU.`,
-  },
-  {
-    title: '9. Partner Handbook — Required Reading',
-    content: `The Worksite Partner Handbook is incorporated by reference into this MOU and forms part of this agreement. The Handbook details the day-to-day responsibilities, compensation requirements, hour tracking procedures, prohibited practices, and communication expectations that govern the worksite relationship.
-
-By signing this MOU, the Shop confirms that it has read and understood the Partner Handbook in full prior to signing. The Handbook is available at: ${PLATFORM_DEFAULTS.canonicalDomain}/partners/barber-host-shop/handbook
-
-Failure to comply with the standards set out in the Handbook constitutes a breach of this MOU and may result in immediate termination of the partnership and notification to USDOL.`,
-  },
-  {
-    title: '10. Dispute Resolution',
-    content: `The parties agree to attempt to resolve any disputes through good-faith negotiation first. If a dispute cannot be resolved through negotiation within 15 business days, either party may submit the dispute to mediation.
-
-If mediation is unsuccessful, the parties consent to jurisdiction in Marion County, Indiana. This MOU is governed by the laws of the State of Indiana.
-
-USDOL/RAPIDS compliance disputes are subject to federal apprenticeship regulations and may be reported to the Indiana Department of Workforce Development or the U.S. Department of Labor, Office of Apprenticeship.`,
-  },
-];
+const MOU_SECTIONS = getHostShopMouSections('barber');
 
 export default function SignMOUPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -177,9 +40,11 @@ export default function SignMOUPage() {
       .then(r => r.ok ? r.json() : null)
       .then(data => {
         if (!data) return;
-        if (data.shop_name)   setShopName(data.shop_name);
-        if (data.owner_name)  setSignerName(data.owner_name);
-        if (data.contact_email || data.email) { /* email display only */ }
+        if (data.shop_name) setShopName(data.shop_name);
+        if (data.owner_name) setSignerName(data.owner_name);
+        else if (data.contact_name) setSignerName(data.contact_name);
+        if (data.supervisor_name) setSupervisorName(data.supervisor_name);
+        if (data.supervisor_license_number) setSupervisorLicense(data.supervisor_license_number);
       })
       .catch((err) => console.warn('[sign-mou] prefill fetch failed', err));
   }, []);

--- a/app/partners/barber-host-shop/apply/page.tsx
+++ b/app/partners/barber-host-shop/apply/page.tsx
@@ -10,6 +10,7 @@ import {
   BookOpen, FileText, ClipboardCheck, ShieldCheck, ArrowRight, Upload,
 } from 'lucide-react';
 import { InstitutionalHeader } from '@/components/documents/InstitutionalHeader';
+import HostShopMouPreview from '@/components/partners/HostShopMouPreview';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 const compensationModels = [
@@ -587,6 +588,8 @@ export default function BarbershopPartnerApplyPage() {
               <textarea rows={4} value={formData.notes} onChange={e => updateField('notes', e.target.value)} placeholder="Any additional information you'd like to share..." className="w-full px-4 py-2 border border-slate-300 rounded-lg focus:ring-2 focus:ring-brand-blue-500" />
             </div>
 
+            <HostShopMouPreview program="barber" />
+
             {/* Acknowledgments */}
             <div className="bg-white p-6 rounded-xl shadow-sm">
               <h2 className="text-xl font-bold text-slate-900 mb-6">Acknowledgments</h2>
@@ -595,7 +598,12 @@ export default function BarbershopPartnerApplyPage() {
                   <label className="flex items-start gap-3 cursor-pointer">
                     <input type="checkbox" checked={formData.mouAcknowledged} onChange={e => updateField('mouAcknowledged', e.target.checked)} className="mt-1" />
                     <span className="text-sm text-slate-900">
-                      I acknowledge that I have reviewed the <Link href="/docs/Indiana-Barbershop-Apprenticeship-MOU" className="text-brand-blue-600 underline" target="_blank">Memorandum of Understanding (MOU)</Link> and understand that signing it is required to participate as a partner. *
+                      I acknowledge that I have reviewed the{' '}
+                      <a href="#host-shop-mou" className="text-brand-blue-600 underline">
+                        Memorandum of Understanding (MOU)
+                      </a>{' '}
+                      above and understand that digitally signing it is required after approval to
+                      participate as a partner. *
                     </span>
                   </label>
                 </div>
@@ -650,9 +658,12 @@ export default function BarbershopPartnerApplyPage() {
               <button type="submit" disabled={loading} className="flex-1 inline-flex items-center justify-center px-8 py-4 bg-brand-blue-600 text-white rounded-lg font-bold hover:bg-brand-blue-700 disabled:opacity-50 transition-colors">
                 {loading ? <><Loader2 className="w-5 h-5 mr-2 animate-spin" /> Submitting...</> : 'Submit Application'}
               </button>
-              <Link href="/docs/Indiana-Barbershop-Apprenticeship-MOU" className="inline-flex items-center justify-center px-6 py-4 border border-slate-300 rounded-lg font-medium hover:bg-white" target="_blank">
-                <Download className="w-5 h-5 mr-2" /> View MOU
-              </Link>
+              <a
+                href="#host-shop-mou"
+                className="inline-flex items-center justify-center px-6 py-4 border border-slate-300 rounded-lg font-medium hover:bg-white"
+              >
+                <Download className="w-5 h-5 mr-2" /> Review MOU
+              </a>
             </div>
           </form>
         </div>

--- a/app/partners/cosmetology-host-shop/(onboarding)/sign-mou/page.tsx
+++ b/app/partners/cosmetology-host-shop/(onboarding)/sign-mou/page.tsx
@@ -7,138 +7,9 @@ import { useState, useRef, useEffect, useCallback } from 'react';
 import { Eraser, Loader2, AlertCircle } from 'lucide-react';
 import { InstitutionalHeader } from '@/components/documents/InstitutionalHeader';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { getHostShopMouSections } from '@/lib/partners/host-shop-mou-sections';
 
-const MOU_SECTIONS = [
-  {
-    title: '1. Parties and Purpose',
-    content: `This Memorandum of Understanding ("MOU") is entered into between 2Exclusive LLC-S d/b/a ${PLATFORM_DEFAULTS.orgName} Career & Technical Institute ("Sponsor") and the salon identified at execution ("Worksite Partner" or "Salon").
-
-This MOU establishes the terms under which the Salon will serve as a worksite for the Indiana Cosmetology Apprenticeship Program, RAPIDS Program ID: 2025-IN-132302, a USDOL Registered Apprenticeship sponsored by ${PLATFORM_DEFAULTS.orgName}.
-
-WHAT THIS AGREEMENT IS: This is a worksite hosting agreement for a federally registered apprenticeship program. The Salon is hosting an apprentice employee and providing on-the-job training under federal Department of Labor oversight.
-
-WHAT THIS AGREEMENT IS NOT: This MOU does not make the Salon a Training Network Partner, a co-owner of Elevate programs, a revenue-sharing partner, or a program delivery site for any Elevate training program other than the cosmetology apprenticeship. The Salon has no ownership rights, governance authority, or decision-making authority over Elevate's programs, curriculum, credentials, or brand.`,
-  },
-  {
-    title: '2. Program Structure — Non-Negotiable Federal Requirements',
-    content: `The Indiana Cosmetology Apprenticeship Program is a USDOL Registered Apprenticeship. Its structure is set by federal law and the registered program standards. These terms are not negotiable.
-
-Program requirements:
-• 2,000 hours of on-the-job training (OJT) at the worksite, supervised by a licensed cosmetologist
-• Related Technical Instruction (RTI) coordinated by the Sponsor (Elevate)
-• Progressive skill development tracked through competency assessments per the registered standards
-• Apprentice must be registered with USDOL/RAPIDS before OJT hours begin
-• All OJT hours must be documented and submitted to the Sponsor monthly
-
-The Sponsor maintains sole authority over: RTI curriculum and delivery; competency assessment standards; RAPIDS registration and reporting; completion certificate issuance; program standards and modifications.`,
-  },
-  {
-    title: '3. Sponsor Responsibilities',
-    content: `${PLATFORM_DEFAULTS.orgName} agrees to:
-
-• Maintain USDOL/RAPIDS registration and all required federal reporting
-• Develop, deliver, and update all Related Technical Instruction (RTI)
-• Maintain official apprentice records and program documentation
-• Issue completion certificates upon successful program completion
-• Screen and refer qualified apprentice candidates to the Salon
-• Provide the Salon with competency checklists and OJT tracking tools
-• Conduct periodic worksite visits to verify program compliance
-• Serve as the point of contact with Indiana DWD and USDOL for all program matters`,
-  },
-  {
-    title: '4. Worksite Partner Responsibilities — Non-Negotiable',
-    content: `These responsibilities are required by federal apprenticeship law and USDOL program standards. They are not optional and are not subject to modification.
-
-The Salon agrees to:
-
-SUPERVISION: Provide direct, on-site supervision of the apprentice by a currently licensed Indiana cosmetologist at all times during OJT hours. The supervising cosmetologist must hold an active Indiana IPLA cosmetology license with at least 2 years of experience. No exceptions.
-
-EMPLOYMENT: The apprentice is a paid employee of the Salon — not a volunteer, intern, or independent contractor. The Salon is the employer of record for the apprentice during OJT. The Salon is responsible for payroll, withholding, workers' compensation, and all employer obligations under Indiana and federal law.
-
-WAGES: Pay the apprentice according to the agreed progressive wage schedule (see Section 5). Failure to pay the apprentice as agreed is grounds for immediate termination of this MOU and will be reported to USDOL.
-
-HOURS TRACKING: Accurately track and submit OJT hours to the Sponsor monthly using the provided tracking forms. Falsifying OJT hours is a federal offense.
-
-SAFETY: Maintain a safe workplace that complies with all OSHA standards and Indiana workplace safety requirements. Report any workplace injury involving the apprentice to the Sponsor within 24 hours.
-
-INSURANCE: Carry workers' compensation insurance covering the apprentice. Provide proof of coverage to the Sponsor before the apprentice begins OJT.
-
-LICENSES: Maintain all required business licenses, health permits, and salon operating licenses throughout the term of this MOU. Notify the Sponsor immediately if any license lapses.
-
-NONDISCRIMINATION: Comply with all federal nondiscrimination requirements under WIOA Section 188, Title VI of the Civil Rights Act, the ADA, and all applicable equal opportunity laws. The apprenticeship program is open to all qualified individuals regardless of race, color, religion, sex, national origin, age, or disability.`,
-  },
-  {
-    title: '5. Apprentice Compensation — Federal Minimum Standards',
-    content: `Apprentice compensation is governed by federal apprenticeship standards and Indiana minimum wage law. These minimums are not negotiable.
-
-The apprentice is a paid employee. Compensation on a sole commission basis is prohibited under federal apprenticeship rules.
-
-Approved compensation models:
-• HOURLY: $10.00–$15.00/hr recommended. Must meet Indiana minimum wage ($7.25/hr) at all times.
-• HYBRID: $8.00–$10.00/hr base wage PLUS 15%–25% commission on services performed. Base wage must meet Indiana minimum wage at all times.
-
-Progressive wage increases are required as the apprentice advances through the program. The wage schedule is set in the registered program standards and must be followed.
-
-Apprentices retain 100% of tips. Tips may not be counted toward the minimum wage requirement.
-
-The Salon is responsible for all payroll taxes, withholding, and employer contributions for the apprentice.`,
-  },
-  {
-    title: '6. Term and Termination — 30-Day Notice Right',
-    content: `This MOU is effective from the date signed and continues until the apprentice completes the program, withdraws, or the agreement is terminated.
-
-YOUR RIGHT TO EXIT: Either party — the Salon or the Sponsor — may terminate this MOU at any time for any reason by providing 30 days written notice. Send written notice (email is acceptable) to your assigned Elevate coordinator and copy elevate4humanityedu@gmail.com. You do not need to provide a reason. You do not need the other party's permission. This right is non-negotiable and cannot be waived.
-
-During the 30-day notice period: the apprentice continues their OJT and the Salon continues its obligations under this MOU. The Sponsor will work with the Salon and the apprentice on a transition plan.
-
-IMMEDIATE TERMINATION BY SPONSOR (no notice required): The Sponsor may terminate this MOU immediately — without the 30-day notice period — if the Salon:
-• Fails to pay the apprentice as agreed
-• Violates any workplace safety or OSHA requirement
-• Loses any required business license or insurance
-• Falsifies OJT hours or program records
-• Engages in misconduct affecting the apprentice's safety or welfare
-• Violates federal nondiscrimination requirements
-
-After termination: the Salon must submit all outstanding OJT hour records to the Sponsor within 10 business days. The apprentice's program records remain with the Sponsor.`,
-  },
-  {
-    title: '7. Confidentiality and Non-Disclosure',
-    content: `Both parties agree to maintain confidentiality of apprentice personally identifiable information (PII) in compliance with applicable privacy laws.
-
-The Salon may not disclose apprentice PII (name, contact information, wage information, program records) to any third party without written apprentice consent and Sponsor authorization, except as required for program administration or by law.
-
-The Salon also receives access to Elevate's operational procedures, program materials, and business information through this collaboration. This information is confidential. The Salon may not disclose or use Elevate's confidential information for any purpose other than fulfilling its obligations under this MOU.
-
-A full Non-Disclosure Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/nda and is incorporated by reference into this MOU.`,
-  },
-  {
-    title: '8. Non-Compete and Non-Replication',
-    content: `The Salon receives access to Elevate's registered apprenticeship program structure, curriculum relationships, RAPIDS registration, and credential pathways through this collaboration. This access is provided to support the apprentice — not to enable the Salon to replicate the program independently.
-
-During the term of this MOU and for three (3) years following termination, the Salon agrees not to:
-• Use Elevate's program structure, RAPIDS registration, or DWD relationships to independently register or operate a competing USDOL Registered Apprenticeship program in cosmetology
-• Solicit or redirect Elevate apprentice candidates, instructors, or credential partners into a competing program derived from the Elevate apprenticeship model
-• Represent to any funding agency, employer, or student that the Salon independently operates the Indiana Cosmetology Apprenticeship Program
-
-These restrictions do not prevent the Salon from: operating as a salon, employing licensed cosmetologists, hiring apprentices through other registered programs, or participating in training programs that are not substantially similar to the Elevate apprenticeship model.`,
-  },
-  {
-    title: '9. Partner Handbook — Required Reading',
-    content: `The Worksite Partner Handbook is incorporated by reference into this MOU and forms part of this agreement. The Handbook details the day-to-day responsibilities, compensation requirements, hour tracking procedures, prohibited practices, and communication expectations that govern the worksite relationship.
-
-By signing this MOU, the Salon confirms that it has read and understood the Partner Handbook in full prior to signing. The Handbook is available at: ${PLATFORM_DEFAULTS.canonicalDomain}/partners/cosmetology-host-shop/handbook
-
-Failure to comply with the standards set out in the Handbook constitutes a breach of this MOU and may result in immediate termination of the partnership and notification to USDOL.`,
-  },
-  {
-    title: '10. Dispute Resolution',
-    content: `The parties agree to attempt to resolve any disputes through good-faith negotiation first. If a dispute cannot be resolved through negotiation within 15 business days, either party may submit the dispute to mediation.
-
-If mediation is unsuccessful, the parties consent to jurisdiction in Marion County, Indiana. This MOU is governed by the laws of the State of Indiana.
-
-USDOL/RAPIDS compliance disputes are subject to federal apprenticeship regulations and may be reported to the Indiana Department of Workforce Development or the U.S. Department of Labor, Office of Apprenticeship.`,
-  },
-];
+const MOU_SECTIONS = getHostShopMouSections('cosmetology');
 
 export default function CosmetologySignMOUPage() {
   const canvasRef = useRef<HTMLCanvasElement>(null);
@@ -164,8 +35,11 @@ export default function CosmetologySignMOUPage() {
       .then((r) => (r.ok ? r.json() : null))
       .then((data) => {
         if (!data) return;
-        if (data.salon_legal_name || data.name) setSalonName(data.salon_legal_name || data.name);
+        if (data.salon_legal_name || data.salon_name || data.name || data.shop_name) {
+          setSalonName(data.salon_legal_name || data.salon_name || data.name || data.shop_name);
+        }
         if (data.owner_name) setSignerName(data.owner_name);
+        else if (data.contact_name) setSignerName(data.contact_name);
         if (data.supervisor_name) setSupervisorName(data.supervisor_name);
         if (data.supervisor_license_number) setSupervisorLicense(data.supervisor_license_number);
         if (data.compensation_model) setCompensationModel(data.compensation_model);

--- a/app/partners/cosmetology-host-shop/apply/page.tsx
+++ b/app/partners/cosmetology-host-shop/apply/page.tsx
@@ -7,6 +7,7 @@ import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 import { InstitutionalHeader } from '@/components/documents/InstitutionalHeader';
 import { Loader2, AlertCircle, CheckCircle, ArrowRight } from 'lucide-react';
 import HostShopComplianceUploads from '@/components/partners/HostShopComplianceUploads';
+import HostShopMouPreview from '@/components/partners/HostShopMouPreview';
 import { encodeDataUrlFile } from '@/lib/files/encode-data-url-file';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
@@ -504,6 +505,8 @@ export default function CosmetologySalonApplyPage() {
             </div>
           </div>
 
+          <HostShopMouPreview program="cosmetology" />
+
           {/* Acknowledgments */}
           <div className={sectionCls}>
             <h2 className="text-lg font-bold text-slate-900">Acknowledgments</h2>
@@ -516,14 +519,12 @@ export default function CosmetologySalonApplyPage() {
               />
               <span className="text-sm text-slate-700">
                 I have read and agree to the{' '}
-                <Link
-                  href="/login?redirect=/partners/cosmetology-host-shop/sign-mou"
-                  className="text-purple-600 hover:underline font-medium"
-                >
+                <a href="#host-shop-mou" className="text-purple-600 hover:underline font-medium">
                   Memorandum of Understanding
-                </Link>{' '}
-                for the Cosmetology Apprenticeship Program and understand my responsibilities as a
-                host salon.
+                </a>{' '}
+                above for the Cosmetology Apprenticeship Program and understand my responsibilities
+                as a host salon. I understand I will digitally sign the MOU after logging in once
+                my application is processed.
               </span>
             </label>
             <label className="flex items-start gap-3 cursor-pointer">

--- a/components/partners/HostShopMouPreview.tsx
+++ b/components/partners/HostShopMouPreview.tsx
@@ -1,0 +1,80 @@
+import Link from 'next/link';
+import { Download } from 'lucide-react';
+import { InstitutionalHeader } from '@/components/documents/InstitutionalHeader';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import {
+  getHostShopMouMeta,
+  getHostShopMouSections,
+  type HostShopMouProgram,
+} from '@/lib/partners/host-shop-mou-sections';
+
+type Props = {
+  program: HostShopMouProgram;
+  /** Anchor id for in-page links from acknowledgment checkboxes */
+  id?: string;
+  className?: string;
+};
+
+export default function HostShopMouPreview({ program, id = 'host-shop-mou', className = '' }: Props) {
+  const meta = getHostShopMouMeta(program);
+  const sections = getHostShopMouSections(program);
+
+  return (
+    <section id={id} className={`scroll-mt-24 ${className}`}>
+      <div className="bg-white rounded-xl shadow-sm border">
+        <div className="p-6 border-b">
+          <InstitutionalHeader
+            documentType={meta.documentType}
+            title={meta.title}
+            subtitle={meta.subtitle}
+            noDivider
+          />
+          <div className="text-sm text-slate-700 border-t border-slate-200 pt-4 mt-2 space-y-1">
+            <p>
+              <strong>Between:</strong> 2Exclusive LLC-S d/b/a {PLATFORM_DEFAULTS.orgName} Career
+              &amp; Technical Institute (&ldquo;Sponsor&rdquo;)
+            </p>
+            <p>
+              <strong>And:</strong> {meta.worksiteLabel} (&ldquo;Worksite Partner&rdquo;)
+            </p>
+            <p>
+              <strong>RAPIDS Program ID:</strong> {meta.rapidsId}
+            </p>
+          </div>
+          <p className="text-sm text-slate-600 mt-3">
+            Read the full agreement below before acknowledging. After your application is approved,
+            you will digitally sign this MOU in your partner onboarding portal.
+          </p>
+        </div>
+        <div className="p-6 space-y-6 max-h-[28rem] overflow-y-auto">
+          {sections.map((section) => (
+            <div key={section.title}>
+              <h3 className="font-bold text-slate-900 mb-1">{section.title}</h3>
+              <p className="text-sm text-slate-800 leading-relaxed whitespace-pre-line">
+                {section.content}
+              </p>
+            </div>
+          ))}
+        </div>
+        <div className="px-6 py-4 border-t bg-slate-50 rounded-b-xl flex flex-wrap items-center gap-4">
+          <Link
+            href={meta.handbookHref}
+            className="text-sm text-brand-blue-600 hover:text-brand-blue-700 font-medium"
+          >
+            Partner Handbook
+          </Link>
+          {meta.fullDocHref ? (
+            <Link
+              href={meta.fullDocHref}
+              target="_blank"
+              className="inline-flex items-center gap-1 text-sm text-brand-blue-600 hover:text-brand-blue-700 font-medium"
+            >
+              <Download className="w-4 h-4" />
+              Download / print full MOU
+            </Link>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/lib/partners/host-shop-mou-sections.ts
+++ b/lib/partners/host-shop-mou-sections.ts
@@ -1,0 +1,312 @@
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+export type HostShopMouProgram = 'barber' | 'cosmetology';
+
+export type MouSection = {
+  title: string;
+  content: string;
+};
+
+export type HostShopMouMeta = {
+  documentType: string;
+  title: string;
+  subtitle: string;
+  worksiteLabel: string;
+  handbookHref: string;
+  fullDocHref?: string;
+  rapidsId: string;
+};
+
+const BARBER_SECTIONS: MouSection[] = [
+  {
+    title: '1. Parties and Purpose',
+    content: `This Memorandum of Understanding ("MOU") is entered into between 2Exclusive LLC-S d/b/a ${PLATFORM_DEFAULTS.orgName} Career & Technical Institute ("Sponsor") and the barbershop identified at execution ("Worksite Partner" or "Shop").
+
+This MOU establishes the terms under which the Shop will serve as a worksite for the Indiana Barber Host Shop Program, RAPIDS Program ID: 2025-IN-132301, a USDOL Registered Apprenticeship sponsored by ${PLATFORM_DEFAULTS.orgName}.
+
+WHAT THIS AGREEMENT IS: This is a worksite hosting agreement for a federally registered apprenticeship program. The Shop is hosting an apprentice employee and providing on-the-job training under federal Department of Labor oversight.
+
+WHAT THIS AGREEMENT IS NOT: This MOU does not make the Shop a Training Network Partner, a co-owner of Elevate programs, a revenue-sharing partner, or a program delivery site for any Elevate training program other than the barber host shop. The Shop has no ownership rights, governance authority, or decision-making authority over Elevate's programs, curriculum, credentials, or brand.`,
+  },
+  {
+    title: '2. Program Structure — Non-Negotiable Federal Requirements',
+    content: `The Indiana Barber Host Shop Program is a USDOL Registered Apprenticeship. Its structure is set by federal law and the registered program standards. These terms are not negotiable.
+
+Program requirements:
+• 2,000 hours of on-the-job training (OJT) at the worksite, supervised by a licensed barber
+• Related Technical Instruction (RTI) coordinated by the Sponsor (Elevate)
+• Progressive skill development tracked through competency assessments per the registered standards
+• Apprentice must be registered with USDOL/RAPIDS before OJT hours begin
+• All OJT hours must be documented and submitted to the Sponsor monthly
+
+The Sponsor maintains sole authority over: RTI curriculum and delivery; competency assessment standards; RAPIDS registration and reporting; completion certificate issuance; program standards and modifications.`,
+  },
+  {
+    title: '3. Sponsor Responsibilities',
+    content: `${PLATFORM_DEFAULTS.orgName} agrees to:
+
+• Maintain USDOL/RAPIDS registration and all required federal reporting
+• Develop, deliver, and update all Related Technical Instruction (RTI)
+• Maintain official apprentice records and program documentation
+• Issue completion certificates upon successful program completion
+• Screen and refer qualified apprentice candidates to the Shop
+• Provide the Shop with competency checklists and OJT tracking tools
+• Conduct periodic worksite visits to verify program compliance
+• Serve as the point of contact with Indiana DWD and USDOL for all program matters`,
+  },
+  {
+    title: '4. Worksite Partner Responsibilities — Non-Negotiable',
+    content: `These responsibilities are required by federal apprenticeship law and USDOL program standards. They are not optional and are not subject to modification.
+
+The Shop agrees to:
+
+SUPERVISION: Provide direct, on-site supervision of the apprentice by a currently licensed Indiana barber at all times during OJT hours. The supervising barber must hold an active Indiana barber license. No exceptions.
+
+EMPLOYMENT: The apprentice is a paid employee of the Shop — not a volunteer, intern, or independent contractor. The Shop is the employer of record for the apprentice during OJT. The Shop is responsible for payroll, withholding, workers' compensation, and all employer obligations under Indiana and federal law.
+
+WAGES: Pay the apprentice according to the agreed progressive wage schedule (see Section 5). Failure to pay the apprentice as agreed is grounds for immediate termination of this MOU and will be reported to USDOL.
+
+HOURS TRACKING: Accurately track and submit OJT hours to the Sponsor monthly using the provided tracking forms. Falsifying OJT hours is a federal offense.
+
+SAFETY: Maintain a safe workplace that complies with all OSHA standards and Indiana workplace safety requirements. Report any workplace injury involving the apprentice to the Sponsor within 24 hours.
+
+INSURANCE: Carry workers' compensation insurance covering the apprentice. Provide proof of coverage to the Sponsor before the apprentice begins OJT.
+
+LICENSES: Maintain all required business licenses, health permits, and barbershop operating licenses throughout the term of this MOU. Notify the Sponsor immediately if any license lapses.
+
+NONDISCRIMINATION: Comply with all federal nondiscrimination requirements under WIOA Section 188, Title VI of the Civil Rights Act, the ADA, and all applicable equal opportunity laws. The apprenticeship program is open to all qualified individuals regardless of race, color, religion, sex, national origin, age, or disability.`,
+  },
+  {
+    title: '5. Apprentice Compensation — Federal Minimum Standards',
+    content: `Apprentice compensation is governed by federal apprenticeship standards and Indiana minimum wage law. These minimums are not negotiable.
+
+The apprentice is a paid employee. Compensation on a sole commission basis is prohibited under federal apprenticeship rules.
+
+Approved compensation models:
+• HOURLY: $10.00–$15.00/hr recommended. Must meet Indiana minimum wage ($7.25/hr) at all times.
+• HYBRID: $8.00–$10.00/hr base wage PLUS 15%–25% commission on services performed. Base wage must meet Indiana minimum wage at all times.
+
+Progressive wage increases are required as the apprentice advances through the program. The wage schedule is set in the registered program standards and must be followed.
+
+Apprentices retain 100% of tips. Tips may not be counted toward the minimum wage requirement.
+
+The Shop is responsible for all payroll taxes, withholding, and employer contributions for the apprentice.`,
+  },
+  {
+    title: '6. Term and Termination — 30-Day Notice Right',
+    content: `This MOU is effective from the date signed and continues until the apprentice completes the program, withdraws, or the agreement is terminated.
+
+YOUR RIGHT TO EXIT: Either party — the Shop or the Sponsor — may terminate this MOU at any time for any reason by providing 30 days written notice. Send written notice (email is acceptable) to your assigned Elevate coordinator and copy elevate4humanityedu@gmail.com. You do not need to provide a reason. You do not need the other party's permission. This right is non-negotiable and cannot be waived.
+
+During the 30-day notice period: the apprentice continues their OJT and the Shop continues its obligations under this MOU. The Sponsor will work with the Shop and the apprentice on a transition plan.
+
+IMMEDIATE TERMINATION BY SPONSOR (no notice required): The Sponsor may terminate this MOU immediately — without the 30-day notice period — if the Shop:
+• Fails to pay the apprentice as agreed
+• Violates any workplace safety or OSHA requirement
+• Loses any required business license or insurance
+• Falsifies OJT hours or program records
+• Engages in misconduct affecting the apprentice's safety or welfare
+• Violates federal nondiscrimination requirements
+
+After termination: the Shop must submit all outstanding OJT hour records to the Sponsor within 10 business days. The apprentice's program records remain with the Sponsor.`,
+  },
+  {
+    title: '7. Confidentiality and Non-Disclosure',
+    content: `Both parties agree to maintain confidentiality of apprentice personally identifiable information (PII) in compliance with applicable privacy laws.
+
+The Shop may not disclose apprentice PII (name, contact information, wage information, program records) to any third party without written apprentice consent and Sponsor authorization, except as required for program administration or by law.
+
+The Shop also receives access to Elevate's operational procedures, program materials, and business information through this collaboration. This information is confidential. The Shop may not disclose or use Elevate's confidential information for any purpose other than fulfilling its obligations under this MOU.
+
+A full Non-Disclosure Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/nda and is incorporated by reference into this MOU.`,
+  },
+  {
+    title: '8. Non-Compete and Non-Replication',
+    content: `The Shop receives access to Elevate's registered apprenticeship program structure, curriculum relationships, RAPIDS registration, and credential pathways through this collaboration. This access is provided to support the apprentice — not to enable the Shop to replicate the program independently.
+
+During the term of this MOU and for three (3) years following termination, the Shop agrees not to:
+• Use Elevate's program structure, RAPIDS registration, or DWD relationships to independently register or operate a competing USDOL Registered Apprenticeship program in barbering
+• Solicit or redirect Elevate apprentice candidates, instructors, or credential partners into a competing program derived from the Elevate apprenticeship model
+• Represent to any funding agency, employer, or student that the Shop independently operates the Indiana Barber Host Shop Program
+
+These restrictions do not prevent the Shop from: operating as a barbershop, employing licensed barbers, hiring apprentices through other registered programs, or participating in training programs that are not substantially similar to the Elevate apprenticeship model.
+
+A full Non-Compete Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/non-compete and is incorporated by reference into this MOU.`,
+  },
+  {
+    title: '9. Partner Handbook — Required Reading',
+    content: `The Worksite Partner Handbook is incorporated by reference into this MOU and forms part of this agreement. The Handbook details the day-to-day responsibilities, compensation requirements, hour tracking procedures, prohibited practices, and communication expectations that govern the worksite relationship.
+
+By signing this MOU, the Shop confirms that it has read and understood the Partner Handbook in full prior to signing. The Handbook is available at: ${PLATFORM_DEFAULTS.canonicalDomain}/partners/barber-host-shop/handbook
+
+Failure to comply with the standards set out in the Handbook constitutes a breach of this MOU and may result in immediate termination of the partnership and notification to USDOL.`,
+  },
+  {
+    title: '10. Dispute Resolution',
+    content: `The parties agree to attempt to resolve any disputes through good-faith negotiation first. If a dispute cannot be resolved through negotiation within 15 business days, either party may submit the dispute to mediation.
+
+If mediation is unsuccessful, the parties consent to jurisdiction in Marion County, Indiana. This MOU is governed by the laws of the State of Indiana.
+
+USDOL/RAPIDS compliance disputes are subject to federal apprenticeship regulations and may be reported to the Indiana Department of Workforce Development or the U.S. Department of Labor, Office of Apprenticeship.`,
+  },
+];
+
+const COSMETOLOGY_SECTIONS: MouSection[] = [
+  {
+    title: '1. Parties and Purpose',
+    content: `This Memorandum of Understanding ("MOU") is entered into between 2Exclusive LLC-S d/b/a ${PLATFORM_DEFAULTS.orgName} Career & Technical Institute ("Sponsor") and the salon identified at execution ("Worksite Partner" or "Salon").
+
+This MOU establishes the terms under which the Salon will serve as a worksite for the Indiana Cosmetology Apprenticeship Program, RAPIDS Program ID: 2025-IN-132302, a USDOL Registered Apprenticeship sponsored by ${PLATFORM_DEFAULTS.orgName}.
+
+WHAT THIS AGREEMENT IS: This is a worksite hosting agreement for a federally registered apprenticeship program. The Salon is hosting an apprentice employee and providing on-the-job training under federal Department of Labor oversight.
+
+WHAT THIS AGREEMENT IS NOT: This MOU does not make the Salon a Training Network Partner, a co-owner of Elevate programs, a revenue-sharing partner, or a program delivery site for any Elevate training program other than the cosmetology apprenticeship. The Salon has no ownership rights, governance authority, or decision-making authority over Elevate's programs, curriculum, credentials, or brand.`,
+  },
+  {
+    title: '2. Program Structure — Non-Negotiable Federal Requirements',
+    content: `The Indiana Cosmetology Apprenticeship Program is a USDOL Registered Apprenticeship. Its structure is set by federal law and the registered program standards. These terms are not negotiable.
+
+Program requirements:
+• 2,000 hours of on-the-job training (OJT) at the worksite, supervised by a licensed cosmetologist
+• Related Technical Instruction (RTI) coordinated by the Sponsor (Elevate)
+• Progressive skill development tracked through competency assessments per the registered standards
+• Apprentice must be registered with USDOL/RAPIDS before OJT hours begin
+• All OJT hours must be documented and submitted to the Sponsor monthly
+
+The Sponsor maintains sole authority over: RTI curriculum and delivery; competency assessment standards; RAPIDS registration and reporting; completion certificate issuance; program standards and modifications.`,
+  },
+  {
+    title: '3. Sponsor Responsibilities',
+    content: `${PLATFORM_DEFAULTS.orgName} agrees to:
+
+• Maintain USDOL/RAPIDS registration and all required federal reporting
+• Develop, deliver, and update all Related Technical Instruction (RTI)
+• Maintain official apprentice records and program documentation
+• Issue completion certificates upon successful program completion
+• Screen and refer qualified apprentice candidates to the Salon
+• Provide the Salon with competency checklists and OJT tracking tools
+• Conduct periodic worksite visits to verify program compliance
+• Serve as the point of contact with Indiana DWD and USDOL for all program matters`,
+  },
+  {
+    title: '4. Worksite Partner Responsibilities — Non-Negotiable',
+    content: `These responsibilities are required by federal apprenticeship law and USDOL program standards. They are not optional and are not subject to modification.
+
+The Salon agrees to:
+
+SUPERVISION: Provide direct, on-site supervision of the apprentice by a currently licensed Indiana cosmetologist at all times during OJT hours. The supervising cosmetologist must hold an active Indiana IPLA cosmetology license with at least 2 years of experience. No exceptions.
+
+EMPLOYMENT: The apprentice is a paid employee of the Salon — not a volunteer, intern, or independent contractor. The Salon is the employer of record for the apprentice during OJT. The Salon is responsible for payroll, withholding, workers' compensation, and all employer obligations under Indiana and federal law.
+
+WAGES: Pay the apprentice according to the agreed progressive wage schedule (see Section 5). Failure to pay the apprentice as agreed is grounds for immediate termination of this MOU and will be reported to USDOL.
+
+HOURS TRACKING: Accurately track and submit OJT hours to the Sponsor monthly using the provided tracking forms. Falsifying OJT hours is a federal offense.
+
+SAFETY: Maintain a safe workplace that complies with all OSHA standards and Indiana workplace safety requirements. Report any workplace injury involving the apprentice to the Sponsor within 24 hours.
+
+INSURANCE: Carry workers' compensation insurance covering the apprentice. Provide proof of coverage to the Sponsor before the apprentice begins OJT.
+
+LICENSES: Maintain all required business licenses, health permits, and salon operating licenses throughout the term of this MOU. Notify the Sponsor immediately if any license lapses.
+
+NONDISCRIMINATION: Comply with all federal nondiscrimination requirements under WIOA Section 188, Title VI of the Civil Rights Act, the ADA, and all applicable equal opportunity laws. The apprenticeship program is open to all qualified individuals regardless of race, color, religion, sex, national origin, age, or disability.`,
+  },
+  {
+    title: '5. Apprentice Compensation — Federal Minimum Standards',
+    content: `Apprentice compensation is governed by federal apprenticeship standards and Indiana minimum wage law. These minimums are not negotiable.
+
+The apprentice is a paid employee. Compensation on a sole commission basis is prohibited under federal apprenticeship rules.
+
+Approved compensation models:
+• HOURLY: $10.00–$15.00/hr recommended. Must meet Indiana minimum wage ($7.25/hr) at all times.
+• HYBRID: $8.00–$10.00/hr base wage PLUS 15%–25% commission on services performed. Base wage must meet Indiana minimum wage at all times.
+
+Progressive wage increases are required as the apprentice advances through the program. The wage schedule is set in the registered program standards and must be followed.
+
+Apprentices retain 100% of tips. Tips may not be counted toward the minimum wage requirement.
+
+The Salon is responsible for all payroll taxes, withholding, and employer contributions for the apprentice.`,
+  },
+  {
+    title: '6. Term and Termination — 30-Day Notice Right',
+    content: `This MOU is effective from the date signed and continues until the apprentice completes the program, withdraws, or the agreement is terminated.
+
+YOUR RIGHT TO EXIT: Either party — the Salon or the Sponsor — may terminate this MOU at any time for any reason by providing 30 days written notice. Send written notice (email is acceptable) to your assigned Elevate coordinator and copy elevate4humanityedu@gmail.com. You do not need to provide a reason. You do not need the other party's permission. This right is non-negotiable and cannot be waived.
+
+During the 30-day notice period: the apprentice continues their OJT and the Salon continues its obligations under this MOU. The Sponsor will work with the Salon and the apprentice on a transition plan.
+
+IMMEDIATE TERMINATION BY SPONSOR (no notice required): The Sponsor may terminate this MOU immediately — without the 30-day notice period — if the Salon:
+• Fails to pay the apprentice as agreed
+• Violates any workplace safety or OSHA requirement
+• Loses any required business license or insurance
+• Falsifies OJT hours or program records
+• Engages in misconduct affecting the apprentice's safety or welfare
+• Violates federal nondiscrimination requirements
+
+After termination: the Salon must submit all outstanding OJT hour records to the Sponsor within 10 business days. The apprentice's program records remain with the Sponsor.`,
+  },
+  {
+    title: '7. Confidentiality and Non-Disclosure',
+    content: `Both parties agree to maintain confidentiality of apprentice personally identifiable information (PII) in compliance with applicable privacy laws.
+
+The Salon may not disclose apprentice PII (name, contact information, wage information, program records) to any third party without written apprentice consent and Sponsor authorization, except as required for program administration or by law.
+
+The Salon also receives access to Elevate's operational procedures, program materials, and business information through this collaboration. This information is confidential. The Salon may not disclose or use Elevate's confidential information for any purpose other than fulfilling its obligations under this MOU.
+
+A full Non-Disclosure Agreement is available at ${PLATFORM_DEFAULTS.canonicalDomain}/legal/nda and is incorporated by reference into this MOU.`,
+  },
+  {
+    title: '8. Non-Compete and Non-Replication',
+    content: `The Salon receives access to Elevate's registered apprenticeship program structure, curriculum relationships, RAPIDS registration, and credential pathways through this collaboration. This access is provided to support the apprentice — not to enable the Salon to replicate the program independently.
+
+During the term of this MOU and for three (3) years following termination, the Salon agrees not to:
+• Use Elevate's program structure, RAPIDS registration, or DWD relationships to independently register or operate a competing USDOL Registered Apprenticeship program in cosmetology
+• Solicit or redirect Elevate apprentice candidates, instructors, or credential partners into a competing program derived from the Elevate apprenticeship model
+• Represent to any funding agency, employer, or student that the Salon independently operates the Indiana Cosmetology Apprenticeship Program
+
+These restrictions do not prevent the Salon from: operating as a salon, employing licensed cosmetologists, hiring apprentices through other registered programs, or participating in training programs that are not substantially similar to the Elevate apprenticeship model.`,
+  },
+  {
+    title: '9. Partner Handbook — Required Reading',
+    content: `The Worksite Partner Handbook is incorporated by reference into this MOU and forms part of this agreement. The Handbook details the day-to-day responsibilities, compensation requirements, hour tracking procedures, prohibited practices, and communication expectations that govern the worksite relationship.
+
+By signing this MOU, the Salon confirms that it has read and understood the Partner Handbook in full prior to signing. The Handbook is available at: ${PLATFORM_DEFAULTS.canonicalDomain}/partners/cosmetology-host-shop/handbook
+
+Failure to comply with the standards set out in the Handbook constitutes a breach of this MOU and may result in immediate termination of the partnership and notification to USDOL.`,
+  },
+  {
+    title: '10. Dispute Resolution',
+    content: `The parties agree to attempt to resolve any disputes through good-faith negotiation first. If a dispute cannot be resolved through negotiation within 15 business days, either party may submit the dispute to mediation.
+
+If mediation is unsuccessful, the parties consent to jurisdiction in Marion County, Indiana. This MOU is governed by the laws of the State of Indiana.
+
+USDOL/RAPIDS compliance disputes are subject to federal apprenticeship regulations and may be reported to the Indiana Department of Workforce Development or the U.S. Department of Labor, Office of Apprenticeship.`,
+  },
+];
+
+const META: Record<HostShopMouProgram, HostShopMouMeta> = {
+  barber: {
+    documentType: 'Memorandum of Understanding',
+    title: 'Indiana Barber Host Shop Program',
+    subtitle: 'Worksite Partner Agreement',
+    worksiteLabel: 'Your barbershop',
+    handbookHref: '/partners/barber-host-shop/handbook',
+    fullDocHref: '/docs/Indiana-Barbershop-Apprenticeship-MOU',
+    rapidsId: '2025-IN-132301',
+  },
+  cosmetology: {
+    documentType: 'Memorandum of Understanding',
+    title: 'Indiana Cosmetology Apprenticeship Program',
+    subtitle: 'Host Salon Worksite Agreement',
+    worksiteLabel: 'Your salon',
+    handbookHref: '/partners/cosmetology-host-shop/handbook',
+    rapidsId: '2025-IN-132302',
+  },
+};
+
+export function getHostShopMouSections(program: HostShopMouProgram): MouSection[] {
+  return program === 'barber' ? BARBER_SECTIONS : COSMETOLOGY_SECTIONS;
+}
+
+export function getHostShopMouMeta(program: HostShopMouProgram): HostShopMouMeta {
+  return META[program];
+}

--- a/tests/unit/host-shop-mou-sections.test.ts
+++ b/tests/unit/host-shop-mou-sections.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest';
+import {
+  getHostShopMouMeta,
+  getHostShopMouSections,
+} from '@/lib/partners/host-shop-mou-sections';
+
+describe('host-shop-mou-sections', () => {
+  it('returns ten barber MOU sections with RAPIDS id in preamble', () => {
+    const sections = getHostShopMouSections('barber');
+    expect(sections).toHaveLength(10);
+    expect(sections[0].content).toContain('2025-IN-132301');
+    expect(getHostShopMouMeta('barber').fullDocHref).toBe(
+      '/docs/Indiana-Barbershop-Apprenticeship-MOU',
+    );
+  });
+
+  it('returns ten cosmetology MOU sections with salon wording', () => {
+    const sections = getHostShopMouSections('cosmetology');
+    expect(sections).toHaveLength(10);
+    expect(sections[0].content).toContain('2025-IN-132302');
+    expect(sections[0].content.toLowerCase()).toContain('salon');
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Host shop applications were broken for MOU review: applicants only saw a checkbox linking to `/login?redirect=.../sign-mou` (cosmetology) or an external docs page (barber), with no full agreement text on the form.

This PR embeds the complete Memorandum of Understanding directly on the barber and cosmetology host shop apply pages and centralizes MOU copy in one module shared with the sign-mou flow.

## Changes

- **`lib/partners/host-shop-mou-sections.ts`** — canonical MOU sections + metadata for barber and cosmetology host shops
- **`components/partners/HostShopMouPreview.tsx`** — scrollable MOU panel with anchor `#host-shop-mou`
- **Apply pages** — barber + cosmetology now render the full MOU before acknowledgments; checkbox links scroll to `#host-shop-mou` instead of login-only routes
- **`my-application` APIs** — return `owner_name`, supervisor fields, and salon name aliases for sign-mou prefill
- **Sign-mou pages** — import shared MOU sections (no content drift)
- **Unit test** — `tests/unit/host-shop-mou-sections.test.ts`

## Verification

- `pnpm test tests/unit/host-shop-mou-sections.test.ts` — pass
- Dev server: `/partners/barber-host-shop/apply` and `/partners/cosmetology-host-shop/apply` return embedded MOU (`host-shop-mou`, `Parties and Purpose`)

## Note

Digital MOU **signing** still happens after login on `/partners/*/sign-mou` (barber requires approval; cosmetology can sign once a partner row exists). This fix ensures applicants can **read** the MOU during application without broken links.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix host shop MOU display and prefill on barber and cosmetology application pages
> - Adds a new `HostShopMouPreview` component that renders the MOU inline on both barber and cosmetology host shop application pages, replacing external/download links with an in-page anchor (`#host-shop-mou`).
> - Extracts shared MOU content into [`lib/partners/host-shop-mou-sections.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/366/files#diff-b27486f09de2038da68594e806e23dcf15be6b019964263e1a4e8a65a1e23816) via `getHostShopMouSections` and `getHostShopMouMeta` helpers, eliminating duplicated text across sign-MOU pages.
> - Improves prefill on sign-MOU pages: barber page falls back to `contact_name` when `owner_name` is absent and populates supervisor fields; cosmetology page resolves salon name from multiple possible keys and prefills `compensation_model`.
> - Extends the `/api/partners/barber-host-shop/my-application` and `/api/partners/cosmetology-host-shop/my-application` GET responses to include the additional fields needed for prefill.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ebc50d2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->