### PR TITLE
fix: Add robots noindex to redirect stub pages

### DIFF
--- a/app/demo/page.tsx
+++ b/app/demo/page.tsx
@@ -3,6 +3,7 @@ import Link from 'next/link';
 import { Play, Monitor, Users, Award } from 'lucide-react';
 
 export const metadata: Metadata = {
+  robots: { index: false, follow: false },
   title: 'Request a Demo | Elevate for Humanity',
   keywords: ["demo", "platform demo", "workforce software", "LMS demo"], description: 'Schedule a demo of the Elevate workforce development platform.',
 };

--- a/app/demos/page.tsx
+++ b/app/demos/page.tsx
@@ -1,6 +1,7 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-export const metadata: Metadata = { title: 'Demos | Elevate', description: 'Demos page.' };
+export const metadata: Metadata = {
+  robots: { index: false, follow: false }, title: 'Demos | Elevate', description: 'Demos page.' };
 export default function Page() {
   return (
     <div className="min-h-screen bg-slate-50">

--- a/app/learner/dashboard/page.tsx
+++ b/app/learner/dashboard/page.tsx
@@ -1,4 +1,9 @@
 import { redirect } from 'next/navigation';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 export default function LearnerDashboardPage() {
   redirect('/lms');

--- a/app/tax/[...path]/page.tsx
+++ b/app/tax/[...path]/page.tsx
@@ -1,4 +1,9 @@
 import { redirect } from 'next/navigation';
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  robots: { index: false, follow: false },
+};
 
 interface PageProps {
   params: { path: string[] };


### PR DESCRIPTION
Closed as stale route-shim work. It targets old root `app/` redirect stub pages, including routes that have since been removed or relocated into the three-app architecture. Current canonical redirects/noindex policy must be enforced in the active app owners instead.