### PR TITLE
fix(marketing): correct responsive header TTS and canonical favicon

### DIFF
--- a/apps/marketing/app/layout.tsx
+++ b/apps/marketing/app/layout.tsx
@@ -28,12 +28,11 @@ export const metadata: Metadata = {
   metadataBase: new URL('https://www.elevateforhumanity.org'),
   manifest: '/manifest-marketing.json',
   icons: {
-    icon: [
-      { url: '/icon-192.png', type: 'image/png', sizes: '192x192' },
-      { url: '/icon-512.png', type: 'image/png', sizes: '512x512' },
-      { url: '/favicon.ico', type: 'image/x-icon', sizes: '32x32' },
-    ],
-    shortcut: [{ url: '/icon-192.png', type: 'image/png', sizes: '192x192' }],
+    // Keep one stable favicon candidate for search engines. The legacy
+    // /favicon.ico remains available for old browsers but is intentionally not
+    // advertised so Google does not have competing brand icons to choose from.
+    icon: [{ url: '/favicon.png', type: 'image/png', sizes: '192x192' }],
+    shortcut: [{ url: '/favicon.png', type: 'image/png', sizes: '192x192' }],
     apple: [{ url: '/apple-touch-icon.png', type: 'image/png', sizes: '180x180' }],
   },
   robots: {

--- a/components/TextToSpeech.tsx
+++ b/components/TextToSpeech.tsx
@@ -122,7 +122,7 @@ export default function TextToSpeech({
 
   return (
     <div
-      className={`relative z-0 inline-flex w-fit max-w-full flex-nowrap items-center gap-2 overflow-x-auto overflow-y-hidden whitespace-nowrap rounded-lg bg-white/95 p-1.5 ${className}`}
+      className={`relative z-0 inline-flex w-auto max-w-full flex-nowrap items-center gap-1 overflow-x-auto overflow-y-hidden whitespace-nowrap bg-transparent p-0 sm:gap-2 sm:rounded-lg sm:bg-white/95 sm:p-1.5 ${className}`}
       data-tts-control
     >
       {!isPlaying && !isPaused && (
@@ -157,11 +157,12 @@ export default function TextToSpeech({
         </button>
       )}
 
-      <label className="flex shrink-0 items-center gap-1.5 text-xs font-semibold text-slate-800">
+      <label className="hidden shrink-0 items-center gap-1.5 text-xs font-semibold text-slate-800 sm:flex">
         <span>Speed</span>
         <select
           value={rate}
-          onChange={(event) => setRate(Number(event.target.value))}
+          onChange={(event) => setRate(Number(event.target.value))
+          }
           className="min-h-9 shrink-0 rounded-md border border-slate-300 bg-white px-2 text-xs text-slate-900"
           disabled={isPlaying}
         >
@@ -175,7 +176,7 @@ export default function TextToSpeech({
       </label>
 
       {voices.length > 0 && (
-        <label className="hidden shrink-0 items-center gap-1.5 text-xs font-semibold text-slate-800 sm:flex">
+        <label className="hidden shrink-0 items-center gap-1.5 text-xs font-semibold text-slate-800 md:flex">
           <span className="shrink-0">Voice</span>
           <select
             value={selectedVoice?.name || ''}

--- a/components/TextToSpeech.tsx
+++ b/components/TextToSpeech.tsx
@@ -161,8 +161,7 @@ export default function TextToSpeech({
         <span>Speed</span>
         <select
           value={rate}
-          onChange={(event) => setRate(Number(event.target.value))
-          }
+          onChange={(event) => setRate(Number(event.target.value))}
           className="min-h-9 shrink-0 rounded-md border border-slate-300 bg-white px-2 text-xs text-slate-900"
           disabled={isPlaying}
         >

--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -4,7 +4,6 @@
 import Link from 'next/link';
 import LogoImage from '@/components/site/LogoImage';
 import HeaderMobileMenu from './HeaderMobileMenu.client';
-import HeaderDesktopMenu from './HeaderDesktopMenu.client';
 import HeaderDesktopNav from './HeaderDesktopNav';
 import { NAV_ITEMS } from '@/lib/navigation';
 import { ROUTES } from '@/lib/navigation/routes';
@@ -17,7 +16,7 @@ export default function Header() {
       role="banner"
       data-site-header
     >
-      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-3 lg:gap-3 lg:px-4 xl:gap-3 xl:px-4 2xl:px-6">
+      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-3 lg:gap-2 lg:px-3 xl:gap-3 xl:px-4 2xl:px-6">
         <Link
           href="/"
           className="flex min-w-0 flex-shrink-0 items-center gap-2"
@@ -29,50 +28,30 @@ export default function Header() {
           </span>
         </Link>
 
-        {/* Full desktop is one horizontal row only. Do not render a second
-            desktop Menu control beside this navigation; that consumed the
-            remaining width and caused the nav to collide with page controls. */}
-        <div className="hidden min-w-0 justify-center overflow-visible xl:flex">
+        {/* Desktop is always one horizontal navigation row from 1024px up.
+            Keep the mobile drawer below lg so standard Windows laptop widths
+            and 125% display scaling do not fall into a compact desktop menu. */}
+        <div className="hidden min-w-0 justify-center overflow-visible lg:flex">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
         <div className="flex min-w-0 flex-shrink-0 flex-nowrap items-center justify-end gap-1.5">
-          {/* Full desktop controls: horizontal nav is already visible, so only
-              authentication/application actions belong in this cluster. */}
-          <div className="hidden flex-nowrap items-center gap-1 xl:flex">
+          <div className="hidden flex-nowrap items-center gap-1 lg:flex">
             <Link
               href={ROUTES.login}
-              className="inline-flex whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950"
+              className="inline-flex whitespace-nowrap px-1.5 py-2 text-[13px] font-semibold text-slate-800 hover:text-slate-950 xl:px-2 xl:text-sm"
             >
               Sign In
             </Link>
             <Link
               href={ROUTES.apply}
-              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700"
+              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-2.5 py-2 text-[13px] font-bold text-white hover:bg-brand-red-700 xl:px-3 xl:text-sm"
             >
               Apply
             </Link>
           </div>
 
-          {/* Compact desktop/tablet controls. HeaderDesktopMenu owns navigation
-              only while the full horizontal row is hidden. */}
-          <div className="hidden flex-nowrap items-center gap-1.5 lg:flex xl:hidden">
-            <HeaderDesktopMenu items={NAV_ITEMS} />
-            <Link
-              href={ROUTES.login}
-              className="inline-flex whitespace-nowrap px-2 py-2 text-sm font-semibold text-slate-800 hover:text-slate-950"
-            >
-              Sign In
-            </Link>
-            <Link
-              href={ROUTES.apply}
-              className="inline-flex whitespace-nowrap rounded-lg bg-brand-red-600 px-3 py-2 text-sm font-bold text-white hover:bg-brand-red-700"
-            >
-              Apply
-            </Link>
-          </div>
-
-          {/* Phones and small tablets use the dedicated mobile drawer. */}
+          {/* Phones and tablets below 1024px use the dedicated mobile drawer. */}
           <div className="flex flex-nowrap items-center gap-1 lg:hidden">
             <span className="hidden whitespace-nowrap text-sm font-bold text-slate-700 sm:inline" aria-hidden="true">
               Menu

--- a/components/site/HeaderDesktopNav.tsx
+++ b/components/site/HeaderDesktopNav.tsx
@@ -50,11 +50,14 @@ function DropdownContent({ subItems }: { subItems: NavSubItem[] }) {
   );
 }
 
+const topLevelClass =
+  'rounded-md px-1.5 py-2 text-[13px] font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:text-brand-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-500 xl:px-2.5 xl:text-sm';
+
 export default function HeaderDesktopNav({ items }: { items: NavItem[] }) {
   return (
     <nav
       aria-label="Main navigation"
-      className="flex min-w-0 flex-row flex-nowrap items-center justify-center gap-0.5 overflow-visible whitespace-nowrap"
+      className="flex min-w-0 flex-row flex-nowrap items-center justify-center gap-0 overflow-visible whitespace-nowrap xl:gap-0.5"
     >
       {items.map((item) => {
         const key = item.id ?? item.name;
@@ -63,12 +66,7 @@ export default function HeaderDesktopNav({ items }: { items: NavItem[] }) {
         if (!hasSubItems) {
           if (!item.href) return null;
           return (
-            <Link
-              key={key}
-              href={item.href}
-              prefetch={false}
-              className="rounded-md px-2.5 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:text-brand-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-500"
-            >
+            <Link key={key} href={item.href} prefetch={false} className={topLevelClass}>
               {item.name}
             </Link>
           );
@@ -81,20 +79,20 @@ export default function HeaderDesktopNav({ items }: { items: NavItem[] }) {
                 <Link
                   href={item.href}
                   prefetch={false}
-                  className="inline-flex items-center gap-1 rounded-md px-2.5 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:text-brand-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-500"
+                  className={`inline-flex items-center gap-0.5 xl:gap-1 ${topLevelClass}`}
                   aria-haspopup="menu"
                 >
                   <span>{item.name}</span>
-                  <ChevronDown className="h-3.5 w-3.5 text-slate-400 transition-transform duration-150 group-hover:rotate-180 group-focus-within:rotate-180" aria-hidden="true" />
+                  <ChevronDown className="h-3 w-3 text-slate-400 transition-transform duration-150 group-hover:rotate-180 group-focus-within:rotate-180 xl:h-3.5 xl:w-3.5" aria-hidden="true" />
                 </Link>
               ) : (
                 <button
                   type="button"
-                  className="inline-flex items-center gap-1 rounded-md px-2.5 py-2 text-sm font-semibold text-slate-700 transition-colors hover:bg-slate-50 hover:text-brand-blue-700 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-500"
+                  className={`inline-flex items-center gap-0.5 xl:gap-1 ${topLevelClass}`}
                   aria-haspopup="menu"
                 >
                   <span>{item.name}</span>
-                  <ChevronDown className="h-3.5 w-3.5 text-slate-400 transition-transform duration-150 group-hover:rotate-180 group-focus-within:rotate-180" aria-hidden="true" />
+                  <ChevronDown className="h-3 w-3 text-slate-400 transition-transform duration-150 group-hover:rotate-180 group-focus-within:rotate-180 xl:h-3.5 xl:w-3.5" aria-hidden="true" />
                 </button>
               )}
             </div>


### PR DESCRIPTION
Fixes the current production UI regressions without adding another header or favicon system.

- Show the canonical horizontal desktop navigation from 1024px (`lg`) instead of waiting until 1280px (`xl`).
- Compact desktop nav spacing at laptop widths so all top-level items remain one row.
- Keep the mobile drawer only below 1024px.
- Remove the TTS white strip on phones and hide Speed/Voice selectors until there is enough width, while retaining one nowrap row.
- Advertise one stable 192x192 `/favicon.png` search-engine favicon instead of multiple competing favicon candidates.
- Verified no `apps/marketing/app/favicon.ico`, `icon.png`, `icon.svg`, or `apple-icon.png` file-based metadata exists to override the root metadata.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix responsive header layout and canonical favicon in marketing app
> - Updates [layout.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/566/files#diff-c7cc05344a50ae04b13d726626cd3494acb1ae1de25ce8166812ab2236e3416f) to advertise only `/favicon.png` for icon and shortcut metadata, removing the previous multi-icon array including `/favicon.ico`.
> - Refactors [Header.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/566/files#diff-ab1fe96a19fb5a4115ecc8932848cfad8d945af1a39528b95ecf35d3e7f1caca) so the full horizontal desktop nav (`HeaderDesktopNav`) appears from `lg` instead of `xl`, removing the intermediate compact desktop menu block entirely.
> - Adjusts [TextToSpeech.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/566/files#diff-202b5aee6a7490ec112688421c525d6df0f82d34f4476ff98803c456f86cb5a5) breakpoints: speed control is hidden on extra-small screens, voice selector appears from `md` instead of `sm`.
> - Centralizes top-level nav item styles in [HeaderDesktopNav.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/566/files#diff-1fb291dbbfc697407bff80e03fa606b60e44437990c04c9d8f2758c9007a0d86) via a shared `topLevelClass` constant, with tighter spacing at base breakpoints and larger sizes restored at `xl`.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 8f70244.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->