### PR TITLE
fix(admin): copy root-level public assets to Docker image

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -131,6 +131,14 @@ COPY --from=builder /app/public/data ./apps/admin/public/data
 COPY --from=builder /app/public/images ./apps/admin/public/images
 COPY --from=builder /app/public/hero-images ./apps/admin/public/hero-images
 COPY --from=builder /app/public/downloads ./apps/admin/public/downloads
+# Copy root-level public assets (favicon, logos, manifest, etc.)
+COPY --from=builder /app/apps/admin/public/*.png ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/*.ico ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/*.svg ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/*.webp ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/*.css ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/*.json ./apps/admin/public/
+COPY --from=builder /app/apps/admin/public/manifest.webmanifest ./apps/admin/public/
 COPY --from=builder /app/remotion-src ./remotion-src
 # DevContainer config for Dev Studio local-fallback when GitHub API is unavailable
 COPY --from=builder /app/.devcontainer/devcontainer.json ./.devcontainer/devcontainer.json


### PR DESCRIPTION
## Summary

The admin Docker image was missing root-level public assets (favicon, logos, manifest) because the Dockerfile only copied subdirectories from `public/`, not individual files.

## Changes

Added COPY commands to include:
- `*.png` files (favicon.png, logo.png, logo-small.png, apple-touch-icon.png)
- `*.ico` files (favicon.ico)
- `*.svg` files (logo-dark.svg, logo.svg)
- `*.webp` files (logo.webp)
- `*.css` files (xterm.css)
- `*.json` files
- `manifest.webmanifest`

## Testing

After merge, verify:
- `https://admin.elevateforhumanity.org/favicon.png` returns 200
- `https://admin.elevateforhumanity.org/logo.png` returns 200

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/aea0943e-52b9-42e3-bd23-4a42ef04e0ca)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Copy root-level public assets into the admin Docker image
> Adds `COPY` instructions to [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/414/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c) to include static files (PNG, ICO, SVG, WEBP, CSS, JSON, and `manifest.webmanifest`) from the builder stage's `/app/apps/admin/public` into the final image. Without these, the admin app was missing root-level public assets at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 112dd97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->