### PR TITLE
fix: move env inside job block in fix-apply-redirect workflow

### DIFF
--- a/.github/workflows/fix-apply-redirect.yml
+++ b/.github/workflows/fix-apply-redirect.yml
@@ -9,13 +9,12 @@ on:
         default: 'true'
         type: boolean
 
-env:
-  NORTHFLANK_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
-  NORTHFLANK_TEAM_ID: ${{ secrets.NORTHFLANK_TEAM_ID || 'elevates-team' }}
-
 jobs:
   audit-and-fix:
     runs-on: ubuntu-latest
+    env:
+      NORTHFLANK_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
+      NORTHFLANK_TEAM_ID: ${{ secrets.NORTHFLANK_TEAM_ID || 'elevates-team' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4


### PR DESCRIPTION
Fixes workflow file error that was preventing the fix-apply-redirect workflow from running. The `env` block was at the top level instead of inside the job block.

@elevateforhumanity can click here to [continue refining the PR](https://app.all-hands.dev/conversations/43a9689a-d72f-45dd-b6d0-4ab8916c1ffa)

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Scope env vars to job level in fix-apply-redirect workflow
> Moves `NORTHFLANK_API_TOKEN` and `NORTHFLANK_TEAM_ID` from the workflow-level `env` block to the `audit-and-fix` job's `env` block in [fix-apply-redirect.yml](.github/workflows/fix-apply-redirect.yml). This restricts the variables to only the job that needs them.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 41ab4f7.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->