### PR TITLE
Fix app subdomain routing away from admin dashboard

### DIFF
--- a/proxy.ts
+++ b/proxy.ts
@@ -335,6 +335,13 @@ export async function middleware(request: NextRequest) {
   let canonicalAdminHost = 'admin.elevateforhumanity.org';
   try {
     canonicalAdminHost = new URL(adminBase).host;
+    if (canonicalAdminHost === 'app.elevateforhumanity.org') {
+      console.error(
+        '[proxy] NEXT_PUBLIC_ADMIN_URL points at app.elevateforhumanity.org. Falling back to default admin host.',
+      );
+      adminBase = DEFAULT_ADMIN_URL;
+      canonicalAdminHost = new URL(DEFAULT_ADMIN_URL).host;
+    }
   } catch (error) {
     console.error('[proxy] Invalid NEXT_PUBLIC_ADMIN_URL. Falling back to default admin host.', error);
     adminBase = DEFAULT_ADMIN_URL;
@@ -571,13 +578,11 @@ export async function middleware(request: NextRequest) {
     if (tenantSlug) requestHeadersWithTenant.set('x-tenant-slug', tenantSlug);
     requestHeadersWithTenant.set('x-pathname', pathname);
 
-    if (pathname === '/' || pathname === '/admin' || pathname.startsWith('/admin/')) {
-      const adminPath = pathname === '/' || pathname === '/admin' ? '/admin/dashboard' : pathname;
-      const rewriteUrl = request.nextUrl.clone();
-      rewriteUrl.pathname = adminPath;
-      return NextResponse.rewrite(rewriteUrl, {
-        request: { headers: requestHeadersWithTenant },
-      });
+    if (pathname === '/') {
+      const learnerUrl = request.nextUrl.clone();
+      learnerUrl.pathname = '/learner/dashboard';
+      learnerUrl.search = '';
+      return NextResponse.redirect(learnerUrl, { status: 307 });
     }
 
     return NextResponse.next({ request: { headers: requestHeadersWithTenant } });

--- a/tests/unit/middleware-tenant-routing.test.ts
+++ b/tests/unit/middleware-tenant-routing.test.ts
@@ -3,6 +3,8 @@ import {
   isTenantAppSubdomainHost,
   tenantSlugFromAppHost,
 } from '@/lib/tenant/middleware-tenant-routing';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
 
 describe('middleware tenant routing', () => {
   it('extracts slug from app subdomain', () => {
@@ -18,5 +20,23 @@ describe('middleware tenant routing', () => {
 
   it('strips port from host', () => {
     expect(tenantSlugFromAppHost('demo.app.elevateforhumanity.org:3000')).toBe('demo');
+  });
+
+  it('does not rewrite the app apex host root to the admin dashboard', () => {
+    const proxySource = readFileSync(join(process.cwd(), 'proxy.ts'), 'utf8');
+    const appHostBlock = proxySource.slice(
+      proxySource.indexOf("hostWithoutPort === 'app.elevateforhumanity.org'"),
+      proxySource.indexOf('// {subdomain}.app.elevateforhumanity.org'),
+    );
+
+    expect(appHostBlock).toContain("learnerUrl.pathname = '/learner/dashboard'");
+    expect(appHostBlock).not.toContain("rewriteUrl.pathname = adminPath");
+    expect(appHostBlock).not.toContain("'/admin/dashboard'");
+  });
+
+  it('guards against configuring app.elevateforhumanity.org as the admin host', () => {
+    const proxySource = readFileSync(join(process.cwd(), 'proxy.ts'), 'utf8');
+    expect(proxySource).toContain("canonicalAdminHost === 'app.elevateforhumanity.org'");
+    expect(proxySource).toContain('Falling back to default admin host');
   });
 });


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What Changed

Fixes `app.elevateforhumanity.org` root routing so it no longer rewrites `/` to `/admin/dashboard`.

- `app.elevateforhumanity.org/` now redirects to `/learner/dashboard`, allowing normal LMS/app auth flow to handle login/redirect.
- If `NEXT_PUBLIC_ADMIN_URL` is accidentally set to `app.elevateforhumanity.org`, proxy now logs the misconfiguration and falls back to `https://admin.elevateforhumanity.org`.
- Added regression tests to prevent the app apex host from being routed to admin dashboard again.

## Why This Changed

Live trace showed:

```
https://app.elevateforhumanity.org/
HTTP/2 200
x-middleware-rewrite: /admin/dashboard
```

That was caused by the `app.elevateforhumanity.org` special-case in `proxy.ts` rewriting `/` to `/admin/dashboard`. This made the app host serve/lead into the super-admin/admin dashboard path instead of the LMS/app entrypoint.

## How to Verify

Before deploy, source/test verification:

```
pnpm vitest run tests/unit/middleware-tenant-routing.test.ts tests/unit/middleware-auth-prefix.test.ts tests/unit/supabase-auth-cookie-domain.test.ts
# 3 files passed, 11 tests passed

pre-push checks passed:
# - redirect conflicts: no conflicts
# - public route guards: no violations
# - TypeScript: no new errors against baseline
# - ESLint: clean
```

After deploy:

```
curl -kIL https://app.elevateforhumanity.org/
# should NOT contain: x-middleware-rewrite: /admin/dashboard
# should go to /learner/dashboard or /login?redirect=/learner/dashboard depending auth state
```

## Deployment Notes

This changes `proxy.ts`, so it should trigger LMS deploy on merge. No database migrations or env var changes.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-cceb198e-2dea-4912-884d-1fc0d99efdfe"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix subdomain routing for `app.elevateforhumanity.org` away from admin dashboard
> - Requests to `app.elevateforhumanity.org/` now 307-redirect to `/learner/dashboard` instead of rewriting to the admin dashboard.
> - Removes the rewrite rules for `/admin` and `/admin/*` on the app subdomain; those paths now pass through unchanged.
> - Adds a guard in [proxy.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/399/files#diff-84ebb7b78a17bdd955d464accb5232ffd9eadafd97d6ca56e90c5281b7201775): if `NEXT_PUBLIC_ADMIN_URL` resolves to `app.elevateforhumanity.org`, it logs an error and falls back to `DEFAULT_ADMIN_URL`.
> - Behavioral Change: `/admin` paths on `app.elevateforhumanity.org` are no longer proxied to the admin dashboard and will return whatever the app host serves at those paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c49de4a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->