### PR TITLE
Add transfer-hours document upload to apprenticeship applications

### DIFF
--- a/apps/marketing/app/api/applications/transfer-hours-document/route.ts
+++ b/apps/marketing/app/api/applications/transfer-hours-document/route.ts
@@ -37,15 +37,15 @@ async function findExistingApplication(
 ) {
   if (!db) return null;
 
-  const base = db
+  const normalized = await db
     .from('applications')
     .select('id')
     .eq('program_interest', program)
+    .eq('normalized_email', normalizedEmail)
     .not('status', 'in', '("rejected","withdrawn","duplicate")')
     .order('created_at', { ascending: false })
-    .limit(1);
-
-  const normalized = await base.eq('normalized_email', normalizedEmail).maybeSingle();
+    .limit(1)
+    .maybeSingle();
   if (!normalized.error && normalized.data?.id) return normalized.data;
 
   const fallback = await db
@@ -89,7 +89,8 @@ async function ensureReviewQueueItem(
     status: 'open',
     metadata: {
       application_id: applicationId,
-      document_type: 'transfer_hours_evidence',
+      document_type: 'transcript',
+      evidence_type: 'transfer_hours',
       hours_claimed: hoursClaimed,
     },
   });
@@ -164,7 +165,7 @@ export async function POST(req: Request) {
       .insert({
         user_id: null,
         application_id: applicationId,
-        document_type: 'transfer_hours_evidence',
+        document_type: 'transcript',
         file_name: file.name,
         file_size: file.size,
         file_size_bytes: file.size,
@@ -174,8 +175,8 @@ export async function POST(req: Request) {
         status: 'pending_review',
         verification_status: 'pending',
         verified: false,
-        owner_type: applicationId ? 'application' : 'pending_application',
-        owner_id: applicationId,
+        owner_type: null,
+        owner_id: null,
         metadata: {
           normalized_email: normalizedEmail,
           program_slug: program,

--- a/apps/marketing/app/api/applications/transfer-hours-document/route.ts
+++ b/apps/marketing/app/api/applications/transfer-hours-document/route.ts
@@ -1,0 +1,214 @@
+import { NextResponse } from 'next/server';
+import { createHash, randomUUID } from 'node:crypto';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+const MAX_FILE_BYTES = 10 * 1024 * 1024;
+const ALLOWED_MIME_TYPES = new Set([
+  'application/pdf',
+  'image/jpeg',
+  'image/png',
+  'image/webp',
+]);
+
+function safeFileName(name: string) {
+  const cleaned = name
+    .normalize('NFKD')
+    .replace(/[^a-zA-Z0-9._-]+/g, '-')
+    .replace(/-+/g, '-')
+    .replace(/^[-.]+|[-.]+$/g, '')
+    .slice(0, 120);
+  return cleaned || 'transfer-hours-document';
+}
+
+function normalizeProgram(value: FormDataEntryValue | null) {
+  return String(value || '').trim().toLowerCase();
+}
+
+async function findExistingApplication(
+  db: Awaited<ReturnType<typeof getAdminClient>>,
+  normalizedEmail: string,
+  program: string,
+) {
+  if (!db) return null;
+
+  const base = db
+    .from('applications')
+    .select('id')
+    .eq('program_interest', program)
+    .not('status', 'in', '("rejected","withdrawn","duplicate")')
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const normalized = await base.eq('normalized_email', normalizedEmail).maybeSingle();
+  if (!normalized.error && normalized.data?.id) return normalized.data;
+
+  const fallback = await db
+    .from('applications')
+    .select('id')
+    .eq('program_interest', program)
+    .ilike('email', normalizedEmail)
+    .not('status', 'in', '("rejected","withdrawn","duplicate")')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  return fallback.error ? null : fallback.data;
+}
+
+async function ensureReviewQueueItem(
+  db: NonNullable<Awaited<ReturnType<typeof getAdminClient>>>,
+  documentId: string,
+  applicationId: string,
+  hoursClaimed: number,
+) {
+  const { data: existing } = await db
+    .from('review_queue')
+    .select('id')
+    .eq('subject_type', 'document')
+    .eq('subject_id', documentId)
+    .in('status', ['open', 'in_progress', 'escalated'])
+    .limit(1)
+    .maybeSingle();
+
+  if (existing?.id) return;
+
+  const { error } = await db.from('review_queue').insert({
+    queue_type: 'transcript_review',
+    subject_type: 'document',
+    subject_id: documentId,
+    priority: 8,
+    reasons: [
+      `Applicant claims ${hoursClaimed.toLocaleString('en-US')} transfer hours. Verify uploaded evidence before awarding credit.`,
+    ],
+    status: 'open',
+    metadata: {
+      application_id: applicationId,
+      document_type: 'transfer_hours_evidence',
+      hours_claimed: hoursClaimed,
+    },
+  });
+
+  if (error) {
+    logger.warn('[transfer-hours-document] review queue insert failed', {
+      documentId,
+      applicationId,
+      error: error.message,
+    });
+  }
+}
+
+export async function POST(req: Request) {
+  const limited = await applyRateLimit(req, 'contact');
+  if (limited) return limited;
+
+  try {
+    const form = await req.formData();
+    const file = form.get('file');
+    const normalizedEmail = String(form.get('email') || '').trim().toLowerCase();
+    const program = normalizeProgram(form.get('program'));
+    const hoursClaimed = Math.floor(Number(form.get('hoursClaimed') || 0));
+
+    if (!(file instanceof File)) {
+      return NextResponse.json({ error: 'Transfer-hours documentation is required.' }, { status: 400 });
+    }
+    if (!normalizedEmail || !normalizedEmail.includes('@')) {
+      return NextResponse.json({ error: 'A valid applicant email is required.' }, { status: 400 });
+    }
+    if (!program || !program.includes('apprenticeship')) {
+      return NextResponse.json({ error: 'Transfer-hours evidence is only accepted for apprenticeship applications.' }, { status: 400 });
+    }
+    if (!Number.isFinite(hoursClaimed) || hoursClaimed <= 0) {
+      return NextResponse.json({ error: 'Enter the number of transfer hours being claimed.' }, { status: 400 });
+    }
+    if (file.size <= 0 || file.size > MAX_FILE_BYTES) {
+      return NextResponse.json({ error: 'Transfer-hours documentation must be 10 MB or smaller.' }, { status: 400 });
+    }
+    if (!ALLOWED_MIME_TYPES.has(file.type)) {
+      return NextResponse.json({ error: 'Upload a PDF, JPG, PNG, or WEBP document.' }, { status: 400 });
+    }
+
+    const db = await getAdminClient();
+    if (!db) {
+      return NextResponse.json({ error: 'Document upload service is temporarily unavailable.' }, { status: 503 });
+    }
+
+    const existingApplication = await findExistingApplication(db, normalizedEmail, program);
+    const applicationId = existingApplication?.id ?? null;
+    const emailKey = createHash('sha256').update(`${normalizedEmail}|${program}`).digest('hex').slice(0, 24);
+    const folder = applicationId ? `applications/${applicationId}` : `pending-applications/${emailKey}`;
+    const path = `${folder}/transfer-hours/${Date.now()}-${randomUUID()}-${safeFileName(file.name)}`;
+    const bytes = Buffer.from(await file.arrayBuffer());
+
+    const { error: storageError } = await db.storage.from('documents').upload(path, bytes, {
+      contentType: file.type,
+      cacheControl: '3600',
+      upsert: false,
+    });
+
+    if (storageError) {
+      logger.error('[transfer-hours-document] storage upload failed', {
+        program,
+        error: storageError.message,
+      });
+      return NextResponse.json({ error: 'Transfer-hours documentation could not be uploaded.' }, { status: 500 });
+    }
+
+    const { data: document, error: documentError } = await db
+      .from('documents')
+      .insert({
+        user_id: null,
+        application_id: applicationId,
+        document_type: 'transfer_hours_evidence',
+        file_name: file.name,
+        file_size: file.size,
+        file_size_bytes: file.size,
+        file_url: null,
+        file_path: path,
+        mime_type: file.type,
+        status: 'pending_review',
+        verification_status: 'pending',
+        verified: false,
+        owner_type: applicationId ? 'application' : 'pending_application',
+        owner_id: applicationId,
+        metadata: {
+          normalized_email: normalizedEmail,
+          program_slug: program,
+          hours_claimed: hoursClaimed,
+          evidence_type: 'transfer_hours',
+          staged: !applicationId,
+        },
+      })
+      .select('id')
+      .single();
+
+    if (documentError || !document?.id) {
+      await db.storage.from('documents').remove([path]);
+      logger.error('[transfer-hours-document] document row insert failed', {
+        program,
+        error: documentError?.message,
+      });
+      return NextResponse.json({ error: 'Transfer-hours documentation could not be recorded.' }, { status: 500 });
+    }
+
+    if (applicationId) {
+      await ensureReviewQueueItem(db, document.id, applicationId, hoursClaimed);
+    }
+
+    return NextResponse.json({
+      ok: true,
+      documentId: document.id,
+      linkedApplicationId: applicationId,
+    });
+  } catch (error) {
+    logger.error('[transfer-hours-document] unexpected failure', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return NextResponse.json({ error: 'Transfer-hours documentation could not be uploaded.' }, { status: 500 });
+  }
+}

--- a/apps/marketing/app/apply/student/StudentApplicationForm.tsx
+++ b/apps/marketing/app/apply/student/StudentApplicationForm.tsx
@@ -3,6 +3,10 @@
 import { useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 import { useApplicationDraft } from '@/hooks/useApplicationDraft';
+import {
+  TRANSFER_HOURS_EVIDENCE_ACCEPT,
+  uploadTransferHoursEvidence,
+} from '@/lib/applications/upload-transfer-hours-evidence';
 
 const WORKONE_INTAKE_URL = 'https://WorkOneIndy.as.me/IntakeApptwithCN';
 
@@ -160,6 +164,7 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
   const [consentAcknowledged, setConsentAcknowledged] = useState(false);
   const [submitting, setSubmitting] = useState(false);
   const [result, setResult] = useState<SubmissionResult | null>(null);
+  const [transferHoursDocument, setTransferHoursDocument] = useState<File | null>(null);
 
   const { hasDraft, savedData, savedStep, savedAt, saveDraft, clearDraft } =
     useApplicationDraft<DraftData>('student-apply');
@@ -170,6 +175,7 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
 
   const requiresWorkOne = form.fundingSource === 'wioa' || form.fundingSource === 'wrg';
   const isApprenticeship = form.program.includes('apprenticeship');
+  const transferHoursClaimed = Math.max(0, Number.parseInt(form.transferHours || '0', 10) || 0);
 
   function handleChange(
     e: React.ChangeEvent<HTMLInputElement | HTMLSelectElement | HTMLTextAreaElement>,
@@ -179,6 +185,12 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
     setResult(null);
     if (name === 'fundingSource' && value !== 'wioa' && value !== 'wrg') {
       setWorkOneAcknowledged(false);
+    }
+    if (name === 'program' && !value.includes('apprenticeship')) {
+      setTransferHoursDocument(null);
+    }
+    if (name === 'transferHours' && (Number.parseInt(value || '0', 10) || 0) <= 0) {
+      setTransferHoursDocument(null);
     }
   }
 
@@ -190,6 +202,7 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
     if (!savedData) return;
     setForm(savedData.form);
     setWorkOneAcknowledged(savedData.workOneAcknowledged);
+    setTransferHoursDocument(null);
     setStep(Math.min(Math.max(savedStep || 1, 1), 5));
     setShowResume(false);
   }
@@ -207,6 +220,9 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
       if (!form.program) return 'Select a program of interest.';
       if (isApprenticeship && form.hasHostShop === 'yes' && !form.hostShopName) {
         return 'Enter the name of your current or proposed Host Shop.';
+      }
+      if (isApprenticeship && transferHoursClaimed > 0 && !transferHoursDocument) {
+        return 'Upload documentation showing the apprenticeship hours you want transferred.';
       }
     }
     if (current === 3) {
@@ -312,6 +328,22 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
     };
 
     try {
+      if (isApprenticeship && transferHoursClaimed > 0) {
+        if (!transferHoursDocument) {
+          setResult({
+            success: false,
+            error: 'Upload documentation showing the apprenticeship hours you want transferred.',
+          });
+          return;
+        }
+        await uploadTransferHoursEvidence({
+          file: transferHoursDocument,
+          email: form.email,
+          program: form.program,
+          hoursClaimed: transferHoursClaimed,
+        });
+      }
+
       const { res, data } = await postApplication(payload);
       if (res.ok && (data.ok ?? data.success ?? true)) {
         clearDraft();
@@ -334,12 +366,14 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
           error: data.error || 'The application could not be submitted. Please review the form and try again.',
         });
       }
-    } catch {
+    } catch (error) {
       persist(step);
       setResult({
         success: false,
         error:
-          'The application service could not be reached. Your progress is saved on this device. Please try again. If the issue continues, call (317) 314-3757.',
+          error instanceof Error
+            ? error.message
+            : 'The application service could not be reached. Your progress is saved on this device. Please try again. If the issue continues, call (317) 314-3757.',
       });
     } finally {
       setSubmitting(false);
@@ -381,6 +415,7 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
               type="button"
               onClick={() => {
                 clearDraft();
+                setTransferHoursDocument(null);
                 setShowResume(false);
               }}
               className="rounded-lg border border-slate-400 bg-white px-4 py-2 text-sm font-bold text-slate-950"
@@ -450,6 +485,23 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
                 <div><label className={labelClass}>Do you already have a Host Shop?</label><select name="hasHostShop" value={form.hasHostShop} onChange={handleChange} className={fieldClass}><option value="">Select</option><option value="yes">Yes</option><option value="no">No</option><option value="need_help">I need placement help</option></select></div>
                 <div><label className={labelClass}>Host Shop Name</label><input name="hostShopName" value={form.hostShopName} onChange={handleChange} className={fieldClass} /></div>
                 <div><label className={labelClass}>Prior/Transfer Hours Claimed</label><input type="number" min="0" name="transferHours" value={form.transferHours} onChange={handleChange} className={fieldClass} /><p className="mt-1 text-xs text-slate-600">Claimed hours require documentation and verification before credit is awarded.</p></div>
+                {transferHoursClaimed > 0 && (
+                  <div className="sm:col-span-2 rounded-lg border border-amber-300 bg-amber-50 p-4">
+                    <label className={labelClass}>Transfer Hours Documentation *</label>
+                    <input
+                      type="file"
+                      required
+                      accept={TRANSFER_HOURS_EVIDENCE_ACCEPT}
+                      onChange={(event) => {
+                        setTransferHoursDocument(event.target.files?.[0] ?? null);
+                        setResult(null);
+                      }}
+                      className="block w-full rounded-lg border border-amber-300 bg-white px-3 py-3 text-sm text-slate-950 file:mr-4 file:rounded-md file:border-0 file:bg-slate-900 file:px-4 file:py-2 file:font-bold file:text-white"
+                    />
+                    <p className="mt-2 text-xs font-semibold text-amber-950">Upload an official transcript, hours statement, state-board record, prior school record, or employer/apprenticeship hours verification. PDF, JPG, PNG, or WEBP; maximum 10 MB.</p>
+                    {transferHoursDocument && <p className="mt-2 text-xs text-slate-700">Selected: {transferHoursDocument.name}</p>}
+                  </div>
+                )}
               </div>
             </div>
           )}
@@ -512,6 +564,7 @@ export default function StudentApplicationForm({ initialProgram = '' }: StudentA
             <p><strong>Location:</strong> {form.city}, {form.state} {form.zipCode}</p>
             <p><strong>Funding:</strong> {form.fundingSource || 'Not selected'}</p>
             {isApprenticeship && <p><strong>Host Shop:</strong> {form.hasHostShop === 'yes' ? form.hostShopName || 'Yes' : form.hasHostShop || 'Not provided'}</p>}
+            {isApprenticeship && transferHoursClaimed > 0 && <p><strong>Transfer Hours:</strong> {transferHoursClaimed.toLocaleString()} claimed — evidence: {transferHoursDocument?.name || 'required'}</p>}
           </div>
           <label className="flex items-start gap-3 rounded-xl border border-slate-300 p-4 text-sm font-semibold leading-6 text-slate-900">
             <input type="checkbox" checked={consentAcknowledged} onChange={(event) => setConsentAcknowledged(event.target.checked)} className="mt-1 h-5 w-5 shrink-0" />

--- a/apps/marketing/app/programs/barber-apprenticeship/apply/ApprenticeForm.tsx
+++ b/apps/marketing/app/programs/barber-apprenticeship/apply/ApprenticeForm.tsx
@@ -24,6 +24,10 @@ import { EmbeddedCheckout, EmbeddedCheckoutProvider } from '@stripe/react-stripe
 import { ACTIVE_BNPL_PROVIDERS } from '@/lib/bnpl-config';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import {
+  TRANSFER_HOURS_EVIDENCE_ACCEPT,
+  uploadTransferHoursEvidence,
+} from '@/lib/applications/upload-transfer-hours-evidence';
 
 const stripePromise = loadStripe(process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY!);
 
@@ -94,6 +98,7 @@ export default function ApprenticeForm({
   const [transferHoursChoice, setTransferHoursChoice] =
     useState<TransferHoursChoice>('undecided');
   const [transferHoursStr, setTransferHoursStr] = useState('');
+  const [transferHoursDocument, setTransferHoursDocument] = useState<File | null>(null);
   const maxTransferHours = TOTAL_HOURS_REQUIRED - 100;
   const transferHours = Math.min(
     maxTransferHours,
@@ -167,7 +172,7 @@ export default function ApprenticeForm({
       return;
     }
 
-    if (!turnstileToken) {
+    if (isSelfPay && !turnstileToken) {
       setError('Please complete the security check above before continuing.');
       setErrorSeverity('info');
       return;
@@ -187,12 +192,26 @@ export default function ApprenticeForm({
       setErrorSeverity('info');
       return;
     }
+    if (transferHoursChoice === 'yes' && !transferHoursDocument) {
+      setError('Upload documentation showing the barber training hours you want transferred.');
+      setErrorSeverity('info');
+      return;
+    }
 
     setLoading(true);
     setError('');
     setErrorSeverity('info');
 
     try {
+      if (transferHoursChoice === 'yes' && transferHoursDocument) {
+        await uploadTransferHoursEvidence({
+          file: transferHoursDocument,
+          email: formData.email,
+          program: 'barber-apprenticeship',
+          hoursClaimed: transferHours,
+        });
+      }
+
       // If returning to complete payment (application already exists), skip the POST
       let applicationId: string | undefined = initialApplicationId;
 
@@ -257,7 +276,7 @@ export default function ApprenticeForm({
           const isBotError = apiError.toLowerCase().includes('bot') || apiError.toLowerCase().includes('verification');
           setError(
             isBotError
-              ? `Security check failed. Please scroll up, complete the verification widget, and try again. Need help? Call {PLATFORM_DEFAULTS.supportPhone}.`
+              ? `Security check failed. Please scroll up, complete the verification widget, and try again. Need help? Call ${PLATFORM_DEFAULTS.supportPhone}.`
               : apiError || `Failed to save your application. Please try again or call ${PLATFORM_DEFAULTS.supportPhone}.`,
           );
           setErrorSeverity('critical');
@@ -505,7 +524,11 @@ export default function ApprenticeForm({
       }
     } catch (err) {
       logger.error('Checkout exception:', err);
-      setError('Something went wrong. Please try again or select a different payment option.');
+      setError(
+        err instanceof Error
+          ? err.message
+          : 'Something went wrong. Please try again or select a different payment option.',
+      );
       setErrorSeverity('critical');
       setLoading(false);
     }
@@ -567,6 +590,7 @@ export default function ApprenticeForm({
                       if (transferHoursChoice === 'undecided' || transferHoursChoice === 'no') {
                         setTransferHoursChoice(val > 0 ? 'yes' : 'no');
                       }
+                      if (val <= 0) setTransferHoursDocument(null);
                     }}
                     disabled={transferHoursChoice === 'no'}
                     className="w-full px-4 py-3 bg-white/20 border border-white/30 rounded-lg text-slate-900 placeholder-white/50 disabled:opacity-60"
@@ -764,6 +788,7 @@ export default function ApprenticeForm({
                         onChange={() => {
                           setTransferHoursChoice('no');
                           setTransferHoursStr('');
+                          setTransferHoursDocument(null);
                         }}
                         className="w-4 h-4 text-amber-600"
                       />
@@ -771,9 +796,32 @@ export default function ApprenticeForm({
                     </label>
                   </div>
                   {transferHoursChoice === 'yes' && (
-                    <p className="text-xs text-amber-700 mt-2">
-                      Adjust your transfer hours in the calculator on the left.
-                    </p>
+                    <div className="mt-3 rounded-lg border border-amber-300 bg-white p-3">
+                      <p className="text-xs text-amber-800 mb-3">
+                        Adjust your transfer hours in the calculator on the left, then upload proof of those hours.
+                      </p>
+                      <label className="block text-sm font-bold text-amber-950 mb-1">
+                        Transfer Hours Documentation *
+                      </label>
+                      <input
+                        type="file"
+                        required
+                        accept={TRANSFER_HOURS_EVIDENCE_ACCEPT}
+                        onChange={(event) => {
+                          setTransferHoursDocument(event.target.files?.[0] ?? null);
+                          setError('');
+                        }}
+                        className="block w-full rounded-lg border border-amber-300 bg-white px-3 py-2 text-sm text-slate-950 file:mr-3 file:rounded-md file:border-0 file:bg-slate-900 file:px-3 file:py-2 file:font-bold file:text-white"
+                      />
+                      <p className="mt-2 text-xs text-amber-800">
+                        Upload an official transcript, hours statement, state-board record, prior school record, or employer/apprenticeship verification. PDF, JPG, PNG, or WEBP; maximum 10 MB.
+                      </p>
+                      {transferHoursDocument && (
+                        <p className="mt-2 text-xs font-semibold text-slate-700">
+                          Selected: {transferHoursDocument.name}
+                        </p>
+                      )}
+                    </div>
                   )}
                 </div>
 
@@ -1146,6 +1194,7 @@ export default function ApprenticeForm({
                         !formData.phone ||
                         (!completingExistingPayment && !formData.fundingInterest) ||
                         (isSelfPay && !turnstileToken) ||
+                        (transferHoursChoice === 'yes' && (!transferHoursDocument || transferHours <= 0)) ||
                         (!isSelfPay && !completingExistingPayment && !fundedOptionsReady)
                       }
                       className="w-full py-4 bg-brand-blue-600 hover:bg-brand-blue-700 disabled:bg-slate-300 text-white font-bold rounded-lg transition-colors flex items-center justify-center gap-2 text-lg"

--- a/lib/applications/upload-transfer-hours-evidence.ts
+++ b/lib/applications/upload-transfer-hours-evidence.ts
@@ -1,0 +1,59 @@
+export const TRANSFER_HOURS_EVIDENCE_ACCEPT =
+  'application/pdf,image/jpeg,image/png,image/webp';
+export const TRANSFER_HOURS_EVIDENCE_MAX_BYTES = 10 * 1024 * 1024;
+
+export type TransferHoursEvidenceUploadInput = {
+  file: File;
+  email: string;
+  program: string;
+  hoursClaimed: number;
+};
+
+export type TransferHoursEvidenceUploadResult = {
+  ok: true;
+  documentId: string;
+  linkedApplicationId?: string | null;
+};
+
+export async function uploadTransferHoursEvidence({
+  file,
+  email,
+  program,
+  hoursClaimed,
+}: TransferHoursEvidenceUploadInput): Promise<TransferHoursEvidenceUploadResult> {
+  if (!file) throw new Error('Transfer-hours documentation is required.');
+  if (!Number.isFinite(hoursClaimed) || hoursClaimed <= 0) {
+    throw new Error('Enter the number of transfer hours before uploading documentation.');
+  }
+  if (file.size > TRANSFER_HOURS_EVIDENCE_MAX_BYTES) {
+    throw new Error('Transfer-hours documentation must be 10 MB or smaller.');
+  }
+
+  const formData = new FormData();
+  formData.set('file', file);
+  formData.set('email', email.trim().toLowerCase());
+  formData.set('program', program);
+  formData.set('hoursClaimed', String(Math.floor(hoursClaimed)));
+
+  const response = await fetch('/api/applications/transfer-hours-document', {
+    method: 'POST',
+    body: formData,
+    credentials: 'same-origin',
+    cache: 'no-store',
+  });
+  const payload = (await response.json().catch(() => ({}))) as {
+    error?: string;
+    documentId?: string;
+    linkedApplicationId?: string | null;
+  };
+
+  if (!response.ok || !payload.documentId) {
+    throw new Error(payload.error || 'Transfer-hours documentation could not be uploaded.');
+  }
+
+  return {
+    ok: true,
+    documentId: payload.documentId,
+    linkedApplicationId: payload.linkedApplicationId ?? null,
+  };
+}

--- a/supabase/migrations/20260808183000_link_application_transfer_hours_evidence.sql
+++ b/supabase/migrations/20260808183000_link_application_transfer_hours_evidence.sql
@@ -1,0 +1,95 @@
+-- Link private transfer-hours evidence uploaded during public apprenticeship intake
+-- to the application row created immediately afterward. Evidence remains pending
+-- until staff verification; claimed hours are never auto-approved.
+
+CREATE OR REPLACE FUNCTION public.link_staged_transfer_hours_evidence()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  evidence_record public.documents%ROWTYPE;
+  program_key text;
+BEGIN
+  IF COALESCE(NEW.transfer_hours_claimed, 0) <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  program_key := COALESCE(NULLIF(NEW.program_slug, ''), NEW.program_interest);
+
+  SELECT d.*
+    INTO evidence_record
+  FROM public.documents d
+  WHERE d.application_id IS NULL
+    AND d.document_type = 'transfer_hours_evidence'
+    AND lower(COALESCE(d.metadata->>'normalized_email', '')) = lower(trim(NEW.email))
+    AND COALESCE(d.metadata->>'program_slug', '') = program_key
+    AND d.created_at >= now() - interval '24 hours'
+  ORDER BY d.created_at DESC
+  LIMIT 1;
+
+  IF evidence_record.id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.documents
+  SET application_id = NEW.id,
+      owner_type = 'application',
+      owner_id = NEW.id,
+      metadata = COALESCE(metadata, '{}'::jsonb)
+        || jsonb_build_object(
+             'staged', false,
+             'linked_at', now(),
+             'application_id', NEW.id,
+             'hours_claimed', NEW.transfer_hours_claimed
+           ),
+      updated_at = now()
+  WHERE id = evidence_record.id;
+
+  INSERT INTO public.review_queue (
+    queue_type,
+    subject_type,
+    subject_id,
+    priority,
+    reasons,
+    status,
+    metadata
+  )
+  SELECT
+    'transcript_review',
+    'document',
+    evidence_record.id,
+    8,
+    ARRAY[
+      format(
+        'Applicant claims %s transfer hours. Verify uploaded evidence before awarding credit.',
+        NEW.transfer_hours_claimed
+      )
+    ],
+    'open',
+    jsonb_build_object(
+      'application_id', NEW.id,
+      'document_type', 'transfer_hours_evidence',
+      'hours_claimed', NEW.transfer_hours_claimed
+    )
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.review_queue rq
+    WHERE rq.subject_type = 'document'
+      AND rq.subject_id = evidence_record.id
+      AND rq.status IN ('open', 'in_progress', 'escalated')
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_link_staged_transfer_hours_evidence ON public.applications;
+CREATE TRIGGER trg_link_staged_transfer_hours_evidence
+AFTER INSERT ON public.applications
+FOR EACH ROW
+EXECUTE FUNCTION public.link_staged_transfer_hours_evidence();
+
+COMMENT ON FUNCTION public.link_staged_transfer_hours_evidence()
+IS 'Links staged transfer-hours evidence to a newly submitted apprenticeship application and queues it for staff verification.';

--- a/supabase/migrations/20260808183500_fix_transfer_hours_evidence_linking.sql
+++ b/supabase/migrations/20260808183500_fix_transfer_hours_evidence_linking.sql
@@ -1,0 +1,90 @@
+-- The documents table constrains document_type and owner_type. Transfer-hours
+-- evidence is stored as a transcript with metadata.evidence_type='transfer_hours'.
+-- Keep ownership nullable until the applicant has a user record; application_id
+-- provides the intake linkage.
+
+CREATE OR REPLACE FUNCTION public.link_staged_transfer_hours_evidence()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  evidence_record public.documents%ROWTYPE;
+  program_key text;
+BEGIN
+  IF COALESCE(NEW.transfer_hours_claimed, 0) <= 0 THEN
+    RETURN NEW;
+  END IF;
+
+  program_key := COALESCE(NULLIF(NEW.program_slug, ''), NEW.program_interest);
+
+  SELECT d.*
+    INTO evidence_record
+  FROM public.documents d
+  WHERE d.application_id IS NULL
+    AND d.document_type = 'transcript'
+    AND COALESCE(d.metadata->>'evidence_type', '') = 'transfer_hours'
+    AND lower(COALESCE(d.metadata->>'normalized_email', '')) = lower(trim(NEW.email))
+    AND COALESCE(d.metadata->>'program_slug', '') = program_key
+    AND d.created_at >= now() - interval '24 hours'
+  ORDER BY d.created_at DESC
+  LIMIT 1;
+
+  IF evidence_record.id IS NULL THEN
+    RETURN NEW;
+  END IF;
+
+  UPDATE public.documents
+  SET application_id = NEW.id,
+      metadata = COALESCE(metadata, '{}'::jsonb)
+        || jsonb_build_object(
+             'staged', false,
+             'linked_at', now(),
+             'application_id', NEW.id,
+             'hours_claimed', NEW.transfer_hours_claimed
+           ),
+      updated_at = now()
+  WHERE id = evidence_record.id;
+
+  INSERT INTO public.review_queue (
+    queue_type,
+    subject_type,
+    subject_id,
+    priority,
+    reasons,
+    status,
+    metadata
+  )
+  SELECT
+    'transcript_review',
+    'document',
+    evidence_record.id,
+    8,
+    ARRAY[
+      format(
+        'Applicant claims %s transfer hours. Verify uploaded evidence before awarding credit.',
+        NEW.transfer_hours_claimed
+      )
+    ],
+    'open',
+    jsonb_build_object(
+      'application_id', NEW.id,
+      'document_type', 'transcript',
+      'evidence_type', 'transfer_hours',
+      'hours_claimed', NEW.transfer_hours_claimed
+    )
+  WHERE NOT EXISTS (
+    SELECT 1
+    FROM public.review_queue rq
+    WHERE rq.subject_type = 'document'
+      AND rq.subject_id = evidence_record.id
+      AND rq.status IN ('open', 'in_progress', 'escalated')
+  );
+
+  RETURN NEW;
+END;
+$$;
+
+COMMENT ON FUNCTION public.link_staged_transfer_hours_evidence()
+IS 'Links staged transcript evidence for claimed transfer hours to a newly submitted apprenticeship application and queues staff verification.';


### PR DESCRIPTION
Superseded by current main. The transfer-hours upload API, shared upload helper, StudentApplicationForm integration, Barber ApprenticeForm integration, and both transfer-hours evidence linking migrations are already present on main. Closing to prevent duplicate/conflicting re-merge of stale code.