### PR TITLE
fix(marketing): recover 503 without rebuild and align health probe

### DIFF
--- a/.github/workflows/recover-marketing.yml
+++ b/.github/workflows/recover-marketing.yml
@@ -1,0 +1,116 @@
+name: Recover Marketing (no rebuild)
+
+on:
+  workflow_dispatch:
+    inputs:
+      build_id:
+        description: 'Existing successful Northflank Marketing build ID'
+        required: true
+        type: string
+      sha:
+        description: 'Commit SHA contained in that build'
+        required: true
+        type: string
+      apply_config:
+        description: 'Reapply canonical Marketing service config before redeploy'
+        required: false
+        default: true
+        type: boolean
+
+permissions:
+  contents: read
+  actions: read
+
+concurrency:
+  group: northflank-marketing-recovery
+  cancel-in-progress: false
+
+jobs:
+  recover-marketing:
+    name: Recover Marketing from an existing build
+    runs-on: ubuntu-latest
+    env:
+      NORTHFLANK_API_TOKEN: ${{ secrets.NORTHFLANK_API_TOKEN }}
+      NORTHFLANK_TEAM_ID: ${{ secrets.NORTHFLANK_TEAM_ID || 'elevates-team' }}
+      NORTHFLANK_PROJECT_ID: ${{ secrets.NORTHFLANK_PROJECT_ID || 'elevate-platform' }}
+      NORTHFLANK_MARKETING_SERVICE_ID: ${{ secrets.NORTHFLANK_MARKETING_SERVICE_ID || 'elevate-marketing' }}
+      NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
+      NEXT_PUBLIC_SUPABASE_ANON_KEY: ${{ secrets.NEXT_PUBLIC_SUPABASE_ANON_KEY }}
+      NEXT_PUBLIC_SITE_URL: https://www.elevateforhumanity.org
+      NEXT_PUBLIC_PUBLIC_SITE_URL: https://www.elevateforhumanity.org
+      NEXT_PUBLIC_APP_URL: https://app.elevateforhumanity.org
+      NEXT_PUBLIC_LMS_URL: https://app.elevateforhumanity.org
+      NEXT_PUBLIC_ADMIN_URL: https://admin.elevateforhumanity.org
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ inputs.sha }}
+          fetch-depth: 1
+          clean: true
+
+      - name: Set up pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --no-frozen-lockfile
+
+      - name: Verify recovery inputs
+        run: |
+          set -euo pipefail
+          test -n "${{ inputs.build_id }}" || { echo 'build_id is required'; exit 1; }
+          test -n "${{ inputs.sha }}" || { echo 'sha is required'; exit 1; }
+          test "$(git rev-parse HEAD)" = "${{ inputs.sha }}"
+          test -n "${NORTHFLANK_API_TOKEN:-}" || { echo 'NORTHFLANK_API_TOKEN is missing'; exit 1; }
+          echo "Recovery will reuse existing build ${{ inputs.build_id }} for ${{ inputs.sha }}"
+
+      - name: Reapply canonical Marketing service configuration
+        if: inputs.apply_config == true
+        run: pnpm tsx scripts/northflank/configure-services.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --execute
+
+      - name: Verify existing build matches requested SHA
+        run: |
+          pnpm tsx scripts/northflank/verify-build.ts \
+            "$NORTHFLANK_MARKETING_SERVICE_ID" \
+            --build-id "${{ inputs.build_id }}" \
+            --sha "${{ inputs.sha }}"
+
+      - name: Deploy existing Marketing build
+        run: |
+          pnpm tsx scripts/northflank/trigger-deployment.ts \
+            "$NORTHFLANK_MARKETING_SERVICE_ID" \
+            --build-id "${{ inputs.build_id }}" \
+            --sha "${{ inputs.sha }}"
+
+      - name: Wait for Marketing recovery
+        run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --timeout-ms 1800000
+
+      - name: Verify recovered deployment SHA
+        run: pnpm tsx scripts/northflank/verify-sha.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --sha "${{ inputs.sha }}"
+
+      - name: Verify recovered public endpoints
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 30); do
+            ping=$(curl -sk --max-time 10 -o /tmp/ping.json -w "%{http_code}" https://www.elevateforhumanity.org/api/ping || true)
+            health=$(curl -sk --max-time 10 -o /tmp/health.json -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
+            version=$(curl -sk --max-time 10 -o /tmp/version.json -w "%{http_code}" https://www.elevateforhumanity.org/api/version || true)
+            live_sha="$(node -e "try{const d=require('/tmp/version.json');process.stdout.write(d.commitSha||d.commit||'')}catch(e){}")"
+            echo "Attempt $i/30 ping=$ping health=$health version=$version sha=${live_sha:-missing}"
+            if [ "$ping" = "200" ] && [ "$health" = "200" ] && [ "$version" = "200" ] && [ "$live_sha" = "${{ inputs.sha }}" ]; then
+              echo 'Marketing recovery verified.'
+              exit 0
+            fi
+            sleep 10
+          done
+          echo 'Marketing did not recover to the requested SHA.'
+          exit 1

--- a/Dockerfile.marketing
+++ b/Dockerfile.marketing
@@ -112,7 +112,9 @@ USER nextjs
 
 EXPOSE 3000
 
+# Container health is pure liveness. /api/version is reserved for deployment
+# identity verification and /api/health is reserved for Northflank readiness.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
-  CMD curl -fsS "http://127.0.0.1:${PORT:-3000}/api/version" || exit 1
+  CMD curl -fsS "http://127.0.0.1:${PORT:-3000}/api/ping" || exit 1
 
 CMD ["node", "--max-old-space-size=4096", "apps/marketing/server.js"]


### PR DESCRIPTION
Narrow production fix only. Changes Docker container liveness from /api/version to /api/ping and adds a manual no-rebuild Marketing recovery workflow that can redeploy an existing successful Northflank build after reapplying canonical service config. No audit/docs/Dev Studio changes included.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add manual recovery workflow for Marketing service and fix container healthcheck endpoint
> - Adds a `Recover Marketing (no rebuild)` GitHub Actions workflow ([recover-marketing.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/550/files#diff-b30ac720e03c267c736725291ea07cf4dcd3897bbcd56ce6d97bfc90103d0f12)) that redeploys the Marketing service from an existing Northflank build ID without triggering a full rebuild.
> - The workflow accepts `build_id`, `sha`, and `apply_config` inputs, optionally reapplies the canonical Northflank service config, waits for recovery, and verifies `/api/ping`, `/api/health`, and `/api/version` endpoints including commit SHA.
> - Updates the [Dockerfile.marketing](https://github.com/elevate-for-humanity/Elevate-lms/pull/550/files#diff-d1c7872239f27c34dfcb01665a6921752815856680aa34584ffb264a861b790b) container `HEALTHCHECK` to use `/api/ping` instead of `/api/version`, aligning liveness checks with the recovery workflow's endpoint expectations.
> - Behavioral Change: containers previously considered healthy based on `/api/version` will now use `/api/ping` for liveness.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8db13ba.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->