### PR TITLE
Fix remaining Dev Studio admin build duplicates

### DIFF
--- a/apps/admin/app/admin/dev-studio/page.tsx
+++ b/apps/admin/app/admin/dev-studio/page.tsx
@@ -13,7 +13,6 @@ export const metadata: Metadata = {
 
 export default async function DevStudioPage() {
   const auth = await requireRole(['super_admin', 'platform_operator']);
-  const isSuperAdmin = auth.effectiveRoles.some((role) => role === 'super_admin' || role === 'platform_operator');
   const isSuperAdmin = auth.effectiveRoles.some(
     (role) => role === 'super_admin' || role === 'platform_operator',
   );

--- a/apps/admin/app/api/devstudio/health/route.ts
+++ b/apps/admin/app/api/devstudio/health/route.ts
@@ -75,10 +75,6 @@ export async function GET(req: NextRequest) {
   const hasGemini = isGeminiConfigured() || dbGemini;
   const hasOpenAI = isOpenAIConfigured() || dbOpenAI;
   const hasAnthropic = isAnthropicConfigured() || dbAnthropic;
-  const hasGitHub = !!process.env.GITHUB_TOKEN || !!process.env.GH_TOKEN || !!process.env.GITHUB_PAT || dbGitHub;
-  const aiConfigured = hasGroq || hasGemini || hasOpenAI || hasAnthropic;
-  const northflankProjectIdPresent = !!getNorthflankProjectId();
-  const northflankTokenPresent = !!(process.env.NORTHFLANK_API_TOKEN || process.env.NORTHFLANK_API_KEY || process.env.NF_API_TOKEN);
   const hasGitHub =
     !!process.env.GITHUB_TOKEN || !!process.env.GH_TOKEN || !!process.env.GITHUB_PAT || dbGitHub;
   const aiConfigured = hasGroq || hasGemini || hasOpenAI || hasAnthropic;

--- a/apps/admin/app/api/devstudio/shell/route.ts
+++ b/apps/admin/app/api/devstudio/shell/route.ts
@@ -148,7 +148,6 @@ export async function POST(request: NextRequest) {
   };
 
   // Normalise to filename
-  const workflowFile = workflowAliases[workflowRaw] ?? (workflowRaw.endsWith('.yml') ? workflowRaw : `${workflowRaw}.yml`);
   const workflowFile =
     workflowAliases[workflowRaw] ??
     (workflowRaw.endsWith('.yml') ? workflowRaw : `${workflowRaw}.yml`);


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

Removes stale merge-artifact duplicates exposed by the Northflank admin Docker build after PR #391 merged:

- `apps/admin/app/api/devstudio/shell/route.ts` — removed duplicate `workflowFile` declaration.
- `apps/admin/app/api/devstudio/health/route.ts` — removed duplicate `hasGitHub`, `aiConfigured`, `northflankProjectIdPresent`, and `northflankTokenPresent` declarations.
- `apps/admin/app/admin/dev-studio/page.tsx` — removed duplicate `isSuperAdmin` declaration.

## Why This Changed

The post-#391 `deploy-admin.yml` run reached the Northflank build and failed during `next build` with webpack parser errors for duplicate identifiers in these Dev Studio files. This PR removes those duplicated merge fragments so admin can compile.

## Verification

```
pnpm lint
pnpm typecheck
# TypeScript baseline errors: 1037
# Current TypeScript errors: 1037
# New TypeScript errors: 0

pre-push checks passed:
# - check-redirect-conflicts: no conflicts
# - guard-public-routes: no violations
# - TypeScript: no new errors against baseline
# - ESLint changed files: clean
```

## Deployment Notes

After this merges to `main`, rerun/monitor `Deploy Admin`; the previous failure was:

- `Module parse failed: Identifier 'workflowFile' has already been declared`
- `Module parse failed: Identifier 'hasGitHub' has already been declared`
- `Module parse failed: Identifier 'isSuperAdmin' has already been declared`

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Reformat Dev Studio admin build files to fix duplicate detection
> Splits multi-line constant assignments across three Dev Studio files — [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/393/files#diff-110b6ad7370e1d80dc036e331598032a9ab77cca999db7f2673797d3a42ea5b2), [health/route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/393/files#diff-a093c024ee8bfbd5dc5549fc0acd0e81c597720a11c2f8bb560150c63eb7752c), and [shell/route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/393/files#diff-2e9f734c1a778ae99f1ce76777c3439f4b6f849941aa2bfd6c736549220237a2) — to resolve duplicate build warnings. No logic or behavior is changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d3dc9df.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->