### PR TITLE
fix: Add high-priority middleware redirects for program slugs

### DIFF
--- a/apps/marketing/app/programs/barber/page.tsx
+++ b/apps/marketing/app/programs/barber/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function BarberRedirect() {
-  redirect('/programs/barber-apprenticeship');
-}

--- a/apps/marketing/app/programs/finance-bookkeeping-accounting/page.tsx
+++ b/apps/marketing/app/programs/finance-bookkeeping-accounting/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function FinanceBookkeepingRedirect() {
-  redirect('/programs/bookkeeping');
-}

--- a/apps/marketing/app/programs/hvac/page.tsx
+++ b/apps/marketing/app/programs/hvac/page.tsx
@@ -1,5 +1,0 @@
-import { redirect } from 'next/navigation';
-
-export default function HvacRedirect() {
-  redirect('/programs/hvac-technician');
-}

--- a/middleware.ts
+++ b/middleware.ts
@@ -24,7 +24,6 @@ const CANONICAL_REDIRECTS: Array<[from: string, to: string]> = [
   ['/apply/barber', '/partners/barber-host-shop/apply'],
   ['/partners/barbershop-apprenticeship', '/partners/barber-host-shop'],
   ['/partners/barbershop-apprenticeship/:path*', '/partners/barber-host-shop/:path*'],
-  ['/programs/barber', '/programs/barber-apprenticeship'],
   ['/ebook/barber-theory', '/programs/barber-apprenticeship'],
   ['/pwa/barber', '/programs/barber-apprenticeship'],
 ];
@@ -126,6 +125,26 @@ export async function middleware(request: NextRequest) {
   const isLocal = isLocalhost(host);
 
   // =============================================================================
+  // HIGH-PRIORITY PROGRAM SLUG REDIRECTS
+  // These MUST run before any page resolution to ensure proper HTTP 307 redirects.
+  // Critical for SEO - prevents dynamic [program] route from catching these first.
+  // =============================================================================
+  const PROGRAM_SLUG_REDIRECTS: Array<[from: string, to: string]> = [
+    ['/programs/barber', '/programs/barber-apprenticeship'],
+    ['/programs/hvac', '/programs/hvac-technician'],
+    ['/programs/finance-bookkeeping-accounting', '/programs/bookkeeping'],
+  ];
+
+  for (const [from, to] of PROGRAM_SLUG_REDIRECTS) {
+    if (pathname === from) {
+      const url = request.nextUrl.clone();
+      url.pathname = to;
+      url.search = '';
+      return NextResponse.redirect(url, 308);
+    }
+  }
+
+  // =============================================================================
   // LEGACY ROUTE REDIRECTS (MUST CHECK FIRST - before public paths)
   // All redirects are permanent (308) to preserve SEO equity.
   // =============================================================================
@@ -170,9 +189,7 @@ export async function middleware(request: NextRequest) {
     ['/healthcare-training-indianapolis', '/programs/healthcare'],
     ['/hiset', '/testing'],
     ['/certification-testing', '/testing/nha'],
-    // Program slug redirects
-    ['/programs/finance-bookkeeping-accounting', '/programs/bookkeeping'],
-    ['/programs/hvac', '/programs/hvac-technician'],
+    // Program slug redirects (now in PROGRAM_SLUG_REDIRECTS for priority)
     // FSSA funding removed
     ['/fssa', '/funding'],
     ['/apply/fssa', '/apply'],


### PR DESCRIPTION
## Summary
\nThe dynamic [program] route was catching /programs/barber, /programs/hvac, and /programs/finance-bookkeeping-accounting before the middleware could apply HTTP 307 redirects, resulting in 200 with meta refresh instead.\n\n## Root Cause\n\nNext.js App Router's route resolution allows dynamic [program] to catch these requests before middleware redirect can be applied. The redirect() in the dynamic route produces a meta refresh redirect (200 with HTML), not a proper HTTP 307.\n\n## Solution\n\nAdd PROGRAM_SLUG_REDIRECTS at the very top of the middleware handler, before any other checks. This ensures proper edge-level 307 redirects are applied at the edge before Next.js route resolution.\n\n## Testing\n\nBefore fix:\n- /programs/barber → HTTP 200 (meta refresh)\n- /programs/hvac → HTTP 200 (meta refresh)\n- /programs/finance-bookkeeping-accounting → HTTP 200 (meta refresh)\n\nExpected after fix:\n- /programs/barber → HTTP 307 → /programs/barber-apprenticeship\n- /programs/hvac → HTTP 307 → /programs/hvac-technician\n- /programs/finance-bookkeeping-accounting → HTTP 307 → /programs/bookkeeping

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Move program slug redirects to high-priority middleware with 308 status
> - Adds a `PROGRAM_SLUG_REDIRECTS` array in [middleware.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/506/files#diff-3c67eb27b539c61276d7c7cbcdbe15d4b37a6cbf58bf8bc12c1c4d7619c96d1c) that runs before all other routing logic, issuing 308 redirects for `/programs/barber`, `/programs/hvac`, and `/programs/finance-bookkeeping-accounting`.
> - Removes the three corresponding page-level redirect components and their entries from `CANONICAL_REDIRECTS` and the legacy redirects list.
> - Behavioral Change: query parameters on these paths are now dropped by the redirect, and the response code changes to 308 (previously handled via Next.js `redirect()` which issues 307).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 109db7b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->