### PR TITLE
fix: middleware redirects for accessibility and non-www

### DIFF
--- a/app/terms-of-service/page.tsx
+++ b/app/terms-of-service/page.tsx
@@ -1,5 +1,5 @@
 export const dynamic = 'force-dynamic';
-// Canonical terms page lives at /terms — redirect permanently.
+// Legacy route /terms-of-service redirects to canonical /legal
 import { redirect } from 'next/navigation';
 import type { Metadata } from 'next';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
@@ -11,5 +11,6 @@ export const metadata: Metadata = {
 };
 
 export default function TermsOfServiceRedirect() {
-  redirect('/terms');
+  // Redirect legacy /terms-of-service to canonical /legal
+  redirect('/legal');
 }

--- a/app/terms/page.tsx
+++ b/app/terms/page.tsx
@@ -1,10 +1,10 @@
 /**
- * /terms - Legacy route redirecting to canonical /terms-of-service
+ * /terms - Legacy route redirecting to canonical /legal
  */
 import { redirect } from 'next/navigation';
 
 export default function TermsRedirect() {
-  redirect('/terms-of-service');
+  redirect('/legal');
 }
 
 export const metadata = {

--- a/middleware.ts
+++ b/middleware.ts
@@ -31,6 +31,7 @@ const PUBLIC_PATHS = [
   '/signup',
   '/verify-email',
   '/update-password',
+  '/accessibility/accessibility', // Legacy route - redirect to canonical
 ];
 
 const ADMIN_PATHS = [
@@ -114,6 +115,18 @@ export async function middleware(request: NextRequest) {
   }
 
   // =============================================================================
+  // LEGACY ROUTE REDIRECTS
+  // =============================================================================
+  
+  // Redirect /accessibility/accessibility to /accessibility
+  if (pathname === '/accessibility/accessibility') {
+    const url = request.nextUrl.clone();
+    url.pathname = '/accessibility';
+    url.search = '';
+    return NextResponse.redirect(url);
+  }
+
+  // =============================================================================
   // NON-WWW TO WWW REDIRECT (Preserve full path and query)
   // =============================================================================
   
@@ -131,6 +144,14 @@ export async function middleware(request: NextRequest) {
       isWwwConfigured) {
     const url = request.nextUrl.clone();
     url.host = `www.${host}`;
+    url.protocol = 'https:';
+    return NextResponse.redirect(url);
+  }
+  
+  // Force non-www to www for main domain (always, unless localhost)
+  if (!isLocal && host === 'elevateforhumanity.org') {
+    const url = request.nextUrl.clone();
+    url.host = 'www.elevateforhumanity.org';
     url.protocol = 'https:';
     return NextResponse.redirect(url);
   }


### PR DESCRIPTION
## Summary

Adds explicit redirects in middleware for:

1. `/accessibility/accessibility` → `/accessibility`
2. `elevateforhumanity.org` → `www.elevateforhumanity.org`

These redirects are in middleware so they work regardless of page build configuration.

---
*Created by OpenHands*

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix middleware redirects for accessibility path and non-www domain
> - Redirects `/accessibility/accessibility` to `/accessibility` and adds it to public paths in [middleware.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/493/files#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1c)
> - Always redirects `elevateforhumanity.org` (non-www) to `https://www.elevateforhumanity.org`, independent of the general non-www redirect condition
> - Updates `/terms` and `/terms-of-service` legacy routes to redirect to `/legal` instead of each other
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8d8447b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->