### PR TITLE
fix: resolve webpack import errors and autopilot route paths

### DIFF
--- a/app/api/apprenticeship/daily-theory/route.ts
+++ b/app/api/apprenticeship/daily-theory/route.ts
@@ -5,7 +5,7 @@ import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError } from '@/lib/api/safe-error';
 import {
   DAILY_THEORY_PASSING_SCORE,
-  isBeautyApprenticeshipSlug,
+  isApprenticeshipProgramSlug,
 } from '@/lib/apprenticeship-programs/constants';
 import {
   dailyTheoryBlockedMessage,
@@ -28,7 +28,7 @@ export async function GET(request: NextRequest) {
   if (!user) return safeError('Unauthorized', 401);
 
   const programSlug = request.nextUrl.searchParams.get('program_slug') ?? '';
-  if (!isBeautyApprenticeshipSlug(programSlug)) {
+  if (!isApprenticeshipProgramSlug(programSlug)) {
     return safeError('Invalid program_slug', 400);
   }
 
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
     const score = Number(body.score);
     const lessonId = body.lesson_id as string | undefined;
 
-    if (!isBeautyApprenticeshipSlug(programSlug)) {
+    if (!isApprenticeshipProgramSlug(programSlug)) {
       return safeError('Invalid program_slug', 400);
     }
     if (!Number.isFinite(score) || score < 0 || score > 100) {

--- a/scripts/autopilot.sh
+++ b/scripts/autopilot.sh
@@ -29,9 +29,9 @@ fi
 # Keep these pointed at the real route owners so the gate does not require
 # legacy redirect shims just to pass.
 REQUIRED_CANONICAL_ROUTE_FILES=(
-  "app/partner/dashboard/page.tsx"
+  "apps/partner/app/partner/dashboard/page.tsx"
   "apps/admin/app/admin/staff-portal/dashboard/page.tsx"
-  "app/admin/dashboard/page.tsx"
+  "apps/admin/app/admin/dashboard/page.tsx"
 )
 
 missing=0


### PR DESCRIPTION
## Summary
Fixes webpack import errors blocking the build.

### Changes
- Fix `isBeautyApprenticeshipSlug` -> `isApprenticeshipProgramSlug` in `app/api/apprenticeship/daily-theory/route.ts`
- Update `autopilot.sh` route paths for new app structure

---
*This PR was created by an AI agent (OpenHands) on behalf of the user.*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix webpack import errors and update autopilot canonical route paths
> - Replaces `isBeautyApprenticeshipSlug` with `isApprenticeshipProgramSlug` in the GET and POST handlers of [`daily-theory/route.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/461/files#diff-39743e4113046957d19885fbc7f1c0f951193d961f18e1d7cc2477ae1f36ae44) to fix incorrect validation helper imports.
> - Updates `REQUIRED_CANONICAL_ROUTE_FILES` in [`autopilot.sh`](https://github.com/elevate-for-humanity/Elevate-lms/pull/461/files#diff-c5e31e3d4e31c0bb2751165e5cd3bb382f8ed26a2b956d272fc400b6b6ee01c5) to check for portal routes at `apps/partner/app/partner/dashboard/page.tsx` and `apps/admin/app/admin/dashboard/page.tsx` instead of the old `app/` prefixed paths.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec1b61c.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->