### PR TITLE
Restore guided Store selling features on current main

### DIFF
--- a/apps/marketing/app/store/apps/website-builder/page.tsx
+++ b/apps/marketing/app/store/apps/website-builder/page.tsx
@@ -3,26 +3,131 @@ import Image from 'next/image';
 import Link from 'next/link';
 import { ArrowRight, Globe2, Layout, Search, Palette, Upload, Pencil } from 'lucide-react';
 import { IndividualAppPlansSection } from '@/components/store/IndividualAppPlansSection';
+import ProductWalkthrough from '@/components/store/ProductWalkthrough';
+import ZeroCodeSetup from '@/components/store/ZeroCodeSetup';
 import { INDIVIDUAL_APP_CATALOG } from '@/lib/apps/individual-app-plans';
 
 export const dynamic = 'force-static';
 
 export const metadata: Metadata = {
   title: 'Website Builder for Training Providers | Elevate Store',
-  description: 'Create, edit, preview, and publish a training-provider website with Elevate. Includes organization branding, homepage content, SEO fields, subdomain publishing, and plan-based site limits.',
-  keywords: ['website builder', 'training provider website', 'workforce website builder', 'education website builder', 'SEO website builder'],
+  description:
+    'Create, edit, preview, and publish a training-provider website with Elevate. Includes organization branding, homepage content, SEO fields, subdomain publishing, and plan-based site limits.',
+  keywords: [
+    'website builder',
+    'training provider website',
+    'workforce website builder',
+    'education website builder',
+    'SEO website builder',
+  ],
   alternates: { canonical: 'https://www.elevateforhumanity.org/store/apps/website-builder' },
-  openGraph: { title: 'Website Builder for Training Providers | Elevate Store', description: 'Create and publish training-provider websites from your Elevate account.', url: 'https://www.elevateforhumanity.org/store/apps/website-builder', type: 'website' },
+  openGraph: {
+    title: 'Website Builder for Training Providers | Elevate Store',
+    description: 'Create and publish training-provider websites from your Elevate account.',
+    url: 'https://www.elevateforhumanity.org/store/apps/website-builder',
+    type: 'website',
+  },
 };
 
 const catalog = INDIVIDUAL_APP_CATALOG['website-builder'];
+
 const features = [
-  { icon: Layout, title: 'Structured site setup', desc: 'Start from an Elevate training-provider site configuration instead of a blank page.' },
-  { icon: Pencil, title: 'Live editing', desc: 'Edit site identity, homepage hero content, branding, and search metadata from the authenticated editor.' },
-  { icon: Globe2, title: 'Subdomain publishing', desc: 'Choose an available Elevate subdomain and publish the current site configuration.' },
-  { icon: Search, title: 'SEO fields', desc: 'Manage the site title and description stored with the website configuration.' },
-  { icon: Palette, title: 'Brand controls', desc: 'Manage logo text, tagline, primary color, and secondary color.' },
-  { icon: Upload, title: 'Existing-site intake', desc: 'The Store includes a separate import entry point for organizations bringing an existing site into the workflow.' },
+  {
+    icon: Layout,
+    title: 'Structured site setup',
+    desc: 'Start from an Elevate training-provider site configuration instead of a blank page.',
+  },
+  {
+    icon: Pencil,
+    title: 'Live editing',
+    desc: 'Edit site identity, homepage hero content, branding, and search metadata from the authenticated editor.',
+  },
+  {
+    icon: Globe2,
+    title: 'Subdomain publishing',
+    desc: 'Choose an available Elevate subdomain and publish the current site configuration.',
+  },
+  {
+    icon: Search,
+    title: 'SEO fields',
+    desc: 'Manage the site title and description stored with the website configuration.',
+  },
+  {
+    icon: Palette,
+    title: 'Brand controls',
+    desc: 'Manage logo text, tagline, primary color, and secondary color.',
+  },
+  {
+    icon: Upload,
+    title: 'Existing-site intake',
+    desc: 'The Store includes a separate import entry point for organizations bringing an existing site into the workflow.',
+  },
+];
+
+const walkthrough = [
+  {
+    label: '1. Describe it',
+    title: 'Tell AI what business you are building',
+    description:
+      'Example: “Build a professional home-healthcare agency website in Indianapolis with services, an about section and a contact call to action.”',
+  },
+  {
+    label: '2. Generate',
+    title: 'Elevate creates your first draft',
+    description:
+      'AI turns your business description into a starting website structure and content so you are not staring at a blank canvas.',
+  },
+  {
+    label: '3. Make it yours',
+    title: 'Edit the words, brand and look',
+    description:
+      'Update your business name, hero message, colors, tagline and search metadata from the visual workspace—no code required.',
+  },
+  {
+    label: '4. Preview',
+    title: 'Review before anybody sees it',
+    description:
+      'Preview the site, refine the message and make sure the business is represented correctly before publishing.',
+  },
+  {
+    label: '5. Publish',
+    title: 'Choose your web address and go live',
+    description:
+      'Select an available Elevate subdomain and publish the saved website configuration when you are ready.',
+  },
+];
+
+const setupQuestions = [
+  {
+    id: 'business',
+    prompt: 'What business or organization are you building this website for?',
+    placeholder: 'Example: A home healthcare agency serving Indianapolis...',
+  },
+  {
+    id: 'goal',
+    prompt: 'What should the website help you accomplish?',
+    choices: [
+      { label: 'Get leads', value: 'lead-generation', description: 'Calls, forms and consultations.' },
+      { label: 'Sell services', value: 'sell-services', description: 'Explain offers and drive purchases.' },
+      { label: 'Enroll students', value: 'student-enrollment', description: 'Programs, applications and enrollment.' },
+      { label: 'Build credibility', value: 'credibility', description: 'Professional presence and trust.' },
+    ],
+  },
+  {
+    id: 'style',
+    prompt: 'How should the site feel?',
+    choices: [
+      { label: 'Professional', value: 'professional' },
+      { label: 'Modern', value: 'modern' },
+      { label: 'Warm', value: 'warm' },
+      { label: 'Bold', value: 'bold' },
+    ],
+  },
+  {
+    id: 'pages',
+    prompt: 'What should the first version include?',
+    placeholder: 'Example: Home, About, Services, Contact, booking form and testimonials.',
+  },
 ];
 
 const jsonLd = {
@@ -33,7 +138,12 @@ const jsonLd = {
   operatingSystem: 'Web',
   url: 'https://www.elevateforhumanity.org/store/apps/website-builder',
   description: 'Website creation and publishing tools for training providers and workforce organizations.',
-  offers: catalog.plans.map((plan) => ({ '@type': 'Offer', price: String(plan.priceMonthly), priceCurrency: 'USD', category: `${plan.name} monthly subscription` })),
+  offers: catalog.plans.map((plan) => ({
+    '@type': 'Offer',
+    price: String(plan.priceMonthly),
+    priceCurrency: 'USD',
+    category: `${plan.name} monthly subscription`,
+  })),
 };
 
 export default function WebsiteBuilderStorePage() {
@@ -52,14 +162,23 @@ export default function WebsiteBuilderStorePage() {
               Build and publish an Elevate-hosted training website from your account. The editor covers site identity, homepage content, branding, SEO, preview, save, publishing, and supported domain workflows.
             </p>
             <div className="mt-8 flex flex-wrap gap-3">
-              <Link href={catalog.trialHref} className="rounded-xl bg-brand-red-700 px-6 py-3 font-black text-white hover:bg-brand-red-800">
-                Start {catalog.trialDays}-day trial
+              <Link
+                href="#guided-setup"
+                className="rounded-xl bg-brand-red-700 px-6 py-3 font-black text-white hover:bg-brand-red-800"
+              >
+                Guided setup
               </Link>
-              <Link href={catalog.appHref} className="rounded-xl border-2 border-white px-6 py-3 font-black text-white hover:bg-white/10">
+              <Link
+                href="#walkthrough"
+                className="rounded-xl border-2 border-white px-6 py-3 font-black text-white hover:bg-white/10"
+              >
+                Watch walkthrough
+              </Link>
+              <Link
+                href={catalog.appHref}
+                className="rounded-xl border-2 border-white/70 px-6 py-3 font-bold text-white hover:bg-white/10"
+              >
                 Open Website Builder
-              </Link>
-              <Link href="/store/apps" className="rounded-xl border-2 border-white/70 px-6 py-3 font-bold text-white hover:bg-white/10">
-                Search all apps
               </Link>
             </div>
           </div>
@@ -80,6 +199,26 @@ export default function WebsiteBuilderStorePage() {
         </div>
       </section>
 
+      <div id="walkthrough">
+        <ProductWalkthrough
+          title="From business idea to a publishable website"
+          subtitle="See the customer journey the Website Builder is designed around. Let it play automatically or choose a step."
+          steps={walkthrough}
+          tryHref={catalog.appHref}
+        />
+      </div>
+
+      <div id="guided-setup">
+        <ZeroCodeSetup
+          productName="AI Website Builder"
+          intro="Answer four simple questions and Elevate carries that context into the Website Builder so you can start with a configured direction instead of an empty canvas."
+          questions={setupQuestions}
+          startHref={catalog.appHref}
+          trialHref={catalog.trialHref}
+          advancedNote="Professional and Enterprise can expose custom domains, imports, white-label, API and multi-user controls after the basic zero-code workflow is working."
+        />
+      </div>
+
       <section className="px-4 py-16">
         <div className="mx-auto max-w-6xl">
           <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-3">
@@ -98,12 +237,14 @@ export default function WebsiteBuilderStorePage() {
         <div className="mx-auto max-w-5xl">
           <h2 className="text-3xl font-black text-slate-950">How the flow works</h2>
           <div className="mt-8 grid gap-4 md:grid-cols-4">
-            {['Start trial or subscribe', 'Create a website', 'Edit and preview', 'Choose a domain and publish'].map((step, index) => (
-              <div key={step} className="rounded-xl border border-slate-300 bg-white p-5">
-                <div className="text-sm font-black text-brand-red-700">{index + 1}</div>
-                <div className="mt-2 font-black text-slate-950">{step}</div>
-              </div>
-            ))}
+            {['Start trial or subscribe', 'Create a website', 'Edit and preview', 'Choose a domain and publish'].map(
+              (step, index) => (
+                <div key={step} className="rounded-xl border border-slate-300 bg-white p-5">
+                  <div className="text-sm font-black text-brand-red-700">{index + 1}</div>
+                  <div className="mt-2 font-black text-slate-950">{step}</div>
+                </div>
+              ),
+            )}
           </div>
           <p className="mt-6 text-sm font-medium leading-6 text-slate-700">
             Domain capabilities depend on the active plan and enabled services. The product page describes the supported customer workflow without creating a second Website Builder implementation.
@@ -114,7 +255,10 @@ export default function WebsiteBuilderStorePage() {
       <IndividualAppPlansSection catalog={catalog} />
 
       <section className="px-4 py-14 text-center">
-        <Link href={catalog.trialHref} className="inline-flex items-center gap-2 font-black text-brand-red-700 hover:underline">
+        <Link
+          href={catalog.trialHref}
+          className="inline-flex items-center gap-2 font-black text-brand-red-700 hover:underline"
+        >
           Start the Website Builder trial <ArrowRight className="h-4 w-4" />
         </Link>
       </section>

--- a/apps/marketing/app/store/page.tsx
+++ b/apps/marketing/app/store/page.tsx
@@ -8,6 +8,8 @@ import heroBanners from '@/content/heroBanners';
 import StoreFAQ from './StoreFAQ';
 import { ROICalculator } from '@/components/store/ROICalculator';
 import { UnifiedSalesMarketplace } from '@/components/store/UnifiedSalesMarketplace';
+import { GuidedProductInterview } from '@/components/store/GuidedProductInterview';
+import { HomeBusinessLaunch } from '@/components/home/HomeBusinessLaunch';
 
 export const metadata: Metadata = {
   title: 'Elevate Store | AI Business, Workforce & Education Platform',
@@ -71,7 +73,7 @@ export default function StorePage() {
         belowHeroSubheadline="Website, CRM, AI assistants, education, workforce, testing and operations in one platform."
         ctas={[
           { label: 'Start 14-Day Free Trial', href: '/store/trial' },
-          { label: 'Explore Everything', href: '#marketplace', variant: 'secondary' },
+          { label: 'Tell AI What I Need', href: '#guided-setup', variant: 'secondary' },
           { label: 'Try Interactive Demo', href: '/store/demo/admin', variant: 'secondary' },
         ]}
         trustIndicators={hero.trustIndicators}
@@ -102,7 +104,9 @@ export default function StorePage() {
         </div>
       </section>
 
+      <GuidedProductInterview />
       <UnifiedSalesMarketplace />
+      <HomeBusinessLaunch />
 
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-5">

--- a/components/home/HomeBusinessLaunch.tsx
+++ b/components/home/HomeBusinessLaunch.tsx
@@ -1,0 +1,83 @@
+import Link from 'next/link';
+import { ArrowRight, BriefcaseBusiness, CheckCircle2, Globe2, Sparkles } from 'lucide-react';
+
+export function HomeBusinessLaunch() {
+  return (
+    <section className="bg-slate-950 py-16 text-white">
+      <div className="mx-auto max-w-7xl px-5 sm:px-6">
+        <div className="grid gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full border border-white/15 bg-white/5 px-4 py-2 text-sm font-black text-slate-200">
+              <BriefcaseBusiness className="h-4 w-4" /> Career skills + business launch tools
+            </span>
+            <h2 className="mt-5 text-4xl font-black leading-tight sm:text-5xl">
+              Get certified. Then build the business around your skills.
+            </h2>
+            <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-300">
+              Elevate does more than career training. Business and entrepreneurship learners can use AI-powered tools to build a website, organize customer follow-up, create training, launch a community and grow their operation without needing to code.
+            </p>
+            <div className="mt-7 space-y-3 text-sm text-slate-200">
+              {[
+                'Describe your business in plain English',
+                'Let AI create the website starting point',
+                'Edit, preview and publish without code',
+                'Add CRM, AI assistants, courses, community and business tools as you grow',
+              ].map((item) => (
+                <div key={item} className="flex items-start gap-3">
+                  <CheckCircle2 className="mt-0.5 h-5 w-5 shrink-0 text-emerald-400" />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link
+                href="/store/apps/website-builder"
+                className="inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-6 py-3.5 font-black hover:bg-brand-red-500"
+              >
+                Build a Website <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link
+                href="/store#guided-setup"
+                className="rounded-xl border border-white/25 px-6 py-3.5 font-black hover:bg-white/10"
+              >
+                Tell AI What I Need
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/10 bg-white/5 p-5 shadow-2xl sm:p-7">
+            <div className="rounded-2xl bg-white p-5 text-slate-950 sm:p-7">
+              <div className="flex items-center justify-between gap-4 border-b border-slate-200 pb-4">
+                <div>
+                  <p className="text-xs font-black uppercase tracking-wider text-brand-red-700">
+                    Elevate AI Website Builder
+                  </p>
+                  <h3 className="mt-1 text-xl font-black">What business are you building?</h3>
+                </div>
+                <Globe2 className="h-8 w-8 text-slate-400" />
+              </div>
+              <div className="mt-5 rounded-xl border border-slate-200 bg-slate-50 p-4 text-slate-600">
+                “Build a professional website for my home-care business with services, about us, contact form and a strong call to action.”
+              </div>
+              <div className="mt-5 flex items-center gap-3 rounded-xl bg-slate-950 p-4 text-white">
+                <Sparkles className="h-5 w-5 text-brand-red-300" />
+                <div>
+                  <p className="font-black">Creating your first draft…</p>
+                  <p className="mt-1 text-sm text-slate-300">Structure • content • branding starting point • SEO fields</p>
+                </div>
+              </div>
+              <div className="mt-5 grid grid-cols-3 gap-3 text-center text-xs font-bold text-slate-600">
+                <div className="rounded-lg border border-slate-200 p-3">Edit</div>
+                <div className="rounded-lg border border-slate-200 p-3">Preview</div>
+                <div className="rounded-lg border border-slate-200 p-3">Publish</div>
+              </div>
+              <p className="mt-4 text-xs leading-5 text-slate-500">
+                No code required to start. Advanced controls are available only when the customer needs them.
+              </p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/store/GuidedProductInterview.tsx
+++ b/components/store/GuidedProductInterview.tsx
@@ -1,0 +1,269 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, Sparkles } from 'lucide-react';
+
+type Goal =
+  | 'business'
+  | 'website'
+  | 'course'
+  | 'community'
+  | 'customers'
+  | 'grants'
+  | 'government'
+  | 'workforce'
+  | 'apprenticeship';
+
+type OrgType = 'solo' | 'small-business' | 'training-provider' | 'nonprofit' | 'employer' | 'agency';
+
+type Recommendation = {
+  name: string;
+  reason: string;
+  href: string;
+  badge?: string;
+};
+
+const GOALS: Array<{ id: Goal; label: string }> = [
+  { id: 'business', label: 'Start or grow a business' },
+  { id: 'website', label: 'Build a website' },
+  { id: 'course', label: 'Create and sell training' },
+  { id: 'community', label: 'Build a community' },
+  { id: 'customers', label: 'Manage leads and customers' },
+  { id: 'grants', label: 'Find and manage grants' },
+  { id: 'government', label: 'Manage SAM.gov / contracting' },
+  { id: 'workforce', label: 'Run workforce programs' },
+  { id: 'apprenticeship', label: 'Run an apprenticeship' },
+];
+
+const ORGS: Array<{ id: OrgType; label: string }> = [
+  { id: 'solo', label: 'Just me' },
+  { id: 'small-business', label: 'Small business' },
+  { id: 'training-provider', label: 'Training provider / school' },
+  { id: 'nonprofit', label: 'Nonprofit' },
+  { id: 'employer', label: 'Employer' },
+  { id: 'agency', label: 'Workforce or government agency' },
+];
+
+function recommend(goal: Goal, org: OrgType): Recommendation[] {
+  const matches: Recommendation[] = [];
+
+  if (goal === 'business' || goal === 'website') {
+    matches.push({
+      name: 'AI Website Builder',
+      reason: 'Create, edit, preview and publish a business website without code.',
+      href: '/store/apps/website-builder',
+      badge: 'Start here',
+    });
+    matches.push({
+      name: 'CRM',
+      reason: 'Capture leads and keep customer follow-up connected to your website.',
+      href: '/store#marketplace',
+    });
+    matches.push({
+      name: 'AI Assistant',
+      reason: 'Automate routine questions, follow-up and business support.',
+      href: '/store#marketplace',
+    });
+  }
+
+  if (goal === 'course') {
+    matches.push({
+      name: 'Course Builder',
+      reason: 'Describe the course and let AI create the starting structure, lessons and assessments.',
+      href: '/store#marketplace',
+      badge: 'Best match',
+    });
+    matches.push({
+      name: 'LMS',
+      reason: 'Deliver training, track progress and manage learners.',
+      href: '/store#marketplace',
+    });
+  }
+
+  if (goal === 'community') {
+    matches.push({
+      name: 'Community Hub',
+      reason: 'Launch groups, discussions, events, achievements and member engagement.',
+      href: '/store#marketplace',
+      badge: 'Best match',
+    });
+    matches.push({
+      name: 'AI Team',
+      reason: 'Add guided onboarding, support and engagement assistance.',
+      href: '/store#marketplace',
+    });
+  }
+
+  if (goal === 'customers') {
+    matches.push({
+      name: 'CRM',
+      reason: 'Create a customer pipeline, follow-up process and shared record of activity.',
+      href: '/store#marketplace',
+      badge: 'Best match',
+    });
+    matches.push({
+      name: 'AI Assistant',
+      reason: 'Reduce manual follow-up and repetitive customer questions.',
+      href: '/store#marketplace',
+    });
+  }
+
+  if (goal === 'grants') {
+    matches.push({
+      name: 'Grants Discovery',
+      reason: 'Search, match and track funding opportunities from one workspace.',
+      href: '/store/apps/grants',
+      badge: 'Best match',
+    });
+  }
+
+  if (goal === 'government') {
+    matches.push({
+      name: 'SAM.gov Manager',
+      reason: 'Use a guided workflow for registration, renewals and compliance tracking.',
+      href: '/store/apps/sam-gov',
+      badge: 'Best match',
+    });
+  }
+
+  if (goal === 'workforce') {
+    matches.push({
+      name: 'Workforce OS',
+      reason: 'Manage enrollment, funding, compliance, outcomes and agency workflows.',
+      href: '/store#marketplace',
+      badge: 'Best match',
+    });
+  }
+
+  if (goal === 'apprenticeship') {
+    matches.push({
+      name: 'Apprenticeship Management',
+      reason: 'Track RTI, OJT, employers, progress and compliance in one workflow.',
+      href: '/store#marketplace',
+      badge: 'Best match',
+    });
+  }
+
+  if ((org === 'training-provider' || org === 'agency') && !matches.some((item) => item.name === 'LMS')) {
+    matches.push({
+      name: 'LMS',
+      reason: 'Add learner delivery, progress and training records when your organization needs them.',
+      href: '/store#marketplace',
+    });
+  }
+
+  return matches.slice(0, 4);
+}
+
+export function GuidedProductInterview() {
+  const [goal, setGoal] = useState<Goal | null>(null);
+  const [org, setOrg] = useState<OrgType | null>(null);
+  const recommendations = useMemo(() => (goal && org ? recommend(goal, org) : []), [goal, org]);
+
+  return (
+    <section className="bg-white py-16" id="guided-setup">
+      <div className="mx-auto max-w-6xl px-5">
+        <div className="mx-auto max-w-3xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full bg-brand-red-50 px-4 py-2 text-sm font-black text-brand-red-700">
+            <Sparkles className="h-4 w-4" /> Zero-code guided setup
+          </span>
+          <h2 className="mt-4 text-3xl font-black text-slate-950 sm:text-5xl">
+            Tell Elevate what you want to accomplish.
+          </h2>
+          <p className="mt-4 text-lg leading-8 text-slate-600">
+            You do not need to understand product names or technical settings. Answer two questions and Elevate will recommend the simplest starting stack.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-8 lg:grid-cols-2">
+          <div className="rounded-3xl border border-slate-200 bg-slate-50 p-6 md:p-8">
+            <p className="text-sm font-black uppercase tracking-wider text-slate-500">1. What are you trying to do?</p>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {GOALS.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setGoal(item.id)}
+                  className={`rounded-xl border px-4 py-3 text-left text-sm font-bold transition ${
+                    goal === item.id
+                      ? 'border-brand-red-600 bg-brand-red-50 text-brand-red-800'
+                      : 'border-slate-200 bg-white text-slate-800 hover:border-slate-300'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+
+            <p className="mt-7 text-sm font-black uppercase tracking-wider text-slate-500">2. Who is this for?</p>
+            <div className="mt-4 grid gap-2 sm:grid-cols-2">
+              {ORGS.map((item) => (
+                <button
+                  key={item.id}
+                  type="button"
+                  onClick={() => setOrg(item.id)}
+                  className={`rounded-xl border px-4 py-3 text-left text-sm font-bold transition ${
+                    org === item.id
+                      ? 'border-brand-red-600 bg-brand-red-50 text-brand-red-800'
+                      : 'border-slate-200 bg-white text-slate-800 hover:border-slate-300'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </div>
+          </div>
+
+          <div className="rounded-3xl bg-slate-950 p-6 text-white md:p-8">
+            <p className="text-sm font-black uppercase tracking-wider text-brand-red-300">Your recommended setup</p>
+            {!goal || !org ? (
+              <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-300">
+                Choose a goal and organization type. Elevate will explain what to start with and why.
+              </div>
+            ) : (
+              <div className="mt-6 space-y-4">
+                {recommendations.map((item) => (
+                  <article key={item.name} className="rounded-2xl border border-white/10 bg-white/5 p-5">
+                    <div className="flex items-start justify-between gap-4">
+                      <div>
+                        <div className="flex flex-wrap items-center gap-2">
+                          <h3 className="font-black">{item.name}</h3>
+                          {item.badge ? (
+                            <span className="rounded-full bg-brand-red-600 px-2 py-1 text-[11px] font-black uppercase">
+                              {item.badge}
+                            </span>
+                          ) : null}
+                        </div>
+                        <p className="mt-2 text-sm leading-6 text-slate-300">{item.reason}</p>
+                      </div>
+                      <CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" />
+                    </div>
+                    <Link href={item.href} className="mt-4 inline-flex items-center gap-2 text-sm font-black text-white">
+                      See this product <ArrowRight className="h-4 w-4" />
+                    </Link>
+                  </article>
+                ))}
+              </div>
+            )}
+
+            {goal && org ? (
+              <div className="mt-6 rounded-2xl bg-white p-5 text-slate-950">
+                <p className="font-black">Simple mode first.</p>
+                <p className="mt-1 text-sm leading-6 text-slate-600">
+                  Elevate guides setup in plain English. Advanced controls stay optional until the customer needs them.
+                </p>
+                <Link
+                  href="/store/trial"
+                  className="mt-4 inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-4 py-3 text-sm font-black text-white"
+                >
+                  Start guided setup <ArrowRight className="h-4 w-4" />
+                </Link>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/store/ProductWalkthrough.tsx
+++ b/components/store/ProductWalkthrough.tsx
@@ -1,0 +1,109 @@
+'use client';
+
+import { useEffect, useState } from 'react';
+import Link from 'next/link';
+import { CheckCircle2, Pause, Play, Sparkles } from 'lucide-react';
+
+type Step = { title: string; description: string; label?: string };
+
+export default function ProductWalkthrough({
+  title,
+  subtitle,
+  steps,
+  tryHref,
+}: {
+  title: string;
+  subtitle: string;
+  steps: Step[];
+  tryHref: string;
+}) {
+  const [active, setActive] = useState(0);
+  const [playing, setPlaying] = useState(true);
+
+  useEffect(() => {
+    if (!playing || steps.length < 2) return;
+    const timer = window.setInterval(() => setActive((value) => (value + 1) % steps.length), 4200);
+    return () => window.clearInterval(timer);
+  }, [playing, steps.length]);
+
+  if (steps.length === 0) return null;
+
+  return (
+    <section className="px-4 py-16" aria-label={`${title} walkthrough`}>
+      <div className="mx-auto max-w-6xl overflow-hidden rounded-3xl bg-slate-950 text-white shadow-2xl">
+        <div className="grid lg:grid-cols-[0.9fr_1.1fr]">
+          <div className="p-8 md:p-12">
+            <p className="text-sm font-black uppercase tracking-[.2em] text-brand-red-400">Watch it work</p>
+            <h2 className="mt-3 text-3xl font-black md:text-4xl">{title}</h2>
+            <p className="mt-4 leading-7 text-slate-300">{subtitle}</p>
+            <div className="mt-8 space-y-3">
+              {steps.map((step, index) => (
+                <button
+                  key={step.title}
+                  type="button"
+                  onClick={() => {
+                    setActive(index);
+                    setPlaying(false);
+                  }}
+                  className={`w-full rounded-xl p-4 text-left transition ${
+                    index === active
+                      ? 'bg-white text-slate-950'
+                      : 'bg-white/5 text-slate-300 hover:bg-white/10'
+                  }`}
+                >
+                  <span className="text-xs font-black uppercase tracking-wider">
+                    {step.label || `Step ${index + 1}`}
+                  </span>
+                  <span className="mt-1 block font-bold">{step.title}</span>
+                </button>
+              ))}
+            </div>
+            <div className="mt-6 flex flex-wrap gap-3">
+              <button
+                type="button"
+                onClick={() => setPlaying((value) => !value)}
+                className="inline-flex items-center gap-2 rounded-xl border border-white/20 px-4 py-3 font-bold"
+              >
+                {playing ? <Pause className="h-4 w-4" /> : <Play className="h-4 w-4" />}
+                {playing ? 'Pause demo' : 'Play demo'}
+              </button>
+              <Link href={tryHref} className="rounded-xl bg-brand-red-600 px-5 py-3 font-bold hover:bg-brand-red-700">
+                Try it yourself
+              </Link>
+            </div>
+          </div>
+
+          <div className="flex min-h-[460px] items-center bg-slate-100 p-6 text-slate-950 md:p-10">
+            <div className="w-full rounded-2xl border border-slate-200 bg-white shadow-xl">
+              <div className="flex items-center gap-2 border-b border-slate-200 px-4 py-3">
+                <span className="h-3 w-3 rounded-full bg-slate-300" />
+                <span className="h-3 w-3 rounded-full bg-slate-300" />
+                <span className="h-3 w-3 rounded-full bg-slate-300" />
+                <span className="ml-3 text-xs font-semibold text-slate-400">Elevate AI workspace</span>
+              </div>
+              <div className="p-7 md:p-10">
+                <div className="flex items-center gap-2 text-brand-red-700">
+                  <Sparkles className="h-5 w-5" />
+                  <span className="text-sm font-black uppercase tracking-wider">
+                    {steps[active]?.label || `Step ${active + 1}`}
+                  </span>
+                </div>
+                <h3 className="mt-4 text-2xl font-black">{steps[active]?.title}</h3>
+                <p className="mt-3 text-lg leading-8 text-slate-600">{steps[active]?.description}</p>
+                <div className="mt-8 h-2 overflow-hidden rounded-full bg-slate-100">
+                  <div
+                    className="h-full bg-slate-900 transition-all duration-700"
+                    style={{ width: `${((active + 1) / steps.length) * 100}%` }}
+                  />
+                </div>
+                <div className="mt-5 flex items-center gap-2 text-sm font-bold text-emerald-700">
+                  <CheckCircle2 className="h-4 w-4" /> No code required to start
+                </div>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/store/ZeroCodeSetup.tsx
+++ b/components/store/ZeroCodeSetup.tsx
@@ -1,0 +1,215 @@
+'use client';
+
+import { useMemo, useState } from 'react';
+import Link from 'next/link';
+import { ArrowRight, CheckCircle2, ChevronLeft, Sparkles, WandSparkles } from 'lucide-react';
+
+export type ZeroCodeChoice = {
+  label: string;
+  value: string;
+  description?: string;
+};
+
+export type ZeroCodeQuestion = {
+  id: string;
+  prompt: string;
+  helper?: string;
+  choices?: ZeroCodeChoice[];
+  placeholder?: string;
+};
+
+interface ZeroCodeSetupProps {
+  productName: string;
+  intro: string;
+  questions: ZeroCodeQuestion[];
+  startHref: string;
+  trialHref?: string;
+  advancedNote?: string;
+}
+
+export default function ZeroCodeSetup({
+  productName,
+  intro,
+  questions,
+  startHref,
+  trialHref,
+  advancedNote,
+}: ZeroCodeSetupProps) {
+  const [step, setStep] = useState(0);
+  const [answers, setAnswers] = useState<Record<string, string>>({});
+  const current = questions[step];
+  const complete = step >= questions.length;
+
+  const setupHref = useMemo(() => {
+    const params = new URLSearchParams({ setup: 'guided', source: 'store' });
+    Object.entries(answers).forEach(([key, value]) => {
+      if (value.trim()) params.set(key, value.trim());
+    });
+    return `${startHref}${startHref.includes('?') ? '&' : '?'}${params.toString()}`;
+  }, [answers, startHref]);
+
+  function answerCurrent(value: string) {
+    if (!current) return;
+    setAnswers((previous) => ({ ...previous, [current.id]: value }));
+  }
+
+  function next() {
+    if (!current || !answers[current.id]?.trim()) return;
+    setStep((value) => value + 1);
+  }
+
+  function reset() {
+    setAnswers({});
+    setStep(0);
+  }
+
+  return (
+    <section className="px-4 py-16" aria-label={`${productName} zero-code setup`}>
+      <div className="mx-auto max-w-6xl rounded-3xl border border-slate-200 bg-white p-6 shadow-xl md:p-10">
+        <div className="grid gap-10 lg:grid-cols-[0.85fr_1.15fr] lg:items-start">
+          <div>
+            <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-sm font-black text-emerald-800">
+              <WandSparkles className="h-4 w-4" /> Zero-code guided setup
+            </span>
+            <h2 className="mt-5 text-3xl font-black tracking-tight text-slate-950 md:text-4xl">
+              Tell Elevate what you want. We configure the starting point.
+            </h2>
+            <p className="mt-4 text-lg leading-8 text-slate-600">{intro}</p>
+            <div className="mt-8 space-y-3 text-sm text-slate-700">
+              {[
+                'Answer in plain English',
+                'Review the recommended setup',
+                'Open a configured starting workspace',
+                'Keep advanced controls optional',
+              ].map((item) => (
+                <div key={item} className="flex items-center gap-3">
+                  <CheckCircle2 className="h-5 w-5 text-emerald-600" />
+                  <span>{item}</span>
+                </div>
+              ))}
+            </div>
+            {advancedNote ? (
+              <div className="mt-8 rounded-2xl bg-slate-950 p-5 text-sm leading-6 text-slate-300">
+                <strong className="text-white">Advanced Mode:</strong> {advancedNote}
+              </div>
+            ) : null}
+          </div>
+
+          <div className="rounded-3xl bg-slate-950 p-6 text-white md:p-8">
+            {!complete && current ? (
+              <>
+                <div className="flex items-center justify-between gap-4">
+                  <p className="text-xs font-black uppercase tracking-[.18em] text-brand-red-300">
+                    Question {step + 1} of {questions.length}
+                  </p>
+                  <span className="text-xs font-bold text-slate-400">{productName}</span>
+                </div>
+                <div className="mt-4 h-2 overflow-hidden rounded-full bg-white/10">
+                  <div
+                    className="h-full bg-brand-red-500 transition-all"
+                    style={{ width: `${((step + 1) / questions.length) * 100}%` }}
+                  />
+                </div>
+                <h3 className="mt-7 text-2xl font-black">{current.prompt}</h3>
+                {current.helper ? (
+                  <p className="mt-2 text-sm leading-6 text-slate-300">{current.helper}</p>
+                ) : null}
+
+                {current.choices?.length ? (
+                  <div className="mt-6 grid gap-3 sm:grid-cols-2">
+                    {current.choices.map((choice) => {
+                      const selected = answers[current.id] === choice.value;
+                      return (
+                        <button
+                          key={choice.value}
+                          type="button"
+                          onClick={() => answerCurrent(choice.value)}
+                          className={`rounded-2xl border p-4 text-left transition ${
+                            selected
+                              ? 'border-brand-red-400 bg-brand-red-500/15'
+                              : 'border-white/15 bg-white/5 hover:bg-white/10'
+                          }`}
+                        >
+                          <span className="font-black">{choice.label}</span>
+                          {choice.description ? (
+                            <span className="mt-1 block text-xs leading-5 text-slate-300">{choice.description}</span>
+                          ) : null}
+                        </button>
+                      );
+                    })}
+                  </div>
+                ) : (
+                  <textarea
+                    value={answers[current.id] || ''}
+                    onChange={(event) => answerCurrent(event.target.value)}
+                    placeholder={current.placeholder || 'Describe what you want in plain English...'}
+                    rows={5}
+                    className="mt-6 w-full rounded-2xl border border-white/15 bg-white p-4 text-slate-950 outline-none ring-brand-red-500 focus:ring-2"
+                  />
+                )}
+
+                <div className="mt-7 flex items-center justify-between gap-3">
+                  <button
+                    type="button"
+                    disabled={step === 0}
+                    onClick={() => setStep((value) => Math.max(0, value - 1))}
+                    className="inline-flex items-center gap-2 rounded-xl border border-white/20 px-4 py-3 font-bold disabled:cursor-not-allowed disabled:opacity-30"
+                  >
+                    <ChevronLeft className="h-4 w-4" /> Back
+                  </button>
+                  <button
+                    type="button"
+                    disabled={!answers[current.id]?.trim()}
+                    onClick={next}
+                    className="inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3 font-black hover:bg-brand-red-500 disabled:cursor-not-allowed disabled:opacity-40"
+                  >
+                    Continue <ArrowRight className="h-4 w-4" />
+                  </button>
+                </div>
+              </>
+            ) : (
+              <div className="py-4">
+                <Sparkles className="h-9 w-9 text-brand-red-300" />
+                <p className="mt-5 text-xs font-black uppercase tracking-[.18em] text-brand-red-300">
+                  Your guided setup is ready
+                </p>
+                <h3 className="mt-3 text-3xl font-black">Open {productName} with your answers attached.</h3>
+                <p className="mt-4 leading-7 text-slate-300">
+                  Elevate carries this setup context into the product instead of making you start from a blank screen. Review before publishing or activating anything.
+                </p>
+                <div className="mt-7 space-y-2 rounded-2xl border border-white/10 bg-white/5 p-5">
+                  {questions.map((question) => (
+                    <div key={question.id} className="text-sm">
+                      <span className="font-bold text-slate-400">{question.prompt}</span>
+                      <span className="mt-1 block text-white">{answers[question.id]}</span>
+                    </div>
+                  ))}
+                </div>
+                <div className="mt-7 flex flex-wrap gap-3">
+                  <Link
+                    href={setupHref}
+                    className="inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3 font-black hover:bg-brand-red-500"
+                  >
+                    Open guided workspace <ArrowRight className="h-4 w-4" />
+                  </Link>
+                  {trialHref ? (
+                    <Link href={trialHref} className="rounded-xl border border-white/20 px-5 py-3 font-black hover:bg-white/10">
+                      Start free trial
+                    </Link>
+                  ) : null}
+                  <button
+                    type="button"
+                    onClick={reset}
+                    className="rounded-xl px-4 py-3 font-bold text-slate-300 hover:bg-white/10"
+                  >
+                    Start over
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}


### PR DESCRIPTION
Fresh reimplementation of the valuable work from feat/store-self-selling-demos on top of current main.

Keeps:
- zero-code product recommendation interview on the current Store
- business launch showcase
- reusable interactive product walkthrough
- reusable zero-code guided setup
- Website Builder walkthrough + guided setup integrated into the current page

Does not replace current Store/homepage implementations with the 278-commit-old branch versions.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Restore guided Store selling features with walkthrough and zero-code setup sections
> - Adds a `ProductWalkthrough` component with autoplay and manual step controls to the Website Builder store page, driven by a new `walkthrough` steps array.
> - Adds a `ZeroCodeSetup` multi-step guided setup component that collects user answers and encodes them as query parameters in a deep link to the product.
> - Adds a `GuidedProductInterview` component to the store landing page that maps a selected goal and org type to tailored product recommendations.
> - Adds a `HomeBusinessLaunch` section promoting website and guided setup CTAs after certification content.
> - Updates hero CTAs on both the store landing page and Website Builder page to anchor-link to the new `#guided-setup` and `#walkthrough` sections instead of linking directly to a trial.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 91b1f0d.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->