### PR TITLE
[apply-northflank-config] finalize Marketing deployment controller

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -149,6 +149,7 @@ jobs:
       - name: Sync production env to Marketing + LMS + Admin
         run: pnpm tsx scripts/northflank/sync-env.ts --execute
 
+      # Routine code deploys must not mutate service configuration.
       - name: Configure Northflank Marketing service
         if: github.event_name == 'workflow_dispatch' || contains(github.event.head_commit.message, '[apply-northflank-config]')
         run: pnpm tsx scripts/northflank/configure-services.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --execute


### PR DESCRIPTION
Runs the one-time Marketing service configuration so GitHub Actions is the sole controller and future commits no longer trigger automatic Northflank builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add comment to marketing deploy workflow clarifying config mutation policy
> Adds a comment to the 'Configure Northflank Marketing service' step in [deploy-marketing.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/545/files#diff-7ed4e9c6c7fd619fac2e29bf6d09777971cacb52529cde4889d592e845752e8f) stating that routine code deploys must not mutate service configuration. No execution semantics are changed.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 3cf60b5.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->