### PR TITLE
fix(seo): unify Google canonical, favicon, sitemap, redirects

### DIFF
--- a/apps/marketing/app/layout.tsx
+++ b/apps/marketing/app/layout.tsx
@@ -24,14 +24,28 @@ import { AssociateFormLabels } from '@/components/accessibility/AssociateFormLab
 export const metadata: Metadata = {
   title: { default: 'Elevate for Humanity', template: '%s | Elevate for Humanity' },
   description: 'Vocational education and workforce development',
+  applicationName: 'Elevate for Humanity',
   metadataBase: new URL('https://www.elevateforhumanity.org'),
   manifest: '/manifest-marketing.json',
   icons: {
     icon: [
-      { url: '/favicon.ico', sizes: 'any' },
-      { url: '/favicon.png', type: 'image/png' },
+      { url: '/icon-192.png', type: 'image/png', sizes: '192x192' },
+      { url: '/icon-512.png', type: 'image/png', sizes: '512x512' },
+      { url: '/favicon.ico', type: 'image/x-icon', sizes: '32x32' },
     ],
-    apple: '/apple-touch-icon.png',
+    shortcut: [{ url: '/icon-192.png', type: 'image/png', sizes: '192x192' }],
+    apple: [{ url: '/apple-touch-icon.png', type: 'image/png', sizes: '180x180' }],
+  },
+  robots: {
+    index: true,
+    follow: true,
+    googleBot: {
+      index: true,
+      follow: true,
+      'max-image-preview': 'large',
+      'max-snippet': -1,
+      'max-video-preview': -1,
+    },
   },
 };
 

--- a/apps/marketing/app/legal/page.tsx
+++ b/apps/marketing/app/legal/page.tsx
@@ -15,7 +15,7 @@ export const metadata: Metadata = {
 
 const LEGAL_DOCS = [
   { icon: FileText, title: 'Terms of Service', desc: 'User agreement governing access to the Elevate platform and programs.', href: '/legal' },
-  { icon: Lock, title: 'Privacy Policy', desc: 'How we collect, use, and protect your personal information.', href: '/legal/privacy' },
+  { icon: Lock, title: 'Privacy Policy', desc: 'How we collect, use, and protect your personal information.', href: '/privacy' },
   { icon: Shield, title: 'Security & Data Protection', desc: 'Technical and organizational measures protecting student and partner data.', href: '/security-and-data-protection' },
   { icon: Scale, title: 'License Agreement', desc: 'Software license terms for LMS platform licensees.', href: '/legal/license-agreement' },
   { icon: Scale, title: 'Program License Agreement', desc: 'Terms governing the licensing of Elevate training programs to external organizations.', href: '/legal/program-license-agreement' },

--- a/apps/marketing/app/legal/privacy/page.tsx
+++ b/apps/marketing/app/legal/privacy/page.tsx
@@ -1,102 +1,11 @@
-export const dynamic = 'force-dynamic';
-import { Metadata } from 'next';
-import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
-import Link from 'next/link';
-import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { permanentRedirect } from 'next/navigation';
 
-export const metadata: Metadata = {
+export const metadata = {
   title: 'Privacy Policy',
-  description:
-    'Privacy Policy describing how Elevate For Humanity collects, uses, and protects personal information.',
+  description: 'Elevate for Humanity Privacy Policy',
+  robots: { index: false, follow: true },
 };
 
-export default function PrivacyPolicyPage() {
-  return (
-    <div className="min-h-screen bg-white py-12">
-      <div className="max-w-7xl mx-auto px-4 py-4">
-        <Breadcrumbs items={[{ label: 'Legal', href: '/legal' }, { label: 'Privacy Policy' }]} />
-      </div>
-      <div className="max-w-4xl mx-auto px-4">
-        <div className="bg-white rounded-xl shadow-sm p-8 md:p-12">
-          <h1 className="text-3xl font-bold text-slate-900 mb-2">Privacy Policy</h1>
-          <p className="text-slate-500 mb-8">Version 1.0 | Effective: April 1, 2026</p>
-
-          <div className="prose prose-gray max-w-none">
-            <p className="text-lg text-slate-700 mb-6">
-              {PLATFORM_DEFAULTS.orgName} collects information you provide when you use our website, submit
-              applications, request information, enroll in programs, or contact us.
-            </p>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">1. Information We Collect</h2>
-            <ul className="list-disc pl-6 text-slate-700 mb-4 space-y-2">
-              <li>Name, email address, phone number, and mailing address</li>
-              <li>Program interest and application details</li>
-              <li>Payment and transaction records, when applicable</li>
-              <li>
-                Technical information such as IP address, browser type, and device information
-              </li>
-              <li>Attendance, progress, and assessment records for enrolled learners</li>
-            </ul>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">2. How We Use Information</h2>
-            <ul className="list-disc pl-6 text-slate-700 mb-4 space-y-2">
-              <li>To respond to inquiries and process applications</li>
-              <li>To deliver training, program administration, and learner support</li>
-              <li>To process payments and maintain records</li>
-              <li>To improve site performance, security, and user experience</li>
-              <li>To comply with legal, regulatory, or reporting obligations</li>
-            </ul>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">3. Information Sharing</h2>
-            <p className="text-slate-700 mb-4">
-              We do not sell personal information. We may share information with service providers,
-              payment processors, learning technology vendors, and government or program partners
-              when required to operate services, fulfill program requirements, or comply with law.
-            </p>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">4. Data Security</h2>
-            <p className="text-slate-700 mb-4">
-              We use reasonable administrative, technical, and physical safeguards to protect
-              personal information. No method of transmission or storage is completely secure.
-            </p>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">5. Your Choices</h2>
-            <p className="text-slate-700 mb-4">
-              You may contact us to update your information, ask questions about our practices, or
-              request assistance regarding your data.
-            </p>
-
-            <h2 className="text-xl font-bold text-slate-900 mt-8 mb-4">6. Contact</h2>
-            <p className="text-slate-700 mb-4">
-              For privacy-related questions, contact:{' '}
-              <a
-                href="mailto:info@elevateforhumanity.org"
-                className="text-brand-green-600 hover:underline"
-              >
-                info@elevateforhumanity.org
-              </a>
-            </p>
-
-            <div className="mt-12 pt-8 border-t border-slate-200">
-              <p className="text-slate-600 text-sm">
-                By using the Elevate For Humanity platform, you acknowledge that you have read and
-                understood this Privacy Policy.
-              </p>
-              <div className="mt-6 flex gap-4">
-                <Link href="/legal/acceptable-use" className="text-brand-green-600 hover:underline">
-                  Acceptable Use Policy
-                </Link>
-                <Link href="/legal" className="text-brand-green-600 hover:underline">
-                  Terms of Use
-                </Link>
-                <Link href="/legal/disclosures" className="text-brand-green-600 hover:underline">
-                  Disclosures
-                </Link>
-              </div>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  );
+export default function LegacyPrivacyRedirect() {
+  permanentRedirect('/privacy');
 }

--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -11,6 +11,7 @@ import { HomeEmployerStrip } from '@/components/home/HomeEmployerStrip';
 import { HomeFinalCTA } from '@/components/home/HomeFinalCTA';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { ParisFloatingButton } from '@/components/paris/ParisFloatingButton';
+import StructuredData from '@/components/StructuredData';
 
 export const revalidate = 300;
 
@@ -31,12 +32,12 @@ export const metadata: Metadata = {
     'career training Marion County',
     PLATFORM_DEFAULTS.orgName,
   ],
-  alternates: { canonical: PLATFORM_DEFAULTS.siteUrl },
+  alternates: { canonical: 'https://www.elevateforhumanity.org' },
   openGraph: {
     title: `${PLATFORM_DEFAULTS.orgName} | Workforce Training, Apprenticeships & Career Programs`,
     description:
       'DOL-registered apprenticeship sponsor and Indiana ETPL-listed training provider. Career programs in healthcare, skilled trades, CDL, technology, and beauty — funding options may be available.',
-    url: PLATFORM_DEFAULTS.siteUrl,
+    url: 'https://www.elevateforhumanity.org',
     siteName: PLATFORM_DEFAULTS.orgName,
     images: [
       {
@@ -85,6 +86,8 @@ export default function HomePage() {
 
   return (
     <>
+      <StructuredData />
+
       {/* 1. Immediate visual identity + primary action */}
       <HomeHeroVideo banner={banner} />
 

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -2,7 +2,6 @@ import type { MetadataRoute } from 'next';
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const baseUrl = 'https://www.elevateforhumanity.org';
-  const now = new Date();
 
   const coreRoutes: Array<{
     path: string;
@@ -12,8 +11,6 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: '/', changeFrequency: 'weekly', priority: 1 },
     { path: '/programs', changeFrequency: 'weekly', priority: 0.95 },
     { path: '/apply', changeFrequency: 'monthly', priority: 0.95 },
-    { path: '/host-shop', changeFrequency: 'weekly', priority: 0.9 },
-    { path: '/host-shop/apply', changeFrequency: 'monthly', priority: 0.85 },
     { path: '/apprenticeships', changeFrequency: 'weekly', priority: 0.9 },
     { path: '/testing', changeFrequency: 'weekly', priority: 0.9 },
     { path: '/funding', changeFrequency: 'weekly', priority: 0.9 },
@@ -75,19 +72,16 @@ export default function sitemap(): MetadataRoute.Sitemap {
   return [
     ...coreRoutes.map(({ path, changeFrequency, priority }) => ({
       url: `${baseUrl}${path === '/' ? '' : path}`,
-      lastModified: now,
       changeFrequency,
       priority,
     })),
     ...programRoutes.map((path) => ({
       url: `${baseUrl}${path}`,
-      lastModified: now,
       changeFrequency: 'weekly' as const,
       priority: path.includes('barber-apprenticeship') ? 0.9 : 0.8,
     })),
     ...appStoreRoutes.map((path) => ({
       url: `${baseUrl}${path}`,
-      lastModified: now,
       changeFrequency: 'weekly' as const,
       priority: 0.8,
     })),

--- a/apps/marketing/app/terms/page.tsx
+++ b/apps/marketing/app/terms/page.tsx
@@ -1,14 +1,14 @@
 /**
  * /terms - Legacy route redirecting to canonical /legal
  */
-import { redirect } from 'next/navigation';
+import { permanentRedirect } from 'next/navigation';
 
 export default function TermsRedirect() {
-  redirect('/legal');
+  permanentRedirect('/legal');
 }
 
 export const metadata = {
   title: 'Terms of Service',
   description: 'Elevate for Humanity Terms of Service',
-  robots: { index: false, follow: false },
+  robots: { index: false, follow: true },
 };

--- a/apps/marketing/next.config.mjs
+++ b/apps/marketing/next.config.mjs
@@ -41,17 +41,25 @@ const nextConfig = {
 
   async redirects() {
     return [
-      // Admin is a standalone service at admin.elevateforhumanity.org.
-      // Strip the historical /admin prefix when crossing to that container.
-      { source: '/admin', destination: 'https://admin.elevateforhumanity.org/dashboard', permanent: false },
-      { source: '/admin/:path*', destination: 'https://admin.elevateforhumanity.org/:path*', permanent: false },
-      { source: '/lms/:path*', destination: 'https://app.elevateforhumanity.org/lms/:path*', permanent: false },
-      { source: '/employer/:path*', destination: 'https://app.elevateforhumanity.org/employer/:path*', permanent: false },
-      { source: '/apprentice/:path*', destination: 'https://app.elevateforhumanity.org/apprentice/:path*', permanent: false },
-      { source: '/parent-portal/:path*', destination: 'https://app.elevateforhumanity.org/parent-portal/:path*', permanent: false },
-      { source: '/workforce/:path*', destination: 'https://app.elevateforhumanity.org/workforce/:path*', permanent: false },
-      { source: '/cosmetology-host-shop/:path*', destination: 'https://app.elevateforhumanity.org/cosmetology-host-shop/:path*', permanent: false },
-      { source: '/host-shop/:path*', destination: 'https://app.elevateforhumanity.org/host-shop/:path*', permanent: false },
+      // Canonical public hostname. Keep all indexable Marketing URLs on www.
+      {
+        source: '/:path*',
+        has: [{ type: 'host', value: 'elevateforhumanity.org' }],
+        destination: 'https://www.elevateforhumanity.org/:path*',
+        permanent: true,
+      },
+
+      // Historical cross-service paths remain as one-hop permanent redirects.
+      // Internal navigation should point directly to the destination hosts.
+      { source: '/admin', destination: 'https://admin.elevateforhumanity.org/dashboard', permanent: true },
+      { source: '/admin/:path*', destination: 'https://admin.elevateforhumanity.org/:path*', permanent: true },
+      { source: '/lms/:path*', destination: 'https://app.elevateforhumanity.org/lms/:path*', permanent: true },
+      { source: '/employer/:path*', destination: 'https://app.elevateforhumanity.org/employer/:path*', permanent: true },
+      { source: '/apprentice/:path*', destination: 'https://app.elevateforhumanity.org/apprentice/:path*', permanent: true },
+      { source: '/parent-portal/:path*', destination: 'https://app.elevateforhumanity.org/parent-portal/:path*', permanent: true },
+      { source: '/workforce/:path*', destination: 'https://app.elevateforhumanity.org/workforce/:path*', permanent: true },
+      { source: '/cosmetology-host-shop/:path*', destination: 'https://app.elevateforhumanity.org/cosmetology-host-shop/:path*', permanent: true },
+      { source: '/host-shop/:path*', destination: 'https://app.elevateforhumanity.org/host-shop/:path*', permanent: true },
     ];
   },
 };

--- a/components/StructuredData.tsx
+++ b/components/StructuredData.tsx
@@ -9,17 +9,21 @@ export default function StructuredData() {
     telephoneDigits.length === 11 && telephoneDigits.startsWith('1')
       ? `+${telephoneDigits}`
       : `+1${telephoneDigits}`;
+  const canonicalSiteUrl = 'https://www.elevateforhumanity.org';
 
   const organizationSchema = {
     '@context': 'https://schema.org',
     '@type': 'EducationalOrganization',
-    '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization`,
+    '@id': `${canonicalSiteUrl}/#organization`,
     name: PLATFORM_DEFAULTS.orgName,
     legalName: `2Exclusive LLC-S d/b/a ${PLATFORM_DEFAULTS.orgLegalName}`,
-    url: PLATFORM_DEFAULTS.siteUrl,
+    url: canonicalSiteUrl,
     logo: {
       '@type': 'ImageObject',
-      url: `${PLATFORM_DEFAULTS.siteUrl}/images/Elevate_for_Humanity_logo_81bf0fab.jpg`,
+      url: `${canonicalSiteUrl}/icon-512.png`,
+      contentUrl: `${canonicalSiteUrl}/icon-512.png`,
+      width: 512,
+      height: 512,
     },
     description:
       'Career training, registered apprenticeship, workforce-development, testing, and employer-connected education services based in Indianapolis, Indiana.',
@@ -43,7 +47,10 @@ export default function StructuredData() {
       availableLanguage: ['English'],
     },
     sameAs: [
-      'https://www.instagram.com/elevateforhumanity',
+      'https://facebook.com/elevateforhumanity',
+      'https://twitter.com/elevatefh',
+      'https://linkedin.com/company/elevateforhumanity',
+      'https://instagram.com/elevateforhumanity',
       'https://www.youtube.com/@elevateforhumanity',
     ],
     hasOfferCatalog: {
@@ -57,13 +64,13 @@ export default function StructuredData() {
             '@type': 'Course',
             name: barber.name,
             description: `DOL Registered Apprenticeship requiring ${barber.totalHours.toLocaleString()} supervised OJL hours plus ${barber.relatedInstructionHours} hours of Related Technical Instruction under the registered program standards.`,
-            url: `${PLATFORM_DEFAULTS.siteUrl}/programs/barber-apprenticeship`,
-            provider: { '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization` },
+            url: `${canonicalSiteUrl}/programs/barber-apprenticeship`,
+            provider: { '@id': `${canonicalSiteUrl}/#organization` },
             offers: {
               '@type': 'Offer',
               price: String(BARBER_PRICING.fullPrice),
               priceCurrency: 'USD',
-              url: `${PLATFORM_DEFAULTS.siteUrl}/programs/barber-apprenticeship/apply`,
+              url: `${canonicalSiteUrl}/programs/barber-apprenticeship/apply`,
             },
           },
         },
@@ -72,8 +79,8 @@ export default function StructuredData() {
           itemOffered: {
             '@type': 'Course',
             name: 'HVAC Technician Training',
-            url: `${PLATFORM_DEFAULTS.siteUrl}/programs/hvac-technician`,
-            provider: { '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization` },
+            url: `${canonicalSiteUrl}/programs/hvac-technician`,
+            provider: { '@id': `${canonicalSiteUrl}/#organization` },
           },
         },
         {
@@ -81,8 +88,8 @@ export default function StructuredData() {
           itemOffered: {
             '@type': 'Course',
             name: 'Certified Nursing Assistant (CNA)',
-            url: `${PLATFORM_DEFAULTS.siteUrl}/programs/cna`,
-            provider: { '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization` },
+            url: `${canonicalSiteUrl}/programs/cna`,
+            provider: { '@id': `${canonicalSiteUrl}/#organization` },
           },
         },
         {
@@ -90,8 +97,8 @@ export default function StructuredData() {
           itemOffered: {
             '@type': 'Course',
             name: 'IT Help Desk',
-            url: `${PLATFORM_DEFAULTS.siteUrl}/programs/it-help-desk`,
-            provider: { '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization` },
+            url: `${canonicalSiteUrl}/programs/it-help-desk`,
+            provider: { '@id': `${canonicalSiteUrl}/#organization` },
           },
         },
         {
@@ -99,8 +106,8 @@ export default function StructuredData() {
           itemOffered: {
             '@type': 'Course',
             name: 'CDL Training',
-            url: `${PLATFORM_DEFAULTS.siteUrl}/programs/cdl-training`,
-            provider: { '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization` },
+            url: `${canonicalSiteUrl}/programs/cdl-training`,
+            provider: { '@id': `${canonicalSiteUrl}/#organization` },
           },
         },
       ],
@@ -110,21 +117,13 @@ export default function StructuredData() {
   const websiteSchema = {
     '@context': 'https://schema.org',
     '@type': 'WebSite',
-    '@id': `${PLATFORM_DEFAULTS.siteUrl}/#website`,
-    url: PLATFORM_DEFAULTS.siteUrl,
+    '@id': `${canonicalSiteUrl}/#website`,
+    url: canonicalSiteUrl,
     name: PLATFORM_DEFAULTS.orgName,
     description:
       'Career training, registered apprenticeship, workforce pathways, and testing services.',
     publisher: {
-      '@id': `${PLATFORM_DEFAULTS.siteUrl}/#organization`,
-    },
-    potentialAction: {
-      '@type': 'SearchAction',
-      target: {
-        '@type': 'EntryPoint',
-        urlTemplate: `${PLATFORM_DEFAULTS.siteUrl}/search?q={search_term_string}`,
-      },
-      'query-input': 'required name=search_term_string',
+      '@id': `${canonicalSiteUrl}/#organization`,
     },
   };
 

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -127,7 +127,7 @@ export function SiteFooter() {
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-wrap gap-4 text-sm font-medium text-slate-700">
               <Link href="/privacy" className="hover:text-slate-950 hover:underline">Privacy Policy</Link>
-              <Link href="/terms" className="hover:text-slate-950 hover:underline">Terms of Service</Link>
+              <Link href="/legal" className="hover:text-slate-950 hover:underline">Terms of Service</Link>
               <Link href="/accessibility" className="hover:text-slate-950 hover:underline">Accessibility</Link>
               <Link href="/federal-compliance" className="hover:text-slate-950 hover:underline">Federal Compliance</Link>
               <a href="https://www.dol.gov/agencies/eta/apprenticeship" target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-1 hover:text-slate-950 hover:underline">DOL Apprenticeship <ExternalLink className="h-3 w-3" /></a>

--- a/docs/audits/GOOGLE-SEO-CANONICAL-CLEANUP-2026-08-09.md
+++ b/docs/audits/GOOGLE-SEO-CANONICAL-CLEANUP-2026-08-09.md
@@ -1,0 +1,20 @@
+# Google SEO canonical cleanup — 2026-08-09
+
+Production target: `https://www.elevateforhumanity.org`
+
+Implemented in this branch:
+
+- Google-facing favicon now prefers the canonical 192x192 and 512x512 Elevate logo assets, with the ICO retained only as a fallback.
+- Marketing PWA manifest no longer references `admin-*` icon assets; it uses the canonical local Elevate icon set.
+- Homepage publishes canonical Organization and WebSite JSON-LD using the same `www` host and 512x512 logo.
+- Removed the placeholder SearchAction from WebSite structured data because the current `/search` route is not a real search implementation.
+- Organization social profile URLs are aligned with the public footer.
+- Marketing sitemap contains canonical public Marketing pages only; redirect-only `/host-shop` URLs were removed.
+- Removed synthetic `lastModified: new Date()` values from the sitemap so every URL is not falsely reported as changed on every sitemap request.
+- `elevateforhumanity.org/*` permanently redirects in one hop to `www.elevateforhumanity.org/*`.
+- Historical Marketing paths that belong to Admin/LMS use permanent one-hop cross-service redirects.
+- Duplicate `/legal/privacy` content was consolidated into canonical `/privacy` with a permanent redirect.
+- `/terms` is an explicitly non-indexed permanent redirect to canonical `/legal`.
+- Footer and legal-hub links now point directly to canonical destinations instead of creating internal redirect hops.
+
+Crawler policy remains in `apps/marketing/app/robots.ts`: public pages are crawlable, private/auth/API surfaces are disallowed, and the canonical sitemap is declared at `https://www.elevateforhumanity.org/sitemap.xml`.

--- a/public/manifest-marketing.json
+++ b/public/manifest-marketing.json
@@ -13,25 +13,25 @@
   "categories": ["education", "business"],
   "icons": [
     {
-      "src": "https://cuxzzpsyufcewtmicszk.supabase.co/storage/v1/object/public/images/icons/admin-192.png",
+      "src": "/icon-192.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "https://cuxzzpsyufcewtmicszk.supabase.co/storage/v1/object/public/images/icons/admin-512.png",
+      "src": "/icon-512.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "any"
     },
     {
-      "src": "https://cuxzzpsyufcewtmicszk.supabase.co/storage/v1/object/public/images/icons/admin-192.png",
+      "src": "/icon-192-maskable.png",
       "sizes": "192x192",
       "type": "image/png",
       "purpose": "maskable"
     },
     {
-      "src": "https://cuxzzpsyufcewtmicszk.supabase.co/storage/v1/object/public/images/icons/admin-512.png",
+      "src": "/icon-512-maskable.png",
       "sizes": "512x512",
       "type": "image/png",
       "purpose": "maskable"


### PR DESCRIPTION
Global Google/SEO cleanup for the public Marketing site. This makes `https://www.elevateforhumanity.org` the canonical host, unifies favicon/PWA branding, removes redirect-only URLs and fake last-modified timestamps from the sitemap, consolidates duplicate privacy content, makes legacy redirects permanent, publishes canonical Organization/WebSite schema on the homepage, and removes internal redirect hops from footer/legal navigation.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Unify canonical URL, favicon, sitemap, and redirects for Google SEO
> - Adds a permanent redirect from the apex domain `elevateforhumanity.org` to `www.elevateforhumanity.org` in [next.config.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/565/files#diff-b6f8c7e55392c514b0cedc00e85dbb5c099429f4dc75f8d795e0468af35bec2e), and converts all cross-service redirects from temporary to permanent.
> - Sets explicit `https://www.elevateforhumanity.org` canonical and Open Graph URLs on the homepage and adds JSON-LD structured data via [StructuredData.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/565/files#diff-6b863b183a4b89a7a4ae69624f2c810e61da65c502d15fee405b978fd893ef90), which now uses the www host, a 512×512 logo, and updated social profile links.
> - Adds `robots` directives to the root layout allowing indexing with full Googlebot preview, while marking `/legal/privacy` and `/terms` as non-indexable. Both legacy routes now emit `permanentRedirect` to their canonical destinations.
> - Removes `lastModified` timestamps and `/host-shop` routes from the sitemap, and updates the PWA manifest to use local icon assets instead of remote URLs.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e375495.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->