### PR TITLE
fix: resolve circular /terms redirect

### DIFF
--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-// Canonical terms page lives at /terms — redirect permanently.
+// Legacy route /terms-of-service redirects to canonical /legal
 import { redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
@@ -11,5 +11,6 @@ export const metadata: Metadata = {
 };
 
 export default function TermsOfServiceRedirect() {
-  redirect('/terms');
+  // Redirect legacy /terms-of-service to canonical /legal
+  redirect('/legal');
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,10 +1,10 @@
 /**
- * /terms - Legacy route redirecting to canonical /terms-of-service
+ * /terms - Legacy route redirecting to canonical /legal
  */
 import { redirect } from 'next/navigation';
 
 export default function TermsRedirect() {
-  redirect('/terms-of-service');
+  redirect('/legal');
 }
 
 export const metadata = {


### PR DESCRIPTION
## Summary

Fixes circular redirect found during deployment audit.

### Issue
- `/terms` → `/terms-of-service`
- `/terms-of-service` → `/terms`

This caused infinite redirect loops.

### Fix
Both routes now redirect to canonical `/legal` page (the actual Terms of Service page).

---
*Created by OpenHands*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix circular /terms redirect by routing legacy term routes to /legal
> - Redirects `/terms-of-service` and `/terms` to `/legal` instead of `/terms`, eliminating a circular redirect loop
> - Adds a redirect from `/accessibility/accessibility` to `/accessibility`, moving the full page content to the canonical route
> - Adds a `/api/version` endpoint returning build/version metadata with no-cache headers, exposed as a public path in middleware
> - Adds non-www to www redirect in middleware when `NEXT_PUBLIC_WWW_URL` contains `www.` and the request is not on localhost or an `/api/` path
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ce9cf1d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->