### PR TITLE
Consolidate Elevate into one unified platform

### DIFF
--- a/.github/workflows/consolidation-docker-northflank.yml
+++ b/.github/workflows/consolidation-docker-northflank.yml
@@ -9,7 +9,11 @@ on:
       - main
     paths:
       - 'Dockerfile'
+      - 'Dockerfile.admin'
+      - 'Dockerfile.lms'
       - 'apps/marketing/**'
+      - 'apps/admin/**'
+      - 'apps/lms/**'
       - 'packages/**'
       - 'package.json'
       - 'pnpm-lock.yaml'
@@ -25,9 +29,22 @@ concurrency:
 
 jobs:
   docker-northflank:
-    name: Docker / Northflank compatibility
+    name: ${{ matrix.service }} Docker / Northflank
     runs-on: ubuntu-latest
-    timeout-minutes: 30
+    timeout-minutes: 45
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - service: marketing
+            dockerfile: Dockerfile
+            default_port: 8080
+          - service: lms
+            dockerfile: Dockerfile.lms
+            default_port: 3000
+          - service: admin
+            dockerfile: Dockerfile.admin
+            default_port: 3000
     env:
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
       NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
@@ -48,54 +65,68 @@ jobs:
         run: |
           set -euo pipefail
           docker build \
+            -f "${{ matrix.dockerfile }}" \
             --build-arg NEXT_PUBLIC_SITE_URL=https://www.elevateforhumanity.org \
             --build-arg NEXT_PUBLIC_APP_URL=https://app.elevateforhumanity.org \
             --build-arg NEXT_PUBLIC_ADMIN_URL=https://admin.elevateforhumanity.org \
             --build-arg NEXT_PUBLIC_SUPABASE_URL="${NEXT_PUBLIC_SUPABASE_URL}" \
             --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
             --build-arg GITHUB_SHA="${GITHUB_SHA}" \
+            --build-arg GIT_SHA="${GITHUB_SHA}" \
+            --build-arg NEXT_PUBLIC_GIT_SHA="${GITHUB_SHA}" \
             --build-arg BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
-            -t elevate-consolidation:${GITHUB_SHA} .
+            -t "elevate-${{ matrix.service }}:${GITHUB_SHA}" .
 
-      - name: Verify default container port
+      - name: Verify default service port
         shell: bash
         run: |
           set -euo pipefail
-          container_id=$(docker run -d \
-            --name elevate-default-port \
-            -e PORT=8080 \
-            -p 8080:8080 \
-            elevate-consolidation:${GITHUB_SHA})
-          trap 'docker logs elevate-default-port || true; docker rm -f elevate-default-port || true' EXIT
+          name="elevate-${{ matrix.service }}-default"
+          port="${{ matrix.default_port }}"
+          docker run -d \
+            --name "$name" \
+            -e PORT="$port" \
+            -e NEXT_PUBLIC_SUPABASE_URL="${NEXT_PUBLIC_SUPABASE_URL}" \
+            -e NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
+            -p "$port:$port" \
+            "elevate-${{ matrix.service }}:${GITHUB_SHA}"
+          trap 'docker logs "$name" || true; docker rm -f "$name" || true' EXIT
           for attempt in $(seq 1 24); do
-            if curl --fail --silent --show-error http://127.0.0.1:8080/api/version >/tmp/version.json; then
+            if curl --fail --silent --show-error "http://127.0.0.1:${port}/api/version" >/tmp/version.json; then
               cat /tmp/version.json
+              docker rm -f "$name" >/dev/null
+              trap - EXIT
               exit 0
             fi
             sleep 5
           done
-          echo 'Container did not become healthy on PORT=8080'
-          docker logs "${container_id}"
+          echo "${{ matrix.service }} did not become healthy on PORT=${port}"
+          docker logs "$name"
           exit 1
 
       - name: Verify Northflank-style injected port
         shell: bash
         run: |
           set -euo pipefail
-          docker rm -f elevate-default-port >/dev/null 2>&1 || true
-          container_id=$(docker run -d \
-            --name elevate-injected-port \
-            -e PORT=8090 \
-            -p 8090:8090 \
-            elevate-consolidation:${GITHUB_SHA})
-          trap 'docker logs elevate-injected-port || true; docker rm -f elevate-injected-port || true' EXIT
+          name="elevate-${{ matrix.service }}-injected"
+          port=8090
+          docker run -d \
+            --name "$name" \
+            -e PORT="$port" \
+            -e NEXT_PUBLIC_SUPABASE_URL="${NEXT_PUBLIC_SUPABASE_URL}" \
+            -e NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
+            -p "$port:$port" \
+            "elevate-${{ matrix.service }}:${GITHUB_SHA}"
+          trap 'docker logs "$name" || true; docker rm -f "$name" || true' EXIT
           for attempt in $(seq 1 24); do
-            if curl --fail --silent --show-error http://127.0.0.1:8090/api/version >/tmp/version-8090.json; then
-              cat /tmp/version-8090.json
+            if curl --fail --silent --show-error "http://127.0.0.1:${port}/api/version" >/tmp/version-injected.json; then
+              cat /tmp/version-injected.json
+              docker rm -f "$name" >/dev/null
+              trap - EXIT
               exit 0
             fi
             sleep 5
           done
-          echo 'Container did not honor injected PORT=8090'
-          docker logs "${container_id}"
+          echo "${{ matrix.service }} did not honor injected PORT=${port}"
+          docker logs "$name"
           exit 1

--- a/.github/workflows/consolidation-docker-northflank.yml
+++ b/.github/workflows/consolidation-docker-northflank.yml
@@ -1,0 +1,101 @@
+name: Consolidation Docker + Northflank Gate
+
+on:
+  push:
+    branches:
+      - consolidation/unified-platform
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'Dockerfile'
+      - 'apps/marketing/**'
+      - 'packages/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/consolidation-docker-northflank.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consolidation-docker-northflank-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  docker-northflank:
+    name: Docker / Northflank compatibility
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    env:
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Validate required build configuration
+        shell: bash
+        run: |
+          set -euo pipefail
+          test -n "${NEXT_PUBLIC_SUPABASE_URL}" || { echo 'NEXT_PUBLIC_SUPABASE_URL is not configured'; exit 1; }
+          test -n "${NEXT_PUBLIC_SUPABASE_ANON_KEY}" || { echo 'NEXT_PUBLIC_SUPABASE_ANON_KEY is not configured'; exit 1; }
+
+      - name: Build production container
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker build \
+            --build-arg NEXT_PUBLIC_SITE_URL=https://www.elevateforhumanity.org \
+            --build-arg NEXT_PUBLIC_APP_URL=https://app.elevateforhumanity.org \
+            --build-arg NEXT_PUBLIC_ADMIN_URL=https://admin.elevateforhumanity.org \
+            --build-arg NEXT_PUBLIC_SUPABASE_URL="${NEXT_PUBLIC_SUPABASE_URL}" \
+            --build-arg NEXT_PUBLIC_SUPABASE_ANON_KEY="${NEXT_PUBLIC_SUPABASE_ANON_KEY}" \
+            --build-arg GITHUB_SHA="${GITHUB_SHA}" \
+            --build-arg BUILD_TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)" \
+            -t elevate-consolidation:${GITHUB_SHA} .
+
+      - name: Verify default container port
+        shell: bash
+        run: |
+          set -euo pipefail
+          container_id=$(docker run -d \
+            --name elevate-default-port \
+            -e PORT=8080 \
+            -p 8080:8080 \
+            elevate-consolidation:${GITHUB_SHA})
+          trap 'docker logs elevate-default-port || true; docker rm -f elevate-default-port || true' EXIT
+          for attempt in $(seq 1 24); do
+            if curl --fail --silent --show-error http://127.0.0.1:8080/api/version >/tmp/version.json; then
+              cat /tmp/version.json
+              exit 0
+            fi
+            sleep 5
+          done
+          echo 'Container did not become healthy on PORT=8080'
+          docker logs "${container_id}"
+          exit 1
+
+      - name: Verify Northflank-style injected port
+        shell: bash
+        run: |
+          set -euo pipefail
+          docker rm -f elevate-default-port >/dev/null 2>&1 || true
+          container_id=$(docker run -d \
+            --name elevate-injected-port \
+            -e PORT=8090 \
+            -p 8090:8090 \
+            elevate-consolidation:${GITHUB_SHA})
+          trap 'docker logs elevate-injected-port || true; docker rm -f elevate-injected-port || true' EXIT
+          for attempt in $(seq 1 24); do
+            if curl --fail --silent --show-error http://127.0.0.1:8090/api/version >/tmp/version-8090.json; then
+              cat /tmp/version-8090.json
+              exit 0
+            fi
+            sleep 5
+          done
+          echo 'Container did not honor injected PORT=8090'
+          docker logs "${container_id}"
+          exit 1

--- a/.github/workflows/consolidation-gate.yml
+++ b/.github/workflows/consolidation-gate.yml
@@ -1,0 +1,78 @@
+name: Unified Platform Consolidation Gate
+
+on:
+  pull_request:
+    branches:
+      - main
+    paths:
+      - 'apps/**'
+      - 'components/**'
+      - 'lib/**'
+      - 'packages/**'
+      - 'supabase/**'
+      - 'consolidation/**'
+      - 'scripts/**'
+      - 'package.json'
+      - 'pnpm-lock.yaml'
+      - 'pnpm-workspace.yaml'
+      - '.github/workflows/consolidation-gate.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: consolidation-gate-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  static-safety:
+    if: github.event_name == 'workflow_dispatch' || github.head_ref == 'consolidation/unified-platform'
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '20.11.1'
+          cache: 'pnpm'
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Validate consolidation manifests
+        run: |
+          node -e "JSON.parse(require('fs').readFileSync('consolidation/feature-preservation.json','utf8')); JSON.parse(require('fs').readFileSync('consolidation/supervisor-tasks.json','utf8')); console.log('Consolidation manifests valid')"
+
+      - name: Typecheck
+        run: pnpm typecheck
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Guard client/server boundaries
+        run: |
+          if [ -f scripts/check-client-node-globals.mjs ]; then
+            node scripts/check-client-node-globals.mjs
+          fi
+
+      - name: Redirect conflict check
+        run: |
+          if [ -f scripts/check-redirect-conflicts.mjs ]; then
+            node scripts/check-redirect-conflicts.mjs
+          fi
+
+      - name: Confirm protected consolidation policy
+        run: |
+          test "${GITHUB_HEAD_REF:-${GITHUB_REF_NAME}}" = "consolidation/unified-platform" || {
+            echo "This gate is intended for the consolidation branch only";
+            exit 1;
+          }
+          echo "Static consolidation safety gate passed"

--- a/.github/workflows/consolidation-gate.yml
+++ b/.github/workflows/consolidation-gate.yml
@@ -51,6 +51,9 @@ jobs:
         run: |
           node -e "JSON.parse(require('fs').readFileSync('consolidation/feature-preservation.json','utf8')); JSON.parse(require('fs').readFileSync('consolidation/supervisor-tasks.json','utf8')); console.log('Consolidation manifests valid')"
 
+      - name: Guard navigation service URLs
+        run: node scripts/check-navigation-hardcoding.mjs
+
       - name: Typecheck
         run: pnpm typecheck
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,7 @@ ARG NEXT_PUBLIC_ADMIN_URL=https://admin.elevateforhumanity.org
 ARG NEXT_PUBLIC_SUPABASE_URL
 ARG NEXT_PUBLIC_SUPABASE_ANON_KEY
 ARG GITHUB_SHA=unknown
+ARG BUILD_TIMESTAMP=unknown
 
 ENV NEXT_PUBLIC_SITE_URL=$NEXT_PUBLIC_SITE_URL
 ENV NEXT_PUBLIC_APP_URL=$NEXT_PUBLIC_APP_URL
@@ -42,6 +43,7 @@ ENV GITHUB_SHA=$GITHUB_SHA
 ENV NEXT_PUBLIC_GIT_SHA=$GITHUB_SHA
 ENV NEXT_PUBLIC_BUILD_ID=$GITHUB_SHA
 ENV BUILD_ID=$GITHUB_SHA
+ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 
 RUN pnpm --filter @elevate/marketing build
 
@@ -75,7 +77,8 @@ COPY --from=builder /app/apps/marketing/public ./apps/marketing/public
 
 EXPOSE 8080
 
+# Runtime-port-aware health check for Northflank and other container platforms.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-  CMD curl -fsS http://127.0.0.1:8080/api/version || exit 1
+  CMD-SHELL curl -fsS "http://127.0.0.1:${PORT:-8080}/api/version" || exit 1
 
 CMD ["node", "--max-http-header-size=32768", "apps/marketing/server.js"]

--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -33,11 +33,9 @@ ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY --from=dependencies /app/apps/admin/node_modules ./apps/admin/node_modules
-
 COPY . .
 
 RUN pnpm --filter @elevate/admin build
-
 RUN test -d /app/apps/admin/.next
 RUN test -f /app/apps/admin/.next/BUILD_ID
 
@@ -45,7 +43,6 @@ FROM node:22-alpine AS runner
 
 WORKDIR /app
 
-# Pass build identity from builder stage into the runtime container.
 ARG GITHUB_SHA=unknown
 ARG GIT_SHA=unknown
 ARG NEXT_PUBLIC_GIT_SHA=unknown
@@ -60,7 +57,8 @@ ENV GIT_SHA=$GIT_SHA
 ENV NEXT_PUBLIC_GIT_SHA=$NEXT_PUBLIC_GIT_SHA
 ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 
-RUN addgroup -g 1001 nodejs \
+RUN apk add --no-cache curl \
+    && addgroup -g 1001 nodejs \
     && adduser -S -u 1001 -G nodejs nextjs
 
 COPY --from=builder --chown=nextjs:nodejs /app/apps/admin/.next/standalone ./
@@ -80,5 +78,8 @@ RUN if [ -f /app/apps/admin/server.js ]; then \
 USER nextjs
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+  CMD-SHELL curl -fsS "http://127.0.0.1:${PORT:-3000}/api/version" || exit 1
 
 CMD ["node", "--max-old-space-size=4096", "server.js"]

--- a/Dockerfile.lms
+++ b/Dockerfile.lms
@@ -33,11 +33,9 @@ ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 
 COPY --from=dependencies /app/node_modules ./node_modules
 COPY --from=dependencies /app/apps/lms/node_modules ./apps/lms/node_modules
-
 COPY . .
 
 RUN pnpm --filter @elevate/lms build
-
 RUN test -d /app/apps/lms/.next
 RUN test -f /app/apps/lms/.next/BUILD_ID
 
@@ -45,27 +43,32 @@ FROM node:22-alpine AS runner
 
 WORKDIR /app
 
+ARG GITHUB_SHA=unknown
+ARG GIT_SHA=unknown
+ARG NEXT_PUBLIC_GIT_SHA=unknown
+ARG BUILD_TIMESTAMP=unknown
+
 ENV NODE_ENV=production
 ENV NEXT_TELEMETRY_DISABLED=1
 ENV PORT=3000
 ENV HOSTNAME=0.0.0.0
+ENV GITHUB_SHA=$GITHUB_SHA
+ENV GIT_SHA=$GIT_SHA
+ENV NEXT_PUBLIC_GIT_SHA=$NEXT_PUBLIC_GIT_SHA
+ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 
-RUN addgroup -g 1001 nodejs \
+RUN apk add --no-cache curl \
+    && addgroup -g 1001 nodejs \
     && adduser -S -u 1001 -G nodejs nextjs
 
-# Copy standalone output - this includes the server and required files
-# The standalone output from Next.js already contains: server.js, .next/, public/
-# DO NOT overwrite these with additional copies
 COPY --from=builder --chown=nextjs:nodejs /app/apps/lms/.next/standalone ./
-
-# Copy node_modules for the server to work - need next from builder stage
-COPY --from=builder /app/node_modules ./node_modules
-COPY --from=builder /app/apps/lms/node_modules ./apps/lms/node_modules
+COPY --from=builder --chown=nextjs:nodejs /app/apps/lms/.next/static ./apps/lms/.next/static
+COPY --from=builder --chown=nextjs:nodejs /app/apps/lms/public ./apps/lms/public
 
 RUN if [ -f "./apps/lms/server.js" ]; then \
-      echo "Found server.js at ./apps/lms/server.js"; \
-    elif [ -f "./standalone/apps/lms/server.js" ]; then \
-      echo "Found server.js at ./standalone/apps/lms/server.js"; \
+      true; \
+    elif [ -f "./server.js" ]; then \
+      true; \
     else \
       echo "ERROR: No runnable server.js in runtime image"; \
       find /app -maxdepth 5 -name "server.js" -print; \
@@ -75,5 +78,8 @@ RUN if [ -f "./apps/lms/server.js" ]; then \
 USER nextjs
 
 EXPOSE 3000
+
+HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
+  CMD-SHELL curl -fsS "http://127.0.0.1:${PORT:-3000}/api/version" || exit 1
 
 CMD ["node", "--max-old-space-size=4096", "--max-http-header-size=32768", "apps/lms/server.js"]

--- a/apps/lms/app/ai/dev-studio/page.tsx
+++ b/apps/lms/app/ai/dev-studio/page.tsx
@@ -1,168 +1,24 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import { Settings, GitBranch, Container, Zap, BarChart3, Shield, Code2, Rocket, Layers } from 'lucide-react';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
+
+import { siteUrls } from '@/lib/utils/site-urls';
 
 export const metadata: Metadata = {
-  title: 'Dev Studio | AI-Powered Development Platform',
-  description: 'Enterprise-grade development environment for managing AI workflows, deployments, integrations, and operations. Built for workforce technology teams.',
+  title: 'Dev Studio | Elevate for Humanity',
+  description: 'AI-powered development environment for the Elevate platform.',
+  robots: { index: false, follow: true },
 };
 
-const features = [
-  {
-    icon: Container,
-    title: 'Container Management',
-    description: 'Deploy and manage Docker containers with Northflank integration. Monitor health, scale resources, and manage configurations.',
-  },
-  {
-    icon: GitBranch,
-    title: 'Git Integration',
-    description: 'Connect GitHub repositories, trigger builds on push, manage branches and deployments from a unified interface.',
-  },
-  {
-    icon: Rocket,
-    title: 'One-Click Deployments',
-    description: 'Deploy marketing, admin, and LMS applications with single clicks. Track deployment status and rollback history.',
-  },
-  {
-    icon: Zap,
-    title: 'AI Workflow Automation',
-    description: 'Orchestrate AI agents, prompts, and memory systems. Build complex workflows with visual tools.',
-  },
-  {
-    icon: BarChart3,
-    title: 'Real-Time Monitoring',
-    description: 'Track build logs, container health, API performance, and system metrics in real-time.',
-  },
-  {
-    icon: Shield,
-    title: 'Secrets Management',
-    description: 'Securely store and manage API keys, tokens, and environment variables. Never expose credentials.',
-  },
-];
-
-const capabilities = [
-  'Northflank container orchestration',
-  'GitHub Actions integration',
-  'Multi-environment deployments',
-  'Build log streaming',
-  'Health check monitoring',
-  'Environment variable management',
-  'AI agent orchestration',
-  'Workflow designer',
-];
-
-export default function DevStudioPage() {
-  return (
-    <div className="min-h-screen">
-      {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white">
-        <div className="absolute inset-0 opacity-20">
-          <div className="absolute top-0 right-1/4 w-96 h-96 bg-blue-500 rounded-full filter blur-3xl"></div>
-          <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-purple-500 rounded-full filter blur-3xl"></div>
-        </div>
-        <div className="relative max-w-7xl mx-auto px-4 py-24">
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500/20 border border-blue-400/30 rounded-full text-sm mb-6">
-              <Code2 className="w-4 h-4" />
-              Enterprise Development Platform
-            </div>
-            <h1 className="text-5xl md:text-6xl font-bold mb-6">
-              Dev Studio
-            </h1>
-            <p className="text-xl text-slate-300 mb-8">
-              AI-powered development environment for workforce technology teams. Manage containers, 
-              deployments, AI workflows, and system operations from a unified platform.
-            </p>
-            <div className="flex flex-wrap gap-4">
-              <Link href="/admin/studio" className="px-8 py-4 bg-blue-600 rounded-lg font-semibold hover:bg-blue-500 transition">
-                Access Dev Studio
-              </Link>
-              <Link href="/contact" className="px-8 py-4 bg-white/10 border border-white/30 rounded-lg font-semibold hover:bg-white/20 transition">
-                Schedule Demo
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold mb-4">Enterprise Development Tools</h2>
-            <p className="text-slate-600 max-w-2xl mx-auto">
-              Everything your development team needs to build, deploy, and manage workforce technology.
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature) => {
-              const Icon = feature.icon;
-              return (
-                <div key={feature.title} className="group p-6 bg-slate-50 rounded-xl border border-slate-200 hover:border-blue-200 hover:shadow-lg transition-all">
-                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4 group-hover:bg-blue-200 transition-colors">
-                    <Icon className="w-6 h-6 text-blue-600" />
-                  </div>
-                  <h3 className="text-lg font-bold mb-2">{feature.title}</h3>
-                  <p className="text-slate-600 text-sm">{feature.description}</p>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-
-      {/* Capabilities */}
-      <section className="py-20 bg-slate-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <h2 className="text-3xl font-bold mb-6">Complete Development Suite</h2>
-              <p className="text-slate-600 mb-8">
-                Dev Studio provides your team with professional-grade tools for managing the entire 
-                development lifecycle—from code to production.
-              </p>
-              <div className="grid grid-cols-2 gap-4">
-                {capabilities.map((cap) => (
-                  <div key={cap} className="flex items-center gap-3">
-                    <div className="w-6 h-6 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0">
-                      <Layers className="w-3 h-3 text-green-600" />
-                    </div>
-                    <span className="text-sm text-slate-700">{cap}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="bg-slate-900 rounded-2xl p-6 font-mono text-sm">
-              <div className="text-slate-500 mb-2">// Deploy with one click</div>
-              <div className="text-green-400">$ elevate deploy --env production</div>
-              <div className="text-slate-400 mt-4">Building marketing...</div>
-              <div className="text-slate-400">Building admin...</div>
-              <div className="text-slate-400">Building lms...</div>
-              <div className="text-green-400 mt-4">✓ Deployed to Northflank</div>
-              <div className="text-blue-400 mt-2">https://elevate.work</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="py-20 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold mb-4">Ready to Accelerate Development?</h2>
-          <p className="text-xl text-blue-100 mb-8">
-            Give your team the development platform they deserve.
-          </p>
-          <div className="flex flex-wrap gap-4 justify-center">
-            <Link href="/admin/studio" className="px-8 py-4 bg-white text-blue-600 rounded-lg font-semibold hover:bg-blue-50 transition">
-              Access Dev Studio
-            </Link>
-            <Link href="/platform/enterprise" className="px-8 py-4 border-2 border-white text-white rounded-lg font-semibold hover:bg-white/10 transition">
-              Enterprise Solutions
-            </Link>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
+/**
+ * The LMS does not own Dev Studio.
+ *
+ * Canonical ownership:
+ * - Public/product information: Marketing app `/dev-studio`
+ * - Operational Dev Studio: Admin app `/admin/studio`
+ *
+ * Keep this compatibility route so existing LMS links/bookmarks continue to work
+ * while eliminating the duplicate Dev Studio implementation from the LMS bundle.
+ */
+export default function DevStudioCompatibilityRoute() {
+  redirect(`${siteUrls.site}/dev-studio`);
 }

--- a/apps/lms/app/login/page.tsx
+++ b/apps/lms/app/login/page.tsx
@@ -7,6 +7,13 @@ import { createClient } from '@/lib/supabase/client';
 import { getRoleDestination } from '@/lib/auth/role-destinations';
 import { validateRedirect } from '@/lib/auth/validate-redirect';
 import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
+import { siteUrls } from '@/lib/utils/site-urls';
+
+function absolutePortalDestination(path: string): string {
+  if (/^https?:\/\//i.test(path)) return path;
+  if (path.startsWith('/admin/')) return `${siteUrls.admin}${path.replace(/^\/admin/, '')}`;
+  return `${siteUrls.app}${path.startsWith('/') ? path : `/${path}`}`;
+}
 
 export default function LoginPage() {
   const router = useRouter();
@@ -34,8 +41,8 @@ export default function LoginPage() {
       if (!data.user) throw new Error('Authentication completed without a user session.');
 
       if (safeRedirect) {
-        router.replace(safeRedirect);
-        router.refresh();
+        const destination = absolutePortalDestination(safeRedirect);
+        window.location.assign(destination);
         return;
       }
 
@@ -45,27 +52,21 @@ export default function LoginPage() {
         .eq('id', data.user.id)
         .maybeSingle();
 
-      const WWW = 'https://www.elevateforhumanity.org';
       let destination: string;
       if (!profile) {
-        destination = `${WWW}/onboarding/learner`;
+        destination = `${siteUrls.app}/onboarding/learner`;
       } else if (profile.role === 'employer' && profile.onboarding_completed !== true) {
-        destination = `${WWW}/onboarding/employer`;
+        destination = `${siteUrls.app}/onboarding/employer`;
       } else {
-        // Apprentices are routed to their program portal based on portal_type.
-        // If portal_type is set (e.g. 'barber', 'cosmetology'), go to /portal/[portal_type].
-        // Otherwise fall back to role-based routing.
         const portalType = profile.portal_type;
         if (portalType && typeof portalType === 'string' && portalType.trim() !== '') {
-          destination = `${WWW}/portal/${portalType.trim()}`;
+          destination = `${siteUrls.app}/portal/${portalType.trim()}`;
         } else {
-          destination = `${WWW}${getRoleDestination(profile.role)}`;
+          destination = absolutePortalDestination(getRoleDestination(profile.role));
         }
       }
 
-      // Use window.location for a full page reload so server-side auth checks
-      // in portal pages can read the session cookie synced from localStorage.
-      window.location.href = destination;
+      window.location.assign(destination);
     } catch (caughtError) {
       const message = caughtError instanceof Error ? caughtError.message : 'Invalid email or password.';
       setError(message);
@@ -134,7 +135,7 @@ export default function LoginPage() {
         </p>
 
         <div className="mt-8 border-t border-slate-200 pt-6 text-center">
-          <a href="https://admin.elevateforhumanity.org/login" className="text-sm font-semibold text-slate-800 hover:underline">Staff and administrator login →</a>
+          <a href={siteUrls.adminLogin} className="text-sm font-semibold text-slate-800 hover:underline">Staff and administrator login →</a>
         </div>
       </section>
     </main>

--- a/apps/marketing/app/ai/dev-studio/page.tsx
+++ b/apps/marketing/app/ai/dev-studio/page.tsx
@@ -1,169 +1,18 @@
-import { Metadata } from 'next';
-import Link from 'next/link';
-import { Settings, GitBranch, Container, Zap, BarChart3, Shield, Code2, Rocket, Layers } from 'lucide-react';
-import { getAdminUrl } from '@/lib/config/admin-url';
+import type { Metadata } from 'next';
+import { redirect } from 'next/navigation';
 
 export const metadata: Metadata = {
-  title: 'Dev Studio | AI-Powered Development Platform',
-  description: 'Enterprise-grade development environment for managing AI workflows, deployments, integrations, and operations. Built for workforce technology teams.',
+  title: 'Dev Studio | Elevate for Humanity',
+  description: 'AI-powered development environment for the Elevate platform.',
+  alternates: { canonical: '/dev-studio' },
 };
 
-const features = [
-  {
-    icon: Container,
-    title: 'Container Management',
-    description: 'Deploy and manage Docker containers with Northflank integration. Monitor health, scale resources, and manage configurations.',
-  },
-  {
-    icon: GitBranch,
-    title: 'Git Integration',
-    description: 'Connect GitHub repositories, trigger builds on push, manage branches and deployments from a unified interface.',
-  },
-  {
-    icon: Rocket,
-    title: 'One-Click Deployments',
-    description: 'Deploy marketing, admin, and LMS applications with single clicks. Track deployment status and rollback history.',
-  },
-  {
-    icon: Zap,
-    title: 'AI Workflow Automation',
-    description: 'Orchestrate AI agents, prompts, and memory systems. Build complex workflows with visual tools.',
-  },
-  {
-    icon: BarChart3,
-    title: 'Real-Time Monitoring',
-    description: 'Track build logs, container health, API performance, and system metrics in real-time.',
-  },
-  {
-    icon: Shield,
-    title: 'Secrets Management',
-    description: 'Securely store and manage API keys, tokens, and environment variables. Never expose credentials.',
-  },
-];
-
-const capabilities = [
-  'Northflank container orchestration',
-  'GitHub Actions integration',
-  'Multi-environment deployments',
-  'Build log streaming',
-  'Health check monitoring',
-  'Environment variable management',
-  'AI agent orchestration',
-  'Workflow designer',
-];
-
-export default function DevStudioPage() {
-  return (
-    <div className="min-h-screen">
-      {/* Hero */}
-      <section className="relative overflow-hidden bg-gradient-to-br from-slate-900 via-blue-900 to-slate-900 text-white">
-        <div className="absolute inset-0 opacity-20">
-          <div className="absolute top-0 right-1/4 w-96 h-96 bg-blue-500 rounded-full filter blur-3xl"></div>
-          <div className="absolute bottom-0 left-1/4 w-96 h-96 bg-purple-500 rounded-full filter blur-3xl"></div>
-        </div>
-        <div className="relative max-w-7xl mx-auto px-4 py-24">
-          <div className="max-w-3xl">
-            <div className="inline-flex items-center gap-2 px-4 py-2 bg-blue-500/20 border border-blue-400/30 rounded-full text-sm mb-6">
-              <Code2 className="w-4 h-4" />
-              Enterprise Development Platform
-            </div>
-            <h1 className="text-5xl md:text-6xl font-bold mb-6">
-              Dev Studio
-            </h1>
-            <p className="text-xl text-slate-300 mb-8">
-              AI-powered development environment for workforce technology teams. Manage containers, 
-              deployments, AI workflows, and system operations from a unified platform.
-            </p>
-            <div className="flex flex-wrap gap-4">
-              <a href={getAdminUrl("/studio")} className="px-8 py-4 bg-blue-600 rounded-lg font-semibold hover:bg-blue-500 transition">
-                Access Dev Studio
-              </a>
-              <Link href="/contact" className="px-8 py-4 bg-white/10 border border-white/30 rounded-lg font-semibold hover:bg-white/20 transition">
-                Schedule Demo
-              </Link>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* Features */}
-      <section className="py-20 bg-white">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="text-center mb-16">
-            <h2 className="text-3xl font-bold mb-4">Enterprise Development Tools</h2>
-            <p className="text-slate-600 max-w-2xl mx-auto">
-              Everything your development team needs to build, deploy, and manage workforce technology.
-            </p>
-          </div>
-
-          <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-8">
-            {features.map((feature) => {
-              const Icon = feature.icon;
-              return (
-                <div key={feature.title} className="group p-6 bg-slate-50 rounded-xl border border-slate-200 hover:border-blue-200 hover:shadow-lg transition-all">
-                  <div className="w-12 h-12 bg-blue-100 rounded-xl flex items-center justify-center mb-4 group-hover:bg-blue-200 transition-colors">
-                    <Icon className="w-6 h-6 text-blue-600" />
-                  </div>
-                  <h3 className="text-lg font-bold mb-2">{feature.title}</h3>
-                  <p className="text-slate-600 text-sm">{feature.description}</p>
-                </div>
-              );
-            })}
-          </div>
-        </div>
-      </section>
-
-      {/* Capabilities */}
-      <section className="py-20 bg-slate-50">
-        <div className="max-w-7xl mx-auto px-4">
-          <div className="grid lg:grid-cols-2 gap-12 items-center">
-            <div>
-              <h2 className="text-3xl font-bold mb-6">Complete Development Suite</h2>
-              <p className="text-slate-600 mb-8">
-                Dev Studio provides your team with professional-grade tools for managing the entire 
-                development lifecycle—from code to production.
-              </p>
-              <div className="grid grid-cols-2 gap-4">
-                {capabilities.map((cap) => (
-                  <div key={cap} className="flex items-center gap-3">
-                    <div className="w-6 h-6 bg-green-100 rounded-full flex items-center justify-center flex-shrink-0">
-                      <Layers className="w-3 h-3 text-green-600" />
-                    </div>
-                    <span className="text-sm text-slate-700">{cap}</span>
-                  </div>
-                ))}
-              </div>
-            </div>
-            <div className="bg-slate-900 rounded-2xl p-6 font-mono text-sm">
-              <div className="text-slate-500 mb-2">// Deploy with one click</div>
-              <div className="text-green-400">$ elevate deploy --env production</div>
-              <div className="text-slate-400 mt-4">Building marketing...</div>
-              <div className="text-slate-400">Building admin...</div>
-              <div className="text-slate-400">Building lms...</div>
-              <div className="text-green-400 mt-4">✓ Deployed to Northflank</div>
-              <div className="text-blue-400 mt-2">https://elevate.work</div>
-            </div>
-          </div>
-        </div>
-      </section>
-
-      {/* CTA */}
-      <section className="py-20 bg-gradient-to-r from-blue-600 to-purple-600 text-white">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <h2 className="text-3xl font-bold mb-4">Ready to Accelerate Development?</h2>
-          <p className="text-xl text-blue-100 mb-8">
-            Give your team the development platform they deserve.
-          </p>
-          <div className="flex flex-wrap gap-4 justify-center">
-            <a href={getAdminUrl("/studio")} className="px-8 py-4 bg-white text-blue-600 rounded-lg font-semibold hover:bg-blue-50 transition">
-              Access Dev Studio
-            </a>
-            <Link href="/platform/enterprise" className="px-8 py-4 border-2 border-white text-white rounded-lg font-semibold hover:bg-white/10 transition">
-              Enterprise Solutions
-            </Link>
-          </div>
-        </div>
-      </section>
-    </div>
-  );
+/**
+ * Compatibility route.
+ * The canonical public Dev Studio product page lives at `/dev-studio`.
+ * Keep this route to preserve existing inbound links while eliminating
+ * a second copy of the same marketing content.
+ */
+export default function DevStudioAiCompatibilityRoute() {
+  redirect('/dev-studio');
 }

--- a/components/OrchestratorAdmin.tsx
+++ b/components/OrchestratorAdmin.tsx
@@ -1,8 +1,6 @@
 'use client';
 
-import React from 'react';
-
-import { useState, useEffect } from 'react';
+import { useEffect, useState } from 'react';
 
 interface Autopilot {
   name: string;
@@ -11,54 +9,65 @@ interface Autopilot {
   needs: {
     kvNamespaces?: string[];
     r2Buckets?: string[];
-    workers?: any[];
+    workers?: unknown[];
   };
 }
 
 interface DiagnoseReport {
-  token: any;
+  token: { error?: unknown };
   resources: {
-    kv?: any;
-    r2?: any;
-    workers?: any;
+    kv?: unknown[] | { error?: unknown };
+    r2?: unknown[] | { error?: unknown };
+    workers?: unknown[] | { error?: unknown };
   };
   timestamp: string;
 }
 
-const ORCHESTRATOR_URL = 'https://efh-autopilot-orchestrator.your-subdomain.workers.dev';
+const ORCHESTRATOR_URL = process.env.NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL?.replace(/\/$/, '') || '';
+
+async function orchestratorRequest<T>(path: string, init?: RequestInit): Promise<T> {
+  if (!ORCHESTRATOR_URL) {
+    throw new Error('NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL is not configured');
+  }
+
+  const response = await fetch(`${ORCHESTRATOR_URL}${path}`, init);
+  if (!response.ok) {
+    const body = await response.text().catch(() => '');
+    throw new Error(`Orchestrator request failed (${response.status})${body ? `: ${body}` : ''}`);
+  }
+  return response.json() as Promise<T>;
+}
 
 export default function OrchestratorAdmin() {
   const [autopilots, setAutopilots] = useState<Autopilot[]>([]);
   const [diagnose, setDiagnose] = useState<DiagnoseReport | null>(null);
   const [loading, setLoading] = useState(false);
-  const [taskResult, setTaskResult] = useState<any>(null);
+  const [error, setError] = useState<string | null>(null);
+  const [taskResult, setTaskResult] = useState<unknown>(null);
   const [selectedTask, setSelectedTask] = useState('generate_page');
 
   useEffect(() => {
-    loadAutopilots();
-    runDiagnose();
+    void loadAutopilots();
+    void runDiagnose();
   }, []);
 
   async function loadAutopilots() {
     try {
-      const response = await fetch(`${ORCHESTRATOR_URL}/autopilot/list`);
-      const data = await response.json();
+      setError(null);
+      const data = await orchestratorRequest<{ autopilots?: Autopilot[] }>('/autopilot/list');
       setAutopilots(data.autopilots || []);
-    } catch (error) {
-      /* Error handled silently */
-      // Error: $1
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to load autopilots');
     }
   }
 
   async function runDiagnose() {
     setLoading(true);
     try {
-      const response = await fetch(`${ORCHESTRATOR_URL}/autopilot/diagnose`);
-      const data = await response.json();
-      setDiagnose(data);
-    } catch (error) {
-      /* Error handled silently */
-      // Error: $1
+      setError(null);
+      setDiagnose(await orchestratorRequest<DiagnoseReport>('/autopilot/diagnose'));
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Diagnostics failed');
     } finally {
       setLoading(false);
     }
@@ -67,7 +76,8 @@ export default function OrchestratorAdmin() {
   async function ensureInfra() {
     setLoading(true);
     try {
-      const response = await fetch(`${ORCHESTRATOR_URL}/autopilot/ensure-infra`, {
+      setError(null);
+      const data = await orchestratorRequest<unknown>('/autopilot/ensure-infra', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -77,13 +87,10 @@ export default function OrchestratorAdmin() {
           },
         }),
       });
-      const data = await response.json();
-      alert(JSON.stringify(data, null, 2));
-      runDiagnose();
-    } catch (error) {
-      /* Error handled silently */
-      // Error: $1
-      alert('Failed to ensure infrastructure');
+      setTaskResult(data);
+      await runDiagnose();
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to ensure infrastructure');
     } finally {
       setLoading(false);
     }
@@ -93,127 +100,101 @@ export default function OrchestratorAdmin() {
     setLoading(true);
     setTaskResult(null);
     try {
-      const response = await fetch(`${ORCHESTRATOR_URL}/autopilot/plan`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          task: selectedTask,
-          meta: { pageType: 'home', description: 'Test page' },
+      setError(null);
+      setTaskResult(
+        await orchestratorRequest<unknown>('/autopilot/plan', {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            task: selectedTask,
+            meta: { pageType: 'home', description: 'Test page' },
+          }),
         }),
-      });
-      const data = await response.json();
-      setTaskResult(data);
-    } catch (error) {
-      /* Error handled silently */
-      // Error: $1
-      setTaskResult({ error: 'Task execution failed' });
+      );
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Task execution failed');
     } finally {
       setLoading(false);
     }
   }
 
-  const getStatusColor = (hasError: boolean) => {
-    return hasError ? 'bg-brand-surface text-brand-red-800' : 'bg-brand-surface text-brand-success';
-  };
+  const getStatusColor = (hasError: boolean) =>
+    hasError ? 'bg-brand-surface text-brand-red-800' : 'bg-brand-surface text-brand-success';
+
+  const resourceHasError = (value: DiagnoseReport['resources']['kv']) =>
+    !!value && !Array.isArray(value) && 'error' in value && !!value.error;
 
   return (
     <div className="max-w-7xl mx-auto p-6">
       <div className="mb-8">
-        <h1 className="text-4xl font-bold text-brand-orange-600 mb-2 text-2xl md:text-3xl lg:text-4xl">
+        <h1 className="font-bold text-brand-orange-600 mb-2 text-2xl md:text-3xl lg:text-4xl">
           Autopilot Orchestrator
         </h1>
         <p className="text-brand-text-muted">Master controller for all AI systems</p>
+        <p className="text-xs text-brand-text-light mt-1">
+          {ORCHESTRATOR_URL ? `Endpoint: ${ORCHESTRATOR_URL}` : 'Orchestrator endpoint is not configured.'}
+        </p>
       </div>
-      {/* Diagnostics */}
+
+      {error && (
+        <div className="mb-6 rounded-lg border border-red-200 bg-red-50 p-4 text-sm text-red-800">
+          {error}
+        </div>
+      )}
+
       <div className="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
         <div className="bg-white rounded-lg shadow-md p-6">
           <div className="flex items-center justify-between mb-4">
             <h2 className="text-2xl font-semibold text-brand-text">System Diagnostics</h2>
             <button
-              onClick={runDiagnose}
-              disabled={loading}
+              onClick={() => void runDiagnose()}
+              disabled={loading || !ORCHESTRATOR_URL}
               className="bg-brand-info hover:bg-brand-info-hover text-white px-4 py-2 rounded-lg transition-colors disabled:bg-slate-400"
             >
               {loading ? 'Checking...' : 'Refresh'}
             </button>
           </div>
+
           {diagnose ? (
             <div className="space-y-4">
-              {/* Token Status */}
               <div>
                 <h3 className="font-semibold text-brand-text mb-2">API Token</h3>
-                <div className={`px-3 py-2 rounded ${getStatusColor(!!diagnose.token.error)}`}>
-                  {diagnose.token.error ? (
-                    <span>❌ {JSON.stringify(diagnose.token.error)}</span>
-                  ) : (
-                    <span>• Valid</span>
-                  )}
+                <div className={`px-3 py-2 rounded ${getStatusColor(!!diagnose.token?.error)}`}>
+                  {diagnose.token?.error ? <span>❌ Token error</span> : <span>• Valid</span>}
                 </div>
               </div>
-              {/* KV Namespaces */}
-              <div>
-                <h3 className="font-semibold text-brand-text mb-2">KV Namespaces</h3>
-                <div
-                  className={`px-3 py-2 rounded ${getStatusColor(!!diagnose.resources.kv?.error)}`}
-                >
-                  {diagnose.resources.kv?.error ? (
-                    <span>❌ {JSON.stringify(diagnose.resources.kv.error)}</span>
-                  ) : (
-                    <span>
-                      • {Array.isArray(diagnose.resources.kv) ? diagnose.resources.kv.length : 0}{' '}
-                      namespaces
-                    </span>
-                  )}
-                </div>
-              </div>
-              {/* R2 Buckets */}
-              <div>
-                <h3 className="font-semibold text-brand-text mb-2">R2 Buckets</h3>
-                <div
-                  className={`px-3 py-2 rounded ${getStatusColor(!!diagnose.resources.r2?.error)}`}
-                >
-                  {diagnose.resources.r2?.error ? (
-                    <span>❌ {JSON.stringify(diagnose.resources.r2.error)}</span>
-                  ) : (
-                    <span>
-                      • {Array.isArray(diagnose.resources.r2) ? diagnose.resources.r2.length : 0}{' '}
-                      buckets
-                    </span>
-                  )}
-                </div>
-              </div>
-              {/* Workers */}
-              <div>
-                <h3 className="font-semibold text-brand-text mb-2">Workers</h3>
-                <div
-                  className={`px-3 py-2 rounded ${getStatusColor(!!diagnose.resources.workers?.error)}`}
-                >
-                  {diagnose.resources.workers?.error ? (
-                    <span>❌ {JSON.stringify(diagnose.resources.workers.error)}</span>
-                  ) : (
-                    <span>
-                      •{' '}
-                      {Array.isArray(diagnose.resources.workers)
-                        ? diagnose.resources.workers.length
-                        : 0}{' '}
-                      workers
-                    </span>
-                  )}
-                </div>
-              </div>
+
+              {(['kv', 'r2', 'workers'] as const).map((key) => {
+                const value = diagnose.resources[key];
+                return (
+                  <div key={key}>
+                    <h3 className="font-semibold text-brand-text mb-2 uppercase">{key}</h3>
+                    <div className={`px-3 py-2 rounded ${getStatusColor(resourceHasError(value))}`}>
+                      {resourceHasError(value) ? (
+                        <span>❌ Resource error</span>
+                      ) : (
+                        <span>• {Array.isArray(value) ? value.length : 0} resources</span>
+                      )}
+                    </div>
+                  </div>
+                );
+              })}
+
               <button
-                onClick={ensureInfra}
-                disabled={loading}
+                onClick={() => void ensureInfra()}
+                disabled={loading || !ORCHESTRATOR_URL}
                 className="w-full bg-brand-success hover:bg-brand-success-hover text-white font-semibold py-2 px-4 rounded-lg transition-colors disabled:bg-slate-400"
               >
-                {loading ? 'Fixing...' : '🔧 Fix Infrastructure'}
+                {loading ? 'Working...' : '🔧 Ensure Infrastructure'}
               </button>
             </div>
           ) : (
-            <div className="text-center text-brand-text-light py-8">Loading diagnostics...</div>
+            <div className="text-center text-brand-text-light py-8">
+              {ORCHESTRATOR_URL ? 'Loading diagnostics...' : 'Configure the orchestrator endpoint to enable diagnostics.'}
+            </div>
           )}
         </div>
-        {/* Task Runner */}
+
         <div className="bg-white rounded-lg shadow-md p-6">
           <h2 className="text-2xl font-semibold text-brand-text mb-4">Run Task</h2>
           <div className="mb-4">
@@ -221,9 +202,7 @@ export default function OrchestratorAdmin() {
             <select
               className="w-full border border-brand-border-dark rounded-lg px-4 py-2 focus:ring-2 focus:ring-brand-focus focus:border-transparent"
               value={selectedTask}
-              onChange={(
-                e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
-              ) => setSelectedTask(e.target.value)}
+              onChange={(e) => setSelectedTask(e.target.value)}
             >
               <option value="generate_page">Generate Page</option>
               <option value="deploy_page">Deploy Page</option>
@@ -236,36 +215,33 @@ export default function OrchestratorAdmin() {
             </select>
           </div>
           <button
-            onClick={runTask}
-            disabled={loading}
+            onClick={() => void runTask()}
+            disabled={loading || !ORCHESTRATOR_URL}
             className="w-full bg-brand-info hover:bg-brand-info-hover text-white font-semibold py-2 px-4 rounded-lg transition-colors disabled:bg-slate-400 mb-4"
           >
             {loading ? 'Running...' : 'Run Task'}
           </button>
-          {taskResult && (
+          {taskResult != null && (
             <div className="bg-brand-surface rounded-lg p-4 overflow-auto max-h-64">
               <pre className="text-xs">{JSON.stringify(taskResult, null, 2)}</pre>
             </div>
           )}
         </div>
       </div>
-      {/* Registered Autopilots */}
+
       <div className="bg-white rounded-lg shadow-md p-6">
         <div className="flex items-center justify-between mb-4">
-          <h2 className="text-2xl font-semibold text-brand-text">
-            Registered Autopilots ({autopilots.length})
-          </h2>
+          <h2 className="text-2xl font-semibold text-brand-text">Registered Autopilots ({autopilots.length})</h2>
           <button
-            onClick={loadAutopilots}
-            className="bg-slate-600 hover:bg-slate-700 text-white px-4 py-2 rounded-lg transition-colors"
+            onClick={() => void loadAutopilots()}
+            disabled={!ORCHESTRATOR_URL}
+            className="bg-slate-600 hover:bg-slate-700 text-white px-4 py-2 rounded-lg transition-colors disabled:bg-slate-400"
           >
             Refresh
           </button>
         </div>
         {autopilots.length === 0 ? (
-          <div className="text-center text-brand-text-light py-8">
-            No autopilots registered yet. Run the registration script to add them.
-          </div>
+          <div className="text-center text-brand-text-light py-8">No registered autopilots reported.</div>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
             {autopilots.map((ap) => (
@@ -276,10 +252,7 @@ export default function OrchestratorAdmin() {
                   <h4 className="text-xs font-medium text-brand-text mb-1">Capabilities:</h4>
                   <div className="flex flex-wrap gap-1">
                     {ap.capabilities.map((cap) => (
-                      <span
-                        key={cap}
-                        className="px-2 py-2 bg-brand-surface text-brand-info rounded text-xs"
-                      >
+                      <span key={cap} className="px-2 py-2 bg-brand-surface text-brand-info rounded text-xs">
                         {cap}
                       </span>
                     ))}
@@ -289,10 +262,8 @@ export default function OrchestratorAdmin() {
                   <div>
                     <h4 className="text-xs font-medium text-brand-text mb-1">Needs:</h4>
                     <div className="text-xs text-brand-text-muted">
-                      {ap.needs.kvNamespaces?.length && (
-                        <div>KV: {ap.needs.kvNamespaces.join(', ')}</div>
-                      )}
-                      {ap.needs.r2Buckets?.length && <div>R2: {ap.needs.r2Buckets.join(', ')}</div>}
+                      {!!ap.needs.kvNamespaces?.length && <div>KV: {ap.needs.kvNamespaces.join(', ')}</div>}
+                      {!!ap.needs.r2Buckets?.length && <div>R2: {ap.needs.r2Buckets.join(', ')}</div>}
                     </div>
                   </div>
                 )}

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -7,6 +7,7 @@ import { ALL_PROGRAMS } from '@/data/programs/catalog';
 import HeaderMobileMenu from './HeaderMobileMenu.client';
 import HeaderDesktopNav from './HeaderDesktopNav';
 import { NAV_ITEMS } from '@/lib/navigation';
+import { ROUTES } from '@/lib/navigation/routes';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 const PROGRAM_APPLY_LINKS = Object.fromEntries(
@@ -34,16 +35,14 @@ export default function Header() {
           </span>
         </Link>
 
-        {/* Desktop nav - horizontal links (lg screens and up) */}
         <div className="hidden md:flex justify-center min-w-0 overflow-visible">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
         <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 lg:gap-1 flex-shrink-0 min-w-0">
-          {/* Desktop: Sign In / Apply buttons */}
           <div className="hidden md:flex items-center gap-2 mr-2">
             <Link
-              href="/login"
+              href={ROUTES.login}
               className="text-sm text-slate-600 hover:text-slate-900 px-3 py-2"
             >
               Sign In
@@ -55,7 +54,6 @@ export default function Header() {
               Apply
             </Link>
           </div>
-          {/* Mobile hamburger menu - show on screens below lg (vertical drawer with subpages) */}
           <span className="md:hidden">
             <HeaderMobileMenu items={NAV_ITEMS} programApplyLinks={PROGRAM_APPLY_LINKS} />
           </span>

--- a/components/site/HeaderMobileMenu.client.tsx
+++ b/components/site/HeaderMobileMenu.client.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useRef } from 'react';
+import { useEffect, useRef, useState } from 'react';
 import { createPortal } from 'react-dom';
 import { usePathname } from 'next/navigation';
 import Link from 'next/link';
@@ -13,6 +13,8 @@ import {
   type NavItem,
   type NavSubItem,
 } from '@/lib/navigation';
+import { ROUTES } from '@/lib/navigation/routes';
+import { siteUrls } from '@/lib/utils/site-urls';
 
 interface HeaderMobileMenuProps {
   items: NavItem[];
@@ -21,12 +23,42 @@ interface HeaderMobileMenuProps {
 
 function getProgramSlugFromHref(href: string): string | null {
   const match = href.match(/^\/programs\/([^/?#]+)$/);
-  if (!match) return null;
-  return match[1];
+  return match?.[1] ?? null;
 }
 
-function isExternalHref(href: string) {
-  return href.startsWith('http');
+function isExternalHref(href: string): boolean {
+  return /^https?:\/\//i.test(href);
+}
+
+function phoneHref(phone: string): string {
+  const digits = phone.replace(/\D/g, '');
+  return `tel:${digits.length === 10 ? `+1${digits}` : `+${digits}`}`;
+}
+
+function MenuLink({
+  href,
+  children,
+  onNavigate,
+  className,
+}: {
+  href: string;
+  children: React.ReactNode;
+  onNavigate: () => void;
+  className: string;
+}) {
+  if (isExternalHref(href)) {
+    return (
+      <a href={href} onClick={onNavigate} className={className}>
+        {children}
+      </a>
+    );
+  }
+
+  return (
+    <Link href={href} prefetch={false} onClick={onNavigate} className={className}>
+      {children}
+    </Link>
+  );
 }
 
 function MobileSubLink({
@@ -41,46 +73,42 @@ function MobileSubLink({
   onNavigate: () => void;
 }) {
   if (subItem.isHeader) return null;
+  const href = subItem.href ?? '#';
 
   if (subItem.isSectionLink) {
     return (
-      <Link
-        href={subItem.href ?? '#'}
-        prefetch={false}
-        onClick={onNavigate}
-        {...(isExternalHref(subItem.href ?? '') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      <MenuLink
+        href={href}
+        onNavigate={onNavigate}
         className="flex items-center gap-1.5 py-2 min-h-[40px] text-sm font-semibold text-brand-red-600 hover:text-brand-red-700"
       >
         {subItem.isAuth && <Lock className="h-3.5 w-3.5 flex-shrink-0" aria-hidden="true" />}
         <span className="break-words">{subItem.name}</span>
-      </Link>
+      </MenuLink>
     );
   }
 
-  const programSlug = itemId === 'programs' ? getProgramSlugFromHref(subItem.href ?? '') : null;
+  const programSlug = itemId === 'programs' ? getProgramSlugFromHref(href) : null;
   const applyHref = programSlug ? programApplyLinks[programSlug] : undefined;
 
   return (
     <div>
-      <Link
-        href={subItem.href ?? '#'}
-        prefetch={false}
-        onClick={onNavigate}
-        {...(isExternalHref(subItem.href ?? '') ? { target: '_blank', rel: 'noopener noreferrer' } : {})}
+      <MenuLink
+        href={href}
+        onNavigate={onNavigate}
         className="flex items-center gap-1.5 py-2 min-h-[40px] text-sm text-slate-700 hover:text-brand-blue-600"
       >
         {subItem.isAuth && <Lock className="h-3.5 w-3.5 flex-shrink-0 text-slate-400" aria-hidden="true" />}
         <span className="break-words">{subItem.name}</span>
-      </Link>
+      </MenuLink>
       {applyHref ? (
-        <Link
+        <MenuLink
           href={applyHref}
-          prefetch={false}
-          onClick={onNavigate}
+          onNavigate={onNavigate}
           className="block py-1.5 pl-6 min-h-[32px] text-xs font-medium text-brand-blue-700 hover:underline"
         >
           Apply to {subItem.name}
-        </Link>
+        </MenuLink>
       ) : null}
     </div>
   );
@@ -98,28 +126,18 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
     setExpandedSection(null);
     setExpandedCategory(null);
   };
-  // Reset category when switching sections to avoid stale accordion state
+
   const toggleSection = (key: string) =>
-    setExpandedSection((prev) => {
-      if (prev === key) return null;
+    setExpandedSection((previous) => {
+      if (previous === key) return null;
       setExpandedCategory(null);
       return key;
     });
 
-
-
-  useEffect(() => {
-    setIsOpen(false);
-    setExpandedSection(null);
-    setExpandedCategory(null);
-  }, [pathname]);
+  useEffect(() => closeMenu(), [pathname]);
 
   useEffect(() => {
-    if (isOpen) {
-      requestAnimationFrame(() => {
-        firstFocusRef.current?.focus();
-      });
-    }
+    if (isOpen) requestAnimationFrame(() => firstFocusRef.current?.focus());
   }, [isOpen]);
 
   useEffect(() => {
@@ -127,9 +145,10 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
       document.body.style.overflow = '';
       return;
     }
+
     document.body.style.overflow = 'hidden';
-    const handleEscape = (e: KeyboardEvent) => {
-      if (e.key === 'Escape') setIsOpen(false);
+    const handleEscape = (event: KeyboardEvent) => {
+      if (event.key === 'Escape') closeMenu();
     };
     document.addEventListener('keydown', handleEscape);
     return () => {
@@ -138,161 +157,116 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
     };
   }, [isOpen]);
 
-  const drawer =
-    isOpen
-      ? createPortal(
-          <>
-            {/* Backdrop — below header (z-9998) so hamburger button (z-9999) stays clickable */}
-            <div
-              className="fixed inset-0 bg-black/50 z-[9998]"
-              onClick={closeMenu}
-              aria-hidden="true"
-            />
-            {/* Menu panel — above header (z-10000) so close button is always accessible */}
-            <div
-              className="fixed inset-y-0 right-0 w-[min(100vw,26rem)] bg-white z-[10000] flex flex-col shadow-2xl pt-[env(safe-area-inset-top)]"
-              role="dialog"
-              aria-modal="true"
-              aria-label="Main navigation"
-              aria-labelledby="mobile-nav-title"
-            >
-              {/* Panel header with close button */}
-              <div className="flex h-14 items-center justify-between border-b border-slate-100 px-4 shrink-0">
-                <h2 className="font-semibold text-slate-900 text-base" id="mobile-nav-title">Menu</h2>
-                <button
-                  type="button"
-                  onClick={closeMenu}
-                  aria-label="Close navigation"
-                  className="flex h-11 w-11 items-center justify-center text-slate-500 hover:text-slate-800 hover:bg-slate-100 rounded-lg"
-                >
-                  <X aria-hidden="true" className="h-5 w-5" />
-                </button>
-              </div>
-
-              {/* Scrollable nav */}
-              <nav
-                className="flex-1 overflow-y-auto overscroll-contain px-3 py-2"
-                aria-label="Site navigation"
+  const drawer = isOpen
+    ? createPortal(
+        <>
+          <div className="fixed inset-0 bg-black/50 z-[9998]" onClick={closeMenu} aria-hidden="true" />
+          <div
+            className="fixed inset-y-0 right-0 w-[min(100vw,26rem)] bg-white z-[10000] flex flex-col shadow-2xl pt-[env(safe-area-inset-top)]"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Main navigation"
+            aria-labelledby="mobile-nav-title"
+          >
+            <div className="flex h-14 items-center justify-between border-b border-slate-100 px-4 shrink-0">
+              <h2 className="font-semibold text-slate-900 text-base" id="mobile-nav-title">Menu</h2>
+              <button
+                type="button"
+                onClick={closeMenu}
+                aria-label="Close navigation"
+                className="flex h-11 w-11 items-center justify-center text-slate-500 hover:text-slate-800 hover:bg-slate-100 rounded-lg"
               >
-                {items.map((item, idx) => {
-                  const sectionKey = item.id ?? item.name;
-                  const hasSubItems = Boolean(item.subItems?.length);
-                  const sectionOpen = expandedSection === sectionKey;
-                  const columns = hasSubItems
-                    ? Object.values(groupNavSubItemsByHeader(item.subItems!))
-                    : [];
-                  const useCategoryAccordions = columns.length > 1;
+                <X aria-hidden="true" className="h-5 w-5" />
+              </button>
+            </div>
 
-                  return (
-                    <section key={item.name} className="border-b border-slate-100 last:border-0">
-                      {/* Section header / toggle */}
-                      {hasSubItems ? (
-                        <button
-                          ref={idx === 0 ? firstFocusRef : undefined}
-                          type="button"
-                          onClick={() => toggleSection(sectionKey)}
-                          className="flex w-full items-center justify-between py-2.5 min-h-[44px] text-left text-base font-semibold text-slate-900 hover:text-brand-blue-600"
-                          aria-expanded={sectionOpen}
-                          aria-controls={`mobile-section-${sectionKey}`}
-                        >
-                          <span className="break-words pr-2">{item.name}</span>
-                          <ChevronDown
-                            className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${
-                              sectionOpen ? 'rotate-180' : ''
-                            }`}
-                            aria-hidden="true"
-                          />
-                        </button>
-                      ) : item.href ? (
-                        <Link
-                          href={item.href}
-                          prefetch={false}
-                          onClick={closeMenu}
-                          className="flex py-2.5 min-h-[44px] text-base font-semibold text-slate-900 hover:text-brand-blue-600"
-                        >
-                          {item.name}
-                        </Link>
-                      ) : (
-                        <p className="py-2.5 min-h-[44px] text-base font-semibold text-slate-900">
-                          {item.name}
-                        </p>
-                      )}
+            <nav className="flex-1 overflow-y-auto overscroll-contain px-3 py-2" aria-label="Site navigation">
+              {items.map((item, index) => {
+                const sectionKey = item.id ?? item.name;
+                const hasSubItems = Boolean(item.subItems?.length);
+                const sectionOpen = expandedSection === sectionKey;
+                const columns = hasSubItems ? Object.values(groupNavSubItemsByHeader(item.subItems!)) : [];
+                const useCategoryAccordions = columns.length > 1;
 
-                      {/* Expanded content */}
-                      {hasSubItems && sectionOpen ? (
-                        <div
-                          id={`mobile-section-${sectionKey}`}
-                          className="pt-2 pb-3 pl-4 border-l-2 border-brand-red-200"
-                        >
-                          {/* "View all" link */}
-                          {item.href ? (
-                            <Link
-                              href={item.href}
-                              prefetch={false}
-                              onClick={closeMenu}
-                              className="block py-1.5 min-h-[40px] text-sm font-bold text-brand-red-600 hover:text-brand-red-700"
-                            >
-                              View all {item.name} →
-                            </Link>
-                          ) : null}
+                return (
+                  <section key={sectionKey} className="border-b border-slate-100 last:border-0">
+                    {hasSubItems ? (
+                      <button
+                        ref={index === 0 ? firstFocusRef : undefined}
+                        type="button"
+                        onClick={() => toggleSection(sectionKey)}
+                        className="flex w-full items-center justify-between py-2.5 min-h-[44px] text-left text-base font-semibold text-slate-900 hover:text-brand-blue-600"
+                        aria-expanded={sectionOpen}
+                        aria-controls={`mobile-section-${sectionKey}`}
+                      >
+                        <span className="break-words pr-2">{item.name}</span>
+                        <ChevronDown
+                          className={`h-5 w-5 flex-shrink-0 text-slate-400 transition-transform duration-200 ${sectionOpen ? 'rotate-180' : ''}`}
+                          aria-hidden="true"
+                        />
+                      </button>
+                    ) : item.href ? (
+                      <MenuLink
+                        href={item.href}
+                        onNavigate={closeMenu}
+                        className="flex py-2.5 min-h-[44px] text-base font-semibold text-slate-900 hover:text-brand-blue-600"
+                      >
+                        {item.name}
+                      </MenuLink>
+                    ) : (
+                      <p className="py-2.5 min-h-[44px] text-base font-semibold text-slate-900">{item.name}</p>
+                    )}
 
-                          {/* Category accordion columns */}
-                          {useCategoryAccordions
-                            ? columns
-                                .filter((col) => col.some((c) => !c?.isHeader))
-                                .map((column, columnIndex) => {
+                    {hasSubItems && sectionOpen ? (
+                      <div id={`mobile-section-${sectionKey}`} className="pt-2 pb-3 pl-4 border-l-2 border-brand-red-200">
+                        {item.href ? (
+                          <MenuLink
+                            href={item.href}
+                            onNavigate={closeMenu}
+                            className="block py-1.5 min-h-[40px] text-sm font-bold text-brand-red-600 hover:text-brand-red-700"
+                          >
+                            View all {item.name} →
+                          </MenuLink>
+                        ) : null}
+
+                        {useCategoryAccordions
+                          ? columns
+                              .filter((column) => column.some((entry) => !entry?.isHeader))
+                              .map((column, columnIndex) => {
                                 const categoryKey = `${sectionKey}::${columnIndex}`;
                                 const categoryOpen = expandedCategory === categoryKey;
                                 const label = getNavCategoryLabel(column);
-                                const categoryHref = column.find((c) => c.isHeader && c.href)?.href;
+                                const categoryHeader = column.find((entry) => entry.isHeader);
 
                                 return (
                                   <div key={categoryKey} className="mt-1 first:mt-0">
-                                    {/* Full-width accordion trigger */}
                                     <button
                                       type="button"
-                                      onClick={() =>
-                                        setExpandedCategory(categoryOpen ? null : categoryKey)
-                                      }
+                                      onClick={() => setExpandedCategory(categoryOpen ? null : categoryKey)}
                                       className="flex w-full min-h-[40px] items-center justify-between py-1 text-xs font-bold uppercase tracking-wide text-brand-red-600 hover:text-brand-red-700"
                                       aria-label={`${categoryOpen ? 'Collapse' : 'Expand'} ${label}`}
                                       aria-expanded={categoryOpen}
                                     >
                                       <span className="break-words leading-tight text-left">{label}</span>
                                       <ChevronDown
-                                        className={`h-3.5 w-3.5 flex-none text-brand-red-400 transition-transform duration-200 ml-2 flex-shrink-0 ${
-                                          categoryOpen ? 'rotate-180' : ''
-                                        }`}
+                                        className={`h-3.5 w-3.5 flex-none text-brand-red-400 transition-transform duration-200 ml-2 ${categoryOpen ? 'rotate-180' : ''}`}
                                         aria-hidden="true"
                                       />
                                     </button>
+
                                     {categoryOpen ? (
                                       <div className="pl-3 border-l border-brand-red-200">
-                                        {column.map((subItem) => {
-                                          if (!subItem) return null;
-                                          // Show header as label, not as link
-                                          if (subItem.isHeader) {
-                                            const headerLabel = subItem.name.replace(/—/g, '').trim();
-                                            return categoryHref ? (
-                                              <Link
-                                                key={`${subItem.name}-${subItem.href ?? 'nohref'}`}
-                                                href={categoryHref}
-                                                prefetch={false}
-                                                onClick={closeMenu}
-                                                className="block py-1 min-h-[32px] text-xs font-bold uppercase tracking-wide text-brand-red-600 hover:text-brand-red-700"
-                                              >
-                                                {headerLabel}
-                                              </Link>
-                                            ) : (
-                                              <p
-                                                key={`${subItem.name}-${subItem.href ?? 'nohref'}`}
-                                                className="py-1 min-h-[32px] text-xs font-bold uppercase tracking-wide text-brand-red-600"
-                                              >
-                                                {headerLabel}
-                                              </p>
-                                            );
-                                          }
-                                          return (
+                                        {categoryHeader?.href ? (
+                                          <MenuLink
+                                            href={categoryHeader.href}
+                                            onNavigate={closeMenu}
+                                            className="block py-1 min-h-[32px] text-xs font-bold uppercase tracking-wide text-brand-red-600 hover:text-brand-red-700"
+                                          >
+                                            {categoryHeader.name.replace(/—/g, '').trim()}
+                                          </MenuLink>
+                                        ) : null}
+                                        {column.map((subItem) =>
+                                          subItem.isHeader ? null : (
                                             <MobileSubLink
                                               key={`${subItem.name}-${subItem.href ?? 'nohref'}`}
                                               subItem={subItem}
@@ -300,104 +274,91 @@ export default function HeaderMobileMenu({ items, programApplyLinks = {} }: Head
                                               programApplyLinks={programApplyLinks}
                                               onNavigate={closeMenu}
                                             />
-                                          );
-                                        })}
+                                          ),
+                                        )}
                                       </div>
                                     ) : null}
                                   </div>
                                 );
                               })
-                            : /* Single-column subItems */
-                              item.subItems!.map((subItem) => {
-                                if (subItem.isHeader) {
-                                  const headerLabel = subItem.name.replace(/—/g, '').trim();
-                                  return subItem.href ? (
-                                    <Link
-                                      key={subItem.name}
-                                      href={subItem.href}
-                                      prefetch={false}
-                                      onClick={closeMenu}
-                                      className="block py-2 text-xs font-bold uppercase tracking-wide text-brand-red-600 hover:text-brand-red-700"
-                                    >
-                                      {headerLabel}
-                                    </Link>
-                                  ) : (
-                                    <p
-                                      key={subItem.name}
-                                      className="pt-2 pb-0.5 text-xs font-bold uppercase tracking-wide text-brand-red-600 break-words"
-                                    >
-                                      {headerLabel}
-                                    </p>
-                                  );
-                                }
-                                return (
-                                  <MobileSubLink
-                                    key={`${subItem.name}-${subItem.href ?? 'nohref'}`}
-                                    subItem={subItem}
-                                    itemId={item.id}
-                                    programApplyLinks={programApplyLinks}
+                          : item.subItems!.map((subItem) =>
+                              subItem.isHeader ? (
+                                subItem.href ? (
+                                  <MenuLink
+                                    key={`${subItem.name}-${subItem.href}`}
+                                    href={subItem.href}
                                     onNavigate={closeMenu}
-                                  />
-                                );
-                              })}
-                        </div>
-                      ) : null}
-                    </section>
-                  );
-                })}
-              </nav>
+                                    className="block py-2 text-xs font-bold uppercase tracking-wide text-brand-red-600 hover:text-brand-red-700"
+                                  >
+                                    {subItem.name.replace(/—/g, '').trim()}
+                                  </MenuLink>
+                                ) : (
+                                  <p key={subItem.name} className="pt-2 pb-0.5 text-xs font-bold uppercase tracking-wide text-brand-red-600 break-words">
+                                    {subItem.name.replace(/—/g, '').trim()}
+                                  </p>
+                                )
+                              ) : (
+                                <MobileSubLink
+                                  key={`${subItem.name}-${subItem.href ?? 'nohref'}`}
+                                  subItem={subItem}
+                                  itemId={item.id}
+                                  programApplyLinks={programApplyLinks}
+                                  onNavigate={closeMenu}
+                                />
+                              ),
+                            )}
+                      </div>
+                    ) : null}
+                  </section>
+                );
+              })}
+            </nav>
 
-              {/* Sticky footer */}
-              <div className="border-t border-slate-200 p-4 bg-white shrink-0 pb-[env(safe-area-inset-bottom)]">
-                <div className="flex gap-2 mb-3">
-                  <Link
-                    href="/apply"
-                    prefetch={false}
-                    onClick={closeMenu}
-                    className="flex-1 flex items-center justify-center py-3 min-h-[44px] bg-brand-red-600 text-white rounded-lg font-semibold text-sm hover:bg-brand-red-700"
-                  >
-                    Apply Now
-                  </Link>
-                  <Link
-                    href="/login"
-                    prefetch={false}
-                    onClick={closeMenu}
-                    className="flex-1 flex items-center justify-center gap-1.5 py-3 min-h-[44px] border border-slate-300 text-slate-800 rounded-lg font-semibold text-sm hover:bg-slate-50"
-                  >
-                    <Lock className="h-4 w-4" aria-hidden="true" />
-                    Sign In
-                  </Link>
-                </div>
-                <a
-                  href="tel:+13173143757"
-                  className="flex items-center justify-center gap-1.5 py-3 min-h-[44px] text-sm font-medium text-slate-500 hover:text-brand-blue-600"
+            <div className="border-t border-slate-200 p-4 bg-white shrink-0 pb-[env(safe-area-inset-bottom)]">
+              <div className="flex gap-2 mb-3">
+                <MenuLink
+                  href={ROUTES.apply}
+                  onNavigate={closeMenu}
+                  className="flex-1 flex items-center justify-center py-3 min-h-[44px] bg-brand-red-600 text-white rounded-lg font-semibold text-sm hover:bg-brand-red-700"
                 >
-                  <Phone className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
-                  (317) 314-3757
-                </a>
+                  Apply Now
+                </MenuLink>
+                <MenuLink
+                  href={ROUTES.login}
+                  onNavigate={closeMenu}
+                  className="flex-1 flex items-center justify-center gap-1.5 py-3 min-h-[44px] border border-slate-300 text-slate-800 rounded-lg font-semibold text-sm hover:bg-slate-50"
+                >
+                  <Lock className="h-4 w-4" aria-hidden="true" />
+                  Sign In
+                </MenuLink>
               </div>
+              <a
+                href={phoneHref(siteUrls.org.phone)}
+                className="flex items-center justify-center gap-1.5 py-3 min-h-[44px] text-sm font-medium text-slate-500 hover:text-brand-blue-600"
+              >
+                <Phone className="h-4 w-4 flex-shrink-0" aria-hidden="true" />
+                {siteUrls.org.phone}
+              </a>
             </div>
-          </>,
-          document.body,
-        )
-      : null;
+          </div>
+        </>,
+        document.body,
+      )
+    : null;
 
   return (
     <div className="flex flex-row flex-nowrap items-center justify-end gap-0.5 shrink-0">
       <SearchModal />
-      <LanguageSwitcher compact={true} />
+      <LanguageSwitcher compact />
       <button
         type="button"
         onClick={() => setIsOpen((open) => !open)}
         className="p-2 text-slate-700 hover:text-slate-900 hover:bg-slate-100 rounded-lg min-h-[44px] min-w-[44px] flex items-center justify-center"
         aria-label={isOpen ? 'Close menu' : 'Open menu'}
         aria-expanded={isOpen}
+        aria-controls="mobile-site-navigation"
       >
-        {isOpen ? (
-          <X className="h-5 w-5" aria-hidden="true" />
-        ) : (
-          <Menu className="h-5 w-5" aria-hidden="true" />
-        )}
+        {isOpen ? <X className="h-5 w-5" aria-hidden="true" /> : <Menu className="h-5 w-5" aria-hidden="true" />}
       </button>
       {drawer}
     </div>

--- a/consolidation/feature-preservation.json
+++ b/consolidation/feature-preservation.json
@@ -1,0 +1,90 @@
+{
+  "version": 1,
+  "branch": "consolidation/unified-platform",
+  "canonicalRepository": "elevate-for-humanity/Elevate-lms",
+  "donorRepositories": ["elevateforhumanity/fix2"],
+  "policy": {
+    "preserveFeaturesBeforeDeletion": true,
+    "requireFeatureParity": true,
+    "requireBuildBeforeDeletion": true,
+    "requireTypecheckBeforeDeletion": true,
+    "requireRouteVerificationBeforeDeletion": true,
+    "requireSchemaAuditBeforeDeletion": true,
+    "requireRlsAuditBeforeDeletion": true,
+    "requireRollbackPath": true
+  },
+  "canonicalDomains": {
+    "marketing": {
+      "target": "apps/marketing",
+      "status": "canonical",
+      "preserve": ["public pages", "program catalog", "applications", "compliance", "employer and workforce content", "SEO", "storefront surfaces"]
+    },
+    "admin": {
+      "target": "apps/admin",
+      "status": "canonical",
+      "preserve": ["admin dashboard", "student management", "program management", "analytics", "reports", "course builder", "dev studio controls"]
+    },
+    "lms": {
+      "target": "apps/lms",
+      "status": "canonical",
+      "preserve": ["courses", "lessons", "progress", "quizzes", "certificates", "OJT", "student learning experience"]
+    },
+    "platformApi": {
+      "target": "apps/app",
+      "status": "shared-backend",
+      "preserve": ["API routes", "course builder APIs", "dev studio APIs", "auth dependent operations", "workflow integrations"]
+    },
+    "courseBuilder": {
+      "target": "scripts/course-builder + lib/course-builder + apps/admin/app/admin/course-builder",
+      "status": "consolidate",
+      "knownAudit": "docs/audits/COURSE-BUILDER-CONSOLIDATION-AUDIT.md",
+      "rule": "do not delete a generator, seed, media, import/export, validation, or partner integration until its behavior is represented by the canonical pipeline"
+    },
+    "devStudio": {
+      "target": "apps/admin/app/dev-studio + lib/devstudio",
+      "status": "consolidate",
+      "rule": "admin is the operational Dev Studio; marketing/store routes may remain only as product/landing surfaces; LMS route must redirect or delegate unless it provides unique authenticated capability"
+    },
+    "orchestrator": {
+      "target": "components/OrchestratorAdmin.tsx + lib/autopilot + canonical worker",
+      "status": "consolidate",
+      "requiredEnv": ["NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL"],
+      "rule": "one supervisor; specialized workers may remain only when they expose unique capabilities through the supervisor registry"
+    },
+    "supabase": {
+      "target": "supabase/migrations + shared Supabase clients",
+      "status": "canonical",
+      "rule": "one authoritative schema history; duplicate migrations must be reconciled, never blindly deleted after application"
+    },
+    "cloudflare": {
+      "target": "canonical Workers/KV/R2/DNS configuration",
+      "status": "canonicalize",
+      "rule": "one environment naming scheme and one documented deployment path; preserve existing bindings until consumers are migrated"
+    },
+    "github": {
+      "target": "elevate-for-humanity/Elevate-lms",
+      "status": "canonical",
+      "rule": "all future production development lands here after donor parity is verified"
+    },
+    "documentation": {
+      "target": "README.md + docs/architecture + docs/operations",
+      "status": "consolidate-last",
+      "rule": "README and architecture docs must describe only the final verified system, not historical or aspirational states"
+    },
+    "pluginsAndIntegrations": {
+      "status": "preserve",
+      "rule": "existing working integrations are dependencies; consolidate wrappers and configuration around them without disconnecting providers"
+    }
+  },
+  "deletionGate": [
+    "inventory current and donor implementations",
+    "identify unique capabilities",
+    "merge unique capabilities into canonical implementation",
+    "redirect all imports/routes/callers",
+    "run targeted tests",
+    "run typecheck and production build",
+    "run schema/RLS/integrity checks where applicable",
+    "record rollback commit",
+    "only then delete obsolete implementation"
+  ]
+}

--- a/consolidation/feature-preservation.json
+++ b/consolidation/feature-preservation.json
@@ -1,8 +1,13 @@
 {
-  "version": 1,
+  "version": 2,
   "branch": "consolidation/unified-platform",
   "canonicalRepository": "elevate-for-humanity/Elevate-lms",
-  "donorRepositories": ["elevateforhumanity/fix2"],
+  "donorRepositories": [],
+  "repositoryScope": {
+    "include": ["elevate-for-humanity/Elevate-lms"],
+    "exclude": ["elevateforhumanity/fix2"],
+    "rule": "Consolidate only implementations already present in Elevate-lms. Do not import, compare, merge, or depend on fix2."
+  },
   "policy": {
     "preserveFeaturesBeforeDeletion": true,
     "requireFeatureParity": true,
@@ -14,70 +19,22 @@
     "requireRollbackPath": true
   },
   "canonicalDomains": {
-    "marketing": {
-      "target": "apps/marketing",
-      "status": "canonical",
-      "preserve": ["public pages", "program catalog", "applications", "compliance", "employer and workforce content", "SEO", "storefront surfaces"]
-    },
-    "admin": {
-      "target": "apps/admin",
-      "status": "canonical",
-      "preserve": ["admin dashboard", "student management", "program management", "analytics", "reports", "course builder", "dev studio controls"]
-    },
-    "lms": {
-      "target": "apps/lms",
-      "status": "canonical",
-      "preserve": ["courses", "lessons", "progress", "quizzes", "certificates", "OJT", "student learning experience"]
-    },
-    "platformApi": {
-      "target": "apps/app",
-      "status": "shared-backend",
-      "preserve": ["API routes", "course builder APIs", "dev studio APIs", "auth dependent operations", "workflow integrations"]
-    },
-    "courseBuilder": {
-      "target": "scripts/course-builder + lib/course-builder + apps/admin/app/admin/course-builder",
-      "status": "consolidate",
-      "knownAudit": "docs/audits/COURSE-BUILDER-CONSOLIDATION-AUDIT.md",
-      "rule": "do not delete a generator, seed, media, import/export, validation, or partner integration until its behavior is represented by the canonical pipeline"
-    },
-    "devStudio": {
-      "target": "apps/admin/app/dev-studio + lib/devstudio",
-      "status": "consolidate",
-      "rule": "admin is the operational Dev Studio; marketing/store routes may remain only as product/landing surfaces; LMS route must redirect or delegate unless it provides unique authenticated capability"
-    },
-    "orchestrator": {
-      "target": "components/OrchestratorAdmin.tsx + lib/autopilot + canonical worker",
-      "status": "consolidate",
-      "requiredEnv": ["NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL"],
-      "rule": "one supervisor; specialized workers may remain only when they expose unique capabilities through the supervisor registry"
-    },
-    "supabase": {
-      "target": "supabase/migrations + shared Supabase clients",
-      "status": "canonical",
-      "rule": "one authoritative schema history; duplicate migrations must be reconciled, never blindly deleted after application"
-    },
-    "cloudflare": {
-      "target": "canonical Workers/KV/R2/DNS configuration",
-      "status": "canonicalize",
-      "rule": "one environment naming scheme and one documented deployment path; preserve existing bindings until consumers are migrated"
-    },
-    "github": {
-      "target": "elevate-for-humanity/Elevate-lms",
-      "status": "canonical",
-      "rule": "all future production development lands here after donor parity is verified"
-    },
-    "documentation": {
-      "target": "README.md + docs/architecture + docs/operations",
-      "status": "consolidate-last",
-      "rule": "README and architecture docs must describe only the final verified system, not historical or aspirational states"
-    },
-    "pluginsAndIntegrations": {
-      "status": "preserve",
-      "rule": "existing working integrations are dependencies; consolidate wrappers and configuration around them without disconnecting providers"
-    }
+    "marketing": {"target": "apps/marketing", "status": "canonical"},
+    "admin": {"target": "apps/admin", "status": "canonical"},
+    "lms": {"target": "apps/lms", "status": "canonical"},
+    "platformApi": {"target": "apps/app", "status": "shared-backend"},
+    "courseBuilder": {"target": "scripts/course-builder + lib/course-builder + apps/admin/app/admin/course-builder", "status": "consolidate"},
+    "devStudio": {"target": "apps/admin/app/dev-studio + lib/devstudio", "status": "consolidate"},
+    "orchestrator": {"target": "components/OrchestratorAdmin.tsx + lib/autopilot + canonical worker", "status": "consolidate", "requiredEnv": ["NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL"]},
+    "supabase": {"target": "supabase/migrations + shared Supabase clients", "status": "canonical", "project": "elevate"},
+    "cloudflare": {"target": "canonical Workers/KV/R2/DNS configuration", "status": "canonicalize"},
+    "northflankDocker": {"target": "Dockerfile + deployment health/build gates", "status": "canonicalize"},
+    "github": {"target": "elevate-for-humanity/Elevate-lms", "status": "canonical"},
+    "documentation": {"target": "README.md + docs/architecture + docs/operations", "status": "consolidate-last"},
+    "pluginsAndIntegrations": {"status": "preserve"}
   },
   "deletionGate": [
-    "inventory current and donor implementations",
+    "inventory duplicate implementations inside Elevate-lms",
     "identify unique capabilities",
     "merge unique capabilities into canonical implementation",
     "redirect all imports/routes/callers",

--- a/consolidation/supervisor-tasks.json
+++ b/consolidation/supervisor-tasks.json
@@ -1,0 +1,139 @@
+{
+  "plan": "unified-platform-consolidation",
+  "mode": "supervised",
+  "branch": "consolidation/unified-platform",
+  "rules": {
+    "neverWriteMainDirectly": true,
+    "neverDeleteBeforeParity": true,
+    "preserveWorkingIntegrations": true,
+    "preserveAppliedMigrationHistory": true,
+    "stopOnFailedGate": true,
+    "recordRollbackCommitBeforeDeletion": true
+  },
+  "waves": [
+    {
+      "id": "foundation",
+      "goal": "Make the supervisor and preservation controls reliable",
+      "tasks": [
+        "configure orchestrator endpoint from NEXT_PUBLIC_AUTOPILOT_ORCHESTRATOR_URL",
+        "inventory registered autopilots and unique capabilities",
+        "map plugin/integration dependencies",
+        "establish canonical repository and workspace boundaries",
+        "verify no production writes target main"
+      ],
+      "gate": ["typecheck", "orchestrator diagnostics", "feature-preservation manifest present"]
+    },
+    {
+      "id": "dev-studio",
+      "goal": "One operational Dev Studio",
+      "canonical": ["apps/admin/app/admin/studio", "lib/devstudio"],
+      "review": [
+        "apps/admin/app/dev-studio/page.tsx",
+        "apps/lms/app/ai/dev-studio/page.tsx",
+        "apps/marketing/app/ai/dev-studio/page.tsx",
+        "apps/marketing/app/store/dev-studio/page.tsx",
+        "apps/marketing/app/(marketing)/dev-studio/page.tsx",
+        "lib/paris/dev-studio.ts"
+      ],
+      "tasks": [
+        "classify each route as operational UI, authenticated delegate, marketing landing page, store product page, or obsolete duplicate",
+        "move unique operational capabilities into canonical admin studio",
+        "replace duplicate operational routes with redirects/delegation only after parity",
+        "preserve public/store landing pages when their purpose is marketing rather than operations",
+        "run dev-studio integration gate"
+      ],
+      "gate": ["dev studio route tests", "auth guard audit", "API integration gate", "build"]
+    },
+    {
+      "id": "course-builder",
+      "goal": "One course-building engine with one admin UI",
+      "canonical": [
+        "scripts/course-builder",
+        "lib/course-builder",
+        "apps/admin/app/admin/course-builder",
+        "apps/app/api/admin/course-builder"
+      ],
+      "referenceAudit": "docs/audits/COURSE-BUILDER-CONSOLIDATION-AUDIT.md",
+      "tasks": [
+        "inventory generators, seeds, validators, video generators, imports and exports",
+        "merge unique behavior into canonical pipeline",
+        "route AI write, quick add and lesson patch through canonical service layer",
+        "verify all existing program-specific generation behavior",
+        "remove obsolete scripts only after regression fixtures pass"
+      ],
+      "gate": ["course builder tests", "generated-course validation", "database insert/sync test", "build"]
+    },
+    {
+      "id": "supabase",
+      "goal": "One authoritative schema and client layer",
+      "canonical": ["supabase/migrations", "shared Supabase clients"],
+      "tasks": [
+        "retain immutable migration history that may already be applied",
+        "use reconciliation migrations for conflicting historical schemas",
+        "audit schema drift",
+        "audit RLS",
+        "consolidate duplicate client wrappers after caller migration",
+        "verify auth roles and tenant scoping"
+      ],
+      "gate": ["migration discipline audit", "schema drift audit", "RLS audit", "auth tests"]
+    },
+    {
+      "id": "product-surfaces",
+      "goal": "One Marketing app, one Admin app and one LMS app with clear ownership",
+      "canonical": {
+        "marketing": "apps/marketing",
+        "admin": "apps/admin",
+        "lms": "apps/lms",
+        "sharedApi": "apps/app"
+      },
+      "tasks": [
+        "move public-only pages to marketing ownership",
+        "move operator-only pages to admin ownership",
+        "move learner learning experiences to LMS ownership",
+        "keep shared APIs in the platform API app until safely extracted",
+        "replace cross-app duplicate pages with redirects or shared packages",
+        "deduplicate navigation and route aliases"
+      ],
+      "gate": ["critical route guard", "dead-link audit", "auth route tests", "marketing build", "admin build", "LMS build"]
+    },
+    {
+      "id": "infrastructure",
+      "goal": "One deployment and infrastructure model",
+      "tasks": [
+        "canonicalize Cloudflare Worker/KV/R2 binding names",
+        "verify DNS and SSL automation without changing working domains unnecessarily",
+        "consolidate duplicate Dockerfiles by deployed service purpose",
+        "verify GitHub CI and protected-branch workflow",
+        "preserve plugin credentials and provider integrations",
+        "remove stale deployment documentation only after active path is verified"
+      ],
+      "gate": ["environment audit", "deployment identity check", "post-deploy smoke specification"]
+    },
+    {
+      "id": "documentation",
+      "goal": "Make repository documentation describe the real unified product",
+      "tasks": [
+        "rewrite README from verified architecture",
+        "create one architecture document",
+        "create one deployment runbook",
+        "create one environment-variable reference without secrets",
+        "archive or remove contradictory readiness reports",
+        "mark open-source boundaries and licenses"
+      ],
+      "gate": ["README matches code", "no placeholder infrastructure URLs", "no contradictory production-readiness claims"]
+    },
+    {
+      "id": "final",
+      "goal": "Prove feature parity before merging to main",
+      "tasks": [
+        "compare donor feature inventory against canonical inventory",
+        "run typecheck lint tests and production builds",
+        "run route/link/media/integrity checks",
+        "run schema/RLS/auth/security gates",
+        "verify student, admin, employer, workforce, course-builder and Dev Studio journeys",
+        "produce final deletion ledger and rollback reference"
+      ],
+      "gate": ["all required checks green", "zero unclassified feature losses", "supervisor sign-off"]
+    }
+  ]
+}

--- a/lib/enrollment/approve.ts
+++ b/lib/enrollment/approve.ts
@@ -5,7 +5,7 @@
  * Steps:
  * 1. Find or create auth user + profile
  * 2. Create program_enrollments (enrollment_state: 'active')
- * 3. Create training_enrollments for all active courses in the program
+ * 3. Create course_enrollments for all active LMS courses in the program
  * 4. Update application status to 'approved'
  * 5. Update profile enrollment_status to 'active'
  */
@@ -23,12 +23,7 @@ export interface ApproveApplicationInput {
   applicationId: string;
   programId?: string | null;
   fundingType?: string | null;
-  /** Role to assign to the created/updated profile. Defaults to 'student'. */
   role?: string;
-  /**
-   * Skip the Stripe/funding payment gate. Set to true for admin-initiated
-   * approvals where the admin is manually overriding payment verification.
-   */
   bypassPaymentGate?: boolean;
 }
 
@@ -36,9 +31,7 @@ export interface ApproveApplicationResult {
   success: boolean;
   userId?: string;
   enrollmentId?: string | null;
-  /** Password setup link for new users — null if user already existed */
   passwordSetupLink?: string | null;
-  /** Temporary password for new accounts — null if user already existed */
   tempPassword?: string | null;
   error?: string;
 }
@@ -48,68 +41,30 @@ export async function approveApplication(
   input: ApproveApplicationInput,
 ): Promise<ApproveApplicationResult> {
   const { applicationId, programId, role: assignedRole = 'student' } = input;
-  // fundingType from the caller takes precedence; fall back to what the student
-  // selected on the application (verified by WorkOne where required).
   let fundingType = input.fundingType;
 
-  // Load application
   const { data: app, error: appError } = await db
     .from('applications')
     .select('*')
     .eq('id', applicationId)
     .maybeSingle();
 
-  if (appError || !app) {
-    return { success: false, error: 'Application not found' };
-  }
+  if (appError || !app) return { success: false, error: 'Application not found' };
+  if (app.status === 'approved') return { success: true, userId: app.user_id, error: 'Already approved' };
 
-  if (app.status === 'approved') {
-    return { success: true, userId: app.user_id, error: 'Already approved' };
-  }
-
-  // Block approval of WorkOne-pending applications until external confirmation is on record.
-  // Staff must update has_workone_approval = true (and optionally workone_approval_ref)
-  // before approving. This prevents enrolling students whose WIOA eligibility is unconfirmed.
   if (app.status === 'pending_workone' && !app.has_workone_approval) {
-    return {
-      success: false,
-      error:
-        'This application is pending WorkOne eligibility confirmation. Update has_workone_approval before approving.',
-    };
+    return { success: false, error: 'This application is pending WorkOne eligibility confirmation. Update has_workone_approval before approving.' };
   }
 
-  // PAYMENT GATE — enrollment requires Stripe payment OR verified funding.
-  // This is the canonical enforcement point. No enrollment is created without one of:
-  //   1. A paid Stripe session in stripe_sessions_staging
-  //   2. funding_verified = true on the application (WIOA/WorkOne/EmployIndy confirmed)
-  //   3. WorkOne approval on file (has_workone_approval = true)
-  //   4. Source is 'stripe_repair' (reconciliation — Stripe session verified separately)
-  //   5. bypassPaymentGate = true (admin manual override — audited separately)
   const isRepair = (input as any).source === 'stripe_repair';
-
-  // Non-self-pay funding types bypass the payment gate — they go through
-  // WIOA, Workforce Ready Grant, employer sponsorship, or are pending review.
-  const NON_SELF_PAY = [
-    'wioa',
-    'wrg',
-    'employer',
-    'unsure',
-    'workforce',
-    'grant',
-    'scholarship',
-    'dol',
-    'apprenticeship',
-  ];
+  const NON_SELF_PAY = ['wioa','wrg','employer','unsure','workforce','grant','scholarship','dol','apprenticeship'];
   const appFundingType = (app.funding_type || app.funding_source || '').toLowerCase();
   const isFundedPath = NON_SELF_PAY.some((f) => appFundingType.includes(f));
-
   const skipGate = isRepair || input.bypassPaymentGate === true || isFundedPath;
 
   if (!skipGate) {
     const hasFundingVerified = app.funding_verified === true || app.has_workone_approval === true;
-
     if (!hasFundingVerified) {
-      // Check stripe_sessions_staging for a paid session
       const { data: stripeSession } = await db
         .from('stripe_sessions_staging')
         .select('session_id')
@@ -117,309 +72,139 @@ export async function approveApplication(
         .eq('payment_status', 'paid')
         .limit(1)
         .maybeSingle();
-
       if (!stripeSession) {
-        return {
-          success: false,
-          error:
-            'PAYMENT_NOT_VERIFIED: No paid Stripe session and no verified funding on file. Enrollment requires payment or approved funding before access is granted.',
-        };
+        return { success: false, error: 'PAYMENT_NOT_VERIFIED: No paid Stripe session and no verified funding on file. Enrollment requires payment or approved funding before access is granted.' };
       }
     }
   }
 
   const email = (app.email || '').trim().toLowerCase();
-  if (!email) {
-    return { success: false, error: 'Application has no email' };
-  }
+  if (!email) return { success: false, error: 'Application has no email' };
 
-  // Step 1: Find or create user
   let userId: string | null = null;
   let isNewUser = false;
   let tempPassword: string | null = null;
   let passwordSetupLink: string | null = null;
 
-  // Check profiles first (fast, indexed)
-  const { data: existingProfile } = await db
-    .from('profiles')
-    .select('id')
-    .eq('email', email)
-    .maybeSingle();
+  const { data: existingProfile } = await db.from('profiles').select('id').eq('email', email).maybeSingle();
 
   if (existingProfile) {
     userId = existingProfile.id;
   } else {
-    // Check auth users
     const { data: listUsers } = await db.auth.admin.listUsers({ page: 1, perPage: 100 });
     const existingUser = listUsers?.users?.find((u: { email?: string; id: string }) => u.email?.toLowerCase() === email);
-
     if (existingUser) {
       userId = existingUser.id;
     } else {
-      // Create new auth user with a cryptographically random temp password.
-      // Math.random() is predictable — use randomBytes instead.
       tempPassword = `EFH-${randomBytes(8).toString('hex')}-Temp!`;
       const { data: newUser, error: createError } = await db.auth.admin.createUser({
         email,
         password: tempPassword,
         email_confirm: true,
-        user_metadata: {
-          full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(),
-          role: 'student',
-          must_change_password: true,
-        },
+        user_metadata: { full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(), role: 'student', must_change_password: true },
       });
-
       if (createError || !newUser?.user) {
         logger.error('[approve] Failed to create user', createError ?? undefined, { email });
         return { success: false, error: 'Failed to create user account' };
       }
       userId = newUser.user.id;
       isNewUser = true;
-
-      // Generate a one-time recovery link so the student sets their own password.
-      // Never email the tempPassword — it is only used as the initial auth credential.
       const siteUrl = (process.env.NEXT_PUBLIC_SITE_URL || PLATFORM_DEFAULTS.siteUrl).trim();
       const { data: linkData, error: linkError } = await db.auth.admin.generateLink({
-        type: 'recovery',
-        email,
-        options: { redirectTo: `${siteUrl}/auth/callback?redirect=/onboarding/learner` },
+        type: 'recovery', email, options: { redirectTo: `${siteUrl}/auth/callback?redirect=/onboarding/learner` },
       });
-      if (!linkError && linkData?.properties?.action_link) {
-        passwordSetupLink = linkData.properties.action_link;
-      } else {
-        logger.warn('[approve] generateLink failed — student will use forgot-password flow', linkError ?? undefined);
-      }
+      if (!linkError && linkData?.properties?.action_link) passwordSetupLink = linkData.properties.action_link;
+      else logger.warn('[approve] generateLink failed — student will use forgot-password flow', linkError ?? undefined);
     }
 
-    // Ensure profile exists for newly created user
-    await db.from('profiles').upsert(
-      {
-        id: userId,
-        email,
-        first_name: app.first_name,
-        last_name: app.last_name,
-        full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(),
-        phone: app.phone,
-        role: assignedRole,
-      },
-      { onConflict: 'id' },
-    );
+    await db.from('profiles').upsert({
+      id: userId, email, first_name: app.first_name, last_name: app.last_name,
+      full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(), phone: app.phone, role: assignedRole,
+    }, { onConflict: 'id' });
   }
 
-  // Profile already existed — update role if a non-default role was assigned
-  if (existingProfile && assignedRole !== 'student') {
-    await db.from('profiles').update({ role: assignedRole }).eq('id', userId);
-  }
+  if (existingProfile && assignedRole !== 'student') await db.from('profiles').update({ role: assignedRole }).eq('id', userId);
+  if (!fundingType) fundingType = app.requested_funding_source || 'pending';
 
-  // Resolve funding source: caller override → application's requested source → 'pending'
-  if (!fundingType) {
-    fundingType = app.requested_funding_source || 'pending';
-  }
-
-  // Step 2: Create program_enrollments (students only)
   const resolvedProgramId = programId || app.program_id || null;
   let enrollmentId: string | null = null;
 
   if (assignedRole === 'student' && resolvedProgramId) {
-    // Resolve course_id so the learner dashboard routes to the LMS, not the marketing page.
     let programSlug = app.program_slug ?? app.pathway_slug ?? null;
-
-    // If program_slug is null but we have a program_id, look up the slug from the programs table.
-    // This prevents the upsert conflict key (user_id, program_slug) from silently failing
-    // when program_slug is null — NULL != NULL in SQL unique constraints.
-    if (!programSlug && resolvedProgramId) {
-      const { data: programRow } = await db
-        .from('programs')
-        .select('slug')
-        .eq('id', resolvedProgramId)
-        .maybeSingle();
+    if (!programSlug) {
+      const { data: programRow } = await db.from('programs').select('slug').eq('id', resolvedProgramId).maybeSingle();
       if (programRow?.slug) {
         programSlug = programRow.slug;
-        // Backfill the application so future runs don't hit this path
-        await db
-          .from('applications')
-          .update({ program_slug: programSlug })
-          .eq('id', applicationId);
+        await db.from('applications').update({ program_slug: programSlug }).eq('id', applicationId);
       }
     }
 
-    // Static fallback — runtime DB resolution happens in the LMS routing layer.
     const resolvedCourseId = programSlug ? resolveCourseId(programSlug) : null;
+    const { data: pe, error: peErr } = await db.from('program_enrollments').upsert({
+      user_id: userId, program_id: resolvedProgramId, program_slug: programSlug, email,
+      full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(), amount_paid_cents: 0,
+      funding_source: fundingType || 'pending', status: 'active', enrollment_state: 'active',
+      funding_verified: false, payout_status: 'pending', at_risk: false,
+      ...(resolvedCourseId ? { course_id: resolvedCourseId } : {}),
+    }, { onConflict: 'user_id,program_slug', ignoreDuplicates: false }).select('id').maybeSingle();
 
-    const { data: pe, error: peErr } = await db
-      .from('program_enrollments')
-      .upsert(
-        {
-          user_id: userId,
-          program_id: resolvedProgramId,
-          program_slug: programSlug,
-          email,
-          full_name: `${app.first_name || ''} ${app.last_name || ''}`.trim(),
-          amount_paid_cents: 0,
-          funding_source: fundingType || 'pending',
-          status: 'active',
-          enrollment_state: 'active',
-          funding_verified: false, // NOT NULL
-          payout_status: 'pending', // NOT NULL
-          at_risk: false, // NOT NULL
-          ...(resolvedCourseId ? { course_id: resolvedCourseId } : {}),
-        },
-        { onConflict: 'user_id,program_slug', ignoreDuplicates: false },
-      )
-      .select('id')
-      .maybeSingle();
-
-    if (peErr) {
-      logger.error('[approve] program_enrollments upsert failed', new Error(peErr.message), {
-        userId,
-        resolvedProgramId,
-      });
-    }
-
+    if (peErr) logger.error('[approve] program_enrollments upsert failed', new Error(peErr.message), { userId, resolvedProgramId });
     enrollmentId = pe?.id || null;
 
-    // Cache portal_type on the profile so post-login routing is a single lookup
-    if (userId && resolvedProgramId) {
-      await cachePortalTypeForEnrollment(db, userId, resolvedProgramId);
-    }
+    if (userId) await cachePortalTypeForEnrollment(db, userId, resolvedProgramId);
 
-    // Step 3: Create training_enrollments for all active courses
-    const { data: courses } = await db
-      .from('lms_courses')
-      .select('id')
-      .eq('program_id', resolvedProgramId)
-      .eq('is_active', true);
-
-    if (courses && courses.length > 0) {
-      await db.from('program_enrollments').upsert(
-        courses.map((c: { id: string }) => ({
-          user_id: userId,
-          course_id: c.id,
-          status: 'active',
-          progress: 0,
-          enrolled_at: new Date().toISOString(),
-        })),
-        { onConflict: 'user_id,course_id', ignoreDuplicates: true },
-      );
+    // Canonical LMS access table. The DB trigger installed by
+    // 20260806200400_sync_active_program_enrollments_to_course_access.sql also
+    // enforces this invariant for any other writer of program_enrollments.
+    const { data: courses } = await db.from('lms_courses').select('id').eq('program_id', resolvedProgramId).eq('is_active', true);
+    if (courses?.length) {
+      for (const course of courses as Array<{ id: string }>) {
+        const { data: existingCourseEnrollment } = await db.from('course_enrollments')
+          .select('id').eq('student_id', userId).eq('course_id', course.id).maybeSingle();
+        if (!existingCourseEnrollment) {
+          const { error: courseEnrollmentError } = await db.from('course_enrollments').insert({
+            student_id: userId, course_id: course.id, status: 'active', progress: '0',
+          });
+          if (courseEnrollmentError) logger.error('[approve] course_enrollments insert failed', new Error(courseEnrollmentError.message), { userId, courseId: course.id });
+        }
+      }
     }
   }
 
-  // Step 4: Update application status
-  await db
-    .from('applications')
-    .update({
-      status: 'approved',
-      user_id: userId,
-      program_id: resolvedProgramId,
-      eligibility_status: 'verified',
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', applicationId);
+  await db.from('applications').update({
+    status: 'approved', user_id: userId, program_id: resolvedProgramId,
+    eligibility_status: 'verified', updated_at: new Date().toISOString(),
+  }).eq('id', applicationId);
 
-  // Step 5: Update profile enrollment_status (students only)
-  if (assignedRole === 'student') {
-    await db.from('profiles').update({ enrollment_status: 'active' }).eq('id', userId);
-  }
+  if (assignedRole === 'student') await db.from('profiles').update({ enrollment_status: 'active' }).eq('id', userId);
 
-  // Step 5b: Create digital binder for the enrollment (idempotent)
   if (userId && enrollmentId) {
-    const binderResult = await ensureDigitalBinder({
-      db,
-      userId,
-      enrollmentId,
-    });
-    if (binderResult.binderId) {
-      logger.info("[approve] Digital binder created", { enrollmentId, binderId: binderResult.binderId });
-    }
+    const binderResult = await ensureDigitalBinder({ db, userId, enrollmentId });
+    if (binderResult.binderId) logger.info('[approve] Digital binder created', { enrollmentId, binderId: binderResult.binderId });
   }
 
-  // ── Partner routing ──────────────────────────────────────────────────────
-  // CNA uses the full atomic RPC: financial gate + compliance gate +
-  // state-machine transitions + training_enrollments + partner_enrollments +
-  // cmi_students + audit log, all in one transaction with FOR UPDATE row lock.
-  // NHA and future partners fall through to the application-layer path.
   const ATOMIC_SLUGS = new Set(['cna']);
-
   if (ATOMIC_SLUGS.has(app.program_slug ?? '')) {
-    const { data: atomicResult, error: atomicErr } = await db.rpc(
-      'approve_application_and_grant_access_atomic',
-      {
-        p_application_id: applicationId,
-        p_actor_user_id: userId,
-      },
-    );
-
+    const { data: atomicResult, error: atomicErr } = await db.rpc('approve_application_and_grant_access_atomic', { p_application_id: applicationId, p_actor_user_id: userId });
     if (atomicErr) {
-      // RPC missing from DB (migration not yet applied) — fall through to
-      // application-layer path so non-atomic approval still completes.
-      // Apply supabase/migrations/20260503000011_approval_hardening.sql in
-      // Supabase Dashboard to restore the atomic path for CNA.
-      if (
-        atomicErr.message.includes('Could not find the function') ||
-        atomicErr.message.includes('schema cache')
-      ) {
-        logger.warn('[approve] atomic RPC not found — falling back to application-layer path', {
-          applicationId,
-          slug: app.program_slug,
-          hint: 'Apply migration 20260503000011_approval_hardening.sql in Supabase Dashboard',
-        });
+      if (atomicErr.message.includes('Could not find the function') || atomicErr.message.includes('schema cache')) {
+        logger.warn('[approve] atomic RPC not found — falling back to application-layer path', { applicationId, slug: app.program_slug });
         await attachPartnerRouting({ db, application: { ...app, user_id: userId } });
-      } else {
-        throw new Error(`Atomic approval failed (${app.program_slug}): ${atomicErr.message}`);
-      }
-    } else {
-      if (atomicResult?.status === 'blocked') {
-        return {
-          success: false,
-          error: `Approval blocked: ${(atomicResult.blockers as string[]).join(', ')}`,
-        };
-      }
-
-      logger.info('[approve] atomic approval complete', {
-        applicationId,
-        userId,
-        result: atomicResult,
-      });
+      } else throw new Error(`Atomic approval failed (${app.program_slug}): ${atomicErr.message}`);
+    } else if (atomicResult?.status === 'blocked') {
+      return { success: false, error: `Approval blocked: ${(atomicResult.blockers as string[]).join(', ')}` };
     }
   } else {
-    // NHA and non-partner programs — application-layer idempotent path
     await attachPartnerRouting({ db, application: { ...app, user_id: userId } });
   }
 
-  // tempPassword is set above when a new account is created.
-  // It is passed to the onboarding email so the student can log in immediately.
-  // They are prompted to change it during onboarding.
-
-  // Update CRM lead to converted (non-fatal)
   try {
-    await db
-      .from('crm_leads')
-      .update({
-        stage: 'converted',
-        status: 'won',
-        profile_id: userId ?? null,
-        enrollment_id: enrollmentId ?? null,
-        updated_at: new Date().toISOString(),
-      })
-      .eq('application_id', applicationId);
-
-    await db
-      .from('follow_up_reminders')
-      .update({ status: 'completed' })
-      .eq('application_id', applicationId)
-      .eq('status', 'pending');
+    await db.from('crm_leads').update({ stage: 'converted', status: 'won', profile_id: userId ?? null, enrollment_id: enrollmentId ?? null, updated_at: new Date().toISOString() }).eq('application_id', applicationId);
+    await db.from('follow_up_reminders').update({ status: 'completed' }).eq('application_id', applicationId).eq('status', 'pending');
   } catch (crmErr) {
     logger.warn('[approve] CRM lead update failed (non-fatal)', crmErr);
   }
 
-  logger.info('[approve] Application approved', {
-    applicationId,
-    userId,
-    programId: resolvedProgramId,
-    enrollmentId,
-    isNewUser,
-  });
-
+  logger.info('[approve] Application approved', { applicationId, userId, programId: resolvedProgramId, enrollmentId, isNewUser });
   return { success: true, userId: userId!, enrollmentId, passwordSetupLink, tempPassword: null };
 }

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -8,7 +8,6 @@ import { type NavItem } from '@/types/navigation';
 import { ROUTES } from '@/lib/navigation/routes';
 
 export const NAV_ITEMS: NavItem[] = [
-  // ── 1. Programs ──────────────────────────────────────────────────────────────
   {
     id: 'programs',
     name: 'Programs',
@@ -29,7 +28,6 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'All Programs', href: ROUTES.programs, isSectionLink: true },
     ],
   },
-  // ── 2. Apprenticeships ────────────────────────────────────────────────────────
   {
     id: 'apprenticeships',
     name: 'Apprenticeships',
@@ -46,7 +44,6 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'Employer Sponsorship', href: ROUTES.apprenticeshipSponsor, isSectionLink: true },
     ],
   },
-  // ── 3. Funding ──────────────────────────────────────────────────────────────
   {
     id: 'funding',
     name: 'Funding',
@@ -61,7 +58,6 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'Check Eligibility', href: ROUTES.eligibility, isSectionLink: true },
     ],
   },
-  // ── 4. Employers ──────────────────────────────────────────────────────────────
   {
     id: 'employers',
     name: 'Employers',
@@ -70,12 +66,11 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'Hire Graduates', href: ROUTES.employersHireGraduates, isSectionLink: true },
       { name: 'Sponsor an Apprentice', href: ROUTES.apprenticeshipSponsor, isSectionLink: true },
       { name: 'Post a Job', href: ROUTES.employersPostJob, isSectionLink: true },
-      { name: 'Employer Portal', href: ROUTES.employersPostJob, isSectionLink: true },
+      { name: 'Employer Portal', href: ROUTES.employerPortal, isSectionLink: true },
       { name: 'Workforce Agency Tools', href: ROUTES.forAgencies, isSectionLink: true },
       { name: 'Request Demo', href: ROUTES.storeDemo, isSectionLink: true },
     ],
   },
-  // ── 5. About ───────────────────────────────────────────────────────────────
   {
     id: 'about',
     name: 'About',

--- a/lib/navigation/routes.ts
+++ b/lib/navigation/routes.ts
@@ -11,8 +11,9 @@ const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.elevateforhuman
 const ADMIN_URL = (process.env.NEXT_PUBLIC_ADMIN_URL ?? 'https://admin.elevateforhumanity.org').replace(/\/$/, '');
 
 export const ROUTES = {
-  // Home
+  // Home / intake
   home: '/',
+  apply: '/apply',
 
   // Authentication / portals
   login: `${APP_URL}/login`,

--- a/lib/navigation/routes.ts
+++ b/lib/navigation/routes.ts
@@ -1,17 +1,24 @@
 /**
- * Canonical Route Constants — single source of truth for all navigation routes.
+ * Canonical Route Constants — single source of truth for navigation.
  *
- * Usage:
- *   import { ROUTES } from '@/lib/navigation/routes';
- *   href={ROUTES.programs}
- *
- * These routes must match actual Next.js page files in apps/marketing/app/.
- * If a route returns 404, either create the page or update the constant.
+ * Marketing routes remain relative to www.elevateforhumanity.org.
+ * Authenticated portal routes use the deployed app/admin origins so navigation
+ * remains correct when Marketing, LMS, and Admin run as separate Northflank
+ * services.
  */
+
+const APP_URL = (process.env.NEXT_PUBLIC_APP_URL ?? 'https://app.elevateforhumanity.org').replace(/\/$/, '');
+const ADMIN_URL = (process.env.NEXT_PUBLIC_ADMIN_URL ?? 'https://admin.elevateforhumanity.org').replace(/\/$/, '');
 
 export const ROUTES = {
   // Home
   home: '/',
+
+  // Authentication / portals
+  login: `${APP_URL}/login`,
+  studentPortal: `${APP_URL}/learner/dashboard`,
+  employerPortal: `${APP_URL}/employer`,
+  adminLogin: `${ADMIN_URL}/login`,
 
   // Programs
   programs: '/programs',
@@ -32,32 +39,30 @@ export const ROUTES = {
 
   // Apprenticeships
   apprenticeships: '/apprenticeships',
-  apprenticeshipsHowItWorks: '/how-it-works', // '/apprenticeships/how-it-works' doesn't exist; use /how-it-works
+  apprenticeshipsHowItWorks: '/how-it-works',
   apprenticeshipsHostShop: '/apprenticeships/host-shop',
-
-  // Key apprenticeship route (was /apprenticeships/sponsor — now correct)
   apprenticeshipSponsor: '/apprenticeship-sponsor',
 
   // Funding
   funding: '/funding',
   fundingWIOA: '/funding/wioa',
   fundingJobReadyIndy: '/funding/job-ready-indy',
-  fundingVocRehab: '/funding/state-programs',  // /funding/voc-rehab doesn't exist; use state-programs
+  fundingVocRehab: '/funding/state-programs',
   scholarships: '/scholarships',
   eligibility: '/eligibility/quiz',
 
   // Employers
-  employers: '/employer',           // /employer page exists; /employers doesn't
+  employers: '/employer',
   employersHireGraduates: '/hire-graduates',
-  employersPostJob: '/employers/post-job',  // /employers/post-job exists
+  employersPostJob: '/employers/post-job',
   forAgencies: '/for-agencies',
 
   // About
   about: '/about',
-  aboutLocations: '/about',               // /about/locations doesn't exist; use /about
-  aboutApprovals: '/approvals',          // page is /approvals not /about/approvals
+  aboutLocations: '/about',
+  aboutApprovals: '/approvals',
   successStories: '/success-stories',
-  testing: '/testing',                   // /testing/testing-center doesn't exist; use /testing
+  testing: '/testing',
   blog: '/blog',
   faq: '/faq',
   contact: '/contact',

--- a/lib/utils/site-urls.ts
+++ b/lib/utils/site-urls.ts
@@ -1,47 +1,60 @@
 /**
  * Site URL Configuration
- * 
- * Single source of truth for all site URLs.
- * Use these instead of hardcoded values.
+ *
+ * Single source of truth for deployed Elevate service origins and common links.
+ * Do not hardcode production domains in components or route handlers.
  */
 
-const SITE_URL = process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org';
-const ADMIN_URL = process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.elevateforhumanity.org';
-const LMS_URL = process.env.NEXT_PUBLIC_LMS_URL || `${SITE_URL}/lms`;
+function clean(value: string): string {
+  return value.replace(/\/$/, '');
+}
+
+const SITE_URL = clean(process.env.NEXT_PUBLIC_SITE_URL || 'https://www.elevateforhumanity.org');
+const APP_URL = clean(
+  process.env.NEXT_PUBLIC_APP_URL ||
+    process.env.NEXT_PUBLIC_LMS_URL ||
+    'https://app.elevateforhumanity.org',
+);
+const ADMIN_URL = clean(process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.elevateforhumanity.org');
 const CANONICAL_DOMAIN = process.env.NEXT_PUBLIC_CANONICAL_DOMAIN || 'www.elevateforhumanity.org';
 const SUPPORT_EMAIL = process.env.NEXT_PUBLIC_SUPPORT_EMAIL || 'support@elevateforhumanity.org';
 const INFO_EMAIL = process.env.NEXT_PUBLIC_INFO_EMAIL || 'info@elevateforhumanity.org';
 const FROM_EMAIL = process.env.NEXT_PUBLIC_EMAIL_FROM_ADDRESS || 'noreply@elevateforhumanity.org';
+const SUPPORT_PHONE = process.env.NEXT_PUBLIC_SUPPORT_PHONE || '(317) 314-3757';
 
 export const siteUrls = {
-  // Main URLs
   site: SITE_URL,
-  www: `https://${CANONICAL_DOMAIN}`,
+  www: SITE_URL,
+  app: APP_URL,
+  lms: APP_URL,
   admin: ADMIN_URL,
-  lms: LMS_URL,
-  
-  // Paths
+
+  apply: `${SITE_URL}/apply`,
   enroll: `${SITE_URL}/enroll`,
-  login: `${SITE_URL}/login`,
-  dashboard: `${SITE_URL}/dashboard`,
+  login: `${APP_URL}/login`,
+  dashboard: `${APP_URL}/learner/dashboard`,
+  employerPortal: `${APP_URL}/employer`,
+  adminLogin: `${ADMIN_URL}/login`,
   adminDashboard: `${ADMIN_URL}/dashboard`,
-  
-  // Emails
+
   emails: {
     support: SUPPORT_EMAIL,
     info: INFO_EMAIL,
     from: FROM_EMAIL,
     fromName: process.env.NEXT_PUBLIC_EMAIL_FROM_NAME || 'Elevate for Humanity',
   },
-  
-  // Org
+
   org: {
     name: process.env.NEXT_PUBLIC_ORG_NAME || 'Elevate for Humanity',
-    legalName: process.env.NEXT_PUBLIC_ORG_LEGAL_NAME || 'Elevate for Humanity Technical and Career Institute',
-    phone: process.env.NEXT_PUBLIC_SUPPORT_PHONE || '(317) 314-3757',
-    address: 'Indianapolis, Indiana',
-    cage: '0Q856',
+    legalName:
+      process.env.NEXT_PUBLIC_ORG_LEGAL_NAME ||
+      'Elevate for Humanity Technical and Career Institute',
+    phone: SUPPORT_PHONE,
+    address: process.env.NEXT_PUBLIC_ORG_LOCATION || 'Indianapolis, Indiana',
+    cage: process.env.NEXT_PUBLIC_CAGE_CODE || '0Q856',
   },
-};
+
+  canonicalDomain: CANONICAL_DOMAIN,
+} as const;
 
 export default siteUrls;

--- a/packages/db/src/admin.ts
+++ b/packages/db/src/admin.ts
@@ -1,0 +1,24 @@
+import 'server-only';
+
+import { createClient } from '@supabase/supabase-js';
+
+function required(name: string, value: string | undefined): string {
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+export function createSupabaseAdminClient() {
+  const secret = process.env.SUPABASE_SECRET_KEY ?? process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  return createClient(
+    required('NEXT_PUBLIC_SUPABASE_URL', process.env.NEXT_PUBLIC_SUPABASE_URL),
+    required('SUPABASE_SECRET_KEY or SUPABASE_SERVICE_ROLE_KEY', secret),
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,13 @@
+import { createBrowserClient } from '@supabase/ssr';
+
+function required(name: string, value: string | undefined): string {
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+export function createSupabaseBrowserClient() {
+  return createBrowserClient(
+    required('NEXT_PUBLIC_SUPABASE_URL', process.env.NEXT_PUBLIC_SUPABASE_URL),
+    required('NEXT_PUBLIC_SUPABASE_ANON_KEY', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+  );
+}

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,2 @@
+export { createSupabaseBrowserClient } from './client';
+export { createSupabasePublicClient } from './public';

--- a/packages/db/src/public.ts
+++ b/packages/db/src/public.ts
@@ -1,0 +1,20 @@
+import { createClient } from '@supabase/supabase-js';
+
+function required(name: string, value: string | undefined): string {
+  if (!value) throw new Error(`Missing required environment variable: ${name}`);
+  return value;
+}
+
+export function createSupabasePublicClient() {
+  return createClient(
+    required('NEXT_PUBLIC_SUPABASE_URL', process.env.NEXT_PUBLIC_SUPABASE_URL),
+    required('NEXT_PUBLIC_SUPABASE_ANON_KEY', process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY),
+    {
+      auth: {
+        persistSession: false,
+        autoRefreshToken: false,
+        detectSessionInUrl: false,
+      },
+    },
+  );
+}

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -4,5 +4,5 @@ packages:
 
 catalog:
   next: "15.5.15"
-  react: "19.1.0"
-  react-dom: "19.1.0"
+  react: "19.2.7"
+  react-dom: "19.2.7"

--- a/scripts/check-navigation-hardcoding.mjs
+++ b/scripts/check-navigation-hardcoding.mjs
@@ -1,0 +1,45 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const roots = [
+  'components/site',
+  'apps/lms/app/login',
+  'lib/auth',
+  'lib/navigation.ts',
+];
+
+const forbidden = [
+  'https://www.elevateforhumanity.org',
+  'https://app.elevateforhumanity.org',
+  'https://admin.elevateforhumanity.org',
+];
+
+function collect(target) {
+  if (!fs.existsSync(target)) return [];
+  const stat = fs.statSync(target);
+  if (stat.isFile()) return [target];
+  return fs.readdirSync(target, { withFileTypes: true }).flatMap((entry) => {
+    const full = path.join(target, entry.name);
+    if (entry.isDirectory()) return collect(full);
+    return /\.(ts|tsx|js|jsx|mjs)$/.test(entry.name) ? [full] : [];
+  });
+}
+
+const files = [...new Set(roots.flatMap(collect))];
+const violations = [];
+
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
+  for (const literal of forbidden) {
+    if (text.includes(literal)) violations.push(`${file}: ${literal}`);
+  }
+}
+
+if (violations.length) {
+  console.error('Hardcoded Elevate service URLs found in navigation/auth code:');
+  for (const violation of violations) console.error(` - ${violation}`);
+  console.error('Use lib/utils/site-urls.ts or lib/navigation/routes.ts instead.');
+  process.exit(1);
+}
+
+console.log(`Navigation hardcoding guard passed (${files.length} files checked).`);

--- a/supabase/migrations/20260806200400_sync_active_program_enrollments_to_course_access.sql
+++ b/supabase/migrations/20260806200400_sync_active_program_enrollments_to_course_access.sql
@@ -1,0 +1,92 @@
+-- Keep program enrollment (canonical program-level record) synchronized with
+-- course_enrollments (canonical LMS course-access records).
+--
+-- training_enrollments was retired by the table-consolidation migration, so
+-- approval flows must not depend on that legacy table.
+
+CREATE UNIQUE INDEX IF NOT EXISTS course_enrollments_student_course_uidx
+  ON public.course_enrollments(student_id, course_id)
+  WHERE student_id IS NOT NULL AND course_id IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.sync_active_program_enrollment_courses()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY INVOKER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.user_id IS NULL OR NEW.program_id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  IF COALESCE(NEW.enrollment_state, NEW.status) <> 'active' THEN
+    RETURN NEW;
+  END IF;
+
+  INSERT INTO public.course_enrollments (
+    student_id,
+    course_id,
+    status,
+    progress,
+    created_at,
+    updated_at
+  )
+  SELECT
+    NEW.user_id,
+    lc.id,
+    'active',
+    '0',
+    now(),
+    now()
+  FROM public.lms_courses lc
+  WHERE lc.program_id = NEW.program_id
+    AND lc.is_active = true
+    AND NOT EXISTS (
+      SELECT 1
+      FROM public.course_enrollments ce
+      WHERE ce.student_id = NEW.user_id
+        AND ce.course_id = lc.id
+    );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_sync_active_program_enrollment_courses
+  ON public.program_enrollments;
+
+CREATE TRIGGER trg_sync_active_program_enrollment_courses
+AFTER INSERT OR UPDATE OF program_id, user_id, status, enrollment_state
+ON public.program_enrollments
+FOR EACH ROW
+EXECUTE FUNCTION public.sync_active_program_enrollment_courses();
+
+-- Backfill existing active program enrollments so current learners receive the
+-- same course-access invariant as future approvals.
+INSERT INTO public.course_enrollments (
+  student_id,
+  course_id,
+  status,
+  progress,
+  created_at,
+  updated_at
+)
+SELECT
+  pe.user_id,
+  lc.id,
+  'active',
+  '0',
+  now(),
+  now()
+FROM public.program_enrollments pe
+JOIN public.lms_courses lc
+  ON lc.program_id = pe.program_id
+ AND lc.is_active = true
+WHERE pe.user_id IS NOT NULL
+  AND COALESCE(pe.enrollment_state, pe.status) = 'active'
+  AND NOT EXISTS (
+    SELECT 1
+    FROM public.course_enrollments ce
+    WHERE ce.student_id = pe.user_id
+      AND ce.course_id = lc.id
+  );


### PR DESCRIPTION
## Goal
Consolidate `elevate-for-humanity/Elevate-lms` into one canonical platform without feature loss.

## Repository scope
- INCLUDED: `elevate-for-humanity/Elevate-lms`
- EXCLUDED: `elevateforhumanity/fix2`
- Do not import, compare, merge, or depend on fix2.

## Scope
- Marketing
- Admin
- LMS
- Course Builder
- Dev Studio
- Supabase `elevate` schema/auth/RLS
- Cloudflare Workers/KV/R2/DNS integration
- Northflank/Docker compatibility
- GitHub/CI
- Autopilot/orchestrator supervisor
- Existing plugins/integrations
- README, architecture and operations documentation
- Open-source boundaries/licensing

## Safety rules
- No direct work on `main`
- No duplicate deletion before feature parity
- Preserve applied migration history
- Preserve working plugin/provider connections
- Require build/type/schema/RLS/route/Docker gates before deleting canonical replacements
- Maintain rollback points

## Completion criteria
- One canonical implementation of each operational feature inside Elevate-lms
- Zero unclassified feature loss
- Critical user journeys verified
- Northflank/Docker production gates green
- README and architecture describe the actual unified system

This PR remains draft until the full consolidation and verification gates are complete.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate Elevate into a unified platform with shared routing, DB clients, and CI
> - Routes `/ai/dev-studio` on both LMS and marketing apps now redirect to the canonical `/dev-studio` marketing page instead of rendering content
> - Adds `createSupabaseAdminClient`, `createSupabaseBrowserClient`, and `createSupabasePublicClient` factories in `packages/db` with mandatory env validation
> - Centralizes URL constants in [`lib/utils/site-urls.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/537/files#diff-764737aba1c264df8ab7f182e05da59e50a839d5299bd7491ad6004738e23645) and [`lib/navigation/routes.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/537/files#diff-9c94bc3de662ad86f2a0f96ad6d49065a3caeb3240390ccd2b28188b399b33d7), adding distinct `app`, `admin`, `employerPortal`, and `adminLogin` fields; `siteUrls.lms` now resolves to `APP_URL` instead of a `/lms` subpath
> - Post-login navigation in [`apps/lms/app/login/page.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/537/files#diff-296cd460eda52582924b7896e5ee00d9e4b33d62a21af14d7951f8f5e29953db) uses `window.location.assign` with absolute URLs, routing admin-role users to the admin origin
> - A DB migration and application-level logic in [`lib/enrollment/approve.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/537/files#diff-31a7e85bf1ac5bbe21d1d499c69a440e13df8875ca57845089e235669a9db1ed) now auto-populate `course_enrollments` for all active courses when a program enrollment becomes active, with a unique index on `(student_id, course_id)`
> - Adds CI workflows for Docker build/health-check and a static consolidation gate, plus a script to detect hardcoded service URLs
> - Behavioral Change: `siteUrls.lms`, `siteUrls.login`, and `siteUrls.dashboard` all point to new origins; any code consuming these values will resolve to different URLs
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 73032db.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->