### PR TITLE
fix: resolve production errors from audit

### DIFF
--- a/app/apprentice/page.tsx
+++ b/app/apprentice/page.tsx
@@ -198,7 +198,7 @@ export default async function ApprenticePortalPage() {
 
   const skills = [
     { name: 'Haircutting', icon: ScissorsIcon, percent: 80, color: 'bg-blue-100 text-blue-600' },
-    { name: 'Color Theory', icon: Sparkles, Globe, percent: 60, color: 'bg-purple-100 text-purple-600' },
+    { name: 'Color Theory', icon: Globe, percent: 60, color: 'bg-purple-100 text-purple-600' },
     { name: 'Sanitation', icon: CheckCircle, percent: 100, color: 'bg-green-100 text-green-600' },
     { name: 'Shaving', icon: Hammer, percent: 45, color: 'bg-amber-100 text-amber-600' },
   ];

--- a/app/platform/partner-portal/page.tsx
+++ b/app/platform/partner-portal/page.tsx
@@ -114,7 +114,7 @@ export default function PartnerPortalPage() {
         <div className="relative h-[clamp(190px,32vw,360px)] w-full overflow-hidden">
         {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
           <Image
-            src="/hero-images/pathways-hero.jpg"
+            src="/hero-images/pathways-hero.webp"
             alt="Partner Portal"
             fill
             className="object-cover"

--- a/app/platform/training-providers/page.tsx
+++ b/app/platform/training-providers/page.tsx
@@ -129,7 +129,7 @@ export default function TrainingProvidersPage() {
         <div className="relative h-[clamp(190px,32vw,360px)] w-full overflow-hidden">
         {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
           <Image
-            src="/hero-images/programs-hero.jpg"
+            src="/hero-images/pathways-hero.webp"
             alt="Training Provider Solutions"
             fill
             className="object-cover"

--- a/app/platform/workforce-analytics/page.tsx
+++ b/app/platform/workforce-analytics/page.tsx
@@ -129,7 +129,7 @@ export default function WorkforceAnalyticsPage() {
         <div className="relative h-[clamp(190px,32vw,360px)] w-full overflow-hidden">
         {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
           <Image
-            src="/hero-images/technology-hero.jpg"
+            src="/hero-images/technology-hero.webp"
             alt="Workforce Analytics"
             fill
             className="object-cover"

--- a/app/platform/workforce-boards/page.tsx
+++ b/app/platform/workforce-boards/page.tsx
@@ -125,7 +125,7 @@ export default function WorkforceBoardsPage() {
         <div className="relative h-[clamp(190px,32vw,360px)] w-full overflow-hidden">
         {/* IMAGE-CONTRACT: placeholder-review required (blurDataURL or approved fallback) */}
           <Image
-            src="/hero-images/wioa-hero.jpg"
+            src="/hero-images/wioa-hero.webp"
             alt="Workforce Board Solutions"
             fill
             className="object-cover"

--- a/app/platform/workforce-boards/page.tsx
+++ b/app/platform/workforce-boards/page.tsx
@@ -250,7 +250,7 @@ export default function WorkforceBoardsPage() {
             </div>
             <div className="relative h-[400px] rounded-2xl overflow-hidden shadow-xl">
               <Image
-                src="/images/pages/platform-page-7.jpg"
+                src="/images/pages/platform-page-7.webp"
                 alt="Workforce board dashboard"
                 fill
                 sizes="100vw"

--- a/app/store/guides/licensing/page.tsx
+++ b/app/store/guides/licensing/page.tsx
@@ -290,7 +290,7 @@ export default function LicensingGuidePage() {
             </div>
             <div className="relative w-full rounded-xl overflow-hidden mb-5 aspect-[4/3]" style={{ aspectRatio: '16/7' }}>
               <Image
-                src="/images/pages/platform-page-7.jpg"
+                src="/images/pages/platform-page-7.webp"
                 alt="Billing and subscription management"
                 fill
                 className="object-cover"

--- a/apps/admin/app/admin/students/[id]/page.tsx
+++ b/apps/admin/app/admin/students/[id]/page.tsx
@@ -360,7 +360,7 @@ export default async function StudentDetailPage({ params }: { params: Promise<{ 
                     key={e.id}
                     data={{
                       enrollment_id: e.id,
-                      student_name: profile?.full_name ?? '—',
+                      student_name: student?.full_name ?? '—',
                       program_name:
                         programNames[e.program_id] || e.program_slug || e.id.slice(0, 8),
                       partner_name: null,

--- a/lib/images/site-image-paths.ts
+++ b/lib/images/site-image-paths.ts
@@ -52,6 +52,16 @@ const SITE_IMAGE_ALIASES: Record<string, string> = {
   '/images/programs/dental-assistant.jpg': '/images/programs/dental-assistant.webp',
   '/images/gallery/image8.jpg': '/images/gallery/image1.webp',
   '/images/pages/healthcare/cpr-certification-group.jpg': '/images/pages/prog-hero-main-2.webp',
+  // More missing .jpg → existing .webp
+  '/images/pages/marketplace-page-1.jpg': '/images/pages/marketplace-page-1.webp',
+  '/images/pages/employer-handshake.jpg': '/images/pages/employer-handshake.webp',
+  '/images/pages/enrollment-agreement-page-1.jpg': '/images/pages/enrollment-agreement-page-1.webp',
+  '/images/pages/funding-impact-5.jpg': '/images/pages/funding-impact-3.webp',
+  '/images/pages/barber-client-consult.jpg': '/images/pages/barber-client-consult.webp',
+  '/images/gallery/image3.jpg': '/images/gallery/image1.webp',
+  '/images/hvac/hvac-commercial.jpg': '/images/pages/prog-hero-main-2.webp',
+  '/images/pages/programs-hvac-apply-hero.jpg': '/images/pages/prog-hero-main-2.webp',
+  '/images/heroes/hero-state-funding.jpg': '/images/heroes/hero-state-funding.webp',
 };
 
 /** JPG paths retired after WebP migration — map to existing .webp siblings. */

--- a/lib/images/site-image-paths.ts
+++ b/lib/images/site-image-paths.ts
@@ -35,6 +35,23 @@ const SITE_IMAGE_ALIASES: Record<string, string> = {
   '/images/pages/learner/dashboard-page-6.webp': '/images/pages/learner-page-1.webp',
   '/images/pages/learner/dashboard-page-7.webp': '/images/pages/learner-page-1.webp',
   '/media/elevate-watermark.png': '/images/certification-badge.png',
+  // Missing .jpg images → fallbacks
+  '/images/pages/platform-page-7.jpg': '/images/pages/platform-page-7.webp',
+  '/images/pages/platform-page-3.jpg': '/images/pages/platform-page-3.webp',
+  '/images/pages/marketplace.jpg': '/images/pages/marketplace-page-1.webp',
+  '/images/pages/testing-page-1.jpg': '/images/pages/testing-page-1.webp',
+  '/images/pages/barber-shop-interior.jpg': '/images/pages/barber-apprenticeship-hero.jpg',
+  '/images/pages/barber-fade-cut.jpg': '/images/pages/barber-fade-cut.webp',
+  '/images/pages/barber-shop-wide.jpg': '/images/pages/barber-apprenticeship-hero.jpg',
+  '/images/pages/barber-straight-razor.jpg': '/images/pages/barber-apprenticeship-hero.jpg',
+  '/images/pages/barber-tools-closeup.jpg': '/images/pages/barber-apprenticeship-hero.jpg',
+  '/images/pages/urban-build-crew-page-1.jpg': '/images/pages/urban-build-crew-page-1.webp',
+  '/images/pages/login-page-1.jpg': '/images/pages/login-page-1.webp',
+  '/images/pages/technology-sector.jpg': '/images/pages/prog-hero-main-2.webp',
+  '/images/heroes/hero-state-funding.jpg': '/images/heroes/hero-state-funding.webp',
+  '/images/programs/dental-assistant.jpg': '/images/programs/dental-assistant.webp',
+  '/images/gallery/image8.jpg': '/images/gallery/image1.webp',
+  '/images/pages/healthcare/cpr-certification-group.jpg': '/images/pages/prog-hero-main-2.webp',
 };
 
 /** JPG paths retired after WebP migration — map to existing .webp siblings. */


### PR DESCRIPTION
## Fixes Production Errors

### Fixed Issues:
1. **Student detail page crash** - `profile` undefined → `student` (digest 1784144484)
2. **Apprentice page crash** - duplicate icon in skills array (Sparkles, Globe)  
3. **Missing images** - added 13 image fallbacks for .jpg → .webp
4. **Direct .jpg refs** - fixed in workforce-boards and licensing pages

### Known Issues (Not User-Affecting):
- transformAlgorithm stream error - Node/Next.js version compat
- Redis rate limiter - fails open, needs config check
- product_images FK - migration exists, needs production apply

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/f6d7d393-e98f-414e-aab2-edebab8b2f61)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix production errors by correcting image paths and student name source
> - Adds JPG-to-WebP fallback entries in [`SITE_IMAGE_ALIASES`](https://github.com/elevate-for-humanity/Elevate-lms/pull/441/files#diff-6d5d3d96e2e5a3f49034a24fabf474022664cbb7fb26a26a1f0ad08eea37e37f) for platform, marketplace, barber, login, healthcare, and other images, resolving missing-image errors in production.
> - Updates hardcoded `.jpg` src attributes to `.webp` in the [Workforce Boards page](https://github.com/elevate-for-humanity/Elevate-lms/pull/441/files#diff-e4c555035bce1aadf5b67047235139840bcf6d7cbbb586c998d225fe1e48b8f5) and [Licensing Guide page](https://github.com/elevate-for-humanity/Elevate-lms/pull/441/files#diff-c5324e70748350d88ca50ba0b0f090fea797b2b9249c26efa8efb175abb2d602).
> - Fixes `EnrollmentVoucherPanel` in [student detail page](https://github.com/elevate-for-humanity/Elevate-lms/pull/441/files#diff-87e8fb9e4777c7671693d0c81adaa19cad93fbf2d5690c5d979b238f1dc3d246) to read `student_name` from `student?.full_name` instead of `profile?.full_name`.
> - Removes a duplicate icon reference (`Sparkles, Globe` → `Globe`) in the [Apprentice Portal page](https://github.com/elevate-for-humanity/Elevate-lms/pull/441/files#diff-f515bc9751e697514171e9c380a399cdcaa91fe423ddd5304ac855c959ba38cf).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d207a3c. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
> <!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->