### PR TITLE
fix: copy full .next directory to admin runtime image

### DIFF
--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -116,9 +116,8 @@ RUN if [ -f /app/apps/admin/server.js ]; then \
     rm -rf /app/apps
 
 # Copy ALL required Next.js build artifacts to correct locations
-# CRITICAL: Need .next/server for route manifests and build metadata
-COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next/static ./.next/static
-COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next/server ./.next/server
+# Copy FULL .next directory so the standalone server finds BUILD_ID and all root-level files
+COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next ./.next
 COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/public ./public
 
 # Copy node_modules (needed for runtime dependencies)

--- a/scripts/northflank/lib.ts
+++ b/scripts/northflank/lib.ts
@@ -79,12 +79,8 @@ export function resolveAdminServiceId(): string | undefined {
   return process.env.NORTHFLANK_ADMIN_SERVICE_ID;
 }
 
-/** Prefix path with team when NORTHFLANK_TEAM_ID is set. */
+/** Always use project-scoped path — works with both project tokens and team-scoped UI tokens. */
 export function projectApiPath(projectId: string, suffix: string): string {
-  const teamId = resolveTeamId();
-  if (teamId) {
-    return teamPath(teamId, `/${projectId}${suffix}`);
-  }
   return `/projects/${projectId}${suffix}`;
 }
 


### PR DESCRIPTION
## Problem

Admin pod (`elevate-admin`) has been crashing every ~5 minutes since the last deployment with:

```
Error: Could not find a production build in the './.next' directory.
```

## Root Cause

The `Dockerfile.northflank-admin` runtime stage was only copying two subdirectories from `.next/`:

```dockerfile
COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next/static ./.next/static
COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next/server ./.next/server
```

Missing: the **root-level `.next/` files** — `BUILD_ID`, `require-hook.js`, and other production build metadata that the Next.js standalone `server.js` needs to validate the production build.

## Fix

Replace selective subdirectory copies with a **full `.next` directory copy**:

```dockerfile
# Copy FULL .next directory so the standalone server finds BUILD_ID and all root-level files
COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next ./.next
COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/public ./public
```

This ensures all root-level `.next/` artifacts (`BUILD_ID`, `require-hook.js`, etc.) are available at runtime so the standalone server can validate and serve the production build correctly.

Also fixed: `scripts/northflank/lib.ts` — changed `projectApiPath` to always use the project-scoped URL format (`/projects/{projectId}/...`) which works with both project tokens and UI tokens.

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/32adc984-8380-4024-8731-c0828fe017cb)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix admin runtime image to copy the full `.next` directory
> - Replaces two separate `COPY` commands for `.next/static` and `.next/server` with a single `COPY` of the entire `.next` directory in [Dockerfile.northflank-admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/510/files#diff-f0939116df44c0393f387417093782629ea80cfe98a98d3c8002e6acfcd4845c), making root-level Next.js build artifacts available at runtime.
> - Removes team-scoped path logic from `projectApiPath` in [lib.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/510/files#diff-4835e0f2adaf73679af475b90504e7cd9ebdc865b36b7a7bd77d260ab6424492), so the function always returns a project-scoped path regardless of `NORTHFLANK_TEAM_ID`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 70c4f0b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->