### PR TITLE
fix: add workflow to audit and remove Northflank /apply redirect loop

### DIFF
--- a/.github/workflows/fix-apply-redirect.yml
+++ b/.github/workflows/fix-apply-redirect.yml
@@ -1,0 +1,183 @@
+name: Fix /apply redirect loop
+
+on:
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Dry run (list paths only, do not delete)'
+        required: false
+        default: 'true'
+        type: boolean
+
+env:
+  NORTHFLANK_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
+  NORTHFLANK_TEAM_ID: ${{ secrets.NORTHFLANK_TEAM_ID || 'elevates-team' }}
+
+jobs:
+  audit-and-fix:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: 'npm'
+          cache-dependency-path: package-lock.json
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts
+
+      - name: Audit subdomain paths (direct paths)
+        id: audit
+        run: |
+          echo "=== Current subdomain paths for www.elevateforhumanity.org ==="
+          
+          PATHS_RESPONSE=$(curl -sS \
+            -H "Authorization: Bearer $NORTHFLANK_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.northflank.com/v1/domains/elevateforhumanity.org/subdomains/www/paths")
+          
+          echo "$PATHS_RESPONSE" | python3 -m json.tool
+          
+          # Save response for next steps
+          echo "$PATHS_RESPONSE" > paths-response.json
+          
+          # Check for /apply path
+          HAS_APPLY=$(echo "$PATHS_RESPONSE" | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+paths = data.get('paths', [])
+apply_paths = [p for p in paths if p.get('uri') == '/apply']
+print(len(apply_paths))
+print(json.dumps(apply_paths, indent=2) if apply_paths else 'none')
+")
+          
+          echo "apply_paths=$HAS_APPLY" >> "$GITHUB_OUTPUT"
+          echo "paths_json=$(echo '$PATHS_RESPONSE' | python3 -c 'import json,sys; print(json.dumps(json.load(sys.stdin)))')" >> "$GITHUB_OUTPUT"
+
+      - name: Audit subdomain path assignments
+        id: audit-assignments
+        run: |
+          echo "=== Current subdomain path ASSIGNMENTS for www.elevateforhumanity.org ==="
+          
+          # Check if there are path assignments (rewrite rules)
+          ASSIGN_RESPONSE=$(curl -sS \
+            -H "Authorization: Bearer $NORTHFLANK_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.northflank.com/v1/domains/elevateforhumanity.org/subdomains/www")
+          
+          echo "$ASSIGN_RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$ASSIGN_RESPONSE"
+          
+          # Also check root path assignment
+          ROOT_RESPONSE=$(curl -sS \
+            -H "Authorization: Bearer $NORTHFLANK_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.northflank.com/v1/domains/elevateforhumanity.org/subdomains/www/paths/%2F")
+          
+          echo "=== Root path / assignment ==="
+          echo "$ROOT_RESPONSE" | python3 -m json.tool 2>/dev/null || echo "$ROOT_RESPONSE"
+
+      - name: Identify bad /apply path
+        id: identify
+        if: steps.audit.outputs.apply_paths != 'none'
+        run: |
+          echo "=== Found bad /apply path(s) ==="
+          echo "${{ steps.audit.outputs.apply_paths }}"
+          
+          # Extract path IDs for deletion
+          PATH_IDS=$(echo '${{ steps.audit.outputs.apply_paths }}' | python3 -c "
+import json, sys
+data = json.load(sys.stdin)
+for p in data:
+    pid = p.get('id', 'unknown')
+    # URL-encode the path ID in case it contains special chars
+    import urllib.parse
+    print(urllib.parse.quote(str(pid)))
+")
+          echo "path_ids=$PATH_IDS" >> "$GITHUB_OUTPUT"
+          
+          # Also save full path objects for reference
+          echo '${{ steps.audit.outputs.apply_paths }}' > apply-paths.json
+
+      - name: Show found paths
+        if: steps.identify.outputs.path_ids == ''
+        run: |
+          echo "No exact /apply path found. Checking for prefix/rewrite rules..."
+          echo "paths_response=${{ steps.audit.outputs.paths_json }}"
+
+      - name: Delete bad /apply path (DRY RUN)
+        if: github.event.inputs.dry_run == 'true'
+        run: |
+          echo "=== DRY RUN: Would delete these path IDs ==="
+          echo '${{ steps.identify.outputs.path_ids }}'
+          echo ""
+          echo "To execute deletion, set dry_run to false"
+
+      - name: Delete bad /apply path (EXECUTE)
+        if: github.event.inputs.dry_run != 'true' && steps.identify.outputs.path_ids != ''
+        run: |
+          echo "=== EXECUTING: Deleting bad /apply path ==="
+          
+          for PATH_ID in ${{ steps.identify.outputs.path_ids }}; do
+            echo "Deleting path ID: $PATH_ID"
+            RESPONSE=$(curl -sS -w "\n%{http_code}" \
+              -H "Authorization: Bearer $NORTHFLANK_API_TOKEN" \
+              -H "Content-Type: application/json" \
+              -X DELETE \
+              "https://api.northflank.com/v1/domains/elevateforhumanity.org/subdomains/www/paths/$PATH_ID")
+            
+            HTTP_CODE=$(echo "$RESPONSE" | tail -1)
+            BODY=$(echo "$RESPONSE" | head -n -1)
+            
+            echo "HTTP $HTTP_CODE: $BODY"
+            
+            if [ "$HTTP_CODE" != "200" ] && [ "$HTTP_CODE" != "204" ]; then
+              echo "FAILED to delete path $PATH_ID"
+              exit 1
+            fi
+          done
+          
+          echo "=== Deleted successfully ==="
+
+      - name: Check if /apply path was an assignment instead
+        if: github.event.inputs.dry_run != 'true' && steps.identify.outputs.path_ids == ''
+        run: |
+          echo "=== No standalone /apply path found ==="
+          echo "The bad path might be a rewrite rule attached to the root / path."
+          echo ""
+          echo "Checking root path configuration..."
+          
+          # List all paths again
+          curl -sS \
+            -H "Authorization: Bearer $NORTHFLANK_API_TOKEN" \
+            -H "Content-Type: application/json" \
+            "https://api.northflank.com/v1/domains/elevateforhumanity.org/subdomains/www/paths" \
+            | python3 -m json.tool
+          
+          echo ""
+          echo "Check if root / path has a rewrite rule to /apply"
+
+      - name: Verify /apply in production
+        if: github.event.inputs.dry_run != 'true'
+        run: |
+          sleep 5  # Wait for propagation
+          
+          echo "=== Verifying /apply response ==="
+          
+          RESPONSE=$(curl -sS -I "https://www.elevateforhumanity.org/apply")
+          echo "$RESPONSE"
+          
+          # Check for 200 or single redirect to /apply
+          HTTP_CODE=$(echo "$RESPONSE" | grep -i "^HTTP" | head -1 | awk '{print $2}')
+          
+          if [ "$HTTP_CODE" = "200" ]; then
+            echo "✅ /apply returns 200 — FIXED!"
+          elif echo "$RESPONSE" | grep -qi "307\|location: /apply"; then
+            echo "❌ Still redirecting — fix may need more investigation"
+            exit 1
+          else
+            echo "Response code: $HTTP_CODE"
+          fi


### PR DESCRIPTION
## Summary

Creates a `workflow_dispatch` GitHub Actions workflow to audit and fix the `/apply` redirect loop in Northflank.

### Problem
Requests to `https://www.elevateforhumanity.org/apply` return `HTTP 307` with `location: /apply` — a self-referencing redirect that causes `ERR_TOO_MANY_REDIRECTS`. The `server: istio-envoy` header confirms the issue is at the **Northflank Istio ingress layer**, not in Next.js.

### Solution
A manual workflow that:
1. Lists all subdomain paths for `www.elevateforhumanity.org`
2. Identifies any `/apply` self-redirecting path rule
3. Deletes the offending path via the Northflank API
4. Verifies `/apply` returns HTTP 200 in production

### How to use

**Step 1 — Dry run (audit only, no changes):**
Go to Actions → "Fix /apply redirect loop" → Run workflow → keep `dry_run: true`

**Step 2 — Execute (after reviewing the audit output):**
Re-run with `dry_run: false` to delete the bad path rule

### Root cause
Next.js config is clean — no `/apply → /apply` redirect exists. The faulty rule was set up in Northflank's custom domain path configuration before the Next.js code was fixed.

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43a9689a-d72f-45dd-b6d0-4ab8916c1ffa)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add workflow to audit and remove Northflank `/apply` redirect loop
> Adds a manually triggered GitHub Actions workflow ([fix-apply-redirect.yml](.github/workflows/fix-apply-redirect.yml)) that audits Northflank subdomain path configurations for `www.elevateforhumanity.org` and optionally deletes any `/apply` path entries causing a redirect loop.
>
> - In dry-run mode (default), the workflow lists the path IDs that would be deleted without making changes.
> - In execute mode (`dry_run: false`), it deletes the identified `/apply` paths via the Northflank API and verifies the endpoint returns HTTP 200.
> - Risk: execute mode is irreversible — deleted path entries must be manually recreated if removed in error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c06fd5b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->