### PR TITLE
fix: Production fixes for address, images, and program redirects

### DIFF
--- a/Dockerfile.marketing
+++ b/Dockerfile.marketing
@@ -91,6 +91,8 @@ RUN groupadd --system --gid 1001 nodejs && \
 # Copy the entire Next.js build output to /app/
 COPY --from=builder --chown=nextjs:nodejs /app/apps/marketing/.next ./.next
 COPY --from=builder --chown=nextjs:nodejs /app/apps/marketing/public ./public
+# Copy root public folder for marketing assets (images, icons, etc.)
+COPY --from=builder --chown=nextjs:nodejs /app/public ./public
 
 # Copy node_modules (needed for runtime dependencies)
 COPY --from=builder /app/node_modules ./node_modules

--- a/apps/marketing/app/contact/page.tsx
+++ b/apps/marketing/app/contact/page.tsx
@@ -181,7 +181,8 @@ export default function ContactPage() {
                     </div>
                     <div>
                       <p className="text-sm text-slate-500">Location</p>
-                      <p className="font-semibold">Indianapolis, Indiana</p>
+                      <p className="font-semibold">120 E Market St, Suite 930</p>
+                      <p className="font-semibold">Indianapolis, IN 46240</p>
                       <p className="text-sm">Serving all of Indiana</p>
                     </div>
                   </div>

--- a/lib/navigation/site-nav.config.ts
+++ b/lib/navigation/site-nav.config.ts
@@ -733,9 +733,9 @@ export const contactInfo = {
   phone: '1-800-ELEVATE (353-8283)',
   email: 'info@www.elevateforhumanity.org',
   address: {
-    street: '123 Main Street',
+    street: '120 E Market St Suite 930',
     city: 'Indianapolis',
     state: 'IN',
-    zip: '46204',
+    zip: '46240',
   },
 };

--- a/middleware.ts
+++ b/middleware.ts
@@ -153,6 +153,9 @@ export async function middleware(request: NextRequest) {
     ['/healthcare-training-indianapolis', '/programs/healthcare'],
     ['/hiset', '/testing'],
     ['/certification-testing', '/testing/nha'],
+    // Program slug redirects
+    ['/programs/finance-bookkeeping-accounting', '/programs/bookkeeping'],
+    ['/programs/hvac', '/programs/hvac-technician'],
   ];
 
   for (const [from, to] of LEGACY_REDIRECTS) {


### PR DESCRIPTION
## Summary

This PR addresses critical production issues identified in the live site audit:

### Changes Made

1. **Fixed Address in site-nav.config.ts**
   - Changed from `123 Main Street, Indianapolis, IN 46204` to `120 E Market St Suite 930, Indianapolis, IN 46240`

2. **Added Full Address to Contact Page**
   - Contact page now displays `120 E Market St, Suite 930, Indianapolis, IN 46240`

3. **Fixed Image Deployment (Dockerfile.marketing)**
   - Added line to copy root `/public` folder to container for marketing images
   - This fixes the 404 errors for images like `/images/pexels/barber-hero.webp`, `/images/pexels/hvac.webp`, etc.

4. **Added Program Redirects (middleware.ts)**
   - `/programs/finance-bookkeeping-accounting` → `/programs/bookkeeping`
   - `/programs/hvac` → `/programs/hvac-technician`
   - This fixes the empty/broken program pages that were returning 404-like content

### Why These Changes Matter

- **Address issue**: The site was publicly showing a fake placeholder address (`123 Main St, Columbia, MD`) which creates credibility and compliance problems
- **Image 404s**: Multiple homepage images were returning 404, causing broken visuals
- **Empty pages**: Finance and HVAC program pages appeared to exist but had no content

### Testing Notes

After deployment, verify:
- `/api/health` returns 200
- `/api/version` returns 200
- Homepage images load correctly
- Contact page shows correct address
- `/programs/finance-bookkeeping-accounting` redirects to `/programs/bookkeeping`
- `/programs/hvac` redirects to `/programs/hvac-technician`

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/6d6b6bf3-a758-4702-b74c-8e1a1b3c7a40)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix contact address, marketing assets, and legacy program redirects in production
> - Updates the street address and ZIP in [site-nav.config.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/503/files#diff-2ce25356a1f7baa4602affaf11fb86299f7ec2975a7312a700fde406537dfbf3) and the [contact page](https://github.com/elevate-for-humanity/Elevate-lms/pull/503/files#diff-eb794a20f689f48af5f839546c3ee2021a3ec1c6a319cdb5cf553c7249ce1405) to `120 E Market St, Suite 930, Indianapolis, IN 46240`.
> - Adds 308 redirects in [middleware.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/503/files#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1c) for `/programs/finance-bookkeeping-accounting` → `/programs/bookkeeping` and `/programs/hvac` → `/programs/hvac-technician`.
> - Adds a `COPY` step in [Dockerfile.marketing](https://github.com/elevate-for-humanity/Elevate-lms/pull/503/files#diff-d1c7872239f27c34dfcb01665a6921752815856680aa34584ffb264a861b790b) to include the repo root `public/` directory in the built image so marketing assets are available at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 38cac49.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->