### PR TITLE
Fix desktop header: dropdowns from the horizontal header, no side drawer

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -1727,10 +1727,12 @@ header[role='banner'] nav[aria-label='Main navigation'] {
   align-items: center !important;
   justify-content: center !important;
   min-width: 0 !important;
-  overflow-x: auto !important;
-  overflow-y: visible !important;
+  /* Must stay visible on both axes so the hover mega-menu (absolutely
+     positioned below the nav) is not clipped. Note: overflow-x:auto would
+     force overflow-y to compute to auto per spec and clip the dropdown.
+     This nav only renders at lg+, where the items fit. */
+  overflow: visible !important;
   -webkit-overflow-scrolling: touch;
-  scrollbar-width: thin;
 }
 
 header[role='banner'] nav[aria-label='Main navigation'] > div {

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -308,15 +308,21 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
     <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 shrink-0">
       <SearchModal />
       <LanguageSwitcher compact={true} />
-      <button
-        type="button"
-        onClick={() => setIsOpen((open) => !open)}
-        className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[40px] min-w-[40px] flex items-center justify-center lg:hidden"
-        aria-label={isOpen ? 'Close menu' : 'Open menu'}
-        aria-expanded={isOpen}
-      >
-        {isOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
-      </button>
+      {/* Hamburger + side drawer are mobile/tablet only. On lg+ the horizontal
+          HeaderDesktopNav (with hover dropdowns) is the navigation. The wrapper
+          span carries lg:hidden so it doesn't collide with the button's own
+          display:flex utility. */}
+      <span className="lg:hidden">
+        <button
+          type="button"
+          onClick={() => setIsOpen((open) => !open)}
+          className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[40px] min-w-[40px] flex items-center justify-center"
+          aria-label={isOpen ? 'Close menu' : 'Open menu'}
+          aria-expanded={isOpen}
+        >
+          {isOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
+        </button>
+      </span>
       {drawer}
     </div>
   );

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -129,12 +129,12 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
       ? createPortal(
           <>
             <div
-              className="fixed inset-0 bg-black/50 z-[9998]"
+              className="fixed inset-0 bg-black/50 z-[9998] lg:hidden"
               onClick={closeMenu}
               aria-hidden="true"
             />
             <div
-              className="fixed top-[60px] right-0 bottom-0 w-[min(100vw,26rem)] bg-white z-[9999] overflow-y-auto shadow-2xl"
+              className="fixed top-[60px] right-0 bottom-0 w-[min(100vw,26rem)] bg-white z-[9999] overflow-y-auto shadow-2xl lg:hidden"
               role="dialog"
               aria-modal="true"
               aria-label="Main menu"
@@ -311,7 +311,7 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
       <button
         type="button"
         onClick={() => setIsOpen((open) => !open)}
-        className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[40px] min-w-[40px] flex items-center justify-center"
+        className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[40px] min-w-[40px] flex items-center justify-center lg:hidden"
         aria-label={isOpen ? 'Close menu' : 'Open menu'}
         aria-expanded={isOpen}
       >


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

On desktop (`lg+`) the marketing header now shows **only** the horizontal navigation with hover mega-menu dropdowns. The mobile hamburger and the right-side slide-in drawer are now mobile/tablet only. Separately, the horizontal hover dropdowns were never appearing on desktop because an ancestor `overflow` rule clipped them — that's fixed too.

## Why This Changed

The header had two problems on desktop:
1. The hamburger button + right-side drawer rendered at every breakpoint, so desktop users saw two navigation systems and could open a "side dropdown" instead of using the horizontal header — the opposite of the intended UX.
2. The horizontal mega-menu dropdowns did not appear on hover at all, because `header[role='banner'] nav[aria-label='Main navigation']` had `overflow-x: auto`. Per the CSS spec, when `overflow-x` is `auto` and `overflow-y` is `visible`, the browser forces `overflow-y` to compute to `auto`, which clipped the absolutely-positioned dropdown that extends below the nav.

## How to Verify

1. Run the dev server (`pnpm dev`) and open `http://localhost:3000/` at a desktop width (≥1024px).
2. Confirm the top-right of the header shows only the search icon and the `EN` language selector — **no hamburger icon**.
3. Hover "Programs" / "Funding" — a white mega-menu dropdown drops **down from the horizontal header** (not from the side).
4. Narrow the window below 1024px — the hamburger reappears and opens the right-side drawer (mobile behavior preserved).

## Evidence

Demo video (desktop): dropdowns drop down from the horizontal header, no hamburger.

[header_desktop_horizontal_dropdown_demo.webm](https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_desktop_horizontal_dropdown_demo.webm)

Desktop "Programs" mega-menu open (drops down from the horizontal header):

[Desktop Programs dropdown open below horizontal header, no hamburger](https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_desktop_programs_dropdown.png)

Mobile (390px) still shows the hamburger and opens the side drawer:

[Mobile header with hamburger](https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_mobile_hamburger.png)
[Mobile side drawer open](https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fheader_mobile_drawer_open.png)

Headless checks (Playwright):

```
1440px: hamburgerVisible=false, horizontalNavVisible=true, dropdown opacity=1 / not clipped
 390px: hamburgerVisible=true,  horizontalNavVisible=false
pageHorizontalScroll=false at 1024 / 1280 / 1440
```

## Rollback Plan

Revert commits `448cba0cd`, `dacc3b234`, `6402d5acd` on this branch (one component file + one CSS rule).

## Risks & Tradeoffs

- The nav `overflow-x: auto` previously allowed horizontal scrolling in the narrow `lg` band (~1024–1099px), where the 10 items overflow by ~27px. With `overflow: visible` the dropdown is no longer clipped; verified there is no horizontal page-scroll regression down to 1024px.
- This nav only renders at `lg+` (it's `hidden lg:flex`), so the change has no effect on mobile/tablet.

## Related Issues

Relates to reported header issues (side dropdown instead of horizontal header; duplicate desktop nav).


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebfc60c4-a524-402a-900f-bd5c766b1c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix desktop header to show dropdowns inline and hide mobile drawer on large screens
> - Removes `overflow-x: auto` from the main nav container in [globals.css](https://github.com/elevate-for-humanity/Elevate-lms/pull/395/files#diff-79e0914d9fee5ca4432bdb002a24d700d31b5577265f4de3f90d5c292b9f1392), replacing it with `overflow: visible` so absolutely positioned dropdowns are no longer clipped.
> - Adds `lg:hidden` to the hamburger button, backdrop, and drawer panel in [HeaderMobileMenu.client.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/395/files#diff-87be3332ef07c1677edd45f68793b6c4b53f5e8d91feaf1fb1a3c7fcd445a047) so the mobile side drawer is suppressed on large screens.
> - Behavioral Change: On `lg`+ breakpoints, the horizontal header with inline dropdowns is now the sole navigation; the hamburger trigger no longer renders.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized b61b285.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->