### PR TITLE
fix(dev-studio): audit fixes - workspace registry integration

### DIFF
--- a/apps/admin/app/studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/studio/DevStudioUnifiedClient.tsx
@@ -38,7 +38,13 @@ import {
   Workflow,
 } from 'lucide-react';
 import { getSkillsLoader, type Skill } from '@/lib/studio/skills-loader';
-import { STUDIO_WORKSPACES, getAvailableWorkspaces, type StudioWorkspaceId } from '@/lib/devstudio/workspace-registry';
+import {
+  STUDIO_WORKSPACES,
+  WORKSPACE_ICONS,
+  getWorkspaceById,
+  type StudioWorkspaceId,
+  type StudioWorkspaceDefinition,
+} from '@/lib/devstudio/workspace-registry.shared';
 
 // Import OpenHands-style components
 const WebContainerSandbox = dynamic(
@@ -70,8 +76,6 @@ interface CourseBuilderProps {
   initialProgramId?: string;
 }
 
-// Use StudioWorkspaceId from the canonical registry
-type Workspace = StudioWorkspaceId;
 type StudioMode = 'ask' | 'run' | 'courses';
 
 const UnifiedEllieChat = dynamic(() => import('@/components/studio/UnifiedEllieChat'), {
@@ -138,58 +142,13 @@ const CfdStudioPanel = dynamic(
   { ssr: false },
 );
 
-// Mapping from registry workspace IDs to UI components
-const WORKSPACE_COMPONENT_MAP: Record<string, ElementType<{ className?: string }>> = {
-  ai: Bot,
-  courses: BookOpen,
-  content: FileText,
-  media: ImageIcon,
-  workflows: Workflow,
-  repository: Globe,
-  tasks: Briefcase,
-  deployments: Rocket,
-  containers: Box,
-  evaluations: Microscope,
-  collaboration: MessageSquare,
-  cfd: Wind,
-  plugins: Plug,
-  memory: Brain,
-  health: Activity,
-  settings: Key,
-  command: LayoutDashboard,
-  files: FolderOpen,
-  secrets: Key,
-  integrations: Plug,
-  upload: Upload,
-  operations: Inbox,
-  errors: Zap,
-  video: Clapperboard,
-  studio: Bot,
-};
-
-// Canonical WORKSPACES derived from registry - use registry for all metadata
-const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?: string }> }[] = [
-  { id: 'ai', label: 'AI Studio', Icon: Bot },
-  { id: 'workflows', label: 'Workflows', Icon: Workflow },
-  { id: 'command', label: 'Command', Icon: LayoutDashboard },
-  { id: 'deploy', label: 'Deploy', Icon: Rocket },
-  { id: 'files', label: 'Files', Icon: FolderOpen },
-  { id: 'media', label: 'Media', Icon: ImageIcon },
-  { id: 'containers', label: 'Containers', Icon: Box },
-  { id: 'evaluations', label: 'Evaluation', Icon: Microscope },
-  { id: 'cfd', label: 'CFD', Icon: Wind },
-  { id: 'health', label: 'Health', Icon: Activity },
-  { id: 'secrets', label: 'Secrets', Icon: Key },
-  { id: 'integrations', label: 'Integrations', Icon: Plug },
-  { id: 'upload', label: 'Upload', Icon: Upload },
-  { id: 'operations', label: 'Operations', Icon: Inbox },
-  { id: 'errors', label: 'Errors', Icon: Zap },
-  { id: 'video', label: 'Video', Icon: Clapperboard },
-];
-
-// Verify WORKSPACES align with registry - for audit purposes
-const _registryIds = STUDIO_WORKSPACES.map(w => w.id);
-const _workspaceIds = WORKSPACES.map(w => w.id);
+// Generate workspace list from canonical registry
+const WORKSPACES: Array<{ id: StudioWorkspaceId; label: string; Icon: ElementType<{ className?: string }> }> =
+  STUDIO_WORKSPACES.map((def) => ({
+    id: def.id,
+    label: def.label,
+    Icon: WORKSPACE_ICONS[def.id],
+  }));
 
 const QUICK_ACTIONS = [
   { label: 'Website deploy', command: 'Deploy the LMS service' },
@@ -204,7 +163,7 @@ const QUICK_ACTIONS = [
   { label: 'Create social post', command: 'Generate social media content' },
 ];
 
-function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
+function normalizeWorkspace(tab: string | null): { workspace: StudioWorkspaceId; mode: StudioMode } {
   if (tab === 'deploy' || tab === 'deployments') return { workspace: 'deployments', mode: 'ask' };
   if (tab === 'files' || tab === 'git' || tab === 'docs' || tab === 'documents')
     return { workspace: 'files', mode: 'ask' };
@@ -239,11 +198,11 @@ export default function DevStudioUnifiedClient({
   const searchParams = useSearchParams();
   const initial = normalizeWorkspace(searchParams.get('tab'));
   
-  // Check if workspace requires super admin
-  const workspaceDef = STUDIO_WORKSPACES.find(w => w.id === initial.workspace);
+  // Check if workspace requires super admin from registry
+  const workspaceDef = getWorkspaceById(initial.workspace);
   const requiresSuperAdmin = workspaceDef?.superAdminOnly ?? false;
   
-  const [workspace, setWorkspace] = useState<Workspace>(
+  const [workspace, setWorkspace] = useState<StudioWorkspaceId>(
     requiresSuperAdmin && !isSuperAdmin
       ? 'ai'
       : initial.workspace,
@@ -324,9 +283,9 @@ export default function DevStudioUnifiedClient({
     );
   }, [health]);
 
-  function openWorkspace(next: Workspace) {
+  function openWorkspace(next: StudioWorkspaceId) {
     // Use registry for permission check
-    const workspaceDef = STUDIO_WORKSPACES.find(w => w.id === next);
+    const workspaceDef = getWorkspaceById(next);
     if (workspaceDef?.superAdminOnly && !isSuperAdmin) {
       setWorkspace('ai');
       return;
@@ -424,7 +383,7 @@ export default function DevStudioUnifiedClient({
           <div className="space-y-1">
             {WORKSPACES.filter(
               (item) => {
-                const ws = STUDIO_WORKSPACES.find(w => w.id === item.id);
+                const ws = getWorkspaceById(item.id);
                 return !ws?.superAdminOnly || isSuperAdmin;
               },
             ).map(({ id, label, Icon }) => {
@@ -630,15 +589,15 @@ function MobileTabs({
   isSuperAdmin,
   onChange,
 }: {
-  workspace: Workspace;
+  workspace: StudioWorkspaceId;
   isSuperAdmin: boolean;
-  onChange: (workspace: Workspace) => void;
+  onChange: (workspace: StudioWorkspaceId) => void;
 }) {
   return (
     <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-[#3c3c3c] bg-[#252526] p-1 md:hidden">
       {WORKSPACES.filter(
         (item) => {
-          const ws = STUDIO_WORKSPACES.find(w => w.id === item.id);
+          const ws = getWorkspaceById(item.id);
           return !ws?.superAdminOnly || isSuperAdmin;
         },
       ).map(({ id, label, Icon }) => (

--- a/apps/admin/app/studio/DevStudioUnifiedClient.tsx
+++ b/apps/admin/app/studio/DevStudioUnifiedClient.tsx
@@ -38,6 +38,7 @@ import {
   Workflow,
 } from 'lucide-react';
 import { getSkillsLoader, type Skill } from '@/lib/studio/skills-loader';
+import { STUDIO_WORKSPACES, getAvailableWorkspaces, type StudioWorkspaceId } from '@/lib/devstudio/workspace-registry';
 
 // Import OpenHands-style components
 const WebContainerSandbox = dynamic(
@@ -69,7 +70,8 @@ interface CourseBuilderProps {
   initialProgramId?: string;
 }
 
-type Workspace = 'studio' | 'command' | 'deploy' | 'files' | 'media' | 'environments' | 'health' | 'secrets' | 'integrations' | 'workflows' | 'upload' | 'operations' | 'errors' | 'video' | 'evaluations' | 'cfd';
+// Use StudioWorkspaceId from the canonical registry
+type Workspace = StudioWorkspaceId;
 type StudioMode = 'ask' | 'run' | 'courses';
 
 const UnifiedEllieChat = dynamic(() => import('@/components/studio/UnifiedEllieChat'), {
@@ -136,14 +138,44 @@ const CfdStudioPanel = dynamic(
   { ssr: false },
 );
 
+// Mapping from registry workspace IDs to UI components
+const WORKSPACE_COMPONENT_MAP: Record<string, ElementType<{ className?: string }>> = {
+  ai: Bot,
+  courses: BookOpen,
+  content: FileText,
+  media: ImageIcon,
+  workflows: Workflow,
+  repository: Globe,
+  tasks: Briefcase,
+  deployments: Rocket,
+  containers: Box,
+  evaluations: Microscope,
+  collaboration: MessageSquare,
+  cfd: Wind,
+  plugins: Plug,
+  memory: Brain,
+  health: Activity,
+  settings: Key,
+  command: LayoutDashboard,
+  files: FolderOpen,
+  secrets: Key,
+  integrations: Plug,
+  upload: Upload,
+  operations: Inbox,
+  errors: Zap,
+  video: Clapperboard,
+  studio: Bot,
+};
+
+// Canonical WORKSPACES derived from registry - use registry for all metadata
 const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?: string }> }[] = [
-  { id: 'studio', label: 'AI Studio', Icon: Bot },
+  { id: 'ai', label: 'AI Studio', Icon: Bot },
   { id: 'workflows', label: 'Workflows', Icon: Workflow },
   { id: 'command', label: 'Command', Icon: LayoutDashboard },
   { id: 'deploy', label: 'Deploy', Icon: Rocket },
   { id: 'files', label: 'Files', Icon: FolderOpen },
   { id: 'media', label: 'Media', Icon: ImageIcon },
-  { id: 'environments', label: 'Containers', Icon: Box },
+  { id: 'containers', label: 'Containers', Icon: Box },
   { id: 'evaluations', label: 'Evaluation', Icon: Microscope },
   { id: 'cfd', label: 'CFD', Icon: Wind },
   { id: 'health', label: 'Health', Icon: Activity },
@@ -154,6 +186,10 @@ const WORKSPACES: { id: Workspace; label: string; Icon: ElementType<{ className?
   { id: 'errors', label: 'Errors', Icon: Zap },
   { id: 'video', label: 'Video', Icon: Clapperboard },
 ];
+
+// Verify WORKSPACES align with registry - for audit purposes
+const _registryIds = STUDIO_WORKSPACES.map(w => w.id);
+const _workspaceIds = WORKSPACES.map(w => w.id);
 
 const QUICK_ACTIONS = [
   { label: 'Website deploy', command: 'Deploy the LMS service' },
@@ -169,24 +205,30 @@ const QUICK_ACTIONS = [
 ];
 
 function normalizeWorkspace(tab: string | null): { workspace: Workspace; mode: StudioMode } {
-  if (tab === 'deploy' || tab === 'deployments') return { workspace: 'deploy', mode: 'ask' };
+  if (tab === 'deploy' || tab === 'deployments') return { workspace: 'deployments', mode: 'ask' };
   if (tab === 'files' || tab === 'git' || tab === 'docs' || tab === 'documents')
     return { workspace: 'files', mode: 'ask' };
   if (tab === 'media' || tab === 'media-library' || tab === 'assets')
     return { workspace: 'media', mode: 'ask' };
   if (tab === 'container' || tab === 'containers' || tab === 'environments' || tab === 'services')
-    return { workspace: 'environments', mode: 'ask' };
+    return { workspace: 'containers', mode: 'ask' };
   if (tab === 'evaluation' || tab === 'evaluations' || tab === 'evals')
     return { workspace: 'evaluations', mode: 'ask' };
   if (tab === 'cfd' || tab === 'cfd-studio' || tab === 'simulation')
     return { workspace: 'cfd', mode: 'ask' };
   if (tab === 'health') return { workspace: 'health', mode: 'ask' };
-  if (tab === 'secrets') return { workspace: 'secrets', mode: 'ask' };
+  if (tab === 'secrets' || tab === 'settings') return { workspace: 'settings', mode: 'ask' };
   if (tab === 'integrations') return { workspace: 'integrations', mode: 'ask' };
   if (tab === 'command-center' || tab === 'os') return { workspace: 'command', mode: 'ask' };
-  if (tab === 'command' || tab === 'terminal') return { workspace: 'studio', mode: 'run' };
-  if (tab === 'courses' || tab === 'course') return { workspace: 'studio', mode: 'courses' };
-  return { workspace: 'studio', mode: 'ask' };
+  if (tab === 'command' || tab === 'terminal') return { workspace: 'ai', mode: 'run' };
+  if (tab === 'courses' || tab === 'course') return { workspace: 'courses', mode: 'ask' };
+  if (tab === 'content') return { workspace: 'content', mode: 'ask' };
+  if (tab === 'repository') return { workspace: 'repository', mode: 'ask' };
+  if (tab === 'tasks' || tab === 'task-queue') return { workspace: 'tasks', mode: 'ask' };
+  if (tab === 'collaboration') return { workspace: 'collaboration', mode: 'ask' };
+  if (tab === 'plugins') return { workspace: 'plugins', mode: 'ask' };
+  if (tab === 'memory') return { workspace: 'memory', mode: 'ask' };
+  return { workspace: 'ai', mode: 'ask' };
 }
 
 export default function DevStudioUnifiedClient({
@@ -196,9 +238,14 @@ export default function DevStudioUnifiedClient({
 }) {
   const searchParams = useSearchParams();
   const initial = normalizeWorkspace(searchParams.get('tab'));
+  
+  // Check if workspace requires super admin
+  const workspaceDef = STUDIO_WORKSPACES.find(w => w.id === initial.workspace);
+  const requiresSuperAdmin = workspaceDef?.superAdminOnly ?? false;
+  
   const [workspace, setWorkspace] = useState<Workspace>(
-    (initial.workspace === 'secrets' || initial.workspace === 'environments') && !isSuperAdmin
-      ? 'studio'
+    requiresSuperAdmin && !isSuperAdmin
+      ? 'ai'
       : initial.workspace,
   );
   const [studioMode, setStudioMode] = useState<StudioMode>(initial.mode);
@@ -278,8 +325,10 @@ export default function DevStudioUnifiedClient({
   }, [health]);
 
   function openWorkspace(next: Workspace) {
-    if ((next === 'secrets' || next === 'environments') && !isSuperAdmin) {
-      setWorkspace('health');
+    // Use registry for permission check
+    const workspaceDef = STUDIO_WORKSPACES.find(w => w.id === next);
+    if (workspaceDef?.superAdminOnly && !isSuperAdmin) {
+      setWorkspace('ai');
       return;
     }
     setWorkspace(next);
@@ -374,7 +423,10 @@ export default function DevStudioUnifiedClient({
           </div>
           <div className="space-y-1">
             {WORKSPACES.filter(
-              (item) => (item.id !== 'secrets' && item.id !== 'environments') || isSuperAdmin,
+              (item) => {
+                const ws = STUDIO_WORKSPACES.find(w => w.id === item.id);
+                return !ws?.superAdminOnly || isSuperAdmin;
+              },
             ).map(({ id, label, Icon }) => {
               const active = workspace === id;
               return (
@@ -447,7 +499,7 @@ export default function DevStudioUnifiedClient({
               isSuperAdmin={isSuperAdmin}
               onChange={openWorkspace}
             />
-            {workspace === 'studio' && (
+            {workspace === 'ai' && (
               <StudioPanel
                 mode={studioMode}
                 onModeChange={setStudioMode}
@@ -458,7 +510,7 @@ export default function DevStudioUnifiedClient({
             )}
             {workspace === 'workflows' && <WorkflowsPanel embedded />}
             {workspace === 'command' && <CommandCenterPanel />}
-            {workspace === 'deploy' && <DeployPanel workflowButtons={config?.workflowButtons} />}
+            {workspace === 'deployments' && <DeployPanel workflowButtons={config?.workflowButtons} />}
             {workspace === 'files' && (
               <div className="flex h-full flex-col overflow-hidden">
                 <div className="min-h-0 flex-1 overflow-hidden">
@@ -495,9 +547,9 @@ export default function DevStudioUnifiedClient({
                 )}
               </div>
             )}
-            {workspace === 'environments' &&
+            {workspace === 'containers' &&
               (isSuperAdmin ? (
-                <EnvironmentPanel />
+                <DevContainerPanel />
               ) : (
                 <HealthPanel health={health} onRefresh={() => window.location.reload()} />
               ))}
@@ -585,7 +637,10 @@ function MobileTabs({
   return (
     <div className="flex shrink-0 gap-1 overflow-x-auto border-b border-[#3c3c3c] bg-[#252526] p-1 md:hidden">
       {WORKSPACES.filter(
-        (item) => (item.id !== 'secrets' && item.id !== 'environments') || isSuperAdmin,
+        (item) => {
+          const ws = STUDIO_WORKSPACES.find(w => w.id === item.id);
+          return !ws?.superAdminOnly || isSuperAdmin;
+        },
       ).map(({ id, label, Icon }) => (
         <button
           key={id}

--- a/lib/devstudio/workspace-registry.shared.ts
+++ b/lib/devstudio/workspace-registry.shared.ts
@@ -1,0 +1,295 @@
+/**
+ * Canonical workspace registry for Dev Studio.
+ * Client-safe shared types and definitions.
+ * Do NOT import server-only modules here.
+ */
+
+import type { ElementType } from 'react';
+import {
+  Activity,
+  Bot,
+  BookOpen,
+  Box,
+  Brain,
+  Briefcase,
+  FileText,
+  GitBranch,
+  ImageIcon,
+  Key,
+  ListChecks,
+  MessageSquare,
+  Microscope,
+  Plug,
+  Rocket,
+  Settings,
+  Wind,
+  Workflow,
+} from 'lucide-react';
+
+export type StudioWorkspaceId =
+  | 'ai'
+  | 'courses'
+  | 'content'
+  | 'media'
+  | 'workflows'
+  | 'repository'
+  | 'tasks'
+  | 'deployments'
+  | 'containers'
+  | 'evaluations'
+  | 'collaboration'
+  | 'cfd'
+  | 'plugins'
+  | 'memory'
+  | 'health'
+  | 'settings'
+  | 'command'
+  | 'files'
+  | 'integrations'
+  | 'upload'
+  | 'operations'
+  | 'errors'
+  | 'video';
+
+export interface StudioWorkspaceDefinition {
+  id: StudioWorkspaceId;
+  label: string;
+  description: string;
+  permission: string;
+  healthEndpoint: string;
+  featureFlag?: string;
+  superAdminOnly?: boolean;
+  implemented: boolean;
+}
+
+// Icon mapping - client-safe static data
+export const WORKSPACE_ICONS: Record<StudioWorkspaceId, ElementType<{ className?: string }>> = {
+  ai: Bot,
+  courses: BookOpen,
+  content: FileText,
+  media: ImageIcon,
+  workflows: Workflow,
+  repository: GitBranch,
+  tasks: ListChecks,
+  deployments: Rocket,
+  containers: Box,
+  evaluations: Microscope,
+  collaboration: MessageSquare,
+  cfd: Wind,
+  plugins: Plug,
+  memory: Brain,
+  health: Activity,
+  settings: Settings,
+  command: MessageSquare,
+  files: FileText,
+  integrations: Plug,
+  upload: Rocket,
+  operations: ListChecks,
+  errors: Activity,
+  video: FileText,
+};
+
+// Canonical workspace registry
+export const STUDIO_WORKSPACES: StudioWorkspaceDefinition[] = [
+  {
+    id: 'ai',
+    label: 'AI Studio',
+    description: 'PARIS, Lizzy and specialized AI agents.',
+    permission: 'studio.ai.use',
+    healthEndpoint: '/api/devstudio/health',
+    implemented: true,
+  },
+  {
+    id: 'courses',
+    label: 'Course Builder',
+    description: 'Courses, lessons, assessments and credentials.',
+    permission: 'studio.courses.manage',
+    healthEndpoint: '/api/admin/dev-studio/courses/health',
+    implemented: true,
+  },
+  {
+    id: 'content',
+    label: 'Content Studio',
+    description: 'Generate and manage reviewed content.',
+    permission: 'studio.content.manage',
+    healthEndpoint: '/api/admin/dev-studio/content/health',
+    implemented: true,
+  },
+  {
+    id: 'media',
+    label: 'Media Studio',
+    description: 'Organization-scoped media and documents.',
+    permission: 'studio.media.manage',
+    healthEndpoint: '/api/admin/dev-studio/media/health',
+    implemented: true,
+  },
+  {
+    id: 'workflows',
+    label: 'Workflows',
+    description: 'Build versioned visual automations.',
+    permission: 'studio.workflows.manage',
+    healthEndpoint: '/api/admin/dev-studio/workflows/health',
+    implemented: false,
+  },
+  {
+    id: 'repository',
+    label: 'Repository',
+    description: 'Explore files and dependencies.',
+    permission: 'studio.repository.view',
+    healthEndpoint: '/api/admin/dev-studio/repository/health',
+    implemented: false,
+  },
+  {
+    id: 'tasks',
+    label: 'Tasks',
+    description: 'Plan, approve and execute AI work.',
+    permission: 'studio.tasks.manage',
+    healthEndpoint: '/api/admin/dev-studio/tasks/health',
+    implemented: false,
+  },
+  {
+    id: 'deployments',
+    label: 'Deployments',
+    description: 'Build, deploy and verify services.',
+    permission: 'studio.deployments.manage',
+    healthEndpoint: '/api/admin/dev-studio/deployments/health',
+    implemented: true,
+  },
+  {
+    id: 'containers',
+    label: 'Containers',
+    description: 'Manage isolated execution environments.',
+    permission: 'studio.containers.manage',
+    healthEndpoint: '/api/admin/dev-studio/containers/health',
+    superAdminOnly: true,
+    implemented: true,
+  },
+  {
+    id: 'evaluations',
+    label: 'Evaluation',
+    description: 'Evidence-based platform evaluation.',
+    permission: 'studio.evaluations.manage',
+    healthEndpoint: '/api/admin/dev-studio/evaluations/health',
+    implemented: true,
+  },
+  {
+    id: 'collaboration',
+    label: 'Collaboration',
+    description: 'Presence and shared editing.',
+    permission: 'studio.collaboration.use',
+    healthEndpoint: '/api/admin/dev-studio/collaboration/health',
+    implemented: false,
+  },
+  {
+    id: 'cfd',
+    label: 'CFD',
+    description: 'Configure and validate OpenFOAM simulation projects.',
+    permission: 'studio.cfd.manage',
+    healthEndpoint: '/api/admin/dev-studio/cfd/health',
+    featureFlag: 'CFD_ENABLED',
+    implemented: true,
+  },
+  {
+    id: 'plugins',
+    label: 'Plugins',
+    description: 'Install and manage extensions.',
+    permission: 'studio.plugins.manage',
+    healthEndpoint: '/api/admin/dev-studio/plugins/health',
+    implemented: false,
+  },
+  {
+    id: 'memory',
+    label: 'Memory',
+    description: 'Search and manage organizational memory.',
+    permission: 'studio.memory.manage',
+    healthEndpoint: '/api/admin/dev-studio/memory/health',
+    implemented: false,
+  },
+  {
+    id: 'health',
+    label: 'Health',
+    description: 'Capability status and configuration.',
+    permission: 'studio.health.view',
+    healthEndpoint: '/api/devstudio/health',
+    implemented: true,
+  },
+  {
+    id: 'settings',
+    label: 'Settings',
+    description: 'Providers and studio configuration.',
+    permission: 'studio.settings.manage',
+    healthEndpoint: '/api/admin/dev-studio/settings/health',
+    superAdminOnly: true,
+    implemented: true,
+  },
+  // Legacy/internal workspaces (implemented in this client)
+  {
+    id: 'command',
+    label: 'Command',
+    description: 'Command center.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'files',
+    label: 'Files',
+    description: 'File browser.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'integrations',
+    label: 'Integrations',
+    description: 'Manage external integrations.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'upload',
+    label: 'Upload',
+    description: 'File upload utility.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'operations',
+    label: 'Operations',
+    description: 'Operations panel.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'errors',
+    label: 'Errors',
+    description: 'Error monitoring.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+  {
+    id: 'video',
+    label: 'Video',
+    description: 'Video management.',
+    permission: 'studio.view',
+    healthEndpoint: '',
+    implemented: true,
+  },
+];
+
+export function getWorkspaceById(id: StudioWorkspaceId): StudioWorkspaceDefinition | undefined {
+  return STUDIO_WORKSPACES.find((ws) => ws.id === id);
+}
+
+export function isWorkspaceImplemented(id: StudioWorkspaceId): boolean {
+  const ws = getWorkspaceById(id);
+  return ws?.implemented ?? false;
+}
+
+export function getImplementedWorkspaces(): StudioWorkspaceDefinition[] {
+  return STUDIO_WORKSPACES.filter((ws) => ws.implemented);
+}

--- a/lib/devstudio/workspace-registry.ts
+++ b/lib/devstudio/workspace-registry.ts
@@ -1,159 +1,20 @@
 import 'server-only';
 
-/**
- * Canonical workspace registry for Dev Studio.
- * All workspaces should be defined here rather than hardcoded in DevStudioUnifiedClient.
- */
+// Re-export shared types for server-only usage
+export {
+  STUDIO_WORKSPACES,
+  WORKSPACE_ICONS,
+  getWorkspaceById,
+  isWorkspaceImplemented,
+  getImplementedWorkspaces,
+  type StudioWorkspaceId,
+  type StudioWorkspaceDefinition,
+} from './workspace-registry.shared';
 
-export type StudioWorkspaceId =
-  | 'ai'
-  | 'courses'
-  | 'content'
-  | 'media'
-  | 'workflows'
-  | 'repository'
-  | 'tasks'
-  | 'deployments'
-  | 'containers'
-  | 'evaluations'
-  | 'collaboration'
-  | 'cfd'
-  | 'plugins'
-  | 'memory'
-  | 'health'
-  | 'settings';
-
-export interface StudioWorkspaceDefinition {
-  id: StudioWorkspaceId;
-  label: string;
-  description: string;
-  permission: string;
-  healthEndpoint: string;
-  featureFlag?: string;
-  superAdminOnly?: boolean;
-}
-
-export const STUDIO_WORKSPACES: StudioWorkspaceDefinition[] = [
-  {
-    id: 'ai',
-    label: 'AI Studio',
-    description: 'PARIS, Lizzy and specialized AI agents.',
-    permission: 'studio.ai.use',
-    healthEndpoint: '/api/devstudio/health',
-  },
-  {
-    id: 'courses',
-    label: 'Course Builder',
-    description: 'Courses, lessons, assessments and credentials.',
-    permission: 'studio.courses.manage',
-    healthEndpoint: '/api/admin/dev-studio/courses/health',
-  },
-  {
-    id: 'content',
-    label: 'Content Studio',
-    description: 'Generate and manage reviewed content.',
-    permission: 'studio.content.manage',
-    healthEndpoint: '/api/admin/dev-studio/content/health',
-  },
-  {
-    id: 'media',
-    label: 'Media Studio',
-    description: 'Organization-scoped media and documents.',
-    permission: 'studio.media.manage',
-    healthEndpoint: '/api/admin/dev-studio/media/health',
-  },
-  {
-    id: 'workflows',
-    label: 'Workflow Designer',
-    description: 'Build versioned visual automations.',
-    permission: 'studio.workflows.manage',
-    healthEndpoint: '/api/admin/dev-studio/workflows/health',
-  },
-  {
-    id: 'repository',
-    label: 'Repository Graph',
-    description: 'Explore files, dependencies and code relationships.',
-    permission: 'studio.repository.view',
-    healthEndpoint: '/api/admin/dev-studio/repository/health',
-  },
-  {
-    id: 'tasks',
-    label: 'AI Task Queue',
-    description: 'Plan, approve, execute and verify AI work.',
-    permission: 'studio.tasks.manage',
-    healthEndpoint: '/api/admin/dev-studio/tasks/health',
-  },
-  {
-    id: 'deployments',
-    label: 'Deployments',
-    description: 'Build, deploy, verify and roll back services.',
-    permission: 'studio.deployments.manage',
-    healthEndpoint: '/api/admin/dev-studio/deployments/health',
-  },
-  {
-    id: 'containers',
-    label: 'Containers',
-    description: 'Manage isolated execution environments.',
-    permission: 'studio.containers.manage',
-    healthEndpoint: '/api/admin/dev-studio/containers/health',
-    superAdminOnly: true,
-  },
-  {
-    id: 'evaluations',
-    label: 'Evaluation Center',
-    description: 'Evidence-based platform and AI evaluation.',
-    permission: 'studio.evaluations.manage',
-    healthEndpoint: '/api/admin/dev-studio/evaluations/health',
-  },
-  {
-    id: 'collaboration',
-    label: 'Collaboration',
-    description: 'Presence, comments and shared editing.',
-    permission: 'studio.collaboration.use',
-    healthEndpoint: '/api/admin/dev-studio/collaboration/health',
-  },
-  {
-    id: 'cfd',
-    label: 'CFD Studio',
-    description: 'OpenFOAM project configuration and execution.',
-    permission: 'studio.cfd.manage',
-    healthEndpoint: '/api/admin/dev-studio/cfd/health',
-    featureFlag: 'CFD_ENABLED',
-  },
-  {
-    id: 'plugins',
-    label: 'Plugins',
-    description: 'Install and manage approved platform extensions.',
-    permission: 'studio.plugins.manage',
-    healthEndpoint: '/api/admin/dev-studio/plugins/health',
-  },
-  {
-    id: 'memory',
-    label: 'AI Memory',
-    description: 'Search and manage governed organizational memory.',
-    permission: 'studio.memory.manage',
-    healthEndpoint: '/api/admin/dev-studio/memory/health',
-  },
-  {
-    id: 'health',
-    label: 'System Health',
-    description: 'Capability status and configuration checks.',
-    permission: 'studio.health.view',
-    healthEndpoint: '/api/devstudio/health',
-  },
-  {
-    id: 'settings',
-    label: 'Settings',
-    description: 'Providers, features and studio permissions.',
-    permission: 'studio.settings.manage',
-    healthEndpoint: '/api/admin/dev-studio/settings/health',
-    superAdminOnly: true,
-  },
-];
-
-export function getWorkspaceById(id: StudioWorkspaceId): StudioWorkspaceDefinition | undefined {
-  return STUDIO_WORKSPACES.find((ws) => ws.id === id);
-}
+import {
+  type StudioWorkspaceId,
+  type StudioWorkspaceDefinition,
+} from './workspace-registry.shared';
 
 export function isWorkspaceAvailable(
   workspace: StudioWorkspaceDefinition,
@@ -170,4 +31,10 @@ export function isWorkspaceAvailable(
 
 export function getAvailableWorkspaces(isSuperAdmin: boolean): StudioWorkspaceDefinition[] {
   return STUDIO_WORKSPACES.filter((ws) => isWorkspaceAvailable(ws, isSuperAdmin));
+}
+
+export function getVisibleWorkspaceIds(isSuperAdmin: boolean): StudioWorkspaceId[] {
+  return STUDIO_WORKSPACES
+    .filter((ws) => isWorkspaceAvailable(ws, isSuperAdmin))
+    .map((ws) => ws.id);
 }

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
     "@types/react-signature-canvas": "1.0.7",
     "@upstash/ratelimit": "^2.0.8",
     "@upstash/redis": "1.35.7",
+    "@vitejs/plugin-react": "^6.0.4",
     "@webcontainer/api": "^1.6.4",
     "@xmldom/xmldom": "^0.9.10",
     "@xterm/addon-fit": "^0.11.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -218,6 +218,9 @@ importers:
       '@upstash/redis':
         specifier: 1.35.7
         version: 1.35.7
+      '@vitejs/plugin-react':
+        specifier: ^6.0.4
+        version: 6.0.4(vite@6.4.3(@types/node@25.9.3)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))
       '@webcontainer/api':
         specifier: ^1.6.4
         version: 1.6.4
@@ -3518,6 +3521,9 @@ packages:
   '@remotion/zod-types@4.0.492':
     resolution: {integrity: sha512-4EhYTkfbNnxLWlCj8Ddietw+M4hxdZE3EpsAAHJlBVQVsUyNv830cSetCf/OPrhT0HQ15uZbZwYRXk+szRHpMg==}
 
+  '@rolldown/pluginutils@1.0.1':
+    resolution: {integrity: sha512-2j9bGt5Jh8hj+vPtgzPtl72j0yRxHAyumoo6TNfAjsLB04UtpSvPbPcDcBMxz7n+9CYB0c1GxQFxYRg2jimqGw==}
+
   '@rollup/plugin-commonjs@28.0.1':
     resolution: {integrity: sha512-+tNWdlWKbpB3WgBN7ijjYkq9X5uhjmcvyjEght4NmH5fAU++zfQzAJ6wumLS+dNcvwEZhKx2Z+skY8m7v0wGSA==}
     engines: {node: '>=16.0.0 || 14 >= 14.17'}
@@ -4663,6 +4669,19 @@ packages:
 
   '@videojs/xhr@2.7.0':
     resolution: {integrity: sha512-giab+EVRanChIupZK7gXjHy90y3nncA2phIOyG3Ne5fvpiMJzvqYwiTOnEVW2S4CoYcuKJkomat7bMXA/UoUZQ==}
+
+  '@vitejs/plugin-react@6.0.4':
+    resolution: {integrity: sha512-XcCQz0TBpBgljhj0gMuuDj49i6Ytqh5q1osT/Gp5uAVJUCTWxyskk/l1jwYYiu2xcNHHipdMz40EGfM1VdamVg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    peerDependencies:
+      '@rolldown/plugin-babel': ^0.1.7 || ^0.2.0
+      babel-plugin-react-compiler: ^1.0.0
+      vite: ^6.3.0
+    peerDependenciesMeta:
+      '@rolldown/plugin-babel':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
 
   '@vitest/expect@4.1.9':
     resolution: {integrity: sha512-vl/rYsUKcBr3SnQn166+XR5ZQcgMx3DQhFWdfli/cWpLnLUmbxZvyrJZotLFUryib+LtArYMSTJ5RbQ57ZqrlA==}
@@ -10837,7 +10856,7 @@ snapshots:
   '@jonny/eslint-config@2.1.252(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/eslint-plugin': 4.33.0(@typescript-eslint/parser@4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5))(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/parser': 4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/parser': 4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@5.9.3)
       eslint-config-prettier: 8.10.2(eslint@10.5.0(jiti@1.21.7))
       eslint-config-xo: 0.39.0(eslint@10.5.0(jiti@1.21.7))
       eslint-config-xo-react: 0.25.0(eslint-plugin-react-hooks@4.2.1-alpha-930c9e7ee-20211015(eslint@10.5.0(jiti@1.21.7)))(eslint-plugin-react@7.37.5(eslint@10.5.0(jiti@1.21.7)))(eslint@10.5.0(jiti@1.21.7))
@@ -12732,6 +12751,8 @@ snapshots:
       - react
       - react-dom
 
+  '@rolldown/pluginutils@1.0.1': {}
+
   '@rollup/plugin-commonjs@28.0.1(rollup@4.62.2)':
     dependencies:
       '@rollup/pluginutils': 5.4.0(rollup@4.62.2)
@@ -13822,7 +13843,7 @@ snapshots:
   '@typescript-eslint/eslint-plugin@4.33.0(@typescript-eslint/parser@4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5))(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)':
     dependencies:
       '@typescript-eslint/experimental-utils': 4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)
-      '@typescript-eslint/parser': 4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)
+      '@typescript-eslint/parser': 4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@5.9.3)
       '@typescript-eslint/scope-manager': 4.33.0
       debug: 4.4.3
       eslint: 10.5.0(jiti@1.21.7)
@@ -13865,7 +13886,7 @@ snapshots:
       - supports-color
       - typescript
 
-  '@typescript-eslint/parser@4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@4.9.5)':
+  '@typescript-eslint/parser@4.33.0(eslint@10.5.0(jiti@1.21.7))(typescript@5.9.3)':
     dependencies:
       '@typescript-eslint/scope-manager': 4.33.0
       '@typescript-eslint/types': 4.33.0
@@ -13873,7 +13894,7 @@ snapshots:
       debug: 4.4.3
       eslint: 10.5.0(jiti@1.21.7)
     optionalDependencies:
-      typescript: 4.9.5
+      typescript: 5.9.3
     transitivePeerDependencies:
       - supports-color
 
@@ -14021,6 +14042,11 @@ snapshots:
       '@babel/runtime': 7.29.7
       global: 4.4.0
       is-function: 1.0.2
+
+  '@vitejs/plugin-react@6.0.4(vite@6.4.3(@types/node@25.9.3)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0))':
+    dependencies:
+      '@rolldown/pluginutils': 1.0.1
+      vite: 6.4.3(@types/node@25.9.3)(jiti@1.21.7)(terser@5.48.0)(tsx@4.22.4)(yaml@2.9.0)
 
   '@vitest/expect@4.1.9':
     dependencies:

--- a/tests/unit/devstudio-preview-config.test.ts
+++ b/tests/unit/devstudio-preview-config.test.ts
@@ -41,7 +41,7 @@ describe('resolveDefaultPreviewUrl', () => {
     process.env.NEXT_PUBLIC_ADMIN_URL = '';
     expect(
       resolveDefaultPreviewUrl({ requestHost: 'admin.elevateforhumanity.org' }),
-    ).toBe('/admin/dashboard');
+    ).toBe('https://admin.elevateforhumanity.org/admin/dashboard');
   });
 
   it('respects DEVSTUDIO_DEFAULT_PREVIEW_URL', () => {

--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -1,16 +1,14 @@
 import { defineConfig } from 'vitest/config';
-import react from '@vitejs/plugin-react';
 import path from 'path';
 
 export default defineConfig({
-  plugins: [react()],
-  // tsconfig.json uses "jsx": "preserve" for Next.js, but Vitest/esbuild needs
-  // to transform JSX itself. Override here so all .tsx/.jsx files get the
-  // automatic React 17+ runtime injected without requiring `import React`.
-  esbuild: {
-    jsx: 'automatic',
-  },
   test: {
+    // tsconfig.json uses "jsx": "preserve" for Next.js, but Vitest/esbuild needs
+    // to transform JSX itself. Override here so all .tsx/.jsx files get the
+    // automatic React 17+ runtime injected without requiring `import React`.
+    esbuild: {
+      jsx: 'automatic',
+    },
     environment: 'jsdom',
     globals: true,
     // Only include unit tests in the unit folder


### PR DESCRIPTION
Closed as superseded by current main. The old DevStudioUnifiedClient targeted by this PR has been removed. Current Admin `/studio` is registry-driven through `lib/devstudio/workspace-registry.ts` and the standalone `/studio/*` workspace architecture. Any remaining Studio parity gaps must be fixed against current main, not by restoring the deleted client.