### PR TITLE
fix: restore original barber page with BarberApprenticeshipClient

### DIFF
--- a/app/programs/barber-apprenticeship/BarberApprenticeshipClient.tsx
+++ b/app/programs/barber-apprenticeship/BarberApprenticeshipClient.tsx
@@ -372,14 +372,6 @@ export default function BarberApprenticeshipClient({ program: p, heroBanner: b, 
             <p>Equipment: {p.equipmentIncluded}</p>
             <p>Tuition: $4,980 if self-pay. Funding and payment plans available — determined after application review.</p>
           </div>
-          <div className="mt-4 flex flex-wrap gap-2">
-            <Link href="/preview/barber-studio" className="px-3 py-1.5 bg-slate-100 rounded-lg text-xs font-medium text-slate-700 hover:bg-slate-200 transition">
-              Preview Studio
-            </Link>
-            <Link href="/preview/barber-videos" className="px-3 py-1.5 bg-slate-100 rounded-lg text-xs font-medium text-slate-700 hover:bg-slate-200 transition">
-              Preview Videos
-            </Link>
-          </div>
         </div>
       </section>
     </div>

--- a/app/programs/barber-apprenticeship/page.tsx
+++ b/app/programs/barber-apprenticeship/page.tsx
@@ -1,11 +1,10 @@
 import { Metadata } from 'next';
 import { ProgramStructuredData } from '@/components/seo/CourseStructuredData';
-import ProgramDetailPage from '@/components/programs/ProgramDetailPage';
-import BarberApprenticeshipProcess from '@/components/programs/beauty/BarberApprenticeshipProcess';
-import BarberApprenticeshipExtras from '@/components/programs/beauty/BarberApprenticeshipExtras';
 import { BARBER_APPRENTICESHIP } from '@/data/programs/barber-apprenticeship';
 import { validateProgram } from '@/lib/programs/program-schema';
 import heroBanners from '@/content/heroBanners';
+import { createClient } from '@/lib/supabase/server';
+import BarberApprenticeshipClient from './BarberApprenticeshipClient';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -28,6 +27,20 @@ export const metadata: Metadata = {
 export default async function BarberApprenticeshipPage() {
   const heroBanner = heroBanners['barber-apprenticeship'] ?? null;
 
+  // Live enrollment count from DB
+  let enrollmentCount = 0;
+  try {
+    const supabase = await createClient();
+    const { count } = await supabase
+      .from('program_enrollments')
+      .select('*', { count: 'exact', head: true })
+      .eq('program_slug', 'barber-apprenticeship')
+      .eq('status', 'active');
+    enrollmentCount = count ?? 0;
+  } catch {
+    // non-fatal — fall back to 0
+  }
+
   return (
     <>
       <ProgramStructuredData
@@ -43,13 +56,7 @@ export default async function BarberApprenticeshipPage() {
           outcomes: p.outcomes.map((o) => o.statement),
         }}
       />
-      <ProgramDetailPage
-        program={p}
-        banner={heroBanner}
-        processSlot={<BarberApprenticeshipProcess />}
-      >
-        <BarberApprenticeshipExtras />
-      </ProgramDetailPage>
+      <BarberApprenticeshipClient program={p} heroBanner={heroBanner} enrollmentCount={enrollmentCount} />
     </>
   );
 }


### PR DESCRIPTION
Restores the original barber apprenticeship page with full content.

**Changes:**
- Restores  with original implementation (using , )
- Restores original  using  instead of 

**Why:** The previous restore commit (2c6bf99ba) used an older simplified version of  that caused 'Something went wrong' errors on the barber page.

**Verification:**
- HVAC page (uses ) works fine
- Barber/cosmetology pages (custom client components) showed errors

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore barber apprenticeship page with server-side enrollment count via `BarberApprenticeshipClient`
> - Replaces `ProgramDetailPage` in [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/424/files#diff-930920febca1536be3aa04024e5016b04027dbca6db91ab29f68569fa311d192) with a direct render of `BarberApprenticeshipClient`, removing the previous `BarberApprenticeshipProcess` and `BarberApprenticeshipExtras` slots.
> - Adds a server-side Supabase query to count active enrollments for `barber-apprenticeship`, passing the result as `enrollmentCount` to the client component (defaults to `0` on error).
> - Removes the two preview links ("Preview Studio" and "Preview Videos") from [BarberApprenticeshipClient.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/424/files#diff-5929787f72da404a06f09aa2bb6450be0c7fb17d8cfc8bfbe0fb89934d3ba263).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 620cccb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->