### PR TITLE
Fix Dev Studio Container GitHub token (platform_secrets hydration)

### DIFF
--- a/apps/admin/app/api/devstudio/devcontainer/route.ts
+++ b/apps/admin/app/api/devstudio/devcontainer/route.ts
@@ -18,6 +18,12 @@ import { createHash } from 'crypto';
 import { access, mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
+import {
+  ensureDevStudioSecrets,
+  getGitHubHeaders,
+  getGitHubToken,
+  githubApiErrorMessage,
+} from '@/lib/devstudio/github-token';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 
@@ -49,8 +55,8 @@ function getDevcontainerMode(): DevcontainerMode {
   return 'auto';
 }
 
-function hasGitHubToken(): boolean {
-  return Boolean(process.env.GITHUB_TOKEN);
+async function hasGitHubToken(): Promise<boolean> {
+  return (await getGitHubToken()) !== null;
 }
 
 function stripJsonCommentsAndTrailingCommas(input: string): string {
@@ -157,22 +163,11 @@ async function writeLocalDevcontainer(content: string, expectedSha: string) {
   return { conflict: false as const, sha: computeSha(content) };
 }
 
-function ghHeaders(): HeadersInit {
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) throw new Error('GITHUB_TOKEN is not configured');
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-  };
-}
-
 async function readGitHubDevcontainer(authenticated: boolean) {
   const encodedPath = encodeURIComponent(DEVCONTAINER_GH).replace(/%2F/g, '/');
   const res = await fetch(`${GH_API}/repos/${getRepo()}/contents/${encodedPath}?ref=${getBranch()}`, {
     headers: authenticated
-      ? ghHeaders()
+      ? await getGitHubHeaders()
       : {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
@@ -196,8 +191,9 @@ export async function GET(request: NextRequest) {
   if (auth.error) return auth.error;
 
   try {
+    await ensureDevStudioSecrets();
     const mode = getDevcontainerMode();
-    const githubConfigured = hasGitHubToken();
+    const githubConfigured = await hasGitHubToken();
     const repo = getRepo();
     const branch = getBranch();
 
@@ -272,8 +268,8 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      if (gh.status === 404) return safeError('devcontainer.json not found in repo', 404);
-      return safeError('GitHub API error — check GITHUB_TOKEN permissions', gh.status);
+      if (gh.status === 404) return safeError(githubApiErrorMessage(404), 404);
+      return safeError(githubApiErrorMessage(gh.status), gh.status >= 400 && gh.status < 600 ? gh.status : 502);
     }
 
     try {
@@ -329,6 +325,7 @@ export async function PUT(request: NextRequest) {
   if (auth.error) return auth.error;
 
   try {
+    await ensureDevStudioSecrets();
     const mode = getDevcontainerMode();
     const body = await request.json();
     const { content, sha, message } = body as { content: string; sha: string; message?: string };
@@ -341,11 +338,11 @@ export async function PUT(request: NextRequest) {
 
     parseJsonc(content);
 
-    if (mode === 'github-only' && !hasGitHubToken()) {
+    if (mode === 'github-only' && !(await hasGitHubToken())) {
       return safeError('Save requires GITHUB_TOKEN (github-only mode)', 503);
     }
 
-    if (!hasGitHubToken()) {
+    if (!(await hasGitHubToken())) {
       if (mode !== 'local-only') {
         return safeError(
           'Save requires GITHUB_TOKEN. Production admin must use DEVSTUDIO_DEVCONTAINER_MODE=github-only.',
@@ -367,7 +364,7 @@ export async function PUT(request: NextRequest) {
 
     const res = await fetch(`${GH_API}/repos/${getRepo()}/contents/${encodedPath}`, {
       method: 'PUT',
-      headers: ghHeaders(),
+      headers: await getGitHubHeaders(),
       body: JSON.stringify({
         message: message ?? 'chore: update devcontainer.json via Dev Studio',
         content: encoded,
@@ -378,7 +375,7 @@ export async function PUT(request: NextRequest) {
 
     if (!res.ok) {
       await res.json().catch(() => ({}));
-      return safeError('GitHub API error', res.status);
+      return safeError(githubApiErrorMessage(res.status), res.status);
     }
 
     const result = await res.json();

--- a/apps/admin/app/api/devstudio/files/route.ts
+++ b/apps/admin/app/api/devstudio/files/route.ts
@@ -13,7 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getGitHubHeaders } from '@/lib/devstudio/github-token';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -52,39 +52,8 @@ function isBlocked(filePath: string): boolean {
   return BLOCKED_PATTERNS.some((p) => p.test(filePath));
 }
 
-let ghTokenCache: { token: string; expiresAt: number } | null = null;
-
-async function getGhToken(): Promise<string> {
-  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
-  if (ghTokenCache && ghTokenCache.expiresAt > Date.now()) return ghTokenCache.token;
-
-  try {
-    const db = await requireAdminClient();
-    const { data } = await db
-      .from('platform_secrets')
-      .select('value_enc')
-      .eq('key', 'GITHUB_TOKEN')
-      .single();
-    const token = data?.value_enc;
-    if (token && token.length > 10) {
-      ghTokenCache = { token, expiresAt: Date.now() + 5 * 60 * 1000 };
-      return token;
-    }
-  } catch {
-    // fall through
-  }
-
-  throw new Error('GITHUB_TOKEN is not configured. Add it in Dev Studio > Secrets tab.');
-}
-
 async function ghHeaders(): Promise<HeadersInit> {
-  const token = await getGhToken();
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-  };
+  return getGitHubHeaders();
 }
 
 interface GHEntry {

--- a/apps/admin/app/api/devstudio/services/route.ts
+++ b/apps/admin/app/api/devstudio/services/route.ts
@@ -9,6 +9,7 @@ import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
+import { hydrateProcessEnv } from '@/lib/secrets';
 import {
   getNorthflankProjectId,
   getNorthflankService,
@@ -49,6 +50,8 @@ export async function GET(request: NextRequest) {
   if (rateLimited) return rateLimited;
   const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
+
+  await hydrateProcessEnv().catch(() => {});
 
   const projectId = getNorthflankProjectId();
   const nfReady = isNorthflankReady();
@@ -107,6 +110,8 @@ export async function POST(request: NextRequest) {
   if (rateLimited) return rateLimited;
   const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
+
+  await hydrateProcessEnv().catch(() => {});
 
   let body: { action: string; service: string };
   try {

--- a/lib/devstudio/github-token.ts
+++ b/lib/devstudio/github-token.ts
@@ -1,0 +1,72 @@
+/**
+ * Resolve GITHUB_TOKEN for Dev Studio GitHub API routes.
+ * Precedence: hydrate platform_secrets → process.env (see lib/secrets.ts).
+ */
+
+import { getSecret, hydrateProcessEnv } from '@/lib/secrets';
+
+let tokenCache: { token: string; expiresAt: number } | null = null;
+const CACHE_MS = 5 * 60 * 1000;
+
+function looksLikeToken(value: string | undefined | null): value is string {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (trimmed.length < 10) return false;
+  if (/placeholder/i.test(trimmed)) return false;
+  return true;
+}
+
+/** Load platform_secrets into process.env before GitHub calls. */
+export async function ensureDevStudioSecrets(): Promise<void> {
+  await hydrateProcessEnv();
+}
+
+export async function getGitHubToken(): Promise<string | null> {
+  await ensureDevStudioSecrets();
+
+  if (tokenCache && tokenCache.expiresAt > Date.now()) {
+    return tokenCache.token;
+  }
+
+  const fromEnv = process.env.GITHUB_TOKEN;
+  if (looksLikeToken(fromEnv)) {
+    tokenCache = { token: fromEnv.trim(), expiresAt: Date.now() + CACHE_MS };
+    return tokenCache.token;
+  }
+
+  const fromDb = await getSecret('GITHUB_TOKEN');
+  if (looksLikeToken(fromDb)) {
+    const token = fromDb.trim();
+    process.env.GITHUB_TOKEN = token;
+    tokenCache = { token, expiresAt: Date.now() + CACHE_MS };
+    return token;
+  }
+
+  return null;
+}
+
+export async function getGitHubHeaders(): Promise<HeadersInit> {
+  const token = await getGitHubToken();
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is not configured. Add it in Dev Studio > Secrets tab.');
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+export function githubApiErrorMessage(status: number): string {
+  if (status === 401) {
+    return 'GitHub token rejected (401). Rotate GITHUB_TOKEN in Dev Studio > Secrets with repo + workflow scopes.';
+  }
+  if (status === 403) {
+    return 'GitHub API forbidden (403). Ensure GITHUB_TOKEN has contents:read/write on elevate-for-humanity/Elevate-lms.';
+  }
+  if (status === 404) {
+    return 'devcontainer.json not found in repo';
+  }
+  return `GitHub API error (${status}) — check GITHUB_TOKEN in Dev Studio > Secrets`;
+}

--- a/tests/unit/devcontainer-credentials-wiring.test.ts
+++ b/tests/unit/devcontainer-credentials-wiring.test.ts
@@ -56,6 +56,16 @@ describe('dev container credential wiring (no fake secrets in UI)', () => {
     expect(src).not.toContain("'https://admin.${PLATFORM_DEFAULTS.canonicalDomain}'");
   });
 
+  it('devcontainer API hydrates platform_secrets before GitHub calls', () => {
+    const route = readFileSync(
+      join(REPO_ROOT, 'apps/admin/app/api/devstudio/devcontainer/route.ts'),
+      'utf8',
+    );
+    expect(route).toContain('ensureDevStudioSecrets');
+    expect(route).toContain('getGitHubToken');
+    expect(route).not.toMatch(/function hasGitHubToken\(\): boolean/);
+  });
+
   it('devcontainer setup creates local env without production secret pull', () => {
     const setup = readFileSync(join(REPO_ROOT, '.devcontainer/setup-env.sh'), 'utf8');
     expect(setup).toContain('cp .env.example "$ENV_FILE"');


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Cherry-pick of commit missed when #368 merged early.

Hydrates `platform_secrets` before devcontainer GitHub API calls so production Container tab uses GITHUB_TOKEN from Dev Studio > Secrets.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix GitHub token hydration in Dev Studio container and file APIs
> - Adds `ensureDevStudioSecrets()` and `getGitHubToken()` in [`lib/devstudio/github-token.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/369/files#diff-0117bf2231f9d1d22682a1f432964daffba0fca7800efefaa039524926cb7616) to resolve the GitHub token from the database when absent from `process.env`, with short-lived in-memory caching.
> - Updates the devcontainer and files API routes to call `ensureDevStudioSecrets()` at handler start and use the shared async token utilities instead of reading `process.env.GITHUB_TOKEN` directly.
> - Updates the services API routes to call `hydrateProcessEnv()` before reading Northflank configuration or performing deploy/restart actions.
> - Adds `githubApiErrorMessage()` to return specific error messages for GitHub 401/403/404 responses instead of generic errors.
> - Behavioral Change: `hasGitHubToken` is now async; GitHub token resolution now falls back to a DB secrets lookup, so tokens stored only in `platform_secrets` will be picked up at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 195e443.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->