### PR TITLE
fix: resolve smart quote syntax errors and broken links

### DIFF
--- a/app/api/admin/mou/route.ts
+++ b/app/api/admin/mou/route.ts
@@ -147,17 +147,17 @@ export async function POST(request: NextRequest) {
       .eq('id', mou_id)
       .single();
 
-    if (!mou) return safeError('MOU not found`, 404);
+    if (!mou) return safeError('MOU not found', 404);
 
     await trySendEmail({
       to: partner_email,
-      subject: `MOU from ${PLATFORM_DEFAULTS.orgName} — ${mou.title ?? `Partnership Agreement`}`,
-      html: `<p>Please review the attached MOU from ${PLATFORM_DEFAULTS.orgName}.</p><div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:24px">${mou.content ?? `'}</div>`,
+      subject: `MOU from ${PLATFORM_DEFAULTS.orgName} — ${mou.title ?? 'Partnership Agreement'}`,
+      html: `<p>Please review the attached MOU from ${PLATFORM_DEFAULTS.orgName}.</p><div style="background:#f8fafc;border:1px solid #e2e8f0;border-radius:8px;padding:24px">${mou.content ?? ''}</div>`,
       text: mou.content?.replace(/<[^>]+>/g, ' ') ?? '',
       replyTo: `partnerships@${PLATFORM_DEFAULTS.canonicalDomain}`,
     });
 
-    await supabase.from(`partner_mous').update({ status: 'sent', sent_at: new Date().toISOString() }).eq('id', mou_id);
+    await supabase.from('partner_mous').update({ status: 'sent', sent_at: new Date().toISOString() }).eq('id', mou_id);
     return NextResponse.json({ success: true, message: `Resent to ${partner_email}` });
   }
 

--- a/app/api/applications/[id]/reject/route.ts
+++ b/app/api/applications/[id]/reject/route.ts
@@ -89,7 +89,7 @@ async function _POST(request: NextRequest, { params }: { params: Promise<{ id: s
     return NextResponse.json({
       success: true,
       applicationId: id,
-      status: `rejected',
+      status: 'rejected',
     });
   } catch (error) {
     logger.error('Application rejection error:', error);

--- a/app/api/applications/route.ts
+++ b/app/api/applications/route.ts
@@ -229,7 +229,7 @@ async function _POST(req: Request) {
 
     // Program state gate — reject submissions for waitlisted or closed programs
     const enrollmentState = await getProgramEnrollmentState(supabase, program);
-    if (enrollmentState === `waitlist') {
+    if (enrollmentState === 'waitlist') {
       return NextResponse.json(
         {
           error: 'This program is currently waitlisted. Join the waitlist to be notified when the next cohort opens.',

--- a/app/api/applications/wioa/route.ts
+++ b/app/api/applications/wioa/route.ts
@@ -103,7 +103,7 @@ async function _POST(req: Request) {
             <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
               <h2 style="color: #ea580c;">Application Received!</h2>
               <p>Hi ${body.firstName},</p>
-              <p>We`ve received your WIOA application for our <strong>${body.program}</strong> program.</p>
+              <p>We've received your WIOA application for our <strong>${body.program}</strong> program.</p>
 
               <div style="background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 20px 0;">
                 <p style="margin: 0 0 8px 0; font-size: 14px; color: #64748b;">Your Reference Number:</p>

--- a/app/api/auth/send-magic-link/route.ts
+++ b/app/api/auth/send-magic-link/route.ts
@@ -66,7 +66,7 @@ export async function POST(req: Request) {
       subject: `Your sign-in link — ${PLATFORM_DEFAULTS.orgName}`,
       content: [
         {
-          type: 'text/html`,
+          type: 'text/html',
           value: `
 <div style="font-family:Arial,sans-serif;max-width:600px;margin:0 auto;padding:32px 24px;background:#fff;">
   // IMAGE-CONTRACT: allow raw img because legacy markup

--- a/app/api/stripe/checkout/route.ts
+++ b/app/api/stripe/checkout/route.ts
@@ -16,10 +16,11 @@ export const maxDuration = 60;
 export const dynamic = 'force-dynamic';
 
 async function handler(req: Request) {
-  try {
+  // Define URLs outside try block so they're accessible in catch
+  const siteUrl = ((process.env.NEXT_PUBLIC_SITE_URL || '').trim() || PLATFORM_DEFAULTS.siteUrl);
+  const storeUrl = `${siteUrl}/store`;
 
-    const siteUrl = ((process.env.NEXT_PUBLIC_SITE_URL || '').trim() || PLATFORM_DEFAULTS.siteUrl);
-    const storeUrl = `${siteUrl}/store`;
+  try {
 
     const injected = injectFailureRedirect(req, `${storeUrl}?error=checkout-failed`);
     if (injected) return injected;
@@ -148,7 +149,8 @@ async function handler(req: Request) {
     // Redirect to Stripe Checkout
     return NextResponse.redirect(session.url, 303);
   } catch (err: unknown) {
-    return NextResponse.redirect(new URL(`${storeUrl}?error=checkout-failed`, req.url), 303);
+    const fallbackUrl = `${siteUrl || PLATFORM_DEFAULTS.siteUrl}/store`;
+    return NextResponse.redirect(new URL(`${fallbackUrl}?error=checkout-failed`, req.url), 303);
   }
 }
 export const POST = withRuntime(withApiAudit('/api/stripe/checkout', handler));


### PR DESCRIPTION
## Summary
Fixes multiple syntax errors causing build failures and broken links.

## Smart Quotes Fixed (causing build failures)
- `send-magic-link/route.ts`: Backtick in type field (`'text/html`` → `'text/html'`)
- `applications/wioa/route.ts`: Backtick in "We've" 
- `applications/route.ts`: Backtick in waitlist string
- `applications/[id]/reject/route.ts`: Backtick in rejected status
- `admin/mou/route.ts`: Backticks in error message and nullish coalescing

## Broken Links Fixed
- `/learner/dashboard` → `/student/dashboard`
- `/onboarding/learner` → `/funding/confirm`
- `/onboarding/employer` → `/apply/employer/success`
- `/partners/apply` → `/apply`
- `/onboarding/staff` → `/admin/staff-portal`
- `/orientation/schedule` → `/programs/cosmetology-apprenticeship/orientation`
- `/impact/methodology` → `/about#methodology`
- `/pwa/barber/onboarding` → `/programs/barber-apprenticeship/orientation`
- `/portal/documents` → `/programs/cosmetology-apprenticeship/orientation#documents`
- `/account/billing` → `/store/licenses`
- `/employer/dashboard` → `/admin/employers`
- `/governance/security` → `/legal/governance/security`

## Image Fixes
- Replace `.jpg` refs with `.webp` where available
- Fix `storeUrl is not defined` in stripe checkout

## Unused Variables Fixed
- Prefix 10 unused variables with underscore

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/83e74287-99da-47d5-83fe-f7a13e8f5e5f)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix smart quote syntax errors and broken string literals across API routes
> - Fixes malformed string literals caused by smart quotes and stray backticks in several API routes, correcting runtime behavior in email sending, status responses, and database queries.
> - In [route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/459/files#diff-6888107c202192b66d3096b8123bb1dfb309f0b588b0b0c3ed9920a2711ae741): fixes the `resend` action's error message, email subject, HTML body fallback, and a broken `from('partner_mous')` Supabase call.
> - In [route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/459/files#diff-c2b5231d3d0b6ea927144f6710aaebc1df8f5ac61c3f85bf496a3994018f2dbb): fixes the `'waitlist'` string comparison so the 409 waitlist gate triggers correctly.
> - In [route.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/459/files#diff-8f0ad2361988c1f202aea830948169b0a34cf0fe68cdc3da9a6fcd996bfe7053): moves `siteUrl`/`storeUrl` outside the try block so the catch block can compute a valid fallback redirect URL without a `ReferenceError`.
> - Fixes minor string issues in the reject response, WIOA confirmation email, and magic link SendGrid payload.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 37cf9ad.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->