### PR TITLE
Fix apprentice routing to program portals (not learner dashboard)

### DIFF
--- a/app/learner/dashboard/page.tsx
+++ b/app/learner/dashboard/page.tsx
@@ -33,6 +33,8 @@ import heroBanners from '@/content/heroBanners';
 import BillingCard, { type BillingSummary } from '@/components/learner/BillingCard';
 import { ResendMagicLinkForm } from '@/components/auth/ResendMagicLinkForm';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
+import { PORTAL_FALLBACK } from '@/lib/portal/router';
 
 export const metadata: Metadata = {
   title: 'Learner Dashboard | Elevate LMS',
@@ -50,41 +52,17 @@ export default async function LearnerDashboardPage({ searchParams }: Props) {
   const supabase = await createClient();
   const sp = await searchParams;
 
-  // Students with a portal_type get redirected to their industry-specific dashboard.
-  // This makes /learner/dashboard a smart router — no more generic one-size-fits-all.
-  // Only redirect when the portal page actually exists to avoid 404 loops.
-  const VALID_PORTAL_TYPES = new Set([
-    'apprentice', 'barber', 'cosmetology', 'esthetician',
-    'nail-technician', 'culinary', 'electrical', 'plumbing',
-  ]);
   const profileAny = profile as any;
-  if (profile?.role === 'student' && profileAny.portal_type && VALID_PORTAL_TYPES.has(profileAny.portal_type)) {
-    redirect(`/portal/${profileAny.portal_type}`);
-  }
 
-  // Apprenticeship students each get their own dedicated portal dashboard.
+  // Apprenticeship + industry portal routing (same resolver as login / auth callback).
   if (profile?.role === 'student') {
-    const APPRENTICESHIP_SLUG_TO_PORTAL: Record<string, string> = {
-      'barber-apprenticeship':          '/portal/barber',
-      'cosmetology-apprenticeship':     '/portal/cosmetology',
-      'esthetician-apprenticeship':     '/portal/esthetician',
-      'nail-technician-apprenticeship': '/portal/nail-technician',
-      'culinary-apprenticeship':        '/portal/culinary',
-      'electrical':                     '/portal/electrical',
-      'plumbing':                       '/portal/plumbing',
-    };
-    const { data: apEnrollment } = await supabase
-      .from('program_enrollments')
-      .select('program_slug')
-      .eq('user_id', user.id)
-      .in('program_slug', Object.keys(APPRENTICESHIP_SLUG_TO_PORTAL))
-      .in('enrollment_state', ['active', 'enrolled', 'orientation', 'onboarding'])
-      .order('enrolled_at', { ascending: false })
-      .limit(1)
-      .maybeSingle();
-
-    if (apEnrollment?.program_slug) {
-      redirect(APPRENTICESHIP_SLUG_TO_PORTAL[apEnrollment.program_slug] ?? '/portal/apprentice');
+    const home = await resolveStudentHomePath(
+      supabase,
+      user.id,
+      profileAny.portal_type ?? null,
+    );
+    if (home !== PORTAL_FALLBACK) {
+      redirect(home);
     }
   }
 

--- a/lib/enrollment/enrollment-flow.ts
+++ b/lib/enrollment/enrollment-flow.ts
@@ -74,6 +74,20 @@ export const PENDING_ONBOARDING_STATES: readonly ValidEnrollmentState[] = [
   'enrolled',
 ];
 
+/**
+ * Enrollment states that route apprentices to their program portal
+ * (/portal/barber, /portal/cosmetology, …) — not /learner/dashboard.
+ * Includes in-progress onboarding and legacy DB values still on old rows.
+ */
+export const APPRENTICESHIP_PORTAL_ENROLLMENT_STATES = [
+  ...PENDING_ONBOARDING_STATES,
+  'active',
+  // legacy values (see LEGACY_STATE_MAP) — may still exist on program_enrollments
+  'confirmed',
+  'orientation_complete',
+  'documents_complete',
+] as const;
+
 /** States eligible for document submission APIs. */
 export const PRE_DOCUMENTS_STATES: readonly ValidEnrollmentState[] = [
   'enrolled',

--- a/lib/portal/apprenticeship-portal-paths.ts
+++ b/lib/portal/apprenticeship-portal-paths.ts
@@ -3,6 +3,8 @@
  * Used by login, learner dashboard, and portal router — keep in sync.
  */
 
+import { APPRENTICESHIP_PORTAL_ENROLLMENT_STATES } from '@/lib/enrollment/enrollment-flow';
+
 export const APPRENTICESHIP_SLUG_TO_PORTAL_PATH: Record<string, string> = {
   'barber-apprenticeship': '/portal/barber',
   'cosmetology-apprenticeship': '/portal/cosmetology',
@@ -24,14 +26,8 @@ export const APPRENTICESHIP_SLUG_TO_PORTAL_TYPE: Record<string, string> = {
   plumbing: 'plumbing',
 };
 
-export const ACTIVE_ENROLLMENT_STATES = [
-  'active',
-  'enrolled',
-  'onboarding',
-  'confirmed',
-  'orientation_complete',
-  'documents_complete',
-] as const;
+/** @see APPRENTICESHIP_PORTAL_ENROLLMENT_STATES in enrollment-flow.ts */
+export const ACTIVE_ENROLLMENT_STATES = APPRENTICESHIP_PORTAL_ENROLLMENT_STATES;
 
 export function portalPathForProgramSlug(programSlug: string | null | undefined): string | null {
   if (!programSlug) return null;

--- a/tests/unit/portal-routing.test.ts
+++ b/tests/unit/portal-routing.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from 'vitest';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
-import { portalPathForProgramSlug } from '@/lib/portal/apprenticeship-portal-paths';
+import { APPRENTICESHIP_PORTAL_ENROLLMENT_STATES } from '@/lib/enrollment/enrollment-flow';
+import { ACTIVE_ENROLLMENT_STATES, portalPathForProgramSlug } from '@/lib/portal/apprenticeship-portal-paths';
 
 describe('portal routing', () => {
   it('maps beauty apprenticeship slugs to industry portals', () => {
@@ -8,6 +9,13 @@ describe('portal routing', () => {
     expect(portalPathForProgramSlug('cosmetology-apprenticeship')).toBe('/portal/cosmetology');
     expect(portalPathForProgramSlug('esthetician-apprenticeship')).toBe('/portal/esthetician');
     expect(portalPathForProgramSlug('nail-technician-apprenticeship')).toBe('/portal/nail-technician');
+  });
+
+  it('routes in-progress apprenticeship states including orientation', () => {
+    expect(ACTIVE_ENROLLMENT_STATES).toBe(APPRENTICESHIP_PORTAL_ENROLLMENT_STATES);
+    expect(ACTIVE_ENROLLMENT_STATES).toContain('orientation');
+    expect(ACTIVE_ENROLLMENT_STATES).toContain('applied');
+    expect(ACTIVE_ENROLLMENT_STATES).toContain('orientation_complete');
   });
 
   it('includes partner_admin and sponsor destinations', () => {


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

Apprentices in onboarding states (especially `orientation`) were missing from `ACTIVE_ENROLLMENT_STATES`, so login and portal resolution fell back to `/learner/dashboard` instead of their program portal (`/portal/barber`, etc.).

The learner dashboard had a separate, narrower inline state list that did not match login routing.

## Fix

- Add canonical `APPRENTICESHIP_PORTAL_ENROLLMENT_STATES` in `enrollment-flow.ts` (includes `orientation`, `applied`, funding gates, plus legacy `orientation_complete` / `documents_complete` rows)
- Re-export as `ACTIVE_ENROLLMENT_STATES` for all portal resolvers
- Learner dashboard now uses `resolveStudentHomePath()` — same resolver as `/login/apprentice`, auth callback, and `resolvePortalForUser`

## Verification

- `pnpm test tests/unit/portal-routing.test.ts` — passes (asserts `orientation` is included)
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix apprentice routing from learner dashboard to program portals
> - Replaces inline portal routing logic in [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/367/files#diff-16fbab8c09a47fdc747a2872116870085f91e5e905f6170caad7da7cd36b8d3d) with a call to `resolveStudentHomePath`, removing the hardcoded `VALID_PORTAL_TYPES` check and apprenticeship-specific enrollment query.
> - Introduces `APPRENTICESHIP_PORTAL_ENROLLMENT_STATES` in [enrollment-flow.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/367/files#diff-108f304581b59c701824a984b53673671a68e9ce66c008897d711c9228ff5f62), which expands the active enrollment set to include pending onboarding states (`applied`, `waitlisted`, `payment_required`, `orientation`, etc.).
> - `ACTIVE_ENROLLMENT_STATES` in [apprenticeship-portal-paths.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/367/files#diff-4fb4ddb435149de48e07b0e26377c49c0b8c395f27abd15f878a015bc0d0a5f3) now references this constant directly, broadening which enrollments qualify for portal routing.
> - Behavioral Change: Apprentices in pending onboarding states (e.g. `applied`, `waitlisted`) now redirect to the program portal instead of the learner dashboard.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 29cbe96.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->