### PR TITLE
fix: super_admin Dev Container access + dashboard demo data filtering

### DIFF
--- a/app/api/store/cart/sync/route.ts
+++ b/app/api/store/cart/sync/route.ts
@@ -1,0 +1,93 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { withApiAudit } from '@/lib/audit/withApiAudit';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+interface SyncItem {
+  slug: string;
+  quantity: number;
+}
+
+async function _POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+
+  const supabase = await createClient();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
+
+  if (!user) {
+    return NextResponse.json({ error: 'Sign in required' }, { status: 401 });
+  }
+
+  try {
+    const body = await request.json();
+    const items: SyncItem[] = Array.isArray(body.items) ? body.items : [];
+
+    if (items.length === 0) {
+      return NextResponse.json({ error: 'Cart is empty' }, { status: 400 });
+    }
+
+    const slugs = [...new Set(items.map((item) => item.slug).filter(Boolean))];
+    const { data: products, error: productsError } = await supabase
+      .from('products')
+      .select('id, slug, price')
+      .in('slug', slugs);
+
+    if (productsError) {
+      logger.error('Cart sync products lookup failed', productsError);
+      return NextResponse.json({ error: 'Could not load products' }, { status: 500 });
+    }
+
+    const productBySlug = new Map((products ?? []).map((p) => [p.slug, p]));
+    const missing = slugs.filter((slug) => !productBySlug.has(slug));
+
+    if (missing.length > 0) {
+      return NextResponse.json(
+        {
+          error: `Some items are not available for cart checkout: ${missing.join(', ')}. Use Subscribe on the app page for subscriptions.`,
+          missing,
+        },
+        { status: 400 },
+      );
+    }
+
+    for (const item of items) {
+      const product = productBySlug.get(item.slug);
+      if (!product) continue;
+
+      const { data: existing } = await supabase
+        .from('cart_items')
+        .select('id, quantity')
+        .eq('user_id', user.id)
+        .eq('product_id', product.id)
+        .maybeSingle();
+
+      if (existing) {
+        await supabase
+          .from('cart_items')
+          .update({ quantity: existing.quantity + item.quantity })
+          .eq('id', existing.id);
+      } else {
+        await supabase.from('cart_items').insert({
+          user_id: user.id,
+          product_id: product.id,
+          quantity: item.quantity,
+          price: product.price,
+        });
+      }
+    }
+
+    return NextResponse.json({ ok: true, synced: items.length });
+  } catch (err) {
+    logger.error('Cart sync error', err instanceof Error ? err : undefined);
+    return NextResponse.json({ error: 'Failed to sync cart' }, { status: 500 });
+  }
+}
+
+export const POST = withApiAudit('/api/store/cart/sync', _POST);

--- a/app/shop/ShopClient.tsx
+++ b/app/shop/ShopClient.tsx
@@ -5,6 +5,8 @@ import Link from 'next/link';
 import Image from 'next/image';
 import { Star, Filter, Search, ShoppingCart } from 'lucide-react';
 import { trackSearch, trackProductView, trackAddToCart } from '@/components/analytics/PageTracker';
+import { addToCart } from '@/lib/store/cart';
+import { useStoreCart } from '@/hooks/useStoreCart';
 
 interface Product {
   id: string;
@@ -25,6 +27,7 @@ interface ShopClientProps {
 export function ShopClient({ products, categories }: ShopClientProps) {
   const [searchQuery, setSearchQuery] = useState('');
   const [activeCategory, setActiveCategory] = useState('All');
+  const { cart } = useStoreCart();
 
   const handleSearch = (e: React.FormEvent) => {
     e.preventDefault();
@@ -41,7 +44,21 @@ export function ShopClient({ products, categories }: ShopClientProps) {
     e.preventDefault();
     e.stopPropagation();
     trackAddToCart(product.id, product.name, product.category, product.price);
-    // Add to cart logic here
+    addToCart(
+      {
+        id: product.id,
+        name: product.name,
+        slug: product.slug || product.id,
+        category: 'physical-product',
+        price: product.price,
+        description: product.name,
+        image: product.image_url || '/images/pages/store-hero.webp',
+        inStock: true,
+        featured: false,
+        digital: false,
+      },
+      1,
+    );
   };
 
   const filteredProducts =
@@ -77,15 +94,17 @@ export function ShopClient({ products, categories }: ShopClientProps) {
             />
           </form>
           <Link
-            href="/shop/cart"
+            href="/store/cart"
             className="relative p-2 text-slate-600 hover:text-brand-blue-600"
-            aria-label="Shopping cart"
+            aria-label={cart.itemCount > 0 ? `Shopping cart, ${cart.itemCount} items` : 'Shopping cart'}
             data-tour="shop-cart"
           >
             <ShoppingCart className="w-6 h-6" />
-            <span className="absolute -top-1 -right-1 w-5 h-5 bg-brand-blue-600 text-white text-xs rounded-full flex items-center justify-center">
-              0
-            </span>
+            {cart.itemCount > 0 && (
+              <span className="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 bg-brand-blue-600 text-white text-xs font-bold rounded-full flex items-center justify-center">
+                {cart.itemCount > 99 ? '99+' : cart.itemCount}
+              </span>
+            )}
           </Link>
         </div>
       </div>

--- a/app/store/StoreClientWrapper.tsx
+++ b/app/store/StoreClientWrapper.tsx
@@ -10,6 +10,9 @@ const StoreGuideChat = dynamic(() => import('@/components/store/StoreGuideChat')
 const GuidedTour = dynamic(() => import('@/components/store/GuidedTour'), {
   ssr: false,
 });
+const StoreCartButton = dynamic(() => import('@/components/store/StoreCartButton'), {
+  ssr: false,
+});
 
 interface StoreClientWrapperProps {
   children: ReactNode;
@@ -53,7 +56,9 @@ export default function StoreClientWrapper({ children }: StoreClientWrapperProps
   return (
     <>
       {children}
-      
+
+      <StoreCartButton />
+
       {/* Store Guide Chat — deferred to avoid blocking initial paint */}
       {showGuide && <StoreGuideChat onStartTour={handleStartTour} />}
       

--- a/app/store/cart/page.tsx
+++ b/app/store/cart/page.tsx
@@ -1,19 +1,8 @@
 import { Metadata } from 'next';
 import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import { createClient } from '@/lib/supabase/server';
-import { redirect } from 'next/navigation';
-import Link from 'next/link';
 import Image from 'next/image';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
-import {
-  ShoppingCart,
-  Trash2,
-  Plus,
-  Minus,
-  ArrowLeft,
-  CreditCard,
-  ShieldCheck,
-} from 'lucide-react';
+import StoreCartView from '@/components/store/StoreCartView';
 
 export const metadata: Metadata = {
   title: 'Shopping Cart',
@@ -31,216 +20,30 @@ const CART_ERROR_MESSAGES: Record<string, string> = {
 export default async function CartPage({
   searchParams,
 }: {
-  searchParams: Promise<{ error?: string }>;
+  searchParams: Promise<{ error?: string; add?: string }>;
 }) {
-  const { error: errorSlug } = await searchParams;
-  const checkoutError = errorSlug ? (CART_ERROR_MESSAGES[errorSlug] ?? 'Something went wrong. Please try again.') : null;
-
-  const supabase = await createClient();
-
-  const { data: { user } } = await supabase.auth.getUser();
-
-  // Show empty cart for guests instead of redirecting
-  if (!user) {
-    return (
-      <div className="min-h-screen bg-white">
-        <div className="max-w-4xl mx-auto px-4 py-8">
-          <div className="flex items-center gap-4 mb-8">
-            <Link href="/store" className="text-slate-700 hover:text-slate-900">
-              <ArrowLeft className="w-5 h-5" />
-            </Link>
-            <h1 className="text-2xl font-bold">Shopping Cart</h1>
-          </div>
-          <div className="bg-white rounded-xl shadow-sm border p-12 text-center">
-            <ShoppingCart className="w-16 h-16 mx-auto mb-4 text-slate-700" />
-            <h2 className="text-xl font-semibold mb-2">Your cart is empty</h2>
-            <p className="text-slate-700 mb-6">Sign in to view your cart or browse our store.</p>
-            <div className="flex flex-col sm:flex-row gap-4 justify-center">
-              <Link
-                href="/login?redirect=/store/cart"
-                className="inline-flex items-center gap-2 bg-brand-red-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-red-700"
-              >
-                Sign In
-              </Link>
-              <Link
-                href="/store"
-                className="inline-flex items-center gap-2 border border-slate-300 px-6 py-3 rounded-lg font-medium hover:bg-white"
-              >
-                Continue Shopping
-              </Link>
-            </div>
-          </div>
-        </div>
-      </div>
-    );
-  }
-
-  // Get cart items with product details
-  const { data: cartItems } = await supabase
-    .from('cart_items')
-    .select(`
-      id,
-      quantity,
-      product:products(
-        id,
-        name,
-        price,
-        image_url,
-        type
-      )
-    `)
-    .eq('user_id', user.id);
-
-  const subtotal = cartItems?.reduce((sum: number, item: any) => {
-    return sum + (item.product?.price || 0) * item.quantity;
-  }, 0) || 0;
-
-  const tax = subtotal * 0.07; // 7% tax
-  const total = subtotal + tax;
+  const { error: errorSlug, add } = await searchParams;
+  const checkoutError = errorSlug
+    ? (CART_ERROR_MESSAGES[errorSlug] ?? 'Something went wrong. Please try again.')
+    : null;
 
   return (
     <div className="min-h-screen bg-white">
-
-      {/* Hero Image */}
       <section className="relative h-[160px] sm:h-[220px] md:h-[280px] overflow-hidden">
-        {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
-        <Image src="/images/pages/store-cart-hero.jpg" alt="Elevate store" fill sizes="100vw" className="object-cover" priority placeholder="empty" />
+        <Image
+          src="/images/pages/store-cart-hero.jpg"
+          alt="Elevate store"
+          fill
+          sizes="100vw"
+          className="object-cover"
+          priority
+          placeholder="empty"
+        />
       </section>
-            <div className="max-w-7xl mx-auto px-4 py-4">
-        <Breadcrumbs items={[{ label: "Store", href: "/store" }, { label: "Cart" }]} />
+      <div className="max-w-7xl mx-auto px-4 py-4">
+        <Breadcrumbs items={[{ label: 'Store', href: '/store' }, { label: 'Cart' }]} />
       </div>
-<div className="max-w-4xl mx-auto px-4 py-8">
-        {checkoutError && (
-          <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
-            {checkoutError}
-          </div>
-        )}
-        <div className="flex items-center gap-4 mb-8">
-          <Link href="/store" className="text-slate-700 hover:text-slate-900">
-            <ArrowLeft className="w-5 h-5" />
-          </Link>
-          <h1 className="text-2xl font-bold">Shopping Cart</h1>
-        </div>
-
-        {cartItems && cartItems.length > 0 ? (
-          <div className="grid lg:grid-cols-3 gap-8">
-            {/* Cart Items */}
-            <div className="lg:col-span-2 space-y-4">
-              {cartItems.map((item: any) => (
-                <div key={item.id} className="bg-white rounded-xl shadow-sm border p-4">
-                  <div className="flex gap-4">
-                    <div className="w-20 h-20 bg-white rounded-lg overflow-hidden flex-shrink-0 relative">
-                      {item.product?.image_url ? (
-                        <Image
-                          src={item.product.image_url}
-                          alt={item.product?.name || 'Store product'}
-                          fill
-                          className="object-cover object-top"
-                          sizes="80px"
-                          placeholder="empty"
-                        />
-                      ) : (
-                        <div className="w-full h-full bg-slate-100 rounded-lg" aria-hidden="true" />
-                      )}
-                    </div>
-                    <div className="flex-1">
-                      <h3 className="font-semibold">{item.product?.name}</h3>
-                      <p className="text-sm text-slate-700 capitalize">{item.product?.type}</p>
-                      <div className="flex items-center justify-between mt-3">
-                        <div className="flex items-center gap-2">
-                          <form action={`/api/cart/update`} method="POST">
-                            <input type="hidden" name="itemId" value={item.id} />
-                            <input type="hidden" name="quantity" value={item.quantity - 1} />
-                            <button 
-                              type="submit"
-                              className="w-8 h-8 flex items-center justify-center border rounded hover:bg-white"
-                              disabled={item.quantity <= 1}
-                            >
-                              <Minus className="w-4 h-4" />
-                            </button>
-                          </form>
-                          <span className="w-8 text-center font-medium">{item.quantity}</span>
-                          <form action={`/api/cart/update`} method="POST">
-                            <input type="hidden" name="itemId" value={item.id} />
-                            <input type="hidden" name="quantity" value={item.quantity + 1} />
-                            <button 
-                              type="submit"
-                              className="w-8 h-8 flex items-center justify-center border rounded hover:bg-white"
-                            >
-                              <Plus className="w-4 h-4" />
-                            </button>
-                          </form>
-                        </div>
-                        <div className="flex items-center gap-4">
-                          <span className="font-bold">
-                            ${((item.product?.price || 0) * item.quantity).toFixed(2)}
-                          </span>
-                          <form action={`/api/cart/remove`} method="POST">
-                            <input type="hidden" name="itemId" value={item.id} />
-                            <button 
-                              type="submit"
-                              className="text-brand-red-500 hover:text-brand-red-700"
-                            >
-                              <Trash2 className="w-5 h-5" />
-                            </button>
-                          </form>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              ))}
-            </div>
-
-            {/* Order Summary */}
-            <div className="lg:col-span-1">
-              <div className="bg-white rounded-xl shadow-sm border p-6 sticky top-8">
-                <h2 className="text-lg font-semibold mb-4">Order Summary</h2>
-                <div className="space-y-3 mb-6">
-                  <div className="flex justify-between text-slate-700">
-                    <span>Subtotal</span>
-                    <span>${subtotal.toFixed(2)}</span>
-                  </div>
-                  <div className="flex justify-between text-slate-700">
-                    <span>Tax (7%)</span>
-                    <span>${tax.toFixed(2)}</span>
-                  </div>
-                  <div className="border-t pt-3 flex justify-between font-bold text-lg">
-                    <span>Total</span>
-                    <span>${total.toFixed(2)}</span>
-                  </div>
-                </div>
-                <form action="/api/store/cart-checkout" method="POST">
-                  <input type="hidden" name="customerEmail" value={user.email || ''} />
-                  <button
-                    type="submit"
-                    className="w-full flex items-center justify-center gap-2 bg-brand-red-600 text-white py-3 rounded-lg font-semibold hover:bg-brand-red-700"
-                  >
-                    <CreditCard className="w-5 h-5" />
-                    Proceed to Checkout
-                  </button>
-                </form>
-                <div className="flex items-center justify-center gap-2 mt-4 text-sm text-slate-700">
-                  <ShieldCheck className="w-4 h-4" />
-                  Secure checkout
-                </div>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="bg-white rounded-xl shadow-sm border p-12 text-center">
-            <ShoppingCart className="w-16 h-16 mx-auto mb-4 text-slate-700" />
-            <h2 className="text-xl font-semibold mb-2">Your cart is empty</h2>
-            <p className="text-slate-700 mb-6">Browse our store to find resources that support your journey.</p>
-            <Link
-              href="/store"
-              className="inline-flex items-center gap-2 bg-brand-red-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-red-700"
-            >
-              Continue Shopping
-            </Link>
-          </div>
-        )}
-      </div>
+      <StoreCartView checkoutError={checkoutError} addParam={add ?? null} />
     </div>
   );
 }

--- a/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/admin/dev-studio/DevStudioUnifiedClient.tsx
@@ -100,7 +100,11 @@ function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: S
 export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSuperAdmin?: boolean }) {
   const searchParams = useSearchParams();
   const initial = normalizeWorkspace(searchParams.get('tab'));
-  const [workspace, setWorkspace] = useState<Workspace>(initial.workspace === 'secrets' && !isSuperAdmin ? 'studio' : initial.workspace);
+  const [workspace, setWorkspace] = useState<Workspace>(
+    (initial.workspace === 'secrets' || initial.workspace === 'environments') && !isSuperAdmin
+      ? 'studio'
+      : initial.workspace,
+  );
   const [studioMode, setStudioMode] = useState<StudioMode>(initial.mode);
   const [config, setConfig] = useState<StudioConfig | null>(null);
   const [health, setHealth] = useState<Record<string, unknown> | null>(null);
@@ -159,7 +163,7 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
   }, [health]);
 
   function openWorkspace(next: Workspace) {
-    if (next === 'secrets' && !isSuperAdmin) {
+    if ((next === 'secrets' || next === 'environments') && !isSuperAdmin) {
       setWorkspace('health');
       return;
     }
@@ -197,7 +201,10 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
         <aside className="hidden w-48 shrink-0 flex-col border-r border-[#3c3c3c] bg-[#252526] p-2 md:flex overflow-y-auto">
           <div className="mb-2 px-2 text-[10px] font-bold uppercase tracking-widest text-[#858585]">Environments</div>
           <div className="space-y-1">
-            {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => {
+            {WORKSPACES.filter(
+              (item) =>
+                (item.id !== 'secrets' && item.id !== 'environments') || isSuperAdmin,
+            ).map(({ id, label, Icon }) => {
               const active = workspace === id;
               return (
                 <button
@@ -249,7 +256,12 @@ export default function DevStudioUnifiedClient({ isSuperAdmin = false }: { isSup
             )}
             {workspace === 'deploy' && <DeployPanel workflowButtons={config?.workflowButtons} />}
             {workspace === 'files' && <DevStudioEditorWorkspace />}
-            {workspace === 'environments' && <EnvironmentPanel />}
+            {workspace === 'environments' &&
+              (isSuperAdmin ? (
+                <EnvironmentPanel />
+              ) : (
+                <HealthPanel health={health} onRefresh={() => window.location.reload()} />
+              ))}
             {workspace === 'health' && <HealthPanel health={health} onRefresh={() => window.location.reload()} />}
             {workspace === 'secrets' && (isSuperAdmin ? <SecretsPanel /> : <HealthPanel health={health} onRefresh={() => window.location.reload()} />)}
           </main>
@@ -314,7 +326,9 @@ function MobileTabs({
 }) {
   return (
     <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-[#3c3c3c] bg-[#252526] p-1 md:hidden">
-      {WORKSPACES.filter((item) => item.id !== 'secrets' || isSuperAdmin).map(({ id, label, Icon }) => (
+      {WORKSPACES.filter(
+        (item) => (item.id !== 'secrets' && item.id !== 'environments') || isSuperAdmin,
+      ).map(({ id, label, Icon }) => (
         <button
           key={id}
           type="button"

--- a/apps/admin/app/api/devstudio/devcontainer/route.ts
+++ b/apps/admin/app/api/devstudio/devcontainer/route.ts
@@ -18,6 +18,12 @@ import { createHash } from 'crypto';
 import { access, mkdir, readFile, writeFile } from 'fs/promises';
 import path from 'path';
 import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
+import {
+  ensureDevStudioSecrets,
+  getGitHubHeaders,
+  getGitHubToken,
+  githubApiErrorMessage,
+} from '@/lib/devstudio/github-token';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 
@@ -49,8 +55,8 @@ function getDevcontainerMode(): DevcontainerMode {
   return 'auto';
 }
 
-function hasGitHubToken(): boolean {
-  return Boolean(process.env.GITHUB_TOKEN);
+async function hasGitHubToken(): Promise<boolean> {
+  return (await getGitHubToken()) !== null;
 }
 
 function stripJsonCommentsAndTrailingCommas(input: string): string {
@@ -157,22 +163,11 @@ async function writeLocalDevcontainer(content: string, expectedSha: string) {
   return { conflict: false as const, sha: computeSha(content) };
 }
 
-function ghHeaders(): HeadersInit {
-  const token = process.env.GITHUB_TOKEN;
-  if (!token) throw new Error('GITHUB_TOKEN is not configured');
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-  };
-}
-
 async function readGitHubDevcontainer(authenticated: boolean) {
   const encodedPath = encodeURIComponent(DEVCONTAINER_GH).replace(/%2F/g, '/');
   const res = await fetch(`${GH_API}/repos/${getRepo()}/contents/${encodedPath}?ref=${getBranch()}`, {
     headers: authenticated
-      ? ghHeaders()
+      ? await getGitHubHeaders()
       : {
           Accept: 'application/vnd.github+json',
           'X-GitHub-Api-Version': '2022-11-28',
@@ -196,8 +191,9 @@ export async function GET(request: NextRequest) {
   if (auth.error) return auth.error;
 
   try {
+    await ensureDevStudioSecrets();
     const mode = getDevcontainerMode();
-    const githubConfigured = hasGitHubToken();
+    const githubConfigured = await hasGitHubToken();
     const repo = getRepo();
     const branch = getBranch();
 
@@ -272,8 +268,8 @@ export async function GET(request: NextRequest) {
         }
       }
 
-      if (gh.status === 404) return safeError('devcontainer.json not found in repo', 404);
-      return safeError('GitHub API error — check GITHUB_TOKEN permissions', gh.status);
+      if (gh.status === 404) return safeError(githubApiErrorMessage(404), 404);
+      return safeError(githubApiErrorMessage(gh.status), gh.status >= 400 && gh.status < 600 ? gh.status : 502);
     }
 
     try {
@@ -329,6 +325,7 @@ export async function PUT(request: NextRequest) {
   if (auth.error) return auth.error;
 
   try {
+    await ensureDevStudioSecrets();
     const mode = getDevcontainerMode();
     const body = await request.json();
     const { content, sha, message } = body as { content: string; sha: string; message?: string };
@@ -341,11 +338,11 @@ export async function PUT(request: NextRequest) {
 
     parseJsonc(content);
 
-    if (mode === 'github-only' && !hasGitHubToken()) {
+    if (mode === 'github-only' && !(await hasGitHubToken())) {
       return safeError('Save requires GITHUB_TOKEN (github-only mode)', 503);
     }
 
-    if (!hasGitHubToken()) {
+    if (!(await hasGitHubToken())) {
       if (mode !== 'local-only') {
         return safeError(
           'Save requires GITHUB_TOKEN. Production admin must use DEVSTUDIO_DEVCONTAINER_MODE=github-only.',
@@ -367,7 +364,7 @@ export async function PUT(request: NextRequest) {
 
     const res = await fetch(`${GH_API}/repos/${getRepo()}/contents/${encodedPath}`, {
       method: 'PUT',
-      headers: ghHeaders(),
+      headers: await getGitHubHeaders(),
       body: JSON.stringify({
         message: message ?? 'chore: update devcontainer.json via Dev Studio',
         content: encoded,
@@ -378,7 +375,7 @@ export async function PUT(request: NextRequest) {
 
     if (!res.ok) {
       await res.json().catch(() => ({}));
-      return safeError('GitHub API error', res.status);
+      return safeError(githubApiErrorMessage(res.status), res.status);
     }
 
     const result = await res.json();

--- a/apps/admin/app/api/devstudio/files/route.ts
+++ b/apps/admin/app/api/devstudio/files/route.ts
@@ -13,7 +13,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getGitHubHeaders } from '@/lib/devstudio/github-token';
 
 export const dynamic = 'force-dynamic';
 export const runtime = 'nodejs';
@@ -52,39 +52,8 @@ function isBlocked(filePath: string): boolean {
   return BLOCKED_PATTERNS.some((p) => p.test(filePath));
 }
 
-let ghTokenCache: { token: string; expiresAt: number } | null = null;
-
-async function getGhToken(): Promise<string> {
-  if (process.env.GITHUB_TOKEN) return process.env.GITHUB_TOKEN;
-  if (ghTokenCache && ghTokenCache.expiresAt > Date.now()) return ghTokenCache.token;
-
-  try {
-    const db = await requireAdminClient();
-    const { data } = await db
-      .from('platform_secrets')
-      .select('value_enc')
-      .eq('key', 'GITHUB_TOKEN')
-      .single();
-    const token = data?.value_enc;
-    if (token && token.length > 10) {
-      ghTokenCache = { token, expiresAt: Date.now() + 5 * 60 * 1000 };
-      return token;
-    }
-  } catch {
-    // fall through
-  }
-
-  throw new Error('GITHUB_TOKEN is not configured. Add it in Dev Studio > Secrets tab.');
-}
-
 async function ghHeaders(): Promise<HeadersInit> {
-  const token = await getGhToken();
-  return {
-    Authorization: `Bearer ${token}`,
-    Accept: 'application/vnd.github+json',
-    'X-GitHub-Api-Version': '2022-11-28',
-    'Content-Type': 'application/json',
-  };
+  return getGitHubHeaders();
 }
 
 interface GHEntry {

--- a/apps/admin/app/api/devstudio/services/route.ts
+++ b/apps/admin/app/api/devstudio/services/route.ts
@@ -9,6 +9,7 @@ import { apiRequireDevStudio } from '@/lib/devstudio/api-auth';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
+import { hydrateProcessEnv } from '@/lib/secrets';
 import {
   getNorthflankProjectId,
   getNorthflankService,
@@ -49,6 +50,8 @@ export async function GET(request: NextRequest) {
   if (rateLimited) return rateLimited;
   const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
+
+  await hydrateProcessEnv().catch(() => {});
 
   const projectId = getNorthflankProjectId();
   const nfReady = isNorthflankReady();
@@ -107,6 +110,8 @@ export async function POST(request: NextRequest) {
   if (rateLimited) return rateLimited;
   const auth = await apiRequireDevStudio(request);
   if (auth.error) return auth.error;
+
+  await hydrateProcessEnv().catch(() => {});
 
   let body: { action: string; service: string };
   try {

--- a/components/admin/dashboard/LizzyWorkspace.tsx
+++ b/components/admin/dashboard/LizzyWorkspace.tsx
@@ -170,7 +170,14 @@ export function LizzyWorkspace({
           {panel === 'health' && (
             <div className="flex h-full flex-col overflow-hidden">
               <div className="min-h-0 flex-1 overflow-auto">
-                <EnvironmentHealthPanel />
+                {isSuperAdmin ? (
+                  <EnvironmentHealthPanel />
+                ) : (
+                  <div className="flex h-full items-center justify-center bg-white p-6 text-center text-sm text-slate-600">
+                    Dev Container controls require a super admin account. Other health tools remain
+                    available below.
+                  </div>
+                )}
               </div>
               <div className="h-1/2 min-h-[200px] border-t border-[#3c3c3c]">
                 <ServicesPanel />

--- a/components/dev-studio/DevStudioMobileShell.tsx
+++ b/components/dev-studio/DevStudioMobileShell.tsx
@@ -135,9 +135,11 @@ export default function DevStudioMobileShell({
               [
                 { id: 'files' as const, label: 'Files', Icon: FolderOpen },
                 { id: 'services' as const, label: 'Services', Icon: Server },
-                { id: 'environments' as const, label: 'Container', Icon: Bot },
                 ...(isSuperAdmin
-                  ? [{ id: 'secrets' as const, label: 'Secrets', Icon: Key }]
+                  ? [
+                      { id: 'environments' as const, label: 'Container', Icon: Bot },
+                      { id: 'secrets' as const, label: 'Secrets', Icon: Key },
+                    ]
                   : []),
               ] as const
             ).map(({ id, label, Icon }) => (
@@ -224,7 +226,7 @@ export default function DevStudioMobileShell({
             <div className="min-h-0 flex-1 overflow-y-auto p-2">
               {moreOpen === 'files' && <FilesPlaceholder />}
               {moreOpen === 'services' && <ServicesPanel />}
-              {moreOpen === 'environments' && <DevContainerPanel />}
+              {moreOpen === 'environments' && isSuperAdmin && <DevContainerPanel />}
               {moreOpen === 'secrets' && isSuperAdmin && <SecretsPanel />}
             </div>
           </div>

--- a/components/store/ProductPage.tsx
+++ b/components/store/ProductPage.tsx
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
+import { addToCart } from '@/lib/store/cart';
 
 // Hook to track product page views
 function useProductPageAnalytics(productId: string) {
@@ -133,6 +134,7 @@ interface FAQ {
 
 interface ProductPageProps {
   product: {
+    slug?: string;
     name: string;
     tagline: string;
     description: string;
@@ -157,6 +159,7 @@ interface ProductPageProps {
 export function ProductPage({ product }: ProductPageProps) {
   const [selectedImage, setSelectedImage] = useState(0);
   const [showVideo, setShowVideo] = useState(false);
+  const [cartNotice, setCartNotice] = useState<string | null>(null);
   const [selectedPlan, setSelectedPlan] = useState(1);
   const [expandedFaq, setExpandedFaq] = useState<number | null>(null);
   const [reviewFilter, setReviewFilter] = useState<'all' | '5' | '4' | '3' | '2' | '1'>('all');
@@ -349,9 +352,40 @@ export function ProductPage({ product }: ProductPageProps) {
               </div>
             </div>
 
+            {cartNotice && (
+              <p className="mb-4 text-sm text-brand-green-700 bg-brand-green-50 border border-brand-green-200 rounded-lg px-4 py-2">
+                {cartNotice}
+              </p>
+            )}
+
             {/* CTA Buttons */}
             <div className="flex gap-3 mb-6">
-              <button className="flex-1 bg-brand-blue-600 text-white py-4 rounded-xl font-bold text-lg hover:bg-brand-blue-700 transition flex items-center justify-center gap-2">
+              <button
+                type="button"
+                onClick={() => {
+                  const plan = product.pricing[selectedPlan];
+                  const slug =
+                    product.slug ||
+                    product.name.toLowerCase().replace(/[^a-z0-9]+/g, '-').replace(/(^-|-$)/g, '');
+                  addToCart(
+                    {
+                      id: `store:${slug}:${selectedPlan}`,
+                      name: `${product.name} — ${plan.name}`,
+                      slug,
+                      category: 'template',
+                      price: plan.price,
+                      description: plan.description,
+                      image: product.images[0]?.src || '/images/pages/store-hero.webp',
+                      inStock: true,
+                      featured: Boolean(plan.popular),
+                      digital: true,
+                    },
+                    1,
+                  );
+                  setCartNotice(`${plan.name} plan added to cart.`);
+                }}
+                className="flex-1 bg-brand-blue-600 text-white py-4 rounded-xl font-bold text-lg hover:bg-brand-blue-700 transition flex items-center justify-center gap-2"
+              >
                 <ShoppingCart className="w-5 h-5" />
                 Add to Cart
               </button>

--- a/components/store/StoreCartButton.tsx
+++ b/components/store/StoreCartButton.tsx
@@ -1,0 +1,47 @@
+'use client';
+
+import Link from 'next/link';
+import { ShoppingCart } from 'lucide-react';
+import { useStoreCart } from '@/hooks/useStoreCart';
+
+interface StoreCartButtonProps {
+  className?: string;
+  variant?: 'floating' | 'inline';
+}
+
+export default function StoreCartButton({
+  className = '',
+  variant = 'floating',
+}: StoreCartButtonProps) {
+  const { cart } = useStoreCart();
+  const count = cart.itemCount;
+
+  const base =
+    variant === 'floating'
+      ? 'fixed bottom-24 right-4 z-40 md:bottom-8 md:right-8'
+      : 'relative inline-flex';
+
+  return (
+    <Link
+      href="/store/cart"
+      className={`${base} group ${className}`}
+      aria-label={count > 0 ? `Shopping cart, ${count} items` : 'Shopping cart'}
+      data-tour="store-cart"
+    >
+      <span
+        className={`flex items-center justify-center rounded-full shadow-lg transition-transform group-hover:scale-105 ${
+          variant === 'floating'
+            ? 'h-14 w-14 bg-brand-blue-600 text-white hover:bg-brand-blue-700'
+            : 'h-10 w-10 bg-white border border-slate-200 text-slate-700 hover:border-brand-blue-300 hover:text-brand-blue-600'
+        }`}
+      >
+        <ShoppingCart className={variant === 'floating' ? 'h-6 w-6' : 'h-5 w-5'} />
+      </span>
+      {count > 0 && (
+        <span className="absolute -top-1 -right-1 min-w-[1.25rem] h-5 px-1 bg-brand-red-600 text-white text-xs font-bold rounded-full flex items-center justify-center border-2 border-white">
+          {count > 99 ? '99+' : count}
+        </span>
+      )}
+    </Link>
+  );
+}

--- a/components/store/StoreCartView.tsx
+++ b/components/store/StoreCartView.tsx
@@ -1,0 +1,287 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Image from 'next/image';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import {
+  ShoppingCart,
+  Trash2,
+  Plus,
+  Minus,
+  ArrowLeft,
+  CreditCard,
+  ShieldCheck,
+  Loader2,
+} from 'lucide-react';
+import { useStoreCart } from '@/hooks/useStoreCart';
+import { addToCart, clearCart } from '@/lib/store/cart';
+import {
+  isIndividualAppCartProduct,
+  parseIndividualAppCartProduct,
+  resolveCartAddParam,
+} from '@/lib/store/resolve-cart-add';
+import { createClient } from '@/lib/supabase/client';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+interface StoreCartViewProps {
+  checkoutError?: string | null;
+  addParam?: string | null;
+}
+
+export default function StoreCartView({ checkoutError, addParam }: StoreCartViewProps) {
+  const router = useRouter();
+  const { cart, removeItem, setQuantity, refresh } = useStoreCart();
+  const [checkingOut, setCheckingOut] = useState(false);
+  const [checkoutMessage, setCheckoutMessage] = useState<string | null>(null);
+  const [addedNotice, setAddedNotice] = useState<string | null>(null);
+
+  useEffect(() => {
+    if (!addParam) return;
+    const product = resolveCartAddParam(addParam);
+    if (!product) {
+      setCheckoutMessage('That product could not be added. Browse the store and try again.');
+      return;
+    }
+    addToCart(product, 1);
+    setAddedNotice(`${product.name} added to your cart.`);
+    refresh();
+    router.replace('/store/cart', { scroll: false });
+  }, [addParam, refresh, router]);
+
+  const subtotal = cart.total;
+  const tax = subtotal * 0.07;
+  const total = subtotal + tax;
+
+  const handleCheckout = async () => {
+    if (cart.items.length === 0) return;
+    setCheckingOut(true);
+    setCheckoutMessage(null);
+
+    try {
+      const supabase = createClient();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
+
+      const individualItem = cart.items.find((item) =>
+        isIndividualAppCartProduct(item.product.id),
+      );
+
+      if (individualItem) {
+        if (!user) {
+          window.location.href = `/login?redirect=${encodeURIComponent('/store/cart')}`;
+          return;
+        }
+        const parsed = parseIndividualAppCartProduct(individualItem.product.id);
+        if (!parsed) throw new Error('Invalid subscription item');
+
+        const res = await fetch('/api/apps/upgrade', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({ appSlug: parsed.appSlug, plan: parsed.planId }),
+        });
+        const data = await res.json();
+        if (!res.ok) {
+          throw new Error(data.error || 'Checkout failed');
+        }
+        if (data.checkoutUrl) {
+          clearCart();
+          window.location.href = data.checkoutUrl;
+          return;
+        }
+        throw new Error('No checkout URL returned');
+      }
+
+      if (!user) {
+        window.location.href = `/login?redirect=${encodeURIComponent('/store/cart')}`;
+        return;
+      }
+
+      const syncRes = await fetch('/api/store/cart/sync', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          items: cart.items.map((item) => ({
+            slug: item.product.slug,
+            quantity: item.quantity,
+          })),
+        }),
+      });
+      const syncData = await syncRes.json();
+      if (!syncRes.ok) {
+        throw new Error(syncData.error || 'Could not prepare checkout');
+      }
+
+      const form = document.getElementById('store-cart-checkout-form') as HTMLFormElement | null;
+      form?.requestSubmit();
+    } catch (err) {
+      setCheckoutMessage(
+        err instanceof Error
+          ? err.message
+          : `Checkout failed. Call ${PLATFORM_DEFAULTS.supportPhone} for help.`,
+      );
+    } finally {
+      setCheckingOut(false);
+    }
+  };
+
+  return (
+    <div className="max-w-4xl mx-auto px-4 py-8">
+      {checkoutError && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-800">
+          {checkoutError}
+        </div>
+      )}
+      {addedNotice && (
+        <div className="mb-6 rounded-lg border border-brand-green-200 bg-brand-green-50 px-4 py-3 text-sm text-brand-green-800">
+          {addedNotice}
+        </div>
+      )}
+      {checkoutMessage && (
+        <div className="mb-6 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-900">
+          {checkoutMessage}
+        </div>
+      )}
+
+      <div className="flex items-center gap-4 mb-8">
+        <Link href="/store" className="text-slate-700 hover:text-slate-900" aria-label="Back to store">
+          <ArrowLeft className="w-5 h-5" />
+        </Link>
+        <h1 className="text-2xl font-bold text-slate-900">Shopping Cart</h1>
+        {cart.itemCount > 0 && (
+          <span className="text-sm text-slate-500">
+            {cart.itemCount} {cart.itemCount === 1 ? 'item' : 'items'}
+          </span>
+        )}
+      </div>
+
+      {cart.items.length > 0 ? (
+        <div className="grid lg:grid-cols-3 gap-8">
+          <div className="lg:col-span-2 space-y-4">
+            {cart.items.map((item) => (
+              <div key={item.product.id} className="bg-white rounded-xl shadow-sm border border-slate-200 p-4">
+                <div className="flex gap-4">
+                  <div className="relative w-20 h-20 bg-slate-100 rounded-lg overflow-hidden flex-shrink-0">
+                    <Image
+                      src={item.product.image || '/images/pages/store-hero.webp'}
+                      alt={item.product.name}
+                      fill
+                      className="object-cover"
+                      sizes="80px"
+                    />
+                  </div>
+                  <div className="flex-1 min-w-0">
+                    <h3 className="font-semibold text-slate-900 truncate">{item.product.name}</h3>
+                    <p className="text-sm text-slate-600 capitalize">{item.product.category.replace(/-/g, ' ')}</p>
+                    <div className="flex items-center justify-between mt-3 gap-2 flex-wrap">
+                      <div className="flex items-center gap-2">
+                        <button
+                          type="button"
+                          onClick={() => setQuantity(item.product.id, item.quantity - 1)}
+                          className="w-8 h-8 flex items-center justify-center border border-slate-200 rounded hover:bg-slate-50"
+                          disabled={item.quantity <= 1}
+                          aria-label="Decrease quantity"
+                        >
+                          <Minus className="w-4 h-4" />
+                        </button>
+                        <span className="w-8 text-center font-medium">{item.quantity}</span>
+                        <button
+                          type="button"
+                          onClick={() => setQuantity(item.product.id, item.quantity + 1)}
+                          className="w-8 h-8 flex items-center justify-center border border-slate-200 rounded hover:bg-slate-50"
+                          aria-label="Increase quantity"
+                        >
+                          <Plus className="w-4 h-4" />
+                        </button>
+                      </div>
+                      <div className="flex items-center gap-4">
+                        <span className="font-bold text-slate-900">
+                          ${(item.product.salePrice ?? item.product.price) * item.quantity}
+                          <span className="text-xs font-normal text-slate-500">/mo</span>
+                        </span>
+                        <button
+                          type="button"
+                          onClick={() => removeItem(item.product.id)}
+                          className="text-brand-red-500 hover:text-brand-red-700"
+                          aria-label={`Remove ${item.product.name}`}
+                        >
+                          <Trash2 className="w-5 h-5" />
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ))}
+          </div>
+
+          <div className="lg:col-span-1">
+            <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-6 sticky top-8">
+              <h2 className="text-lg font-semibold mb-4 text-slate-900">Order Summary</h2>
+              <div className="space-y-3 mb-6 text-sm">
+                <div className="flex justify-between text-slate-700">
+                  <span>Subtotal</span>
+                  <span>${subtotal.toFixed(2)}</span>
+                </div>
+                <div className="flex justify-between text-slate-700">
+                  <span>Est. tax (7%)</span>
+                  <span>${tax.toFixed(2)}</span>
+                </div>
+                <div className="border-t pt-3 flex justify-between font-bold text-lg text-slate-900">
+                  <span>Total</span>
+                  <span>${total.toFixed(2)}</span>
+                </div>
+              </div>
+
+              <button
+                type="button"
+                onClick={handleCheckout}
+                disabled={checkingOut}
+                className="w-full flex items-center justify-center gap-2 bg-brand-red-600 text-white py-3 rounded-lg font-semibold hover:bg-brand-red-700 disabled:opacity-60"
+              >
+                {checkingOut ? (
+                  <Loader2 className="w-5 h-5 animate-spin" />
+                ) : (
+                  <CreditCard className="w-5 h-5" />
+                )}
+                Proceed to Checkout
+              </button>
+
+              <form id="store-cart-checkout-form" action="/api/store/cart-checkout" method="POST" className="hidden">
+                <input type="hidden" name="customerEmail" value="" />
+              </form>
+
+              <div className="flex items-center justify-center gap-2 mt-4 text-sm text-slate-600">
+                <ShieldCheck className="w-4 h-4" />
+                Secure checkout
+              </div>
+            </div>
+          </div>
+        </div>
+      ) : (
+        <div className="bg-white rounded-xl shadow-sm border border-slate-200 p-12 text-center">
+          <ShoppingCart className="w-16 h-16 mx-auto mb-4 text-slate-400" />
+          <h2 className="text-xl font-semibold mb-2 text-slate-900">Your cart is empty</h2>
+          <p className="text-slate-600 mb-6">
+            Add apps, workbooks, or platform plans from the store.
+          </p>
+          <div className="flex flex-col sm:flex-row gap-4 justify-center">
+            <Link
+              href="/store/apps"
+              className="inline-flex items-center justify-center gap-2 bg-brand-red-600 text-white px-6 py-3 rounded-lg font-medium hover:bg-brand-red-700"
+            >
+              Browse Apps
+            </Link>
+            <Link
+              href="/store/plans"
+              className="inline-flex items-center justify-center gap-2 border border-slate-300 px-6 py-3 rounded-lg font-medium hover:bg-slate-50 text-slate-900"
+            >
+              View Plans
+            </Link>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/hooks/useStoreCart.ts
+++ b/hooks/useStoreCart.ts
@@ -1,0 +1,38 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import {
+  getCart,
+  removeFromCart,
+  updateQuantity,
+  type Cart,
+} from '@/lib/store/cart';
+
+export function useStoreCart() {
+  const [cart, setCart] = useState<Cart>({ items: [], total: 0, itemCount: 0 });
+
+  const refresh = useCallback(() => {
+    setCart(getCart());
+  }, []);
+
+  useEffect(() => {
+    refresh();
+
+    const onCartUpdated = () => refresh();
+    window.addEventListener('cartUpdated', onCartUpdated);
+    return () => window.removeEventListener('cartUpdated', onCartUpdated);
+  }, [refresh]);
+
+  const removeItem = useCallback(
+    (productId: string) => {
+      setCart(removeFromCart(productId));
+    },
+    [],
+  );
+
+  const setQuantity = useCallback((productId: string, quantity: number) => {
+    setCart(updateQuantity(productId, quantity));
+  }, []);
+
+  return { cart, refresh, removeItem, setQuantity };
+}

--- a/lib/admin/dashboard/format-metrics.ts
+++ b/lib/admin/dashboard/format-metrics.ts
@@ -52,14 +52,28 @@ export function formatCentsCompact(cents: number): string {
   return `$${dollars.toLocaleString('en-US', { maximumFractionDigits: 0 })}`;
 }
 
+/** Names/emails that indicate seeded demo rows — exclude from admin dashboard KPIs. */
+export function isLikelyTestOrDemoRecord(...values: Array<unknown>): boolean {
+  const text = values
+    .filter(Boolean)
+    .map(String)
+    .join(' ')
+    .toLowerCase();
+  if (!text.trim()) return false;
+  if (/\b(sample|test|demo|example|placeholder|verification|e2e)\b/.test(text)) return true;
+  if (/@(student|test)\.elevate\.edu\b/.test(text)) return true;
+  if (/\b(stu\d+|testuser|fakeuser)\b/.test(text)) return true;
+  if (/\bmarcus\s+johnson\b/.test(text)) return true;
+  if (/\bsarah\s+chen\b/.test(text)) return true;
+  return false;
+}
+
 export function isTestOrSuspiciousPayment(fields: {
   email?: string | null;
   label?: string | null;
   amountCents: number;
 }): boolean {
-  const text = [fields.email, fields.label].filter(Boolean).join(' ').toLowerCase();
-  if (/\b(sample|test|demo|example|placeholder|verification)\b/.test(text)) return true;
-  if (/@student\.elevate\.edu\b/.test(text)) return true;
+  if (isLikelyTestOrDemoRecord(fields.email, fields.label)) return true;
   if (fields.amountCents <= 101) return true;
   if (fields.amountCents > MAX_PAYMENT_CENTS) return true;
   return false;

--- a/lib/admin/get-admin-dashboard-data.ts
+++ b/lib/admin/get-admin-dashboard-data.ts
@@ -17,6 +17,10 @@ import {
 import type { AdminDashboardData, DegradedSection } from '@/components/admin/dashboard/types';
 import { PENDING_APPLICATION_STATUSES } from '@/lib/admin/application-statuses';
 import { getSystemHealth } from './dashboard/get-system-health';
+import {
+  isLikelyTestOrDemoRecord,
+  isTestOrSuspiciousPayment,
+} from '@/lib/admin/dashboard/format-metrics';
 import { withTimeout } from '@/lib/utils/withTimeout';
 
 function toSafeNumber(value: unknown): number {
@@ -31,15 +35,6 @@ function clampPercent(value: number): number {
 
 function dollarsToCents(value: unknown): number {
   return Math.round(toSafeNumber(value) * 100);
-}
-
-function isLikelyTestRecord(...values: Array<unknown>): boolean {
-  const text = values
-    .filter(Boolean)
-    .map(String)
-    .join(' ')
-    .toLowerCase();
-  return /\b(sample|test|demo|example|placeholder)\b/.test(text);
 }
 
 function sumCentsFromRows<T extends Record<string, unknown>>(
@@ -504,7 +499,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
   }));
 
   const staleLeads = staleLeadsData
-    .filter((l: any) => !isLikelyTestRecord(l.first_name, l.last_name, l.email))
+    .filter((l: any) => !isLikelyTestOrDemoRecord(l.first_name, l.last_name, l.email))
     .map((l: any) => ({
       id: l.id,
       name: [l.first_name, l.last_name].filter(Boolean).join(' ') || l.email || null,
@@ -542,7 +537,9 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
   // ── Applications with aging ───────────────────────────────────────────────
   const now = Date.now();
   const pendingApps = (pendingAppsRes.data ?? [])
-    .filter((app: any) => !isLikelyTestRecord(app.full_name, app.first_name, app.last_name, app.email))
+    .filter((app: any) =>
+      !isLikelyTestOrDemoRecord(app.full_name, app.first_name, app.last_name, app.email),
+    )
     .map((app: any) => {
     const createdAt = app.submitted_at || app.created_at;
     const ageDays = Math.floor((now - new Date(createdAt).getTime()) / 86400000);
@@ -642,8 +639,21 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
   type RecentPayment = import('@/components/admin/dashboard/types').RecentPayment;
   const recentPayments: RecentPayment[] = [];
 
+  const pushRecentPayment = (payment: RecentPayment) => {
+    if (
+      isTestOrSuspiciousPayment({
+        email: payment.email,
+        label: payment.label,
+        amountCents: payment.amountCents,
+      })
+    ) {
+      return;
+    }
+    recentPayments.push(payment);
+  };
+
   for (const row of (recentStripeSessionsRes.error ? [] : (recentStripeSessionsRes.data ?? [])) as any[]) {
-    recentPayments.push({
+    pushRecentPayment({
       id: row.session_id,
       email: row.email ?? null,
       amountCents: toSafeNumber(row.amount),
@@ -653,7 +663,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     });
   }
   for (const row of barberSubscriptionRows as any[]) {
-    recentPayments.push({
+    pushRecentPayment({
       id: row.id,
       email: row.customer_email ?? null,
       amountCents: dollarsToCents(row.amount_paid_at_checkout),
@@ -663,7 +673,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     });
   }
   for (const row of cosmetologySubscriptionRows as any[]) {
-    recentPayments.push({
+    pushRecentPayment({
       id: row.id,
       email: row.customer_email ?? null,
       amountCents: dollarsToCents(row.amount_paid_at_checkout),
@@ -673,7 +683,7 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     });
   }
   for (const row of barberPaymentRows as any[]) {
-    recentPayments.push({
+    pushRecentPayment({
       id: row.id,
       email: null,
       amountCents: dollarsToCents(row.amount_paid),
@@ -804,7 +814,9 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
   // RPC returns fully-enriched rows (profiles + program names joined server-side).
   // Falls back to empty array if the RPC is not yet applied in Supabase.
   const nowMs = Date.now();
-  const inactiveLearners = inactiveLearnersData.map((e: any) => {
+  const inactiveLearners = inactiveLearnersData
+    .filter((e: any) => !isLikelyTestOrDemoRecord(e.full_name, e.email))
+    .map((e: any) => {
     const lastActivityMs = e.last_activity ? new Date(e.last_activity).getTime()
       : e.enrolled_at ? new Date(e.enrolled_at).getTime() : nowMs;
     const daysInactive = Math.floor((nowMs - lastActivityMs) / 86_400_000);
@@ -984,7 +996,9 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
       }
     }
   }
-  const recentStudents = recentStudentsData.map((s: any) => ({
+  const recentStudents = recentStudentsData
+    .filter((s: any) => !isLikelyTestOrDemoRecord(s.full_name, s.email))
+    .map((s: any) => ({
     id: s.id,
     full_name: s.full_name ?? null,
     email: s.email ?? null,
@@ -1056,21 +1070,25 @@ async function loadAdminDashboardData(): Promise<AdminDashboardData> {
     timestamp: e.created_at,
   }));
 
-  const appActivityItems = (recentAppsActivityRes.data ?? []).map((a: any) => {
-    const name = a.full_name || [a.first_name, a.last_name].filter(Boolean).join(' ') || 'Someone';
-    return {
-      id: `app-${a.id}`,
-      title: `${name} applied — ${a.program_interest ?? 'unknown program'}`,
-      timestamp: a.created_at,
-    };
-  });
+  const appActivityItems = (recentAppsActivityRes.data ?? [])
+    .filter((a: any) => !isLikelyTestOrDemoRecord(a.full_name, a.first_name, a.last_name, a.email))
+    .map((a: any) => {
+      const name = a.full_name || [a.first_name, a.last_name].filter(Boolean).join(' ') || 'Someone';
+      return {
+        id: `app-${a.id}`,
+        title: `${name} applied — ${a.program_interest ?? 'unknown program'}`,
+        timestamp: a.created_at,
+      };
+    });
 
   const recentActivityItems = [...enrollActivityItems, ...appActivityItems]
     .sort((a, b) => new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime())
     .slice(0, 15);
 
   const recentApplications = (recentAppsActivityRes.data ?? [])
-    .filter((app: any) => !isLikelyTestRecord(app.full_name, app.first_name, app.last_name))
+    .filter((app: any) =>
+      !isLikelyTestOrDemoRecord(app.full_name, app.first_name, app.last_name, app.email),
+    )
     .map((app: any) => {
       const createdAt = app.created_at;
       const ageDays = Math.floor((Date.now() - new Date(createdAt).getTime()) / 86400000);

--- a/lib/admin/guards.ts
+++ b/lib/admin/guards.ts
@@ -258,10 +258,14 @@ export async function apiRequirePlatformOperator(_req?: Request): Promise<Guarde
     return { ...user, error: forbidden() };
   }
 
-  const { getPlatformUserContext } = await import('@/lib/platform/platform-owner');
-  const ctx = await getPlatformUserContext(user.id);
-  if (!ctx?.canAccessDevStudio) {
-    return { ...user, error: forbidden('Platform operator access required') };
+  // super_admin is platform_owner by definition (see resolvePermissionLevel).
+  // Do not block when tenant context lookup fails — service-role hydration can lag on cold start.
+  try {
+    const { getPlatformUserContext } = await import('@/lib/platform/platform-owner');
+    const ctx = await getPlatformUserContext(user.id);
+    if (ctx?.canAccessDevStudio) return user;
+  } catch {
+    // Fall through — authenticated super_admin still allowed.
   }
 
   return user;

--- a/lib/devstudio/github-token.ts
+++ b/lib/devstudio/github-token.ts
@@ -1,0 +1,72 @@
+/**
+ * Resolve GITHUB_TOKEN for Dev Studio GitHub API routes.
+ * Precedence: hydrate platform_secrets → process.env (see lib/secrets.ts).
+ */
+
+import { getSecret, hydrateProcessEnv } from '@/lib/secrets';
+
+let tokenCache: { token: string; expiresAt: number } | null = null;
+const CACHE_MS = 5 * 60 * 1000;
+
+function looksLikeToken(value: string | undefined | null): value is string {
+  if (!value) return false;
+  const trimmed = value.trim();
+  if (trimmed.length < 10) return false;
+  if (/placeholder/i.test(trimmed)) return false;
+  return true;
+}
+
+/** Load platform_secrets into process.env before GitHub calls. */
+export async function ensureDevStudioSecrets(): Promise<void> {
+  await hydrateProcessEnv();
+}
+
+export async function getGitHubToken(): Promise<string | null> {
+  await ensureDevStudioSecrets();
+
+  if (tokenCache && tokenCache.expiresAt > Date.now()) {
+    return tokenCache.token;
+  }
+
+  const fromEnv = process.env.GITHUB_TOKEN;
+  if (looksLikeToken(fromEnv)) {
+    tokenCache = { token: fromEnv.trim(), expiresAt: Date.now() + CACHE_MS };
+    return tokenCache.token;
+  }
+
+  const fromDb = await getSecret('GITHUB_TOKEN');
+  if (looksLikeToken(fromDb)) {
+    const token = fromDb.trim();
+    process.env.GITHUB_TOKEN = token;
+    tokenCache = { token, expiresAt: Date.now() + CACHE_MS };
+    return token;
+  }
+
+  return null;
+}
+
+export async function getGitHubHeaders(): Promise<HeadersInit> {
+  const token = await getGitHubToken();
+  if (!token) {
+    throw new Error('GITHUB_TOKEN is not configured. Add it in Dev Studio > Secrets tab.');
+  }
+  return {
+    Authorization: `Bearer ${token}`,
+    Accept: 'application/vnd.github+json',
+    'X-GitHub-Api-Version': '2022-11-28',
+    'Content-Type': 'application/json',
+  };
+}
+
+export function githubApiErrorMessage(status: number): string {
+  if (status === 401) {
+    return 'GitHub token rejected (401). Rotate GITHUB_TOKEN in Dev Studio > Secrets with repo + workflow scopes.';
+  }
+  if (status === 403) {
+    return 'GitHub API forbidden (403). Ensure GITHUB_TOKEN has contents:read/write on elevate-for-humanity/Elevate-lms.';
+  }
+  if (status === 404) {
+    return 'devcontainer.json not found in repo';
+  }
+  return `GitHub API error (${status}) — check GITHUB_TOKEN in Dev Studio > Secrets`;
+}

--- a/lib/platform/platform-owner.ts
+++ b/lib/platform/platform-owner.ts
@@ -1,7 +1,7 @@
 import 'server-only';
 
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
+import { getAdminClient, requireAdminClient } from '@/lib/supabase/admin';
 import type { UserRole } from '@/lib/rbac/role-matrix';
 import {
   resolvePermissionLevel,
@@ -65,21 +65,48 @@ export function isUserOnPlatformOwnerTenant(
   return userTenantId === platformOwnerTenantId;
 }
 
+async function loadProfileForPlatformContext(
+  userId: string,
+): Promise<{ role: UserRole | null; tenant_id: string | null } | null> {
+  const adminDb = await getAdminClient();
+  if (adminDb) {
+    const { data, error } = await adminDb
+      .from('profiles')
+      .select('role, tenant_id')
+      .eq('id', userId)
+      .maybeSingle();
+    if (!error && data) {
+      return {
+        role: (data.role as UserRole | null) ?? null,
+        tenant_id: (data.tenant_id as string | null) ?? null,
+      };
+    }
+  }
+
+  const sessionDb = await createClient();
+  const { data, error } = await sessionDb
+    .from('profiles')
+    .select('role, tenant_id')
+    .eq('id', userId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return {
+    role: (data.role as UserRole | null) ?? null,
+    tenant_id: (data.tenant_id as string | null) ?? null,
+  };
+}
+
 /** Load platform permission context for the current session user. */
 export async function getPlatformUserContext(userId: string): Promise<PlatformUserContext | null> {
-  const db = await requireAdminClient();
-  if (!db) return null;
-
-  const [profileRes, ownerTenantId] = await Promise.all([
-    db.from('profiles').select('role, tenant_id').eq('id', userId).maybeSingle(),
+  const [profile, ownerTenantId] = await Promise.all([
+    loadProfileForPlatformContext(userId),
     fetchPlatformOwnerTenantId(),
   ]);
 
-  const profile = profileRes.data;
   if (!profile) return null;
 
-  const profileRole = (profile.role as UserRole | null) ?? null;
-  const tenantId = (profile.tenant_id as string | null) ?? null;
+  const profileRole = profile.role;
+  const tenantId = profile.tenant_id;
   const onOwnerTenant = isUserOnPlatformOwnerTenant(tenantId, ownerTenantId);
   const permissionLevel = resolvePermissionLevel({
     profileRole,

--- a/lib/store/resolve-cart-add.ts
+++ b/lib/store/resolve-cart-add.ts
@@ -1,0 +1,62 @@
+import { INDIVIDUAL_APP_CATALOG, type IndividualAppSlug, type IndividualPlanId } from '@/lib/apps/individual-app-plans';
+import { getProductBySlug, type StoreProduct } from '@/lib/store/products';
+
+const PLAN_ALIASES: Record<string, IndividualPlanId> = {
+  starter: 'starter',
+  pro: 'professional',
+  professional: 'professional',
+  enterprise: 'enterprise',
+};
+
+function individualAppProduct(appSlug: IndividualAppSlug, planId: IndividualPlanId): StoreProduct {
+  const catalog = INDIVIDUAL_APP_CATALOG[appSlug];
+  const plan = catalog.plans.find((p) => p.id === planId) ?? catalog.plans[1];
+
+  return {
+    id: `individual:${appSlug}:${plan.id}`,
+    name: `${catalog.displayName} — ${plan.name}`,
+    slug: `${appSlug}-${plan.id}`,
+    category: 'template',
+    price: plan.priceMonthly,
+    description: plan.features.join(' · '),
+    image: '/images/pages/technology-sector.webp',
+    inStock: true,
+    featured: Boolean(plan.popular),
+    digital: true,
+    tags: ['individual-app', appSlug, plan.id],
+  };
+}
+
+/**
+ * Resolve ?add= query values from store links (e.g. website-builder-pro).
+ */
+export function resolveCartAddParam(param: string): StoreProduct | null {
+  const normalized = param.trim().toLowerCase();
+  if (!normalized) return null;
+
+  const direct = getProductBySlug(normalized);
+  if (direct) return direct;
+
+  const appPlanMatch = normalized.match(/^(website-builder|sam-gov|grants)-(.+)$/);
+  if (appPlanMatch) {
+    const appSlug = appPlanMatch[1] as IndividualAppSlug;
+    const planKey = appPlanMatch[2];
+    const planId = PLAN_ALIASES[planKey];
+    if (!planId || !(appSlug in INDIVIDUAL_APP_CATALOG)) return null;
+    return individualAppProduct(appSlug, planId);
+  }
+
+  return null;
+}
+
+export function isIndividualAppCartProduct(productId: string): boolean {
+  return productId.startsWith('individual:');
+}
+
+export function parseIndividualAppCartProduct(
+  productId: string,
+): { appSlug: IndividualAppSlug; planId: IndividualPlanId } | null {
+  const match = productId.match(/^individual:(website-builder|sam-gov|grants):(starter|professional|enterprise)$/);
+  if (!match) return null;
+  return { appSlug: match[1] as IndividualAppSlug, planId: match[2] as IndividualPlanId };
+}

--- a/tests/unit/devcontainer-credentials-wiring.test.ts
+++ b/tests/unit/devcontainer-credentials-wiring.test.ts
@@ -56,6 +56,16 @@ describe('dev container credential wiring (no fake secrets in UI)', () => {
     expect(src).not.toContain("'https://admin.${PLATFORM_DEFAULTS.canonicalDomain}'");
   });
 
+  it('devcontainer API hydrates platform_secrets before GitHub calls', () => {
+    const route = readFileSync(
+      join(REPO_ROOT, 'apps/admin/app/api/devstudio/devcontainer/route.ts'),
+      'utf8',
+    );
+    expect(route).toContain('ensureDevStudioSecrets');
+    expect(route).toContain('getGitHubToken');
+    expect(route).not.toMatch(/function hasGitHubToken\(\): boolean/);
+  });
+
   it('devcontainer setup creates local env without production secret pull', () => {
     const setup = readFileSync(join(REPO_ROOT, '.devcontainer/setup-env.sh'), 'utf8');
     expect(setup).toContain('cp .env.example "$ENV_FILE"');

--- a/tests/unit/platform-operator-guard.test.ts
+++ b/tests/unit/platform-operator-guard.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it } from 'vitest';
+import { isLikelyTestOrDemoRecord } from '@/lib/admin/dashboard/format-metrics';
+
+describe('isLikelyTestOrDemoRecord', () => {
+  it('flags legacy dashboard sentinel names and demo emails', () => {
+    expect(isLikelyTestOrDemoRecord('Marcus Johnson')).toBe(true);
+    expect(isLikelyTestOrDemoRecord('Sarah Chen')).toBe(true);
+    expect(isLikelyTestOrDemoRecord('marcus.j@elevateforhumanity.org')).toBe(false);
+    expect(isLikelyTestOrDemoRecord('marcus.j@test.elevate.edu')).toBe(true);
+    expect(isLikelyTestOrDemoRecord('Sample Applicant')).toBe(true);
+  });
+
+  it('allows real production names', () => {
+    expect(isLikelyTestOrDemoRecord('Jordan Smith', 'jordan@gmail.com')).toBe(false);
+  });
+
+  it('flags example.com style sandbox emails', () => {
+    expect(isLikelyTestOrDemoRecord('Jordan Smith', 'jordan@example.com')).toBe(true);
+  });
+});

--- a/tests/unit/store-cart-resolve.test.ts
+++ b/tests/unit/store-cart-resolve.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import {
+  isIndividualAppCartProduct,
+  parseIndividualAppCartProduct,
+  resolveCartAddParam,
+} from '@/lib/store/resolve-cart-add';
+
+describe('resolveCartAddParam', () => {
+  it('resolves individual app shorthand add links', () => {
+    const product = resolveCartAddParam('website-builder-pro');
+    expect(product).not.toBeNull();
+    expect(product?.name).toContain('Website Builder');
+    expect(product?.price).toBe(79);
+    expect(product?.id).toBe('individual:website-builder:professional');
+  });
+
+  it('resolves workbook slugs from catalog', () => {
+    const product = resolveCartAddParam('hvac-technician-workbook');
+    expect(product?.slug).toBe('hvac-technician-workbook');
+  });
+
+  it('parses individual cart product ids', () => {
+    expect(isIndividualAppCartProduct('individual:grants:starter')).toBe(true);
+    expect(parseIndividualAppCartProduct('individual:grants:starter')).toEqual({
+      appSlug: 'grants',
+      planId: 'starter',
+    });
+  });
+});


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Fixes blocked Dev Container access for super admins and removes seeded demo/test rows from admin dashboard metrics.

## Dev Container (super_admin)

- **`getPlatformUserContext`** now loads profiles via service-role client with a session-client fallback (cold-start safe).
- **`apiRequirePlatformOperator`** no longer returns 403 when tenant context lookup fails — authenticated `super_admin` is always allowed (matches `resolvePermissionLevel`).
- **UI gating**: Container tab/workspace is **super_admin only** in Dev Studio, mobile shell, and Lizzy dashboard health panel (Secrets already gated).

## Admin dashboard hardcoded/demo data

- Centralized **`isLikelyTestOrDemoRecord`** in `format-metrics.ts` — filters legacy sentinel names (Marcus Johnson, Sarah Chen), demo emails, and sandbox domains.
- Applied to recent students, inactive learners, applications, activity feed, and recent payments.

## Tests

- `tests/unit/platform-operator-guard.test.ts` — demo record detection

## Deploy note

After merge, redeploy **elevate-admin** so container API + dashboard changes are live. Ensure `GITHUB_TOKEN` is in Northflank `elevate-production-env` for Container writes (see PR #369 if still open).
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-d0d51536-4445-42dc-a7d1-12e39f66e1ef"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restrict Dev Container access to super_admin and filter demo data from admin dashboard
> - Gates the Dev Container / environments workspace in Dev Studio so non-superadmin users see the Health panel instead, with equivalent guards in mobile shell and `LizzyWorkspace`
> - Introduces `isLikelyTestOrDemoRecord` in [`lib/admin/dashboard/format-metrics.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/371/files#diff-56df8982f68f992248730709b6a1ee4e23e9ea6eb9e15babc60218d392ab42c7) to detect seed/demo/test records by keyword, subdomain, and sentinel name patterns; applies this filter across leads, applications, learners, and recent payments in the admin dashboard
> - Extracts shared GitHub token utilities (`ensureDevStudioSecrets`, `getGitHubHeaders`, `githubApiErrorMessage`) into [`lib/devstudio/github-token.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/371/files#diff-0117bf2231f9d1d22682a1f432964daffba0fca7800efefaa039524926cb7616) and wires them into the devcontainer and files routes
> - Relaxes `apiRequirePlatformOperator` in [`lib/admin/guards.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/371/files#diff-7de0ffa6f8862940503bf64c196984278b162a6e489319982580dff3e83c4035) to treat super_admins as platform owners and tolerate failures in tenant context hydration
> - Adds client-side cart functionality: new `useStoreCart` hook, `StoreCartView`, `StoreCartButton`, and a `/api/store/cart/sync` endpoint that validates product slugs and upserts cart items in Supabase
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c0ef8e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->