### PR TITLE
Fix apprentice dashboard crash (client function called from server layout)

### DIFF
--- a/app/apprentice/layout.tsx
+++ b/app/apprentice/layout.tsx
@@ -3,10 +3,8 @@ import { redirect } from 'next/navigation';
 import { headers } from 'next/headers';
 import { createClient } from '@/lib/supabase/server';
 import { getAdminClient } from '@/lib/supabase/admin';
-import {
-  ApprenticeSubNav,
-  resolveApprenticeNavConfig,
-} from '@/components/portal/ApprenticeSubNav';
+import { ApprenticeSubNav } from '@/components/portal/ApprenticeSubNav';
+import { resolveApprenticeNavConfig } from '@/lib/portal/apprentice-nav-config';
 import { resolveApprenticeProgramSlug } from '@/lib/portal/resolve-apprentice-program';
 import { canAccessApprenticeTools } from '@/lib/portal/apprentice-access';
 

--- a/components/portal/ApprenticeSubNav.tsx
+++ b/components/portal/ApprenticeSubNav.tsx
@@ -2,10 +2,7 @@
 
 import Link from 'next/link';
 import { usePathname } from 'next/navigation';
-import {
-  APPRENTICE_PORTAL_CONFIGS,
-  type ApprenticePortalConfig,
-} from '@/components/portal/ApprenticePortalShell';
+import type { ApprenticePortalConfig } from '@/components/portal/ApprenticePortalShell';
 import {
   apprenticeshipDocumentsPath,
   apprenticeshipLmsCoursePath,
@@ -85,14 +82,4 @@ export function ApprenticeSubNav({
       </div>
     </nav>
   );
-}
-
-export function resolveApprenticeNavConfig(programSlug: string | null): {
-  programSlug: string;
-  config: ApprenticePortalConfig;
-} | null {
-  if (!programSlug) return null;
-  const config = APPRENTICE_PORTAL_CONFIGS[programSlug];
-  if (!config) return null;
-  return { programSlug, config };
 }

--- a/lib/portal/apprentice-nav-config.ts
+++ b/lib/portal/apprentice-nav-config.ts
@@ -1,0 +1,21 @@
+import {
+  APPRENTICE_PORTAL_CONFIGS,
+  type ApprenticePortalConfig,
+} from '@/components/portal/ApprenticePortalShell';
+
+/**
+ * Resolves the apprentice sub-nav config for a program slug.
+ *
+ * Lives here (server-safe module) rather than in ApprenticeSubNav.tsx, which is
+ * a 'use client' component. A function exported from a client module cannot be
+ * invoked from a server component — doing so crashed the apprentice layout.
+ */
+export function resolveApprenticeNavConfig(programSlug: string | null): {
+  programSlug: string;
+  config: ApprenticePortalConfig;
+} | null {
+  if (!programSlug) return null;
+  const config = APPRENTICE_PORTAL_CONFIGS[programSlug];
+  if (!config) return null;
+  return { programSlug, config };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

Moved the pure helper `resolveApprenticeNavConfig` out of the `'use client'` component `ApprenticeSubNav.tsx` into a new server-safe module `lib/portal/apprentice-nav-config.ts`, and updated `app/apprentice/layout.tsx` to import it from there.

## Why This Changed

Every `/apprentice*` page crashed with an error boundary: *"Attempted to call `resolveApprenticeNavConfig()` from the server but `resolveApprenticeNavConfig` is on the client."* The apprentice layout is a server component, but it imported and **called** `resolveApprenticeNavConfig` from `ApprenticeSubNav.tsx`, which is a `'use client'` module. Next.js does not allow invoking a function exported from a client module on the server. The helper is pure (it only reads the server-safe `APPRENTICE_PORTAL_CONFIGS` from `ApprenticePortalShell`, which is not a client module), so it belongs in a shared server-safe file.

## How to Verify

1. Run `pnpm dev`, log in as a user with apprentice-tools access (student/staff/admin/super_admin).
2. Navigate to `http://localhost:3000/apprentice`.
3. Before: the page renders the "Something Went Wrong" error boundary. After: it renders the Apprentice Portal dashboard.

## Evidence

`/apprentice` rendering correctly after the fix (logged in via the provided super_admin account):

[Apprentice Portal dashboard rendering after fix](https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapprentice_dashboard_after_fix.png)

```
after-login url: https://admin.elevateforhumanity.org/login?redirect=%2Fadmin%2Fdashboard
GET /apprentice -> 200
hasErrorBoundary: false
body: "Apprentice Portal | Payment Method Required | ... | Welcome, Admin User"
```

Lint of changed files passes (`npx eslint app/apprentice/layout.tsx components/portal/ApprenticeSubNav.tsx lib/portal/apprentice-nav-config.ts` → 0 errors).

## Rollback Plan

Revert the single commit on this branch (one new file + two edited imports).

## Risks & Tradeoffs

Low risk: behavior is identical (same pure mapping), only the module location changed so the server can call it. `resolveApprenticeNavConfig` had a single importer (the apprentice layout).

## Related Issues

Addresses the reported broken apprenticeship dashboard.


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ebfc60c4-a524-402a-900f-bd5c766b1c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ebfc60c4-a524-402a-900f-bd5c766b1c91"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix apprentice dashboard crash by moving `resolveApprenticeNavConfig` to a server-safe module
> The crash occurred because `resolveApprenticeNavConfig` was exported from [ApprenticeSubNav.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/396/files#diff-1efc11cfc94a3f38e045a3ba4895453a3fe10288904012edfef112eb16cb16dc), a client component, but called from the server layout [app/apprentice/layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/396/files#diff-0473d66abc50e8ddd3b80d1e5578160fc623d9eb813b2dd1b6892ac1b1c03cdf).
>
> - Moves `resolveApprenticeNavConfig` into a new server-safe module at [lib/portal/apprentice-nav-config.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/396/files#diff-be8a983fc642cb65619e18fa39e403053d33d0ad70ffa608e67d30429ff1c982).
> - Updates the layout import to pull from the new module, and updates `ApprenticeSubNav.tsx` to remove the function and drop its direct import of `APPRENTICE_PORTAL_CONFIGS`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86ff64f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->