### PR TITLE
Restore community engagement features on current main

### DIFF
--- a/apps/lms/app/lms/(app)/community/page.tsx
+++ b/apps/lms/app/lms/(app)/community/page.tsx
@@ -1,5 +1,7 @@
 import { Metadata } from 'next';
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { Users } from 'lucide-react';
 import { createClient } from '@/lib/supabase/server';
 import SocialLearningCommunity from '@/components/SocialLearningCommunity';
 
@@ -12,7 +14,9 @@ export const metadata: Metadata = {
 
 export default async function CommunityPage() {
   const supabase = await createClient();
-  const { data: { user } } = await supabase.auth.getUser();
+  const {
+    data: { user },
+  } = await supabase.auth.getUser();
   if (!user) redirect('/login?redirect=/lms/community');
 
   const { data: profile } = await supabase
@@ -23,7 +27,24 @@ export default async function CommunityPage() {
 
   return (
     <main className="mx-auto w-full max-w-7xl px-4 py-6 md:px-6 md:py-8">
-      <SocialLearningCommunity userId={user.id} userName={profile?.full_name ?? user.email?.split('@')[0] ?? 'Learner'} />
+      <div className="mb-5 flex flex-col gap-3 rounded-2xl border border-slate-200 bg-white p-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <p className="text-sm font-black text-slate-900">Community groups</p>
+          <p className="mt-1 text-sm text-slate-600">
+            Join study groups, cohorts, career circles, and professional interest groups.
+          </p>
+        </div>
+        <Link
+          href="/lms/groups"
+          className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-blue-600 px-4 py-2.5 text-sm font-bold text-white hover:bg-brand-blue-700"
+        >
+          <Users className="h-4 w-4" /> Browse groups
+        </Link>
+      </div>
+      <SocialLearningCommunity
+        userId={user.id}
+        userName={profile?.full_name ?? user.email?.split('@')[0] ?? 'Learner'}
+      />
     </main>
   );
 }

--- a/apps/lms/app/lms/(app)/groups/page.tsx
+++ b/apps/lms/app/lms/(app)/groups/page.tsx
@@ -1,0 +1,292 @@
+'use client';
+
+import { useEffect, useMemo, useState } from 'react';
+import { CalendarDays, Plus, Users } from 'lucide-react';
+import { createClient } from '@/lib/supabase/client';
+
+type Group = {
+  id: string;
+  name: string;
+  topic: string | null;
+  description: string | null;
+  next_session: string | null;
+  max_members: number | null;
+  created_by: string | null;
+  member_count: number | null;
+  study_group_members?: { count: number }[];
+};
+
+export default function GroupsPage() {
+  const supabase = useMemo(() => createClient(), []);
+  const [groups, setGroups] = useState<Group[]>([]);
+  const [joined, setJoined] = useState<Set<string>>(new Set());
+  const [userId, setUserId] = useState<string | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [showCreate, setShowCreate] = useState(false);
+  const [name, setName] = useState('');
+  const [topic, setTopic] = useState('');
+  const [description, setDescription] = useState('');
+  const [error, setError] = useState('');
+
+  async function load() {
+    setLoading(true);
+    setError('');
+
+    const { data: authData } = await supabase.auth.getUser();
+    const uid = authData.user?.id ?? null;
+    setUserId(uid);
+
+    const { data, error: groupError } = await supabase
+      .from('study_groups')
+      .select(
+        'id, name, topic, description, next_session, max_members, created_by, member_count, study_group_members(count)',
+      )
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(100);
+
+    if (groupError) {
+      setError('Groups could not be loaded.');
+      setGroups([]);
+    } else {
+      setGroups((data ?? []) as Group[]);
+    }
+
+    if (uid) {
+      const { data: memberships, error: membershipError } = await supabase
+        .from('study_group_members')
+        .select('study_group_id')
+        .eq('user_id', uid);
+
+      if (membershipError) {
+        setError('Your group memberships could not be loaded.');
+      } else {
+        setJoined(new Set((memberships ?? []).map((item) => item.study_group_id)));
+      }
+    } else {
+      setJoined(new Set());
+    }
+
+    setLoading(false);
+  }
+
+  useEffect(() => {
+    void load();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  const sortedGroups = useMemo(
+    () => [...groups].sort((a, b) => Number(joined.has(b.id)) - Number(joined.has(a.id))),
+    [groups, joined],
+  );
+
+  async function toggleMembership(groupId: string) {
+    if (!userId) {
+      setError('Sign in to join a group.');
+      return;
+    }
+
+    setError('');
+    if (joined.has(groupId)) {
+      const { error: leaveError } = await supabase
+        .from('study_group_members')
+        .delete()
+        .eq('study_group_id', groupId)
+        .eq('user_id', userId);
+
+      if (leaveError) {
+        setError('Could not leave this group.');
+        return;
+      }
+    } else {
+      const { error: joinError } = await supabase
+        .from('study_group_members')
+        .insert({ study_group_id: groupId, user_id: userId });
+
+      if (joinError) {
+        setError('Could not join this group.');
+        return;
+      }
+    }
+
+    await load();
+  }
+
+  async function createGroup() {
+    if (!userId || !name.trim()) return;
+
+    setError('');
+    const { data: created, error: createError } = await supabase
+      .from('study_groups')
+      .insert({
+        name: name.trim(),
+        topic: topic.trim() || null,
+        description: description.trim() || null,
+        created_by: userId,
+        is_active: true,
+      })
+      .select('id')
+      .single();
+
+    if (createError || !created) {
+      setError('Could not create the group.');
+      return;
+    }
+
+    const { error: membershipError } = await supabase
+      .from('study_group_members')
+      .insert({ study_group_id: created.id, user_id: userId });
+
+    if (membershipError) {
+      setError('The group was created, but your membership could not be added automatically.');
+    }
+
+    setName('');
+    setTopic('');
+    setDescription('');
+    setShowCreate(false);
+    await load();
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-6 md:px-8">
+      <div className="mx-auto max-w-6xl space-y-6">
+        <header className="flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <div className="mb-2 flex items-center gap-2 text-brand-blue-600">
+              <Users className="h-5 w-5" />
+              <span className="text-sm font-bold">Elevate Community</span>
+            </div>
+            <h1 className="text-3xl font-black text-slate-900">Groups</h1>
+            <p className="mt-2 text-slate-600">
+              Join your cohort, study group, career circle, or professional interest group.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setShowCreate((value) => !value)}
+            disabled={!userId}
+            className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-blue-600 px-4 py-3 font-bold text-white hover:bg-brand-blue-700 disabled:cursor-not-allowed disabled:opacity-50"
+          >
+            <Plus className="h-4 w-4" /> Create group
+          </button>
+        </header>
+
+        {showCreate && userId && (
+          <section className="grid gap-3 rounded-2xl border border-slate-200 bg-white p-5 md:grid-cols-2">
+            <label className="text-sm font-bold text-slate-700">
+              Group name
+              <input
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                maxLength={120}
+                className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2.5 outline-none focus:border-brand-blue-500"
+              />
+            </label>
+            <label className="text-sm font-bold text-slate-700">
+              Topic or program
+              <input
+                value={topic}
+                onChange={(event) => setTopic(event.target.value)}
+                maxLength={120}
+                className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2.5 outline-none focus:border-brand-blue-500"
+              />
+            </label>
+            <label className="text-sm font-bold text-slate-700 md:col-span-2">
+              Description
+              <textarea
+                value={description}
+                onChange={(event) => setDescription(event.target.value)}
+                maxLength={1000}
+                rows={3}
+                className="mt-1 w-full rounded-xl border border-slate-200 px-3 py-2.5 outline-none focus:border-brand-blue-500"
+              />
+            </label>
+            <div className="flex justify-end md:col-span-2">
+              <button
+                type="button"
+                onClick={() => void createGroup()}
+                disabled={!name.trim()}
+                className="rounded-xl bg-slate-900 px-5 py-2.5 font-bold text-white disabled:opacity-40"
+              >
+                Create group
+              </button>
+            </div>
+          </section>
+        )}
+
+        {error && (
+          <div className="rounded-xl border border-red-200 bg-red-50 p-4 text-sm text-red-700">
+            {error}
+          </div>
+        )}
+
+        {loading ? (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {[1, 2, 3, 4, 5, 6].map((item) => (
+              <div key={item} className="h-48 animate-pulse rounded-2xl bg-slate-200" />
+            ))}
+          </div>
+        ) : sortedGroups.length === 0 ? (
+          <div className="rounded-2xl border border-slate-200 bg-white p-10 text-center text-slate-600">
+            No groups have been created yet.
+          </div>
+        ) : (
+          <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
+            {sortedGroups.map((group) => {
+              const relationalCount = group.study_group_members?.[0]?.count;
+              const memberCount = relationalCount ?? group.member_count ?? 0;
+              const isJoined = joined.has(group.id);
+              const isFull = Boolean(group.max_members && memberCount >= group.max_members);
+
+              return (
+                <article key={group.id} className="rounded-2xl border border-slate-200 bg-white p-5 shadow-sm">
+                  <div className="flex items-start justify-between gap-3">
+                    <div>
+                      <h2 className="text-lg font-black text-slate-900">{group.name}</h2>
+                      {group.topic && (
+                        <p className="mt-1 text-sm font-semibold text-brand-blue-600">{group.topic}</p>
+                      )}
+                    </div>
+                    {isJoined && (
+                      <span className="rounded-full bg-green-100 px-2 py-1 text-xs font-bold text-green-700">
+                        Joined
+                      </span>
+                    )}
+                  </div>
+
+                  {group.description && <p className="mt-3 text-sm text-slate-600">{group.description}</p>}
+                  <div className="mt-4 space-y-1 text-sm text-slate-500">
+                    <p className="flex items-center gap-2">
+                      <Users className="h-4 w-4" />
+                      {memberCount} members
+                      {group.max_members ? ` / ${group.max_members}` : ''}
+                    </p>
+                    {group.next_session && (
+                      <p className="flex items-center gap-2">
+                        <CalendarDays className="h-4 w-4" />
+                        {new Date(group.next_session).toLocaleString()}
+                      </p>
+                    )}
+                  </div>
+
+                  <button
+                    type="button"
+                    onClick={() => void toggleMembership(group.id)}
+                    disabled={!userId || (!isJoined && isFull)}
+                    className={`mt-5 w-full rounded-xl px-4 py-2.5 text-sm font-bold transition disabled:cursor-not-allowed disabled:opacity-50 ${
+                      isJoined
+                        ? 'border border-slate-300 text-slate-700 hover:bg-slate-50'
+                        : 'bg-brand-blue-600 text-white hover:bg-brand-blue-700'
+                    }`}
+                  >
+                    {isJoined ? 'Leave group' : isFull ? 'Group full' : 'Join group'}
+                  </button>
+                </article>
+              );
+            })}
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}

--- a/components/lms/GroupDiscussions.tsx
+++ b/components/lms/GroupDiscussions.tsx
@@ -1,23 +1,40 @@
 'use client';
 
-import { useEffect, useRef, useState, useTransition } from 'react';
+import { useEffect, useMemo, useRef, useState, useTransition } from 'react';
 import { createClient } from '@/lib/supabase/client';
-import { MessageSquare, Send, ThumbsUp, Clock, User } from 'lucide-react';
+import {
+  ChevronDown,
+  ChevronUp,
+  Clock,
+  MessageSquare,
+  Send,
+  ThumbsUp,
+  User,
+} from 'lucide-react';
+
+interface Comment {
+  id: string;
+  content: string;
+  created_at: string;
+  author_name: string;
+  author_avatar: string | null;
+}
 
 interface Post {
   id: string;
   content: string;
   created_at: string;
   likes_count: number;
+  comments_count: number;
   tags: string[];
   author_name: string;
   author_avatar: string | null;
+  liked_by_me: boolean;
 }
 
 interface Props {
-  /** Slug used as the tag filter, e.g. "healthcare", "trades", "career" */
+  /** Slug used as the tag filter. Use "all" for the full community feed. */
   groupSlug: string;
-  /** Accent colour class for the post button, e.g. "bg-brand-red-600 hover:bg-brand-red-700" */
   accentClass?: string;
 }
 
@@ -28,177 +45,361 @@ function timeAgo(iso: string): string {
   if (mins < 60) return `${mins}m ago`;
   const hrs = Math.floor(mins / 60);
   if (hrs < 24) return `${hrs}h ago`;
-  const days = Math.floor(hrs / 24);
-  return `${days}d ago`;
+  return `${Math.floor(hrs / 24)}d ago`;
 }
 
 export default function GroupDiscussions({
   groupSlug,
   accentClass = 'bg-brand-blue-600 hover:bg-brand-blue-700',
 }: Props) {
-  const supabase = createClient();
+  const supabase = useMemo(() => createClient(), []);
   const [posts, setPosts] = useState<Post[]>([]);
   const [loading, setLoading] = useState(true);
   const [draft, setDraft] = useState('');
   const [submitting, startSubmit] = useTransition();
   const [error, setError] = useState('');
   const [userId, setUserId] = useState<string | null>(null);
+  const [openComments, setOpenComments] = useState<string | null>(null);
+  const [comments, setComments] = useState<Record<string, Comment[]>>({});
+  const [commentDrafts, setCommentDrafts] = useState<Record<string, string>>({});
   const textareaRef = useRef<HTMLTextAreaElement>(null);
 
   useEffect(() => {
-    supabase.auth.getUser().then(({ data }) => setUserId(data.user?.id ?? null));
+    void supabase.auth.getUser().then(({ data }) => setUserId(data.user?.id ?? null));
   }, [supabase]);
 
   async function fetchPosts() {
     setLoading(true);
-    const { data } = await supabase
+    setError('');
+
+    let query = supabase
       .from('community_posts')
       .select(
-        `
-        id, content, created_at, likes_count, tags,
-        profiles:user_id ( full_name, avatar_url )
-      `,
+        'id, content, created_at, likes_count, comments_count, tags, profiles:user_id ( full_name, avatar_url )',
       )
-      .contains('tags', [groupSlug])
       .order('created_at', { ascending: false })
       .limit(50);
 
+    if (groupSlug !== 'all') query = query.contains('tags', [groupSlug]);
+
+    const { data, error: fetchError } = await query;
+    if (fetchError) {
+      setError('Community feed could not be loaded.');
+      setLoading(false);
+      return;
+    }
+
+    let likedIds = new Set<string>();
+    if (userId && data?.length) {
+      const postIds = data.map((post: any) => post.id);
+      const { data: likes } = await supabase
+        .from('community_post_likes')
+        .select('post_id')
+        .eq('user_id', userId)
+        .in('post_id', postIds);
+      likedIds = new Set((likes ?? []).map((like: any) => like.post_id));
+    }
+
     setPosts(
-      (data ?? []).map((p: any) => ({
-        id: p.id,
-        content: p.content,
-        created_at: p.created_at,
-        likes_count: p.likes_count ?? 0,
-        tags: p.tags ?? [],
-        author_name: p.profiles?.full_name ?? 'Member',
-        author_avatar: p.profiles?.avatar_url ?? null,
+      (data ?? []).map((post: any) => ({
+        id: post.id,
+        content: post.content,
+        created_at: post.created_at,
+        likes_count: post.likes_count ?? 0,
+        comments_count: post.comments_count ?? 0,
+        tags: post.tags ?? [],
+        author_name: post.profiles?.full_name ?? 'Member',
+        author_avatar: post.profiles?.avatar_url ?? null,
+        liked_by_me: likedIds.has(post.id),
       })),
     );
     setLoading(false);
   }
 
   useEffect(() => {
-    fetchPosts();
-  }, [groupSlug]); // eslint-disable-line react-hooks/exhaustive-deps
+    void fetchPosts();
+  }, [groupSlug, userId]); // eslint-disable-line react-hooks/exhaustive-deps
 
   function handleSubmit() {
     const content = draft.trim();
     if (!content || !userId) return;
+
     setError('');
-
     startSubmit(async () => {
-      const { error: err } = await supabase
+      const tags = groupSlug === 'all' ? ['community'] : [groupSlug];
+      const { error: insertError } = await supabase
         .from('community_posts')
-        .insert({ content, user_id: userId, tags: [groupSlug] });
+        .insert({ content, user_id: userId, tags });
 
-      if (err) {
+      if (insertError) {
         setError('Failed to post. Please try again.');
         return;
       }
+
       setDraft('');
       await fetchPosts();
     });
   }
 
-  async function handleLike(postId: string, current: number) {
-    await supabase
-      .from('community_posts')
-      .update({ likes_count: current + 1 })
-      .eq('id', postId);
-    setPosts((prev) =>
-      prev.map((p) => (p.id === postId ? { ...p, likes_count: p.likes_count + 1 } : p)),
-    );
+  async function handleLike(post: Post) {
+    if (!userId) return;
+    setError('');
+
+    if (post.liked_by_me) {
+      const { error: deleteError } = await supabase
+        .from('community_post_likes')
+        .delete()
+        .eq('post_id', post.id)
+        .eq('user_id', userId);
+
+      if (deleteError) {
+        setError('Could not update your reaction.');
+        return;
+      }
+    } else {
+      const { error: insertError } = await supabase
+        .from('community_post_likes')
+        .insert({ post_id: post.id, user_id: userId });
+
+      if (insertError) {
+        setError('Could not update your reaction.');
+        return;
+      }
+    }
+
+    await fetchPosts();
+  }
+
+  async function loadComments(postId: string, force = false) {
+    if (!force && comments[postId]) return;
+
+    const { data, error: commentsError } = await supabase
+      .from('community_post_comments')
+      .select('id, content, created_at, profiles:user_id ( full_name, avatar_url )')
+      .eq('post_id', postId)
+      .order('created_at', { ascending: true })
+      .limit(100);
+
+    if (commentsError) {
+      setError('Comments could not be loaded.');
+      return;
+    }
+
+    setComments((previous) => ({
+      ...previous,
+      [postId]: (data ?? []).map((comment: any) => ({
+        id: comment.id,
+        content: comment.content,
+        created_at: comment.created_at,
+        author_name: comment.profiles?.full_name ?? 'Member',
+        author_avatar: comment.profiles?.avatar_url ?? null,
+      })),
+    }));
+  }
+
+  async function toggleComments(postId: string) {
+    if (openComments === postId) {
+      setOpenComments(null);
+      return;
+    }
+
+    setOpenComments(postId);
+    await loadComments(postId);
+  }
+
+  async function submitComment(postId: string) {
+    const content = (commentDrafts[postId] ?? '').trim();
+    if (!content || !userId) return;
+
+    setError('');
+    const { error: insertError } = await supabase
+      .from('community_post_comments')
+      .insert({ post_id: postId, user_id: userId, content });
+
+    if (insertError) {
+      setError('Your comment could not be posted.');
+      return;
+    }
+
+    setCommentDrafts((previous) => ({ ...previous, [postId]: '' }));
+    await Promise.all([loadComments(postId, true), fetchPosts()]);
   }
 
   return (
     <div className="space-y-4">
-      {/* Composer */}
-      {userId && (
-        <div className="bg-white border border-slate-200 rounded-xl p-4">
+      {userId ? (
+        <div className="rounded-xl border border-slate-200 bg-white p-4">
           <textarea
             ref={textareaRef}
             value={draft}
-            onChange={(e) => setDraft(e.target.value)}
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' && (e.metaKey || e.ctrlKey)) handleSubmit();
+            onChange={(event) => setDraft(event.target.value)}
+            onKeyDown={(event) => {
+              if (event.key === 'Enter' && (event.metaKey || event.ctrlKey)) handleSubmit();
             }}
-            placeholder="Share something with the group…"
+            placeholder="Share an update, ask a question, or help your community…"
             rows={3}
-            className="w-full resize-none text-sm text-slate-900 placeholder-slate-400 border-0 outline-none focus:ring-0 bg-transparent"
+            maxLength={5000}
+            className="w-full resize-none border-0 bg-transparent text-sm text-slate-900 outline-none placeholder-slate-400 focus:ring-0"
           />
-          <div className="flex items-center justify-between mt-2 pt-2 border-t border-slate-100">
+          <div className="mt-2 flex items-center justify-between border-t border-slate-100 pt-2">
             <span className="text-xs text-slate-400">Ctrl+Enter to post</span>
             <button
+              type="button"
               onClick={handleSubmit}
               disabled={!draft.trim() || submitting}
-              className={`inline-flex items-center gap-1.5 px-4 py-1.5 rounded-lg text-white text-sm font-medium transition disabled:opacity-40 ${accentClass}`}
+              className={`inline-flex items-center gap-1.5 rounded-lg px-4 py-1.5 text-sm font-medium text-white transition disabled:opacity-40 ${accentClass}`}
             >
-              <Send className="w-3.5 h-3.5" />
+              <Send className="h-3.5 w-3.5" />
               {submitting ? 'Posting…' : 'Post'}
             </button>
           </div>
-          {error && <p className="text-xs text-red-500 mt-1">{error}</p>}
+        </div>
+      ) : (
+        <div className="rounded-xl border border-amber-200 bg-amber-50 p-4 text-sm text-amber-900">
+          Sign in to participate in the community.
         </div>
       )}
 
-      {/* Feed */}
+      {error && <p className="rounded-lg bg-red-50 px-3 py-2 text-sm text-red-700">{error}</p>}
+
       {loading ? (
         <div className="space-y-3">
-          {[1, 2, 3].map((i) => (
-            <div key={i} className="bg-white border border-slate-200 rounded-xl p-4 animate-pulse">
+          {[1, 2, 3].map((item) => (
+            <div key={item} className="animate-pulse rounded-xl border border-slate-200 bg-white p-4">
               <div className="flex gap-3">
-                <div className="w-8 h-8 rounded-full bg-slate-200 flex-shrink-0" />
+                <div className="h-8 w-8 flex-shrink-0 rounded-full bg-slate-200" />
                 <div className="flex-1 space-y-2">
-                  <div className="h-3 bg-slate-200 rounded w-1/4" />
-                  <div className="h-3 bg-slate-200 rounded w-3/4" />
-                  <div className="h-3 bg-slate-200 rounded w-1/2" />
+                  <div className="h-3 w-1/4 rounded bg-slate-200" />
+                  <div className="h-3 w-3/4 rounded bg-slate-200" />
+                  <div className="h-3 w-1/2 rounded bg-slate-200" />
                 </div>
               </div>
             </div>
           ))}
         </div>
       ) : posts.length === 0 ? (
-        <div className="bg-white border border-slate-200 rounded-xl p-10 text-center">
-          <MessageSquare className="w-10 h-10 text-slate-300 mx-auto mb-3" />
+        <div className="rounded-xl border border-slate-200 bg-white p-10 text-center">
+          <MessageSquare className="mx-auto mb-3 h-10 w-10 text-slate-300" />
           <p className="font-medium text-slate-700">No posts yet</p>
-          <p className="text-sm text-slate-500 mt-1">
-            Be the first to start a discussion in this group.
-          </p>
+          <p className="mt-1 text-sm text-slate-500">Be the first to start the conversation.</p>
         </div>
       ) : (
         <div className="space-y-3">
           {posts.map((post) => (
-            <div key={post.id} className="bg-white border border-slate-200 rounded-xl p-4">
+            <article key={post.id} className="rounded-xl border border-slate-200 bg-white p-4">
               <div className="flex gap-3">
-                <div className="w-8 h-8 rounded-full bg-slate-200 flex-shrink-0 flex items-center justify-center overflow-hidden">
+                <div className="flex h-9 w-9 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-200">
                   {post.author_avatar ? (
-                    // IMAGE-CONTRACT: allow raw img because author_avatar is a user-supplied external URL incompatible with next/image domain config
-                    <img src={post.author_avatar} alt="" className="w-full h-full object-cover" />
+                    // User-uploaded avatar URLs are not constrained to Next Image remote domains.
+                    <img src={post.author_avatar} alt="" className="h-full w-full object-cover" />
                   ) : (
-                    <User className="w-4 h-4 text-slate-400" />
+                    <User className="h-4 w-4 text-slate-400" />
                   )}
                 </div>
-                <div className="flex-1 min-w-0">
-                  <div className="flex items-center gap-2 mb-1">
+                <div className="min-w-0 flex-1">
+                  <div className="mb-1 flex flex-wrap items-center gap-2">
                     <span className="text-sm font-semibold text-slate-900">{post.author_name}</span>
                     <span className="flex items-center gap-1 text-xs text-slate-400">
-                      <Clock className="w-3 h-3" />
-                      {timeAgo(post.created_at)}
+                      <Clock className="h-3 w-3" /> {timeAgo(post.created_at)}
                     </span>
                   </div>
-                  <p className="text-sm text-slate-700 whitespace-pre-wrap break-words">
-                    {post.content}
-                  </p>
-                  <button
-                    onClick={() => handleLike(post.id, post.likes_count)}
-                    className="mt-2 inline-flex items-center gap-1 text-xs text-slate-400 hover:text-brand-blue-600 transition"
-                  >
-                    <ThumbsUp className="w-3.5 h-3.5" />
-                    {post.likes_count > 0 && <span>{post.likes_count}</span>}
-                  </button>
+                  <p className="whitespace-pre-wrap break-words text-sm text-slate-700">{post.content}</p>
+
+                  {post.tags.length > 0 && (
+                    <div className="mt-2 flex flex-wrap gap-1.5">
+                      {post.tags.map((tag) => (
+                        <span key={tag} className="rounded-full bg-slate-100 px-2 py-0.5 text-xs font-medium text-slate-600">
+                          #{tag}
+                        </span>
+                      ))}
+                    </div>
+                  )}
+
+                  <div className="mt-3 flex items-center gap-4 border-t border-slate-100 pt-2">
+                    <button
+                      type="button"
+                      onClick={() => void handleLike(post)}
+                      disabled={!userId}
+                      className={`inline-flex items-center gap-1 text-xs font-medium transition disabled:opacity-40 ${
+                        post.liked_by_me
+                          ? 'text-brand-blue-600'
+                          : 'text-slate-500 hover:text-brand-blue-600'
+                      }`}
+                    >
+                      <ThumbsUp className="h-3.5 w-3.5" />
+                      {post.likes_count} {post.likes_count === 1 ? 'Like' : 'Likes'}
+                    </button>
+                    <button
+                      type="button"
+                      onClick={() => void toggleComments(post.id)}
+                      className="inline-flex items-center gap-1 text-xs font-medium text-slate-500 hover:text-brand-blue-600"
+                    >
+                      <MessageSquare className="h-3.5 w-3.5" />
+                      {post.comments_count} {post.comments_count === 1 ? 'Comment' : 'Comments'}
+                      {openComments === post.id ? (
+                        <ChevronUp className="h-3 w-3" />
+                      ) : (
+                        <ChevronDown className="h-3 w-3" />
+                      )}
+                    </button>
+                  </div>
+
+                  {openComments === post.id && (
+                    <div className="mt-3 space-y-3 rounded-xl bg-slate-50 p-3">
+                      {(comments[post.id] ?? []).map((comment) => (
+                        <div key={comment.id} className="flex gap-2">
+                          <div className="flex h-7 w-7 flex-shrink-0 items-center justify-center overflow-hidden rounded-full bg-slate-200">
+                            {comment.author_avatar ? (
+                              <img src={comment.author_avatar} alt="" className="h-full w-full object-cover" />
+                            ) : (
+                              <User className="h-3.5 w-3.5 text-slate-400" />
+                            )}
+                          </div>
+                          <div className="min-w-0 rounded-lg bg-white px-3 py-2">
+                            <div className="flex items-center gap-2">
+                              <span className="text-xs font-bold text-slate-900">{comment.author_name}</span>
+                              <span className="text-[11px] text-slate-400">{timeAgo(comment.created_at)}</span>
+                            </div>
+                            <p className="mt-0.5 whitespace-pre-wrap break-words text-sm text-slate-700">
+                              {comment.content}
+                            </p>
+                          </div>
+                        </div>
+                      ))}
+
+                      {userId && (
+                        <div className="flex gap-2">
+                          <input
+                            value={commentDrafts[post.id] ?? ''}
+                            onChange={(event) =>
+                              setCommentDrafts((previous) => ({
+                                ...previous,
+                                [post.id]: event.target.value,
+                              }))
+                            }
+                            onKeyDown={(event) => {
+                              if (event.key === 'Enter') void submitComment(post.id);
+                            }}
+                            maxLength={2000}
+                            placeholder="Write a comment…"
+                            className="min-w-0 flex-1 rounded-lg border border-slate-200 bg-white px-3 py-2 text-sm outline-none focus:border-brand-blue-500"
+                          />
+                          <button
+                            type="button"
+                            onClick={() => void submitComment(post.id)}
+                            disabled={!(commentDrafts[post.id] ?? '').trim()}
+                            className="rounded-lg bg-brand-blue-600 px-3 py-2 text-white disabled:opacity-40"
+                            aria-label="Post comment"
+                          >
+                            <Send className="h-4 w-4" />
+                          </button>
+                        </div>
+                      )}
+                    </div>
+                  )}
                 </div>
               </div>
-            </div>
+            </article>
           ))}
         </div>
       )}


### PR DESCRIPTION
Fresh reimplementation of the valuable work from feat/community-launchbox-unification on top of current main.

Keeps:
- /lms/groups with live study_groups/study_group_members data
- join/leave/create group flow
- real per-user likes/unlikes using community_post_likes
- comments using community_post_comments
- Community hub link to Groups

Does not import the stale branch migration because production already has newer tenant-aware community migrations and stricter RLS. No stale sidebar/page replacement.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore community engagement features with groups, per-user likes, and comments
> - Adds a new [/lms/groups page](https://github.com/elevate-for-humanity/Elevate-lms/pull/572/files#diff-5c470821e2271aaf36027b4c4b49258670cf8a60127e6e473d7c16c27efcc801) where authenticated users can browse active study groups, join/leave them, and create new groups; unauthenticated users see disabled controls.
> - Adds a promotional card on the [/lms/community page](https://github.com/elevate-for-humanity/Elevate-lms/pull/572/files#diff-c4c35781c4bc663cb15aa3227ce273866247c685c1cead86dbf502a4e6848d76) linking to the new groups page.
> - Reworks [GroupDiscussions.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/572/files#diff-1044f2c25d5e403e4a6bf8111919af70ff2e71c9b75d2c73407c30fc75248c88) to support an `all` feed view, per-user like toggling via `community_post_likes`, and on-demand comment loading/posting via `community_post_comments`.
> - Unauthenticated users see a sign-in prompt instead of the post composer and cannot like or comment.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1a9d35d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->