### PR TITLE
Roll out LMS image after Northflank build

### DIFF
--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -88,6 +88,9 @@ jobs:
         id: trigger_lms_build
         run: pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_LMS_SERVICE_ID"
 
+      - name: Roll out latest LMS image
+        run: pnpm tsx scripts/northflank/trigger-deployment.ts "$NORTHFLANK_LMS_SERVICE_ID"
+
       - name: Wait for LMS deployment
         run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_LMS_SERVICE_ID" --build-id "${{ steps.trigger_lms_build.outputs.build_id }}" --timeout-ms 3600000
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

Adds the missing LMS rollout step to `.github/workflows/deploy-lms.yml`:

```yaml
- name: Roll out latest LMS image
  run: pnpm tsx scripts/northflank/trigger-deployment.ts "$NORTHFLANK_LMS_SERVICE_ID"
```

## Why This Changed

The recent LMS deploy built and exported the Docker image successfully, but the workflow then waited for deployment without explicitly rolling out the built image. Admin already has this step (`Roll out latest admin image`), and LMS needs the same pattern so Northflank deploys the latest build before `wait-service`, SHA verification, and smoke checks run.

## Evidence

Failed LMS run showed Docker image export completed and runtime image steps finished, but `Wait for LMS deployment` timed out. This PR aligns LMS with the admin deploy workflow.

Pre-push checks passed:

```
check-redirect-conflicts: no conflicts
admin/public route guards: no violations
TypeScript: no new errors against baseline
ESLint: no TS/TSX files changed, skipped
```

## Deployment Notes

After merge, `Deploy LMS` should rerun on `main`, trigger the build, explicitly roll out the latest LMS image, then wait/smoke/verify deployed SHA.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger LMS deployment rollout after Northflank build
> Adds a 'Roll out latest LMS image' step to [deploy-lms.yml](.github/workflows/deploy-lms.yml) that runs `trigger-deployment.ts` with the LMS service ID. This ensures the new image is deployed before the workflow waits for the service to become healthy.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9e12aba.</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->