### PR TITLE
fix: auto-enqueue Host Shop applications for Admin review

### DIFF
--- a/supabase/migrations/20260809061500_enqueue_host_shop_application_review.sql
+++ b/supabase/migrations/20260809061500_enqueue_host_shop_application_review.sql
@@ -1,0 +1,65 @@
+-- Ensure every submitted Host Shop application enters the Admin review queue.
+-- Idempotent: one open/in-progress/escalated review item per application.
+
+CREATE OR REPLACE FUNCTION public.enqueue_host_shop_application_review()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  IF NEW.status = 'submitted' THEN
+    INSERT INTO public.review_queue (
+      queue_type,
+      subject_type,
+      subject_id,
+      priority,
+      reasons,
+      status,
+      metadata,
+      entity_type,
+      entity_id,
+      review_type
+    )
+    SELECT
+      'host_shop_review',
+      'host_shop_application',
+      NEW.id,
+      8,
+      ARRAY[
+        'Verify business/shop license, supervising professional license, liability insurance, workers compensation or exemption, EIN/W-9 identity record, worksite capacity, and program fit before approval.'
+      ],
+      'open',
+      jsonb_build_object(
+        'application_id', NEW.id,
+        'shop_name', NEW.shop_name,
+        'business_name', NEW.business_name,
+        'contact_email', NEW.contact_email,
+        'submitted_at', NEW.submitted_at
+      ),
+      'host_shop_application',
+      NEW.id,
+      'host_shop_compliance'
+    WHERE NOT EXISTS (
+      SELECT 1
+      FROM public.review_queue rq
+      WHERE rq.subject_type = 'host_shop_application'
+        AND rq.subject_id = NEW.id
+        AND rq.status IN ('open', 'in_progress', 'escalated')
+    );
+  END IF;
+
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_enqueue_host_shop_application_review
+  ON public.host_shop_applications;
+
+CREATE TRIGGER trg_enqueue_host_shop_application_review
+AFTER INSERT OR UPDATE OF status ON public.host_shop_applications
+FOR EACH ROW
+EXECUTE FUNCTION public.enqueue_host_shop_application_review();
+
+COMMENT ON FUNCTION public.enqueue_host_shop_application_review()
+IS 'Automatically creates one Admin review_queue item for each submitted Host Shop application.';


### PR DESCRIPTION
Adds an idempotent Supabase trigger so every Host Shop application with status `submitted` automatically creates one open `review_queue` item for Admin compliance review. The same migration has already been applied successfully to production Supabase. Verification found zero currently submitted Host Shop applications stranded without an open/in-progress/escalated review item.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Auto-enqueue Host Shop applications for Admin review on submission
> Adds a `SECURITY DEFINER` trigger function [`enqueue_host_shop_application_review`](https://github.com/elevate-for-humanity/Elevate-lms/pull/559/files#diff-14b0f0f60edd32ae5ef37b71458c43ea435d56716eeac2067503e19bd6a055be) and an `AFTER INSERT OR UPDATE OF status` trigger on `public.host_shop_applications`. When a row's status transitions to `submitted`, a row is inserted into `public.review_queue` with type `host_shop_review`, priority 8, and status `open`. A `NOT EXISTS` guard prevents duplicate entries when an `open`, `in_progress`, or `escalated` review already exists for the same application.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1c7211d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->