### PR TITLE
fix: force LMS/Admin runtime closure and canonical dashboard routing

### DIFF
--- a/apps/admin/app/api/health/route.ts
+++ b/apps/admin/app/api/health/route.ts
@@ -1,8 +1,9 @@
 /**
  * GET /api/health
  *
- * Readiness probe - verifies application is initialized
- * and ready to serve requests. Still NO external dependency checks.
+ * Readiness probe - verifies application is initialized and ready to serve
+ * requests. This intentionally performs no external dependency checks so
+ * Northflank readiness cannot remove every pod because of a downstream outage.
  */
 
 import { NextResponse } from 'next/server';
@@ -17,6 +18,8 @@ export async function GET() {
       service: 'admin',
       status: 'healthy',
       ready: true,
+      canonicalDashboard: '/dashboard',
+      healthContract: 'admin-v2',
       commit: process.env.GIT_SHA ?? process.env.GITHUB_SHA ?? 'unknown',
       buildId: process.env.NEXT_PUBLIC_BUILD_ID ?? 'unknown',
       builtAt: process.env.BUILD_TIMESTAMP ?? 'unknown',
@@ -29,6 +32,6 @@ export async function GET() {
       headers: {
         'Cache-Control': 'no-store',
       },
-    }
+    },
   );
 }

--- a/apps/lms/app/api/health/route.ts
+++ b/apps/lms/app/api/health/route.ts
@@ -1,8 +1,9 @@
 /**
  * GET /api/health
  *
- * Readiness probe - verifies application is initialized
- * and ready to serve requests. Still NO external dependency checks.
+ * Readiness probe - verifies application is initialized and ready to serve
+ * requests. This intentionally performs no external dependency checks so
+ * Northflank readiness cannot remove every pod because of a downstream outage.
  */
 
 import { NextResponse } from 'next/server';
@@ -17,6 +18,8 @@ export async function GET() {
       service: 'lms',
       status: 'healthy',
       ready: true,
+      canonicalDashboard: '/lms/dashboard',
+      healthContract: 'lms-v2',
       commit: process.env.GIT_SHA ?? process.env.GITHUB_SHA ?? 'unknown',
       buildId: process.env.NEXT_PUBLIC_BUILD_ID ?? 'unknown',
       builtAt: process.env.BUILD_TIMESTAMP ?? 'unknown',
@@ -29,6 +32,6 @@ export async function GET() {
       headers: {
         'Cache-Control': 'no-store',
       },
-    }
+    },
   );
 }

--- a/apps/lms/app/dashboards/page.tsx
+++ b/apps/lms/app/dashboards/page.tsx
@@ -8,11 +8,11 @@ export const metadata: Metadata = {
 };
 
 const dashboards = [
-  { title: 'Student Dashboard', href: '/student/dashboard', icon: GraduationCap, desc: 'Track your progress, courses, and assignments' },
+  { title: 'Student Dashboard', href: '/lms/dashboard', icon: GraduationCap, desc: 'Track your progress, courses, and assignments' },
   { title: 'Instructor Dashboard', href: '/instructor/dashboard', icon: Users, desc: 'Manage classes, students, and grades' },
   { title: 'Employer Dashboard', href: '/employer/dashboard', icon: Building2, desc: 'View apprentices, post jobs, manage partnerships' },
   { title: 'Apprentice Dashboard', href: '/apprentice/dashboard', icon: User, desc: 'Track hours, log work, view progress' },
-  { title: 'Admin Dashboard', href: '/admin', icon: Shield, desc: 'Platform administration and analytics' },
+  { title: 'Admin Dashboard', href: 'https://admin.elevateforhumanity.org/dashboard', icon: Shield, desc: 'Platform administration and analytics' },
 ];
 
 export default function DashboardsPage() {


### PR DESCRIPTION
Production closure for the remaining LMS/Admin runtime gap.

- Fixes stale LMS dashboard selector link from nonexistent /student/dashboard to canonical /lms/dashboard.
- Sends Admin dashboard selection to the Admin service instead of a shadow LMS-local /admin route.
- Adds explicit dependency-free health contract metadata for LMS and Admin so both service-owned app trees are changed and their deployment workflows must run.
- Preserves the zero-downtime Northflank contract merged in #556.

No Marketing redesign, no legacy route resurrection, no unrelated feature changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix canonical dashboard routing and add health contract fields to LMS and Admin APIs
> - Updates dashboard hrefs in [apps/lms/app/dashboards/page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/557/files#diff-e1cb708417fb061e09c0385dd69971a7ff34096e56207707441199724b08d640): Student Dashboard now points to `/lms/dashboard` and Admin Dashboard to `https://admin.elevateforhumanity.org/dashboard`.
> - Adds `canonicalDashboard` and `healthContract` fields to the `/api/health` response in both the [LMS](https://github.com/elevate-for-humanity/Elevate-lms/pull/557/files#diff-76524f9e51fd0214a02fc63b9773b474469e72d355763c973fce28ad2b48a0b6) and [Admin](https://github.com/elevate-for-humanity/Elevate-lms/pull/557/files#diff-30ab994af8f310dbe793b2eb3dd3ee8ace6a637301281621b9de2fb77c9006e1) apps, with values `lms-v2`/`admin-v2` respectively.
> - Behavioral Change: existing consumers of the LMS dashboard link or the health endpoint response shape will see different values.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized ec196fb.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->