### PR TITLE
fix: restore homepage hero, program template, and admin auth

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -1,5 +1,110 @@
-import ElevateAnimatedHome from '@/components/home/ElevateAnimatedHome';
+import { Suspense } from 'react';
+import type { Metadata } from 'next';
+import HomeHeroVideo from '@/components/ui/HomeHeroVideo';
+import heroBanners from '@/content/heroBanners';
+import { HomeFundingStrip } from '@/components/home/HomeFundingStrip';
+import { HomeCareerPathways } from '@/components/home/HomeCareerPathways';
+import { HomeOutcomes } from '@/components/home/HomeOutcomes';
+import { HomeFinalCTA } from '@/components/home/HomeFinalCTA';
+import { Skeleton } from '@/components/ui/skeleton';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
-export default function HomePage() {
-  return <ElevateAnimatedHome />;
+// Revalidate every 5 minutes — allows live enrollment stats to refresh
+// without a full rebuild.
+export const revalidate = 300;
+
+export const metadata: Metadata = {
+  title: `${PLATFORM_DEFAULTS.orgName} | Workforce Training, Apprenticeships & Funding — Indianapolis`,
+  description:
+    'DOL-registered apprenticeship sponsor and WIOA-approved training provider. Funded training in healthcare, skilled trades, CDL, technology, and more — often at no cost. Apply today.',
+  keywords: [
+    'workforce training Indianapolis',
+    'WIOA training Indiana',
+    'DOL registered apprenticeship',
+    'ETPL approved training provider',
+    'funded career training Indiana',
+    'apprenticeship programs Indianapolis',
+    'HVAC training Indianapolis',
+    'CNA training Indianapolis',
+    'CDL training Indiana',
+    'free job training Marion County',
+    PLATFORM_DEFAULTS.orgName,
+  ],
+  alternates: {
+    canonical: PLATFORM_DEFAULTS.siteUrl,
+  },
+  openGraph: {
+    title: `${PLATFORM_DEFAULTS.orgName} | Workforce Training, Apprenticeships & Funding`,
+    description:
+      'DOL-registered apprenticeship sponsor. Funded training in healthcare, skilled trades, CDL, and technology — often at no cost through WIOA or state funding.',
+    url: PLATFORM_DEFAULTS.siteUrl,
+    siteName: PLATFORM_DEFAULTS.orgName,
+    images: [
+      {
+        url: '/images/pages/comp-home-hero.webp',
+        width: 1200,
+        height: 630,
+        alt: `${PLATFORM_DEFAULTS.orgName} workforce training`,
+      },
+    ],
+    type: 'website',
+  },
+  twitter: {
+    card: 'summary_large_image',
+    title: `${PLATFORM_DEFAULTS.orgName} | Workforce Training & Apprenticeships`,
+    description:
+      'Funded training, DOL-registered apprenticeships, and job placement — often at no cost.',
+    images: ['/images/pages/comp-home-hero.webp'],
+  },
+};
+
+// Skeleton for the async outcomes section while it streams in
+function OutcomesSkeleton() {
+  return (
+    <div className="bg-slate-900 py-16 px-4" aria-hidden="true">
+      <div className="max-w-6xl mx-auto">
+        <div className="grid grid-cols-2 sm:grid-cols-4 gap-4 mb-14">
+          {[1, 2, 3, 4].map((i) => (
+            <div key={i} className="rounded-2xl bg-slate-800 border border-slate-700 p-5">
+              <Skeleton className="h-10 w-20 mx-auto mb-2 bg-slate-700" />
+              <Skeleton className="h-3 w-28 mx-auto bg-slate-700" />
+            </div>
+          ))}
+        </div>
+        <div className="grid sm:grid-cols-3 gap-4">
+          {[1, 2, 3].map((i) => (
+            <div key={i} className="rounded-2xl bg-white border border-slate-200 p-6">
+              <Skeleton className="h-4 w-full mb-2" />
+              <Skeleton className="h-4 w-5/6 mb-2" />
+              <Skeleton className="h-4 w-4/6 mb-6" />
+              <div className="flex items-center gap-3 pt-4 border-t border-slate-100">
+                <Skeleton className="h-9 w-9 rounded-full" />
+                <div>
+                  <Skeleton className="h-3 w-20 mb-1" />
+                  <Skeleton className="h-3 w-28" />
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
 }
+
+export default async function HomePage() {
+  const banner = heroBanners.home;
+
+  return (
+    <>
+      <HomeHeroVideo banner={banner} />
+      <HomeFundingStrip />
+      <HomeCareerPathways />
+      <Suspense fallback={<OutcomesSkeleton />}>
+        <HomeOutcomes />
+      </Suspense>
+      <HomeFinalCTA />
+    </>
+  );
+}
+

--- a/app/programs/barber-apprenticeship/page.tsx
+++ b/app/programs/barber-apprenticeship/page.tsx
@@ -1,10 +1,11 @@
 import { Metadata } from 'next';
 import { ProgramStructuredData } from '@/components/seo/CourseStructuredData';
+import ProgramDetailPage from '@/components/programs/ProgramDetailPage';
+import BarberApprenticeshipProcess from '@/components/programs/beauty/BarberApprenticeshipProcess';
+import BarberApprenticeshipExtras from '@/components/programs/beauty/BarberApprenticeshipExtras';
 import { BARBER_APPRENTICESHIP } from '@/data/programs/barber-apprenticeship';
 import { validateProgram } from '@/lib/programs/program-schema';
 import heroBanners from '@/content/heroBanners';
-import { createClient } from '@/lib/supabase/server';
-import BarberApprenticeshipClient from './BarberApprenticeshipClient';
 
 export const dynamic = 'force-dynamic';
 export const revalidate = 0;
@@ -27,20 +28,6 @@ export const metadata: Metadata = {
 export default async function BarberApprenticeshipPage() {
   const heroBanner = heroBanners['barber-apprenticeship'] ?? null;
 
-  // Live enrollment count from DB
-  let enrollmentCount = 0;
-  try {
-    const supabase = await createClient();
-    const { count } = await supabase
-      .from('program_enrollments')
-      .select('*', { count: 'exact', head: true })
-      .eq('program_slug', 'barber-apprenticeship')
-      .eq('status', 'active');
-    enrollmentCount = count ?? 0;
-  } catch {
-    // non-fatal — fall back to 0
-  }
-
   return (
     <>
       <ProgramStructuredData
@@ -56,7 +43,13 @@ export default async function BarberApprenticeshipPage() {
           outcomes: p.outcomes.map((o) => o.statement),
         }}
       />
-      <BarberApprenticeshipClient program={p} heroBanner={heroBanner} enrollmentCount={enrollmentCount} />
+      <ProgramDetailPage
+        program={p}
+        banner={heroBanner}
+        processSlot={<BarberApprenticeshipProcess />}
+      >
+        <BarberApprenticeshipExtras />
+      </ProgramDetailPage>
     </>
   );
 }

--- a/app/programs/cosmetology-apprenticeship/page.tsx
+++ b/app/programs/cosmetology-apprenticeship/page.tsx
@@ -1,7 +1,11 @@
 import { Metadata } from 'next';
-import BeautyProgramPage from '@/components/beauty/BeautyProgramPage';
+import { ProgramStructuredData } from '@/components/seo/CourseStructuredData';
+import ProgramDetailPage from '@/components/programs/ProgramDetailPage';
+import BarberApprenticeshipProcess from '@/components/programs/beauty/BarberApprenticeshipProcess';
+import BarberApprenticeshipExtras from '@/components/programs/beauty/BarberApprenticeshipExtras';
 import { COSMETOLOGY } from '@/data/programs/cosmetology-apprenticeship';
 import { validateProgram } from '@/lib/programs/program-schema';
+import heroBanners from '@/content/heroBanners';
 
 export const dynamic = 'force-dynamic';
 
@@ -21,5 +25,30 @@ export const metadata: Metadata = {
 };
 
 export default async function CosmetologyApprenticeshipPage() {
-  return <BeautyProgramPage program={p} />;
+  const heroBanner = heroBanners['cosmetology-apprenticeship'] ?? null;
+
+  return (
+    <>
+      <ProgramStructuredData
+        program={{
+          id: p.slug,
+          name: p.title,
+          slug: p.slug,
+          description: p.subtitle,
+          duration_weeks: p.durationWeeks,
+          price: parseInt(p.selfPayCost.replace(/[^0-9]/g, ''), 10) || undefined,
+          image_url: p.heroImage,
+          category: p.category,
+          outcomes: p.outcomes.map((o) => o.statement),
+        }}
+      />
+      <ProgramDetailPage
+        program={p}
+        banner={heroBanner}
+        processSlot={<BarberApprenticeshipProcess />}
+      >
+        <BarberApprenticeshipExtras />
+      </ProgramDetailPage>
+    </>
+  );
 }

--- a/apps/admin/app/admin/layout.tsx
+++ b/apps/admin/app/admin/layout.tsx
@@ -1,10 +1,22 @@
 import React from 'react';
 import { Metadata } from 'next';
-import { unstable_cache } from 'next/cache';
+import { redirect } from 'next/navigation';
+import { headers } from 'next/headers';
+import { createClient } from '@/lib/supabase/server';
+import { logger } from '@/lib/logger';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { AdminLicenseWrapper } from '@/components/licensing/AdminLicenseWrapper';
+import { getLicenseAccessMode } from '@/lib/licensing/billing-authority';
+import { reconcileTrialOnboarding } from '@/lib/trial/reconcile-onboarding';
+import { withTimeout } from '@/lib/utils/withTimeout';
 import { AdminNavShell } from '@/components/admin/AdminNavShell';
 import { RealtimeSystemStatus } from '@/components/admin/RealtimeSystemStatus';
+import { unstable_cache } from 'next/cache';
 import { DEFAULT_NAV, isNavSections, type NavSection } from '@/lib/admin/nav-config';
+import { ADMIN_ROLES } from '@/lib/rbac/role-matrix';
+import { getSecuritySettings } from '@/lib/admin/security-settings';
 import { DemoTourProvider } from '@/components/demo/DemoTourProvider';
+import { IdleTimeoutGuard } from '@/components/auth/IdleTimeoutGuard';
 import PWAManager from '@/components/PWAManager';
 import { UpdatePrompt } from '@/components/pwa/UpdatePrompt';
 import { AdminInstallPrompt } from '@/components/pwa/AdminInstallPrompt';
@@ -97,16 +109,92 @@ async function getLicenseContext(userId: string, db: Awaited<ReturnType<typeof g
 }
 
 export default async function AdminLayout({ children }: { children: React.ReactNode }) {
-  // Auth protection removed - admin pages are now publicly accessible
-  // All auth checks and redirects have been disabled
-  const context = null;
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect=/admin/dashboard');
+  }
+
+  // Effective DB client — prefer service role for RLS-bypassing reads.
+  // AdminNavShell fetches nav config client-side so it never blocks server render.
+  const effectiveDb = await getAdminClient();
+
+  // AdminNavShell fetches it client-side via /api/admin/header-data so it
+  // never blocks the server render.
+  const [roleCheckRes, secondaryRoleRes, context, navSections] = await Promise.all([
+    effectiveDb.from('profiles').select('role').eq('id', user.id).maybeSingle(),
+    effectiveDb.from('user_roles').select('roles(name)').eq('user_id', user.id),
+    withTimeout(getLicenseContext(user.id, effectiveDb), 3000, 'getLicenseContext').catch(
+      () => null,
+    ),
+    // Nav config — served from cache (60s TTL), falls back to DEFAULT_NAV on miss or error
+    getCachedNavSections(process.env.NEXT_PUBLIC_SUPABASE_URL ?? '').catch(() => DEFAULT_NAV),
+  ]);
+
+  // Role enforcement — runs on the result fetched in parallel above.
+  // Must match ADMIN_ROLES in lib/rbac/role-matrix.ts and the admin-login route.
+  const roleCheck = roleCheckRes.data;
+  if (!roleCheck) redirect('/login?error=profile_missing');
+  const secondaryRoles = (secondaryRoleRes.data ?? [])
+    .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
+    .filter((role): role is string => typeof role === 'string');
+  const effectiveRoles = Array.from(new Set([roleCheck.role, ...secondaryRoles]));
+  if (!effectiveRoles.some((role) => ADMIN_ROLES.includes(role as any))) {
+    redirect(`/unauthorized?reason=${encodeURIComponent(String(roleCheck.role ?? 'role_denied'))}`);
+  }
+
+  // MFA enforcement — if mfa_required is enabled in platform_settings,
+  // redirect admins who haven't set up MFA to the security settings page.
+  // Exempt the security settings page itself to avoid a redirect loop.
+  const { mfaRequired, sessionTimeoutMs } = await getSecuritySettings();
+  if (mfaRequired) {
+    const reqHeaders = await headers();
+    // x-pathname is set by apps/admin/middleware.ts on every protected request.
+    const currentPath = reqHeaders.get('x-pathname') ?? '';
+    const isMfaExempt =
+      currentPath.startsWith('/admin/settings/security') ||
+      currentPath.startsWith('/admin/settings/general');
+
+    if (!isMfaExempt) {
+      const { data: mfaRow } = await effectiveDb
+        .from('two_factor_auth')
+        .select('enabled')
+        .eq('user_id', user.id)
+        .maybeSingle();
+
+      if (mfaRow?.enabled !== true) {
+        redirect('/admin/settings/security?mfa_required=1');
+      }
+    }
+  }
+
+  // Reconcile trial onboarding — fire and forget
+  if (context?.tenantId) {
+    reconcileTrialOnboarding(supabase, context.tenantId).catch(() => {});
+  }
+
+  // License access enforcement — fail closed
+  if (context?.license) {
+    const accessResult = getLicenseAccessMode(context.license, context.userRole);
+
+    if (accessResult.mode === 'blocked') {
+      redirect(accessResult.redirectTo ?? '/admin/license-required');
+    }
+
+    if (accessResult.mode === 'blocked_billing_issue') {
+      redirect(accessResult.redirectTo ?? '/admin/billing-issue');
+    }
+  }
 
   const content = (
     <div className="min-h-screen bg-white text-slate-900">
-      <AdminNavShell navSections={DEFAULT_NAV} />
+      <AdminNavShell navSections={navSections} />
+      <IdleTimeoutGuard timeoutMs={sessionTimeoutMs} />
       <PWAManager />
       <UpdatePrompt />
       <AdminInstallPrompt />
+      {/* Global operational telemetry bar — visible only when systems need attention */}
       <div className="pt-16">
         <RealtimeSystemStatus />
         <main id="main-content" className="flex-1 overflow-x-hidden px-4 sm:px-6 pb-8">
@@ -116,5 +204,19 @@ export default async function AdminLayout({ children }: { children: React.ReactN
     </div>
   );
 
-  return <DemoTourProvider>{content}</DemoTourProvider>;
+  if (!context) {
+    return <DemoTourProvider>{content}</DemoTourProvider>;
+  }
+
+  return (
+    <DemoTourProvider>
+      <AdminLicenseWrapper
+        license={context.license}
+        userRole={context.userRole}
+        tenantId={context.tenantId}
+      >
+        {content}
+      </AdminLicenseWrapper>
+    </DemoTourProvider>
+  );
 }

--- a/components/home/HomeCareerPathways.tsx
+++ b/components/home/HomeCareerPathways.tsx
@@ -48,6 +48,8 @@ function PathwayCard({ prog, priority }: { prog: ProgramSchema; priority?: boole
     prog.slug === 'barber-apprenticeship' ||
     prog.slug === 'cdl-training' ||
     prog.slug === 'hvac-technician' ||
+    prog.slug === 'electrical' ||
+    prog.slug === 'welding' ||
     prog.slug === 'culinary-apprenticeship';
 
   return (

--- a/components/home/HomeFundingStrip.tsx
+++ b/components/home/HomeFundingStrip.tsx
@@ -22,7 +22,7 @@ export function HomeFundingStrip() {
       <div className="max-w-6xl mx-auto">
         <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4 mb-4">
           <div>
-            <h2 id="funding-strip-heading" className="text-lg font-extrabold text-white">
+            <h2 id="funding-strip-heading" className="text-lg font-extrabold">
               Can training be paid for?
             </h2>
             <p className="text-brand-blue-100 text-sm mt-0.5">
@@ -49,9 +49,9 @@ export function HomeFundingStrip() {
             <Link
               key={path.label}
               href={path.href}
-              className="rounded-lg border border-white/20 hover:bg-white/15 px-3 py-2.5 transition-colors"
+              className="rounded-lg border border-white/20 bg-white/10 hover:bg-white/20 px-3 py-2.5 transition-colors"
             >
-              <p className="text-sm font-bold leading-tight text-white">{path.label}</p>
+              <p className="text-sm font-bold leading-tight">{path.label}</p>
               <p className="text-[11px] text-brand-blue-100 mt-0.5">{path.desc}</p>
             </Link>
           ))}

--- a/lib/devstudio/api-auth.ts
+++ b/lib/devstudio/api-auth.ts
@@ -1,11 +1,9 @@
 /**
- * DevStudio API authentication — platform operator only.
- * Customer tenant admins must never reach these routes.
- *
- * @see docs/platform-owner-tenant-model.md
+ * DevStudio API authentication — admin role required.
+ * No platform operator restriction — any admin can access Dev Studio.
  */
 
 export {
-  apiRequirePlatformOperator as apiRequireDevStudio,
+  apiRequireAdmin as apiRequireDevStudio,
   type GuardedUser,
 } from '@/lib/admin/guards';

--- a/lib/rbac/role-matrix.ts
+++ b/lib/rbac/role-matrix.ts
@@ -40,10 +40,10 @@ export type UserRole =
 // Named sets used by guards. Import these instead of writing inline arrays.
 
 /** Can access /admin/* routes */
-export const ADMIN_ROLES: UserRole[] = ['admin', 'admin', 'staff', 'org_admin', 'platform_operator'];
+export const ADMIN_ROLES: UserRole[] = ['admin', 'staff'];
 
 /** Can access admin API routes (apiRequireAdmin) */
-export const API_ADMIN_ROLES: UserRole[] = ['admin', 'admin', 'staff', 'org_admin', 'platform_operator'];
+export const API_ADMIN_ROLES: UserRole[] = ['admin', 'staff'];
 
 /** Can perform instructor actions (sign-offs, lesson management) */
 export const INSTRUCTOR_ROLES: UserRole[] = ['admin', 'admin', 'staff', 'instructor'];


### PR DESCRIPTION
## Summary

Restores critical functionality:

1. **Homepage Video Hero** - Restores video hero from ef952ad96
2. **Program Pages** - Uses ProgramDetailPage template
3. **Admin Auth** - Restores auth (only admin/staff, no super_admin/platform_operator)
4. **Dev Studio** - Open to admin role only, no platform operator check

### Files Changed
- app/page.tsx
- components/home/HomeFundingStrip.tsx
- components/home/HomeCareerPathways.tsx
- app/programs/barber-apprenticeship/page.tsx
- app/programs/cosmetology-apprenticeship/page.tsx
- apps/admin/app/admin/layout.tsx
- lib/rbac/role-matrix.ts
- lib/devstudio/api-auth.ts

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore homepage hero layout, program template pages, and admin auth gating
> - Replaces `ElevateAnimatedHome` on the home page with a composed layout (`HomeHeroVideo`, `HomeFundingStrip`, `HomeCareerPathways`, `HomeFinalCTA`) and streams `HomeOutcomes` under React Suspense with a skeleton fallback; adds ISR revalidation every 5 minutes and SEO/OG metadata.
> - Converts barber and cosmetology apprenticeship pages to use `ProgramDetailPage` with structured data, hero banners, and process/extras slots, removing the server-side enrollment count fetch.
> - Adds full auth and authorization to [admin layout](https://github.com/elevate-for-humanity/Elevate-lms/pull/426/files#diff-9921d5216c5ab74c5c43248564262bdd36f10017d6471a7805d85154acd9a1d0): unauthenticated users redirect to `/login`, access is restricted to `ADMIN_ROLES`, MFA is enforced when required, and idle session timeout is injected client-side.
> - Narrows `ADMIN_ROLES` and `API_ADMIN_ROLES` in [role-matrix.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/426/files#diff-74d9ebf6877f0d7943c1432b6e2b57b580171e055d203508780138835dde5494) to `['admin', 'staff']`, removing `org_admin` and `platform_operator`.
> - Risk: users previously accessing `/admin/*` with `org_admin` or `platform_operator` roles will now be denied access.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 60a210a.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->