### PR TITLE
fix: prevent Marketing no-healthy-upstream rollouts and correct header

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -150,9 +150,6 @@ jobs:
           done
           echo "Marketing deployment credentials are configured"
 
-      # Secret synchronization is intentionally independent from service
-      # configuration. A secret-group update can recycle every attached runtime,
-      # so normal deploys and rollout-strategy changes must not rewrite it.
       - name: Verify shared production secrets for explicit secret sync
         if: (github.event_name == 'workflow_dispatch' && inputs.sync_secrets == true) || contains(github.event.head_commit.message, '[sync-production-env]')
         run: |
@@ -172,31 +169,25 @@ jobs:
         if: (github.event_name == 'workflow_dispatch' && inputs.sync_secrets == true) || contains(github.event.head_commit.message, '[sync-production-env]')
         run: pnpm tsx scripts/northflank/sync-env.ts --execute
 
-      # Canonical config sets disabledCI=true, port 3000, healthy probes, and a
-      # zero-unavailable rollout. It does NOT modify the shared secret group.
-      - name: Configure Northflank Marketing service
-        if: (github.event_name == 'workflow_dispatch' && inputs.apply_config == true) || contains(github.event.head_commit.message, '[apply-northflank-config]')
+      # Always apply the canonical rollout contract before a production build.
+      # This prevents service-level drift from silently reintroducing a recreate
+      # deployment or stale probe/port configuration.
+      - name: Enforce canonical Northflank Marketing rollout configuration
         run: pnpm tsx scripts/northflank/configure-services.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --execute
 
-      - name: Require healthy upstream before starting a rollout
+      # Existing health is diagnostic only. If production is already unhealthy,
+      # the workflow must still be able to deploy a known-good replacement.
+      - name: Record predeploy upstream health
         run: |
           set -euo pipefail
-          for i in $(seq 1 12); do
-            status=$(curl -sk --max-time 10 -o /tmp/predeploy-health.json -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
-            if [ "$status" = "200" ]; then
-              echo "Existing Marketing upstream is healthy before rollout."
-              exit 0
-            fi
-            echo "Existing Marketing upstream is not healthy: HTTP $status ($i/12)"
-            sleep 5
-          done
-          echo "Refusing to deploy while Marketing has no healthy upstream."
-          cat /tmp/predeploy-health.json 2>/dev/null || true
-          exit 1
+          status=$(curl -sk --max-time 10 -o /tmp/predeploy-health.json -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
+          if [ "$status" = "200" ]; then
+            echo "Existing Marketing upstream is healthy before rollout."
+          else
+            echo "RECOVERY MODE: existing Marketing upstream is HTTP $status; continuing with strict zero-downtime configuration so a healthy replacement can recover service."
+            cat /tmp/predeploy-health.json 2>/dev/null || true
+          fi
 
-      # A burst of commits can leave an older workflow alive long enough to
-      # trigger a Northflank build. Refuse to start a build unless this workflow
-      # still represents the current main SHA.
       - name: Confirm this is still the latest main commit
         id: latest_before_build
         run: |
@@ -236,8 +227,6 @@ jobs:
             --build-id "${{ steps.trigger_build.outputs.build_id }}" \
             --sha "${{ github.sha }}"
 
-      # Re-check main after the potentially long build. An old build may finish,
-      # but it must never replace a newer live deployment.
       - name: Confirm build is still the latest main commit
         if: steps.latest_before_build.outputs.is_latest == 'true'
         id: latest_before_deploy
@@ -253,8 +242,6 @@ jobs:
             echo "Build completed but will not deploy because main advanced. build=${{ github.sha }} latest=$LATEST_SHA"
           fi
 
-      # Keep probing the public upstream throughout the actual replacement. A
-      # zero-downtime rollout must never expose a 503/no-healthy-upstream window.
       - name: Deploy exact Marketing build with availability guard
         if: steps.latest_before_build.outputs.is_latest == 'true' && steps.latest_before_deploy.outputs.is_latest == 'true'
         run: |
@@ -284,13 +271,17 @@ jobs:
           wait "$WATCH_PID" 2>/dev/null || true
           trap - EXIT
 
-          if [ -s /tmp/marketing-downtime.log ]; then
+          # If the service was healthy before rollout, any non-200 during rollout
+          # is a zero-downtime violation. If it was already unhealthy, recovery is
+          # judged by the post-deploy smoke test instead of blocking repair.
+          PRE_STATUS=$(curl -sk --max-time 10 -o /dev/null -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
+          if [ "$PRE_STATUS" = "200" ] && [ -s /tmp/marketing-downtime.log ]; then
             echo "ZERO-DOWNTIME VIOLATION: Marketing returned non-200 health responses during rollout:"
             cat /tmp/marketing-downtime.log
             exit 1
           fi
 
-          echo "Zero-downtime guard passed: no unhealthy-upstream window observed."
+          echo "Marketing rollout completed; post-deploy health verification follows."
 
       - name: Verify Northflank deployment SHA
         if: steps.latest_before_build.outputs.is_latest == 'true' && steps.latest_before_deploy.outputs.is_latest == 'true'

--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -178,12 +178,15 @@ jobs:
       # Existing health is diagnostic only. If production is already unhealthy,
       # the workflow must still be able to deploy a known-good replacement.
       - name: Record predeploy upstream health
+        id: predeploy
         run: |
           set -euo pipefail
           status=$(curl -sk --max-time 10 -o /tmp/predeploy-health.json -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
           if [ "$status" = "200" ]; then
+            echo "was_healthy=true" >> "$GITHUB_OUTPUT"
             echo "Existing Marketing upstream is healthy before rollout."
           else
+            echo "was_healthy=false" >> "$GITHUB_OUTPUT"
             echo "RECOVERY MODE: existing Marketing upstream is HTTP $status; continuing with strict zero-downtime configuration so a healthy replacement can recover service."
             cat /tmp/predeploy-health.json 2>/dev/null || true
           fi
@@ -244,6 +247,8 @@ jobs:
 
       - name: Deploy exact Marketing build with availability guard
         if: steps.latest_before_build.outputs.is_latest == 'true' && steps.latest_before_deploy.outputs.is_latest == 'true'
+        env:
+          WAS_HEALTHY_BEFORE_ROLLOUT: ${{ steps.predeploy.outputs.was_healthy }}
         run: |
           set -euo pipefail
           rm -f /tmp/marketing-downtime.log
@@ -271,14 +276,14 @@ jobs:
           wait "$WATCH_PID" 2>/dev/null || true
           trap - EXIT
 
-          # If the service was healthy before rollout, any non-200 during rollout
-          # is a zero-downtime violation. If it was already unhealthy, recovery is
-          # judged by the post-deploy smoke test instead of blocking repair.
-          PRE_STATUS=$(curl -sk --max-time 10 -o /dev/null -w "%{http_code}" https://www.elevateforhumanity.org/api/health || true)
-          if [ "$PRE_STATUS" = "200" ] && [ -s /tmp/marketing-downtime.log ]; then
+          if [ "$WAS_HEALTHY_BEFORE_ROLLOUT" = "true" ] && [ -s /tmp/marketing-downtime.log ]; then
             echo "ZERO-DOWNTIME VIOLATION: Marketing returned non-200 health responses during rollout:"
             cat /tmp/marketing-downtime.log
             exit 1
+          fi
+
+          if [ "$WAS_HEALTHY_BEFORE_ROLLOUT" != "true" ] && [ -s /tmp/marketing-downtime.log ]; then
+            echo "Recovery rollout began while upstream was already unhealthy; post-deploy convergence will determine success."
           fi
 
           echo "Marketing rollout completed; post-deploy health verification follows."

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -13,45 +13,48 @@ import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 export default function Header() {
   return (
     <header
-      className="fixed inset-x-0 top-0 z-[9999] h-[68px] border-b border-slate-200 bg-white shadow-sm"
+      className="fixed inset-x-0 top-0 z-[9999] isolate h-[68px] overflow-visible border-b border-slate-200 bg-white shadow-sm"
       role="banner"
     >
-      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_1fr_auto] items-center gap-2 px-3 md:gap-3 md:px-4 xl:gap-4 xl:px-6">
+      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-3 lg:gap-3 lg:px-4 xl:gap-4 xl:px-6">
         <Link
           href="/"
           className="flex min-w-0 flex-shrink-0 items-center gap-2"
           aria-label={`${PLATFORM_DEFAULTS.orgName} home`}
         >
           <LogoImage alt="Elevate" width={44} height={56} className="h-10 w-auto" />
-          <span className="hidden whitespace-nowrap text-base font-extrabold tracking-tight text-slate-950 sm:inline">
+          <span className="hidden whitespace-nowrap text-base font-extrabold tracking-tight text-slate-950 xl:inline">
             Elevate
           </span>
         </Link>
 
-        {/* md+ keeps the primary navigation horizontal. */}
-        <div className="hidden min-w-0 justify-center overflow-visible md:flex">
+        {/* Full navigation begins at lg. Below lg, use the compact drawer so
+            header controls never wrap or collide with page accessibility/TTS UI. */}
+        <div className="hidden min-w-0 justify-center overflow-visible lg:flex">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
-        <div className="flex min-w-0 flex-shrink-0 items-center justify-end gap-1.5">
-          <div className="hidden items-center gap-1 md:flex xl:gap-1.5">
-            <HeaderDesktopMenu items={NAV_ITEMS} />
+        <div className="flex min-w-0 flex-shrink-0 flex-nowrap items-center justify-end gap-1.5">
+          <div className="hidden flex-nowrap items-center gap-1 lg:flex xl:gap-1.5">
+            <div className="hidden xl:block">
+              <HeaderDesktopMenu items={NAV_ITEMS} />
+            </div>
             <Link
               href={ROUTES.login}
-              className="whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950 xl:px-2.5 xl:text-base"
+              className="hidden whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950 xl:inline-flex xl:px-2.5 xl:text-base"
             >
               Sign In
             </Link>
             <Link
               href={ROUTES.apply}
-              className="whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700 xl:px-4 xl:py-2.5 xl:text-base"
+              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700 xl:px-4 xl:py-2.5 xl:text-base"
             >
               Apply
             </Link>
           </div>
 
-          <div className="flex items-center gap-1 md:hidden">
-            <span className="hidden text-sm font-bold text-slate-700 sm:inline" aria-hidden="true">
+          <div className="flex flex-nowrap items-center gap-1 lg:hidden">
+            <span className="hidden whitespace-nowrap text-sm font-bold text-slate-700 sm:inline" aria-hidden="true">
               Menu
             </span>
             <HeaderMobileMenu items={NAV_ITEMS} />

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -28,31 +28,49 @@ export default function Header() {
           </span>
         </Link>
 
-        {/* Full navigation begins at lg. Below lg, use the compact drawer so
-            header controls never wrap or collide with page accessibility/TTS UI. */}
-        <div className="hidden min-w-0 justify-center overflow-visible lg:flex">
+        {/* Only render the full horizontal navigation when the viewport has
+            enough room for every group without wrapping or colliding. */}
+        <div className="hidden min-w-0 justify-center overflow-visible xl:flex">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
         <div className="flex min-w-0 flex-shrink-0 flex-nowrap items-center justify-end gap-1.5">
-          <div className="hidden flex-nowrap items-center gap-1 lg:flex xl:gap-1.5">
-            <div className="hidden xl:block">
-              <HeaderDesktopMenu items={NAV_ITEMS} />
-            </div>
+          {/* Full desktop controls. */}
+          <div className="hidden flex-nowrap items-center gap-1.5 xl:flex">
+            <HeaderDesktopMenu items={NAV_ITEMS} />
             <Link
               href={ROUTES.login}
-              className="hidden whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950 xl:inline-flex xl:px-2.5 xl:text-base"
+              className="inline-flex whitespace-nowrap px-2.5 py-2 text-base font-semibold text-slate-800 hover:text-slate-950"
             >
               Sign In
             </Link>
             <Link
               href={ROUTES.apply}
-              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700 xl:px-4 xl:py-2.5 xl:text-base"
+              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-4 py-2.5 text-base font-bold text-white hover:bg-brand-red-700"
             >
               Apply
             </Link>
           </div>
 
+          {/* Compact desktop/tablet controls. HeaderDesktopMenu opens a
+              desktop side panel and does not depend on the mobile drawer. */}
+          <div className="hidden flex-nowrap items-center gap-1.5 lg:flex xl:hidden">
+            <HeaderDesktopMenu items={NAV_ITEMS} />
+            <Link
+              href={ROUTES.login}
+              className="inline-flex whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950"
+            >
+              Sign In
+            </Link>
+            <Link
+              href={ROUTES.apply}
+              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700"
+            >
+              Apply
+            </Link>
+          </div>
+
+          {/* Phones and small tablets use the dedicated mobile drawer. */}
           <div className="flex flex-nowrap items-center gap-1 lg:hidden">
             <span className="hidden whitespace-nowrap text-sm font-bold text-slate-700 sm:inline" aria-hidden="true">
               Menu

--- a/docs/audits/FULL-REPOSITORY-CENSUS-2026-08-08.md
+++ b/docs/audits/FULL-REPOSITORY-CENSUS-2026-08-08.md
@@ -1,0 +1,52 @@
+# Full Repository Census — 2026-08-08
+
+Repository: `elevate-for-humanity/Elevate-lms`
+
+This census is the controlling ledger for the full repository audit requested against live production. It is intentionally separate from historical audit reports. Every active runtime surface must be classified as one of: `CANONICAL`, `MERGE`, `MIGRATE CALLERS`, `REDIRECT`, `DELETE`, `BROKEN`, `UNIMPLEMENTED`, or `ARCHIVE/HISTORICAL`.
+
+## Production application ownership
+
+- `apps/marketing`: canonical public website and designated Marketing-host portals defined by `lib/routing/portal-map.ts`.
+- `apps/lms`: canonical learner, apprentice, employer, host-shop, partner, workforce and LMS runtime.
+- `apps/admin`: canonical staff, instructor, admin, Studio and Course Builder runtime.
+
+## Confirmed remediations already completed
+
+- Legacy `/api/apply` removed; canonical student application API is `/api/applications`.
+- Deprecated `/api/enrollments/checkout` removed in favor of canonical partner-course checkout ownership.
+- Legacy `/api/stripe/webhook` removed in favor of the canonical Stripe webhook handler.
+- Legacy `/dev-studio` route removed; Admin Studio canonical route is `/studio`.
+- Duplicate nested `/admin/course-builder` route removed; `/course-builder` owns the real implementation.
+- Unused legacy Supabase client shim removed.
+- Unused tax-platform RBAC module removed.
+- Active LMS `super_admin` privilege drift retired; production role data reconciled to `admin`.
+- Barber apprenticeship public runtime values moved toward RAPIDS-backed SSOT.
+- Marketing/LMS/Admin deployment health contracts use port 3000, `/api/ping` liveness and `/api/health` readiness.
+
+## Current critical production gaps
+
+- Marketing deployment previously allowed service configuration drift and could expose `503 no healthy upstream` during replacement. The current closure branch enforces strict `maxSurge=1, maxUnavailable=0` and refuses a Marketing deployment if Northflank rejects that contract.
+- Marketing recovery previously deadlocked when the existing upstream was already unhealthy. The current closure branch records predeploy health but permits recovery deployment.
+- Marketing header previously forced full desktop navigation at widths too narrow for all controls. The current closure branch uses mobile drawer below `lg`, compact desktop menu from `lg` to `xl`, and full horizontal navigation at `xl+`.
+
+## Remaining census work
+
+The following trees still require file-by-file classification and caller verification before deletion or consolidation:
+
+- `apps/marketing/app/**`
+- `apps/lms/app/**`
+- `apps/admin/app/**`
+- root/runtime `components/**`
+- root/runtime `lib/**`
+- `packages/**`
+- `.github/workflows/**`
+- `scripts/**`
+- `supabase/migrations/**`
+- active `supabase/seeds/**`
+- root-era application trees and compatibility artifacts
+- generated artifacts that are imported by runtime code
+- historical audit/report/archive files that should be excluded from runtime reasoning but retained or archived as records
+
+## Completion rule
+
+The audit is not complete until every active file or route has an owner, every duplicate has a caller migration/disposition, every canonical route is wired to its API/database/auth path, and the deployed SHA passes live route and authenticated E2E verification.

--- a/docs/audits/ROLLOUT-HEADER-HOTFIX-2026-08-08.md
+++ b/docs/audits/ROLLOUT-HEADER-HOTFIX-2026-08-08.md
@@ -1,0 +1,3 @@
+# Marketing rollout + header hotfix — 2026-08-08
+
+This branch enforces strict Marketing zero-downtime deployment and corrects the responsive public header. It is intentionally narrow so it can be deployed in one Marketing build while the broader repository census continues separately.

--- a/scripts/northflank/configure-services.ts
+++ b/scripts/northflank/configure-services.ts
@@ -226,6 +226,18 @@ async function patchWithZeroDowntimeStrategy(
     });
     return { response, rolloutMode: 'custom' };
   } catch (customError) {
+    // Marketing must never fall back to a rollout mode whose availability
+    // semantics are not explicit. With a single steady instance, any strategy
+    // that can remove the old pod before the replacement is ready can expose
+    // "no healthy upstream". Fail closed instead of accepting that risk.
+    if (service.role === 'marketing') {
+      throw new Error(
+        `Northflank rejected the required Marketing zero-downtime strategy ` +
+          `(maxSurge=1,maxUnavailable=0). Refusing deployment rather than risking 503/no healthy upstream. ` +
+          `${customError instanceof Error ? customError.message : String(customError)}`,
+      );
+    }
+
     console.warn(
       `[rollout-retry] ${service.id}: custom maxSurge/maxUnavailable strategy rejected; trying rollout-steady. ` +
         `${customError instanceof Error ? customError.message : String(customError)}`,
@@ -286,10 +298,15 @@ async function configureService(
     );
   }
 
+  const availabilitySummary =
+    appliedRolloutMode === 'custom'
+      ? 'maxUnavailable=0 maxSurge=1'
+      : 'rollout-steady';
+
   console.info(
     `[patch-ok] ${service.role}:${service.id} dockerfile=${service.dockerfile} ` +
       `port=${RUNTIME_PORT} instances=${DESIRED_INSTANCES} rollout=${appliedRolloutMode} ` +
-      `maxUnavailable=0 maxSurge=1 health=startup:/api/ping,readiness:/api/health,liveness:/api/ping ` +
+      `${availabilitySummary} health=startup:/api/ping,readiness:/api/health,liveness:/api/ping ` +
       `ci=github-actions buildPlan=${billing.buildPlan} deploymentPlan=${billing.deploymentPlan} ` +
       `ephemeralMB=${appliedEphemeralMb}`,
   );


### PR DESCRIPTION
Hotfix bundle for the current production regressions.

Changes:
- Marketing now always enforces canonical Northflank rollout configuration before deployment.
- Marketing requires explicit custom rollout semantics with maxSurge=1 and maxUnavailable=0; no ambiguous fallback is allowed.
- Existing 503/no-healthy-upstream no longer blocks recovery deployment.
- Availability guard remembers predeploy health and fails only when a previously healthy site becomes unhealthy during rollout.
- Responsive header now uses mobile drawer below lg, compact desktop menu from lg to xl, and full horizontal navigation only at xl+, preventing wrapping/collision with accessibility/TTS controls.
- Full repository census ledger remains in the branch for continued repository-wide classification.

This is one Marketing deployment batch to avoid repeated paid builds.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Prevent Marketing no-healthy-upstream rollout failures and fix header responsive layout
> - The Marketing deploy workflow no longer blocks on upstream health before rollout; instead it records pre-deploy health state and only treats non-200 responses during rollout as a zero-downtime violation when the upstream was healthy beforehand.
> - [`configure-services.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/553/files#diff-a265b10d2431129186c98763c8797fd8b25744b06999524db56b532cf7a5dea9) now hard-fails Marketing deployments if the explicit zero-downtime custom strategy patch is rejected, removing the fallback to `rollout-steady`.
> - [`Header.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/553/files#diff-ab1fe96a19fb5a4115ecc8932848cfad8d945af1a39528b95ecf35d3e7f1caca) adds an intermediate `lg`–`xl` compact nav group, defers to the mobile drawer below `lg`, and restricts full horizontal nav to `xl` and above.
> - Behavioral Change: Marketing deployments that previously fell back to `rollout-steady` on a rejected custom strategy will now fail fast instead.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d9a4bfa.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->