### PR TITLE
fix: Header desktop style, reduce image overlays, add favicon

### DIFF
--- a/apps/marketing/app/layout.tsx
+++ b/apps/marketing/app/layout.tsx
@@ -8,6 +8,13 @@ export const metadata: Metadata = {
   title: { default: 'Elevate for Humanity', template: '%s | Elevate for Humanity' },
   description: 'Vocational education and workforce development',
   metadataBase: new URL('https://www.elevateforhumanity.org'),
+  icons: {
+    icon: [
+      { url: '/favicon.ico', sizes: 'any' },
+      { url: '/favicon.png', type: 'image/png' },
+    ],
+    apple: '/apple-touch-icon.png',
+  },
 };
 
 // Force dynamic rendering to avoid static generation issues

--- a/components/home/HomeFeaturedPrograms.tsx
+++ b/components/home/HomeFeaturedPrograms.tsx
@@ -190,7 +190,7 @@ function FeaturedProgramCard({ program, index }: { program: FeaturedProgram; ind
           fill 
           className="object-cover" 
         />
-        <div className="absolute inset-0 bg-gradient-to-t from-black/60 to-transparent" />
+        <div className="absolute inset-0 bg-gradient-to-t from-black/40 to-transparent" />
         <div className="absolute bottom-4 left-4 right-4">
           <h3 className="text-xl font-bold text-white mb-1">{program.title}</h3>
         </div>

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -22,24 +22,43 @@ export default function Header() {
       className="fixed top-0 left-0 right-0 h-[60px] bg-white/95 backdrop-blur-md z-[9999] shadow-sm border-b border-slate-100 transition-all duration-200"
       role="banner"
     >
-      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 lg:px-8 grid grid-cols-[auto_1fr_auto] items-center gap-2 lg:gap-4">
+      <div className="max-w-screen-2xl mx-auto w-full h-full px-4 xl:px-8 grid grid-cols-[auto_1fr_auto] items-center gap-2 xl:gap-4">
         <Link
           href="/"
           className="flex items-center gap-2 flex-shrink-0 min-w-0"
           aria-label={`${PLATFORM_DEFAULTS.orgName} home`}
         >
           <LogoImage alt="Elevate" width={40} height={60} className="w-auto h-9" priority />
-          <span className="font-bold text-[15px] text-slate-900 hidden sm:block tracking-tight truncate">
+          <span className="font-bold text-[15px] text-slate-900 hidden md:block tracking-tight truncate">
             Elevate
           </span>
         </Link>
 
-        <div className="hidden lg:flex justify-center min-w-0 overflow-visible">
+        {/* Desktop nav - show on xl screens (1280px+) */}
+        <div className="hidden xl:flex justify-center min-w-0 overflow-visible">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
-        <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 sm:gap-1 flex-shrink-0 min-w-0">
-          <HeaderMobileMenu items={NAV_ITEMS} programApplyLinks={PROGRAM_APPLY_LINKS} />
+        <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 md:gap-1 flex-shrink-0 min-w-0">
+          {/* Desktop search/signin - show on md screens and up */}
+          <div className="hidden md:flex items-center gap-2 mr-2">
+            <Link
+              href="/login"
+              className="text-sm text-slate-600 hover:text-slate-900 px-3 py-2"
+            >
+              Sign In
+            </Link>
+            <Link
+              href="/apply"
+              className="text-sm bg-brand-red-600 hover:bg-brand-red-700 text-white px-4 py-2 rounded-lg font-medium"
+            >
+              Apply
+            </Link>
+          </div>
+          {/* Mobile menu button - hide on xl */}
+          <span className="xl:hidden">
+            <HeaderMobileMenu items={NAV_ITEMS} programApplyLinks={PROGRAM_APPLY_LINKS} />
+          </span>
         </div>
       </div>
     </header>


### PR DESCRIPTION
## Fixes

### Header
- Show desktop nav on xl screens (1280px+) instead of lg (1024px)
- Add Sign In/Apply buttons on desktop (md screens and up)
- Mobile menu only shows below xl screens

### Image Overlays
- Reduce overlay opacity from 60% to 40% on featured program cards

### Favicon
- Add proper favicon references to marketing layout metadata

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/fbee0d8b-dc8b-41ea-a120-ad4e894806aa)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Header desktop breakpoints, reduce image overlay opacity, and add favicon
> - Updates [Header.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/502/files#diff-ab1fe96a19fb5a4115ecc8932848cfad8d945af1a39528b95ecf35d3e7f1caca) so desktop navigation only renders at `xl` breakpoints and above; a Sign In and Apply action set appears from `md` screens upward; the mobile menu button is hidden on `xl` and shown below.
> - Reduces the gradient overlay opacity on featured program cards from `black/60` to `black/40`, making the underlying image more visible.
> - Adds favicon and apple-touch icon entries to the marketing app's Next.js metadata in [layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/502/files#diff-c7cc05344a50ae04b13d726626cd3494acb1ae1de25ce8166812ab2236e3416f).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized da13f10.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->