### PR TITLE
Fix LMS login redirect loop and responsive navigation

### DIFF
--- a/apps/lms/app/login/page.tsx
+++ b/apps/lms/app/login/page.tsx
@@ -1,12 +1,129 @@
-// Marketing login redirects to the canonical LMS login
-// The LMS application owns the authentication flow
+'use client';
 
-import { redirect } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import Link from 'next/link';
+import { useRouter } from 'next/navigation';
+import { createClient } from '@/lib/supabase/client';
+import { getRoleDestination } from '@/lib/auth/role-destinations';
+import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
 
-const LMS_LOGIN_URL = process.env.NEXT_PUBLIC_APP_URL 
-  ? `${process.env.NEXT_PUBLIC_APP_URL}/login`
-  : 'https://app.elevateforhumanity.org/login';
+export default function LoginPage() {
+  const router = useRouter();
+  const searchParams = useSafeSearchParams();
+  const requestedRedirect = searchParams.get('next') || searchParams.get('redirect') || '';
+  const safeRedirect = validateRedirect(requestedRedirect, '');
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState('');
+  const [loading, setLoading] = useState(false);
 
-export default function LoginRedirect() {
-  redirect(LMS_LOGIN_URL);
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      const supabase = createClient();
+      const { data, error: signInError } = await supabase.auth.signInWithPassword({
+        email: email.trim(),
+        password,
+      });
+
+      if (signInError) throw signInError;
+      if (!data.user) throw new Error('Authentication completed without a user session.');
+
+      if (safeRedirect) {
+        router.replace(safeRedirect);
+        router.refresh();
+        return;
+      }
+
+      const { data: profile } = await supabase
+        .from('profiles')
+        .select('role, onboarding_completed')
+        .eq('id', data.user.id)
+        .maybeSingle();
+
+      if (!profile) {
+        router.replace('/onboarding/learner');
+      } else if (profile.role === 'employer' && profile.onboarding_completed !== true) {
+        router.replace('/onboarding/employer');
+      } else {
+        router.replace(getRoleDestination(profile.role));
+      }
+      router.refresh();
+    } catch (caughtError) {
+      const message = caughtError instanceof Error ? caughtError.message : 'Invalid email or password.';
+      setError(message);
+      setLoading(false);
+    }
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-12">
+      <section className="mx-auto w-full max-w-md rounded-2xl bg-white p-8 shadow-lg">
+        <div className="mb-8 text-center">
+          <p className="text-sm font-semibold uppercase tracking-wide text-blue-700">Elevate for Humanity</p>
+          <h1 className="mt-2 text-3xl font-bold text-slate-950">Student and Partner Login</h1>
+          <p className="mt-3 text-sm text-slate-600">Access courses, progress, credentials, apprenticeship records, and portal tools.</p>
+        </div>
+
+        {error ? (
+          <div role="alert" className="mb-5 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">
+            {error}
+          </div>
+        ) : null}
+
+        <form onSubmit={handleSubmit} className="space-y-5">
+          <div>
+            <label htmlFor="email" className="mb-2 block text-sm font-semibold text-slate-900">Email address</label>
+            <input
+              id="email"
+              type="email"
+              autoComplete="email"
+              required
+              value={email}
+              onChange={(event) => setEmail(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 px-4 py-3 text-slate-950 outline-none focus:border-blue-600 focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div>
+            <label htmlFor="password" className="mb-2 block text-sm font-semibold text-slate-900">Password</label>
+            <input
+              id="password"
+              type="password"
+              autoComplete="current-password"
+              required
+              value={password}
+              onChange={(event) => setPassword(event.target.value)}
+              className="w-full rounded-lg border border-slate-300 px-4 py-3 text-slate-950 outline-none focus:border-blue-600 focus:ring-2 focus:ring-blue-200"
+            />
+          </div>
+
+          <div className="flex justify-end">
+            <Link href="/reset-password" className="text-sm font-semibold text-blue-700 hover:underline">Forgot password?</Link>
+          </div>
+
+          <button
+            type="submit"
+            disabled={loading}
+            className="w-full rounded-lg bg-blue-700 px-5 py-3 font-bold text-white hover:bg-blue-800 disabled:cursor-not-allowed disabled:bg-slate-400"
+          >
+            {loading ? 'Signing in…' : 'Sign in'}
+          </button>
+        </form>
+
+        <p className="mt-6 text-center text-sm text-slate-600">
+          Need an account?{' '}
+          <Link href="/signup" className="font-semibold text-blue-700 hover:underline">Create one</Link>
+        </p>
+
+        <div className="mt-8 border-t border-slate-200 pt-6 text-center">
+          <a href="https://admin.elevateforhumanity.org/login" className="text-sm font-semibold text-slate-800 hover:underline">Staff and administrator login →</a>
+        </div>
+      </section>
+    </main>
+  );
 }

--- a/components/site/HeaderMainNav.client.tsx
+++ b/components/site/HeaderMainNav.client.tsx
@@ -11,14 +11,10 @@ interface HeaderMainNavProps {
   programApplyLinks?: Record<string, string>;
 }
 
-function getProgramSlugFromHref(href: string): string | null {
-  const match = href.match(/^\/programs\/([^/?#]+)$/);
-  return match ? match[1] : null;
-}
-
 function groupSubItemsByHeader(subItems: NavSubItem[]) {
   const columns: NavSubItem[][] = [];
   let current: NavSubItem[] = [];
+
   for (const sub of subItems) {
     if (sub.isHeader && current.length > 0) {
       columns.push(current);
@@ -27,6 +23,7 @@ function groupSubItemsByHeader(subItems: NavSubItem[]) {
       current.push(sub);
     }
   }
+
   if (current.length > 0) columns.push(current);
   return columns;
 }
@@ -50,14 +47,16 @@ function DropdownLinks({
       return (
         <p
           key={sub.name}
-          className="text-[11px] font-extrabold uppercase tracking-wide text-brand-red-600 px-2 pt-3 pb-1 first:pt-0"
+          className="px-2 pt-3 pb-1 first:pt-0 text-[11px] font-extrabold uppercase tracking-wide text-brand-red-600"
         >
           {sub.name.replace(/—/g, '').trim()}
         </p>
       );
     }
+
+    if (!sub.href) return null;
+
     if (sub.isSectionLink) {
-      if (!sub.href) return null;
       return (
         <Link
           key={sub.name + sub.href}
@@ -65,13 +64,13 @@ function DropdownLinks({
           prefetch={false}
           onClick={onNavigate}
           {...(isExternal(sub.href) ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-          className="block text-xs font-bold text-brand-red-600 hover:text-brand-red-700 px-2 py-1"
+          className="block px-2 py-1 text-xs font-bold text-brand-red-600 hover:text-brand-red-700"
         >
           {sub.name}
         </Link>
       );
     }
-    if (!sub.href) return null;
+
     return (
       <Link
         key={sub.name + sub.href}
@@ -79,7 +78,7 @@ function DropdownLinks({
         prefetch={false}
         onClick={onNavigate}
         {...(isExternal(sub.href) ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
-        className="block text-sm text-slate-700 hover:text-brand-blue-600 hover:bg-slate-50 rounded-lg px-2 py-1.5"
+        className="block rounded-lg px-2 py-1.5 text-sm text-slate-700 hover:bg-slate-50 hover:text-brand-blue-600"
       >
         {sub.name}
       </Link>
@@ -87,14 +86,18 @@ function DropdownLinks({
   };
 
   if (columns.length <= 1) {
-    return <div className="flex flex-col min-w-[200px] max-w-[280px]">{item.subItems.map(renderLink)}</div>;
+    return (
+      <div className="flex min-w-[220px] max-w-[300px] flex-col">
+        {item.subItems.map(renderLink)}
+      </div>
+    );
   }
 
   return (
-    <div className="flex gap-5 max-w-[min(90vw,720px)]">
-      {columns.map((col, ci) => (
-        <div key={ci} className="flex flex-col min-w-[160px]">
-          {col.map(renderLink)}
+    <div className="grid max-w-[min(92vw,900px)] grid-cols-2 gap-5 xl:grid-cols-3">
+      {columns.map((column, index) => (
+        <div key={index} className="flex min-w-[180px] flex-col">
+          {column.map(renderLink)}
         </div>
       ))}
     </div>
@@ -115,7 +118,7 @@ function HorizontalNavItem({
       <Link
         href={item.href}
         prefetch={false}
-        className="text-slate-700 hover:text-brand-blue-600 font-medium text-[13px] px-2.5 py-1.5 rounded-md hover:bg-slate-50 whitespace-nowrap shrink-0"
+        className="shrink-0 whitespace-nowrap rounded-md px-2.5 py-1.5 text-[13px] font-medium text-slate-700 hover:bg-slate-50 hover:text-brand-blue-600"
       >
         {item.name}
       </Link>
@@ -123,35 +126,41 @@ function HorizontalNavItem({
   }
 
   return (
-    <div className="relative group shrink-0">
+    <div className="group relative shrink-0">
       {item.href ? (
         <Link
           href={item.href}
           prefetch={false}
-          className="inline-flex items-center gap-0.5 text-slate-700 hover:text-brand-blue-600 font-medium text-[13px] px-2.5 py-1.5 rounded-md hover:bg-slate-50"
+          className="inline-flex items-center gap-0.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-slate-700 hover:bg-slate-50 hover:text-brand-blue-600"
           aria-haspopup="true"
         >
           {item.name}
-          <ChevronDown className="w-3.5 h-3.5 opacity-60 group-hover:rotate-180 transition-transform" aria-hidden />
+          <ChevronDown
+            className="h-3.5 w-3.5 opacity-60 transition-transform group-hover:rotate-180"
+            aria-hidden
+          />
         </Link>
       ) : (
         <button
           type="button"
-          className="inline-flex items-center gap-0.5 text-slate-700 hover:text-brand-blue-600 font-medium text-[13px] px-2.5 py-1.5 rounded-md hover:bg-slate-50"
+          className="inline-flex items-center gap-0.5 rounded-md px-2.5 py-1.5 text-[13px] font-medium text-slate-700 hover:bg-slate-50 hover:text-brand-blue-600"
           aria-haspopup="true"
         >
           {item.name}
-          <ChevronDown className="w-3.5 h-3.5 opacity-60 group-hover:rotate-180 transition-transform" aria-hidden />
+          <ChevronDown
+            className="h-3.5 w-3.5 opacity-60 transition-transform group-hover:rotate-180"
+            aria-hidden
+          />
         </button>
       )}
 
-      <div className="absolute top-full left-0 pt-1 opacity-0 invisible pointer-events-none group-hover:opacity-100 group-hover:visible group-hover:pointer-events-auto group-focus-within:opacity-100 group-focus-within:visible group-focus-within:pointer-events-auto transition-all duration-150 z-[10001]">
-        <div className="bg-white rounded-xl shadow-xl border border-slate-200 p-4">
+      <div className="pointer-events-none invisible absolute left-0 top-full z-[10001] pt-2 opacity-0 transition-all duration-150 group-hover:pointer-events-auto group-hover:visible group-hover:opacity-100 group-focus-within:pointer-events-auto group-focus-within:visible group-focus-within:opacity-100">
+        <div className="rounded-xl border border-slate-200 bg-white p-4 shadow-xl">
           {item.href && (
             <Link
               href={item.href}
               prefetch={false}
-              className="text-xs font-bold text-brand-red-600 hover:text-brand-red-700 block mb-2 px-2"
+              className="mb-2 block px-2 text-xs font-bold text-brand-red-600 hover:text-brand-red-700"
             >
               View all {item.name} →
             </Link>
@@ -163,7 +172,10 @@ function HorizontalNavItem({
   );
 }
 
-export default function HeaderMainNav({ items, programApplyLinks = {} }: HeaderMainNavProps) {
+export default function HeaderMainNav({
+  items,
+  programApplyLinks = {},
+}: HeaderMainNavProps) {
   const [mobileOpen, setMobileOpen] = useState(false);
   const [expanded, setExpanded] = useState<string | null>(null);
   const pathname = usePathname();
@@ -182,11 +194,15 @@ export default function HeaderMainNav({ items, programApplyLinks = {} }: HeaderM
       document.body.style.overflow = '';
       return;
     }
+
     document.body.style.overflow = 'hidden';
-    const onEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') closeMobile();
+
+    const onEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMobile();
     };
+
     document.addEventListener('keydown', onEscape);
+
     return () => {
       document.body.style.overflow = '';
       document.removeEventListener('keydown', onEscape);
@@ -195,68 +211,83 @@ export default function HeaderMainNav({ items, programApplyLinks = {} }: HeaderM
 
   return (
     <>
-      {/* Tablet / desktop / iPad — horizontal main menu + hover dropdowns */}
+      {/* Desktop: true horizontal navigation with visible dropdown overflow. */}
       <nav
-        className="hidden md:flex flex-1 items-center justify-center gap-0 min-w-0 overflow-x-auto px-1"
+        className="hidden min-w-0 flex-1 items-center justify-center gap-0 overflow-visible px-1 lg:flex"
         aria-label="Main navigation"
       >
         {items.map((item) => (
-          <HorizontalNavItem key={item.id} item={item} programApplyLinks={programApplyLinks} />
+          <HorizontalNavItem
+            key={item.id}
+            item={item}
+            programApplyLinks={programApplyLinks}
+          />
         ))}
       </nav>
 
-      {/* Mobile — hamburger + vertical accordion */}
-      <div className="md:hidden flex items-center">
+      {/* Phone and tablet: hamburger menu. */}
+      <div className="flex items-center lg:hidden">
         <button
           type="button"
-          onClick={() => setMobileOpen(!mobileOpen)}
-          className="flex items-center justify-center min-h-[44px] min-w-[44px] rounded-lg text-slate-700 hover:bg-slate-50"
+          onClick={() => setMobileOpen((open) => !open)}
+          className="flex min-h-[44px] min-w-[44px] items-center justify-center rounded-lg text-slate-700 hover:bg-slate-50"
           aria-label={mobileOpen ? 'Close menu' : 'Open menu'}
           aria-expanded={mobileOpen}
           aria-controls="mobile-main-nav"
         >
-          {mobileOpen ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          {mobileOpen ? <X className="h-6 w-6" /> : <Menu className="h-6 w-6" />}
         </button>
       </div>
 
       {mobileOpen && (
-        <div className="md:hidden fixed inset-0 top-[60px] z-[10000] bg-black/40" onClick={closeMobile} aria-hidden />
+        <div
+          className="fixed inset-0 top-[60px] z-[10000] bg-black/40 lg:hidden"
+          onClick={closeMobile}
+          aria-hidden
+        />
       )}
 
       {mobileOpen && (
         <div
           id="mobile-main-nav"
-          className="md:hidden fixed top-[60px] left-0 right-0 bottom-0 z-[10001] bg-white overflow-y-auto"
+          className="fixed bottom-0 left-0 right-0 top-[60px] z-[10001] overflow-y-auto overscroll-contain bg-white lg:hidden"
           role="dialog"
           aria-modal="true"
           aria-label="Main navigation"
         >
-          <nav className="flex flex-col p-4 max-w-lg mx-auto w-full" aria-label="Mobile navigation">
+          <nav
+            className="mx-auto flex w-full max-w-lg flex-col p-4 pb-[calc(1rem+env(safe-area-inset-bottom))]"
+            aria-label="Mobile navigation"
+          >
             {items.map((item) => (
               <div key={item.id} className="border-b border-slate-100">
                 {item.subItems?.length ? (
                   <>
                     <button
                       type="button"
-                      onClick={() => setExpanded(expanded === item.id ? null : item.id)}
-                      className="flex items-center justify-between w-full py-4 text-left font-semibold text-slate-900 min-h-[48px]"
+                      onClick={() =>
+                        setExpanded(expanded === item.id ? null : item.id)
+                      }
+                      className="flex min-h-[48px] w-full items-center justify-between py-4 text-left font-semibold text-slate-900"
                       aria-expanded={expanded === item.id}
                     >
                       <span>{item.name}</span>
                       <ChevronDown
-                        className={`w-5 h-5 text-slate-400 transition-transform ${
+                        className={`h-5 w-5 text-slate-400 transition-transform ${
                           expanded === item.id ? 'rotate-180' : ''
                         }`}
+                        aria-hidden
                       />
                     </button>
+
                     {expanded === item.id && (
-                      <div className="pb-4 pl-2 border-l-2 border-brand-red-200 ml-2">
+                      <div className="ml-2 border-l-2 border-brand-red-200 pb-4 pl-3">
                         {item.href && (
                           <Link
                             href={item.href}
                             prefetch={false}
                             onClick={closeMobile}
-                            className="block text-sm font-bold text-brand-red-600 mb-3"
+                            className="mb-3 block text-sm font-bold text-brand-red-600"
                           >
                             View all {item.name} →
                           </Link>
@@ -275,7 +306,7 @@ export default function HeaderMainNav({ items, programApplyLinks = {} }: HeaderM
                       href={item.href}
                       prefetch={false}
                       onClick={closeMobile}
-                      className="flex items-center py-4 font-semibold text-slate-900 min-h-[48px]"
+                      className="flex min-h-[48px] items-center py-4 font-semibold text-slate-900"
                     >
                       {item.name}
                     </Link>
@@ -283,25 +314,26 @@ export default function HeaderMainNav({ items, programApplyLinks = {} }: HeaderM
                 )}
               </div>
             ))}
+
             <div className="mt-6 flex flex-col gap-3">
               <Link
                 href="/login"
                 onClick={closeMobile}
-                className="w-full text-center py-3.5 border border-slate-200 rounded-xl font-semibold"
+                className="w-full rounded-xl border border-slate-200 py-3.5 text-center font-semibold"
               >
                 Sign In
               </Link>
               <Link
                 href="/for-students"
                 onClick={closeMobile}
-                className="w-full text-center py-3.5 bg-brand-red-600 text-white rounded-xl font-semibold"
+                className="w-full rounded-xl bg-brand-red-600 py-3.5 text-center font-semibold text-white"
               >
                 Get Started
               </Link>
               <Link
                 href="/apply"
                 onClick={closeMobile}
-                className="w-full text-center py-3.5 bg-slate-900 text-white rounded-xl font-semibold"
+                className="w-full rounded-xl bg-slate-900 py-3.5 text-center font-semibold text-white"
               >
                 Apply
               </Link>


### PR DESCRIPTION
## What changed

Combines fixes from:
- **#526**: Fix LMS login redirect loop (`apps/lms/app/login/page.tsx`)
- **#527**: Fix responsive desktop and mobile navigation (`components/site/HeaderMainNav.client.tsx`)

This PR was created by merging the changes from both PRs into a single branch.

---

_This PR was created by an AI agent (OpenHands) on behalf of Elizabeth Greene._

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix LMS login redirect loop and update responsive navigation breakpoints
> - Replaces the redirect-only `/login` page with a client-side form in [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/529/files#diff-296cd460eda52582924b7896e5ee00d9e4b33d62a21af14d7951f8f5e29953db) that authenticates via Supabase email/password, validates redirect params, and routes users based on their profile role and onboarding status.
> - Shifts the desktop nav breakpoint from `md` to `lg` in [HeaderMainNav.client.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/529/files#diff-1717a8b8d36c4ce9e84f628dc85e6e8064446e3e64f96aeb8216528cd01d234e), so the hamburger menu and mobile overlay now apply up to `lg` screens.
> - Dropdown menus switch from a fixed-width flex layout to a responsive `grid-cols-2`/`xl:grid-cols-3` grid, and items without an `href` are suppressed.
> - Mobile nav panel gains `overscroll-contain` and `env(safe-area-inset-bottom)` padding for better mobile UX.
> - Behavioral Change: the login page no longer redirects on load; users must submit credentials before navigation occurs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 86260b6.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- macroscope-ui-refresh -->
<!-- Macroscope's pull request summary ends here -->