### PR TITLE
Market barber host shops with rotating showcase, maps and SEO profiles

### DIFF
--- a/apps/marketing/app/host-shops/[slug]/page.tsx
+++ b/apps/marketing/app/host-shops/[slug]/page.tsx
@@ -1,0 +1,245 @@
+import type { Metadata } from 'next';
+import Image from 'next/image';
+import Link from 'next/link';
+import { notFound } from 'next/navigation';
+import { ExternalLink, MapPin, Navigation, Phone } from 'lucide-react';
+import {
+  FEATURED_BEAUTY_HOST_PARTNERS,
+  getFeaturedHostPartnerBySlug,
+} from '@/lib/apprenticeship-programs/host-partners';
+
+const SITE_URL = 'https://www.elevateforhumanity.org';
+
+type PageProps = {
+  params: Promise<{ slug: string }>;
+};
+
+function fullAddress(shop: (typeof FEATURED_BEAUTY_HOST_PARTNERS)[number]) {
+  return `${shop.address}, ${shop.city}, ${shop.state} ${shop.zip}`;
+}
+
+function directionsUrl(address: string) {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(address)}`;
+}
+
+function mapEmbedUrl(address: string) {
+  return `https://www.google.com/maps?q=${encodeURIComponent(address)}&z=15&output=embed`;
+}
+
+export function generateStaticParams() {
+  return FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => ({ slug: shop.slug }));
+}
+
+export async function generateMetadata({ params }: PageProps): Promise<Metadata> {
+  const { slug } = await params;
+  const shop = getFeaturedHostPartnerBySlug(slug);
+  if (!shop) return {};
+
+  const publicName = shop.dba ?? shop.name;
+  const canonical = `${SITE_URL}/host-shops/${shop.slug}`;
+  const description = `${publicName} in ${shop.city}, Indiana is part of Elevate for Humanity’s apprenticeship host-shop network. Find the shop address, phone, map, website, booking information, and barber apprenticeship details.`;
+
+  return {
+    title: `${publicName} | Indiana Barber Apprenticeship Host Shop`,
+    description,
+    keywords: [
+      publicName,
+      `${publicName} ${shop.city}`,
+      `barber shop ${shop.city} Indiana`,
+      `barber apprenticeship ${shop.city}`,
+      'Indiana barber apprenticeship host shop',
+      'Elevate for Humanity host shop',
+    ],
+    alternates: { canonical },
+    openGraph: {
+      title: `${publicName} | Apprenticeship Host Shop`,
+      description,
+      url: canonical,
+      type: 'website',
+      images: shop.media?.[0]?.src ? [{ url: shop.media[0].src, alt: shop.media[0].alt }] : undefined,
+    },
+  };
+}
+
+export default async function HostShopProfilePage({ params }: PageProps) {
+  const { slug } = await params;
+  const shop = getFeaturedHostPartnerBySlug(slug);
+  if (!shop) return notFound();
+
+  const publicName = shop.dba ?? shop.name;
+  const address = fullAddress(shop);
+  const image = shop.media?.[0];
+  const sameAs = [shop.websiteUrl, shop.bookingUrl, shop.socialUrl, shop.onlineListingUrl].filter(
+    (value): value is string => Boolean(value),
+  );
+  const canonical = `${SITE_URL}/host-shops/${shop.slug}`;
+
+  const jsonLd = {
+    '@context': 'https://schema.org',
+    '@type': shop.businessType ?? 'BarberShop',
+    name: publicName,
+    legalName: shop.name,
+    url: canonical,
+    description: shop.marketingBlurb ?? shop.note,
+    telephone: shop.phone,
+    address: {
+      '@type': 'PostalAddress',
+      streetAddress: shop.address,
+      addressLocality: shop.city,
+      addressRegion: shop.state,
+      postalCode: shop.zip,
+      addressCountry: 'US',
+    },
+    sameAs: sameAs.length ? sameAs : undefined,
+    areaServed: {
+      '@type': 'City',
+      name: `${shop.city}, Indiana`,
+    },
+  };
+
+  return (
+    <main className="bg-white text-slate-950">
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+
+      <section className="border-b border-slate-200 bg-slate-950 text-white">
+        <div className="mx-auto grid max-w-6xl gap-8 px-4 py-10 sm:px-6 lg:grid-cols-2 lg:items-center lg:py-14">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-[0.18em] text-red-300">
+              Elevate apprenticeship host shop
+            </p>
+            <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">{publicName}</h1>
+            {shop.dba ? <p className="mt-2 text-sm font-semibold text-slate-400">Legal name: {shop.name}</p> : null}
+            <p className="mt-5 max-w-2xl text-lg leading-8 text-slate-300">
+              {shop.marketingBlurb ?? shop.note}
+            </p>
+            <div className="mt-7 flex flex-wrap gap-3">
+              {shop.phone ? (
+                <a
+                  href={`tel:${shop.phone.replace(/[^0-9+]/g, '')}`}
+                  className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl bg-red-600 px-5 py-2.5 text-sm font-extrabold text-white hover:bg-red-500"
+                >
+                  <Phone className="h-4 w-4" /> Call {shop.phone}
+                </a>
+              ) : null}
+              <a
+                href={directionsUrl(address)}
+                target="_blank"
+                rel="noopener noreferrer"
+                className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-white/25 px-5 py-2.5 text-sm font-extrabold text-white hover:bg-white/10"
+              >
+                <Navigation className="h-4 w-4" /> Directions
+              </a>
+            </div>
+          </div>
+
+          {image ? (
+            <div className="relative min-h-[320px] overflow-hidden rounded-3xl border border-white/10 bg-slate-900 sm:min-h-[420px]">
+              <Image
+                src={image.src}
+                alt={image.alt}
+                fill
+                priority
+                sizes="(max-width: 1024px) 100vw, 50vw"
+                className={image.kind === 'flyer' ? 'object-contain bg-white p-4' : 'object-cover'}
+              />
+            </div>
+          ) : (
+            <div className="flex min-h-[300px] items-center justify-center rounded-3xl border border-white/10 bg-slate-900 p-10 text-center">
+              <div>
+                <p className="text-3xl font-black">{publicName}</p>
+                <p className="mt-3 text-slate-300">{shop.city}, Indiana</p>
+              </div>
+            </div>
+          )}
+        </div>
+      </section>
+
+      <section className="px-4 py-12 sm:px-6 sm:py-16">
+        <div className="mx-auto grid max-w-6xl gap-8 lg:grid-cols-[0.9fr_1.1fr]">
+          <div>
+            <h2 className="text-2xl font-black">Visit or contact the shop</h2>
+            <div className="mt-5 rounded-2xl border border-slate-200 bg-slate-50 p-6">
+              <p className="flex items-start gap-3 font-bold text-slate-900">
+                <MapPin className="mt-0.5 h-5 w-5 shrink-0 text-brand-red-700" />
+                <span>{address}</span>
+              </p>
+              {shop.phone ? (
+                <a
+                  href={`tel:${shop.phone.replace(/[^0-9+]/g, '')}`}
+                  className="mt-4 flex items-center gap-3 font-bold text-slate-900 hover:text-brand-red-700"
+                >
+                  <Phone className="h-5 w-5 text-brand-red-700" /> {shop.phone}
+                </a>
+              ) : (
+                <p className="mt-4 text-sm font-semibold text-slate-600">
+                  A direct public phone number has not been verified. Use the verified shop contact link below.
+                </p>
+              )}
+            </div>
+
+            <div className="mt-5 flex flex-col gap-3">
+              {shop.websiteUrl ? (
+                <a href={shop.websiteUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-between rounded-xl border border-slate-300 px-4 py-2.5 font-bold hover:bg-slate-50">
+                  {shop.websiteLabel ?? 'Visit shop website'} <ExternalLink className="h-4 w-4" />
+                </a>
+              ) : null}
+              {shop.bookingUrl ? (
+                <a href={shop.bookingUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-between rounded-xl border border-slate-300 px-4 py-2.5 font-bold hover:bg-slate-50">
+                  Book shop services <ExternalLink className="h-4 w-4" />
+                </a>
+              ) : null}
+              {shop.socialUrl ? (
+                <a href={shop.socialUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-between rounded-xl border border-slate-300 px-4 py-2.5 font-bold hover:bg-slate-50">
+                  {shop.socialLabel ?? 'Photos & social'} <ExternalLink className="h-4 w-4" />
+                </a>
+              ) : null}
+              {shop.onlineListingUrl ? (
+                <a href={shop.onlineListingUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-between rounded-xl border border-slate-300 px-4 py-2.5 font-bold hover:bg-slate-50">
+                  {shop.onlineListingLabel ?? 'View shop listing'} <ExternalLink className="h-4 w-4" />
+                </a>
+              ) : null}
+              {shop.resourceUrl ? (
+                <a href={shop.resourceUrl} target="_blank" rel="noopener noreferrer" className="inline-flex min-h-11 items-center justify-between rounded-xl border border-brand-red-200 bg-brand-red-50 px-4 py-2.5 font-bold text-brand-red-800 hover:bg-brand-red-100">
+                  {shop.resourceLabel ?? 'View apprenticeship document'} <ExternalLink className="h-4 w-4" />
+                </a>
+              ) : null}
+            </div>
+          </div>
+
+          <div>
+            <div className="h-[360px] overflow-hidden rounded-2xl border border-slate-300 sm:h-[480px]">
+              <iframe
+                title={`Map — ${publicName}`}
+                src={mapEmbedUrl(address)}
+                className="h-full w-full border-0"
+                loading="lazy"
+                referrerPolicy="no-referrer-when-downgrade"
+              />
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-slate-200 bg-slate-50 px-4 py-12 sm:px-6">
+        <div className="mx-auto max-w-5xl text-center">
+          <p className="text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">Future apprentices</p>
+          <h2 className="mt-2 text-3xl font-black">Interested in training through an approved host shop?</h2>
+          <p className="mx-auto mt-4 max-w-3xl leading-7 text-slate-700">
+            Start with the Elevate barber apprenticeship application. Host-shop placement, available positions, funding, and transfer-hour documentation are reviewed as part of enrollment.
+          </p>
+          <div className="mt-7 flex flex-wrap justify-center gap-3">
+            <Link href="/programs/barber-apprenticeship/apply" className="rounded-xl bg-brand-red-600 px-6 py-3 font-extrabold text-white hover:bg-brand-red-700">
+              Apply for Barber Apprenticeship
+            </Link>
+            <Link href="/programs/barber-apprenticeship#host-shops" className="rounded-xl border border-slate-300 bg-white px-6 py-3 font-extrabold text-slate-900 hover:bg-slate-50">
+              View all host shops
+            </Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/marketing/app/host-shops/page.tsx
+++ b/apps/marketing/app/host-shops/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import { ExternalLink, MapPin, Phone } from 'lucide-react';
+import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
+
+export const metadata: Metadata = {
+  title: 'Indiana Barber Apprenticeship Host Shops | Elevate for Humanity',
+  description:
+    'Explore Elevate for Humanity apprenticeship host shops across Indiana. Find shop profiles, addresses, phone numbers, maps, websites, booking links, and barber apprenticeship opportunities.',
+  keywords: [
+    'Indiana barber shops',
+    'barber apprenticeship host shops',
+    'barber apprenticeship Indiana',
+    'barber shops hiring apprentices',
+    'barber training shops Indiana',
+  ],
+  alternates: { canonical: 'https://www.elevateforhumanity.org/host-shops' },
+};
+
+export default function HostShopDirectoryPage() {
+  return (
+    <main className="bg-white text-slate-950">
+      <section className="border-b border-slate-200 bg-slate-950 px-4 py-14 text-white sm:px-6 sm:py-20">
+        <div className="mx-auto max-w-5xl text-center">
+          <p className="text-xs font-extrabold uppercase tracking-[0.18em] text-red-300">Indiana host-shop directory</p>
+          <h1 className="mt-3 text-4xl font-black tracking-tight sm:text-5xl">Support local shops. Explore apprenticeship opportunities.</h1>
+          <p className="mx-auto mt-5 max-w-3xl text-lg leading-8 text-slate-300">
+            Elevate’s host-shop network connects future barbers with working Indiana shops while helping customers discover and support the local businesses participating in apprenticeship training.
+          </p>
+        </div>
+      </section>
+
+      <section className="px-4 py-12 sm:px-6 sm:py-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-5 md:grid-cols-2 lg:grid-cols-3">
+            {FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => {
+              const publicName = shop.dba ?? shop.name;
+              const externalUrl = shop.websiteUrl ?? shop.onlineListingUrl ?? shop.socialUrl;
+              const externalLabel = shop.websiteLabel ?? shop.onlineListingLabel ?? shop.socialLabel ?? 'Visit shop online';
+              return (
+                <article key={shop.slug} className="flex flex-col rounded-2xl border border-slate-200 bg-white p-6 shadow-sm">
+                  <p className="text-xs font-extrabold uppercase tracking-wide text-brand-red-700">{shop.city}, Indiana</p>
+                  <h2 className="mt-2 text-2xl font-black">{publicName}</h2>
+                  <p className="mt-3 flex items-start gap-2 text-sm font-semibold text-slate-700">
+                    <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-brand-red-700" />
+                    {shop.address}, {shop.city}, {shop.state} {shop.zip}
+                  </p>
+                  {shop.phone ? (
+                    <a href={`tel:${shop.phone.replace(/[^0-9+]/g, '')}`} className="mt-3 flex items-center gap-2 text-sm font-bold text-slate-800 hover:text-brand-red-700">
+                      <Phone className="h-4 w-4 text-brand-red-700" /> {shop.phone}
+                    </a>
+                  ) : null}
+                  <p className="mt-4 flex-1 text-sm leading-6 text-slate-700">{shop.marketingBlurb ?? shop.note}</p>
+                  <div className="mt-6 flex flex-wrap gap-2">
+                    <Link href={`/host-shops/${shop.slug}`} className="rounded-xl bg-brand-red-600 px-4 py-2 text-sm font-extrabold text-white hover:bg-brand-red-700">
+                      Shop profile
+                    </Link>
+                    {externalUrl ? (
+                      <a href={externalUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold hover:bg-slate-50">
+                        {externalLabel} <ExternalLink className="h-4 w-4" />
+                      </a>
+                    ) : null}
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-slate-200 bg-slate-50 px-4 py-12 text-center sm:px-6">
+        <div className="mx-auto max-w-4xl">
+          <h2 className="text-3xl font-black">Want to become a barber apprentice?</h2>
+          <p className="mt-4 leading-7 text-slate-700">Apply through Elevate for Humanity. Host-shop availability is reviewed during enrollment and placement.</p>
+          <Link href="/programs/barber-apprenticeship/apply" className="mt-7 inline-flex rounded-xl bg-brand-red-600 px-6 py-3 font-extrabold text-white hover:bg-brand-red-700">
+            Apply for Barber Apprenticeship
+          </Link>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/apps/marketing/app/sitemap.ts
+++ b/apps/marketing/app/sitemap.ts
@@ -1,8 +1,9 @@
 import type { MetadataRoute } from 'next';
 import { ROUTES } from '@/lib/navigation/routes';
+import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
 
 const baseUrl = 'https://www.elevateforhumanity.org';
-const lastModified = new Date('2026-08-09T00:00:00-04:00');
+const lastModified = new Date('2026-08-09T20:55:00-04:00');
 
 export default function sitemap(): MetadataRoute.Sitemap {
   const coreRoutes: Array<{
@@ -17,6 +18,7 @@ export default function sitemap(): MetadataRoute.Sitemap {
     { path: ROUTES.apprenticeshipsHowItWorks, changeFrequency: 'monthly', priority: 0.85 },
     { path: ROUTES.programsBeauty, changeFrequency: 'weekly', priority: 0.95 },
     { path: ROUTES.apprenticeshipsHostShop, changeFrequency: 'weekly', priority: 0.9 },
+    { path: '/host-shops', changeFrequency: 'weekly', priority: 0.9 },
     { path: ROUTES.apprenticeshipSponsor, changeFrequency: 'monthly', priority: 0.85 },
     { path: ROUTES.testing, changeFrequency: 'weekly', priority: 0.9 },
     { path: ROUTES.funding, changeFrequency: 'weekly', priority: 0.9 },
@@ -78,6 +80,8 @@ export default function sitemap(): MetadataRoute.Sitemap {
     '/store/testing',
   ];
 
+  const hostShopRoutes = FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => `/host-shops/${shop.slug}`);
+
   const seen = new Set<string>();
   return [
     ...coreRoutes.map(({ path, changeFrequency, priority }) => ({
@@ -91,6 +95,12 @@ export default function sitemap(): MetadataRoute.Sitemap {
       lastModified,
       changeFrequency: 'weekly' as const,
       priority: path.includes('apprenticeship') ? 0.95 : 0.8,
+    })),
+    ...hostShopRoutes.map((path) => ({
+      url: `${baseUrl}${path}`,
+      lastModified,
+      changeFrequency: 'weekly' as const,
+      priority: 0.82,
     })),
     ...appStoreRoutes.map((path) => ({
       url: `${baseUrl}${path}`,

--- a/components/programs/beauty/BarberWorkforceNetworkMap.tsx
+++ b/components/programs/beauty/BarberWorkforceNetworkMap.tsx
@@ -2,59 +2,93 @@
 
 import { useMemo, useState } from 'react';
 import { MapPin, Navigation, Phone } from 'lucide-react';
+import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
 import {
   BARBER_WORKFORCE_NETWORK_PINS,
   type NetworkMapPin,
 } from '@/lib/apprenticeship-programs/workforce-network-locations';
 
-const KIND_LABEL: Record<NetworkMapPin['kind'], string> = {
+type DisplayPin = {
+  id: string;
+  kind: NetworkMapPin['kind'];
+  name: string;
+  address: string;
+  city: string;
+  state: string;
+  zip: string;
+  phone?: string;
+  lat?: number;
+  lng?: number;
+  href?: string;
+};
+
+const KIND_LABEL: Record<DisplayPin['kind'], string> = {
   workone: 'WorkOne',
   elevate: 'Elevate',
   host_shop: 'Host shop',
   satellite: 'Satellite / partner site',
 };
 
-function directionsUrl(pin: NetworkMapPin) {
-  const q = encodeURIComponent(`${pin.address}, ${pin.city}, ${pin.state} ${pin.zip}`);
-  return `https://www.google.com/maps/dir/?api=1&destination=${q}`;
+const HOST_SHOP_PINS: DisplayPin[] = FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => ({
+  id: `host-${shop.slug}`,
+  kind: 'host_shop',
+  name: shop.dba ?? shop.name,
+  address: shop.address,
+  city: shop.city,
+  state: shop.state,
+  zip: shop.zip,
+  phone: shop.phone,
+  href: `/host-shops/${shop.slug}`,
+}));
+
+const SUPPORT_PINS: DisplayPin[] = BARBER_WORKFORCE_NETWORK_PINS
+  .filter((pin) => pin.kind !== 'host_shop')
+  .map((pin) => ({ ...pin }));
+
+const MAP_PINS: DisplayPin[] = [...HOST_SHOP_PINS, ...SUPPORT_PINS];
+
+function fullAddress(pin: DisplayPin) {
+  return `${pin.address}, ${pin.city}, ${pin.state} ${pin.zip}`;
 }
 
-function embedUrl(pin: NetworkMapPin) {
-  const q = encodeURIComponent(`${pin.lat},${pin.lng}`);
-  return `https://www.google.com/maps?q=${q}&z=14&output=embed`;
+function directionsUrl(pin: DisplayPin) {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(fullAddress(pin))}`;
+}
+
+function embedUrl(pin: DisplayPin) {
+  const q = pin.lat != null && pin.lng != null ? `${pin.lat},${pin.lng}` : fullAddress(pin);
+  return `https://www.google.com/maps?q=${encodeURIComponent(q)}&z=14&output=embed`;
 }
 
 export default function BarberWorkforceNetworkMap() {
-  const [selectedId, setSelectedId] = useState(BARBER_WORKFORCE_NETWORK_PINS[0]?.id ?? '');
+  const [selectedId, setSelectedId] = useState(MAP_PINS[0]?.id ?? '');
   const selected = useMemo(
-    () => BARBER_WORKFORCE_NETWORK_PINS.find((p) => p.id === selectedId) ?? BARBER_WORKFORCE_NETWORK_PINS[0],
+    () => MAP_PINS.find((pin) => pin.id === selectedId) ?? MAP_PINS[0],
     [selectedId],
   );
 
   return (
-    <section className="py-12 bg-white border-y border-slate-200" id="network-map">
-      <div className="max-w-6xl mx-auto px-4 sm:px-6">
-        <p className="text-xs font-bold uppercase tracking-widest text-brand-red-700 mb-2">
+    <section className="border-y border-slate-200 bg-white py-12" id="network-map">
+      <div className="mx-auto max-w-6xl px-4 sm:px-6">
+        <p className="mb-2 text-xs font-bold uppercase tracking-widest text-brand-red-700">
           Find support near you
         </p>
-        <h2 className="text-2xl font-bold text-slate-950 mb-3">
-          Barber program map — host shops, WorkOne &amp; satellites
+        <h2 className="mb-3 text-2xl font-bold text-slate-950">
+          Barber program map — every host shop plus workforce support
         </h2>
-        <p className="text-slate-800 mb-8 max-w-3xl leading-relaxed font-medium">
-          Use this map to find Elevate enrollment support, approved host barbershops, and WorkOne
-          locations that can help eligible participants navigate workforce services. Public host-shop
-          listings include Kountry Kutz Barbershop and Style and Scissor Salon, with additional
-          approved shops shown in the host-shop network above.
+        <p className="mb-8 max-w-3xl font-medium leading-relaxed text-slate-800">
+          Select any approved host shop to see its exact public address, phone number when verified,
+          map, and directions. WorkOne and Elevate support locations remain available in the same map.
         </p>
 
-        <div className="grid lg:grid-cols-5 gap-6">
-          <div className="lg:col-span-2 space-y-2 max-h-[420px] overflow-y-auto pr-1">
-            {BARBER_WORKFORCE_NETWORK_PINS.map((pin) => (
+        <div className="grid gap-6 lg:grid-cols-5">
+          <div className="max-h-[520px] space-y-2 overflow-y-auto pr-1 lg:col-span-2">
+            {MAP_PINS.map((pin) => (
               <button
                 key={pin.id}
                 type="button"
                 onClick={() => setSelectedId(pin.id)}
-                className={`w-full text-left rounded-lg border p-4 transition-colors ${
+                className={`w-full rounded-lg border p-4 text-left transition-colors ${
                   pin.id === selected?.id
                     ? 'border-brand-red-500 bg-brand-red-50'
                     : 'border-slate-300 bg-slate-50 hover:border-slate-400'
@@ -63,25 +97,28 @@ export default function BarberWorkforceNetworkMap() {
                 <span className="text-xs font-bold uppercase tracking-wide text-brand-blue-800">
                   {KIND_LABEL[pin.kind]}
                 </span>
-                <p className="font-bold text-slate-950 mt-1">{pin.name}</p>
-                <p className="text-sm text-slate-800 mt-1 font-medium">
-                  {pin.address}, {pin.city}, {pin.state}
-                </p>
+                <p className="mt-1 font-bold text-slate-950">{pin.name}</p>
+                <p className="mt-1 text-sm font-medium text-slate-800">{fullAddress(pin)}</p>
+                {pin.phone ? <p className="mt-1 text-sm font-semibold text-slate-700">{pin.phone}</p> : null}
               </button>
             ))}
           </div>
 
           <div className="lg:col-span-3">
-            {selected && (
+            {selected ? (
               <>
-                <div className="rounded-xl overflow-hidden border border-slate-300 shadow-md h-[280px] sm:h-[360px] mb-4">
+                <div className="mb-4 h-[280px] overflow-hidden rounded-xl border border-slate-300 shadow-md sm:h-[390px]">
                   <iframe
                     title={`Map — ${selected.name}`}
                     src={embedUrl(selected)}
-                    className="w-full h-full border-0"
+                    className="h-full w-full border-0"
                     loading="lazy"
                     referrerPolicy="no-referrer-when-downgrade"
                   />
+                </div>
+                <div className="mb-4">
+                  <p className="text-lg font-black text-slate-950">{selected.name}</p>
+                  <p className="mt-1 text-sm font-medium text-slate-700">{fullAddress(selected)}</p>
                 </div>
                 <div className="flex flex-wrap gap-3">
                   <a
@@ -90,40 +127,37 @@ export default function BarberWorkforceNetworkMap() {
                     rel="noopener noreferrer"
                     className="inline-flex items-center gap-2 rounded-lg bg-brand-red-600 px-5 py-2.5 text-sm font-bold text-white hover:bg-brand-red-700"
                   >
-                    <Navigation className="w-4 h-4" />
-                    Directions
+                    <Navigation className="h-4 w-4" /> Directions
                   </a>
-                  {selected.phone && (
+                  {selected.phone ? (
                     <a
-                      href={`tel:${selected.phone.replace(/[^0-9]/g, '')}`}
+                      href={`tel:${selected.phone.replace(/[^0-9+]/g, '')}`}
                       className="inline-flex items-center gap-2 rounded-lg border border-slate-400 px-5 py-2.5 text-sm font-bold text-slate-900 hover:bg-slate-50"
                     >
-                      <Phone className="w-4 h-4" />
-                      {selected.phone}
+                      <Phone className="h-4 w-4" /> {selected.phone}
                     </a>
-                  )}
-                  {selected.href && (
+                  ) : null}
+                  {selected.href ? (
                     <a
                       href={selected.href}
                       target={selected.href.startsWith('http') ? '_blank' : undefined}
                       rel={selected.href.startsWith('http') ? 'noopener noreferrer' : undefined}
                       className="inline-flex items-center gap-2 rounded-lg border border-slate-400 px-5 py-2.5 text-sm font-bold text-slate-900 hover:bg-slate-50"
                     >
-                      <MapPin className="w-4 h-4" />
-                      More info
+                      <MapPin className="h-4 w-4" /> More info
                     </a>
-                  )}
+                  ) : null}
                 </div>
               </>
-            )}
+            ) : null}
           </div>
         </div>
 
-        <p className="text-xs text-slate-700 mt-6 font-medium">
+        <p className="mt-6 text-xs font-medium text-slate-700">
           All Indiana WorkOne centers:{' '}
           <a
             href="https://www.in.gov/dwd/workone/workone-locations/"
-            className="text-brand-blue-700 font-bold hover:underline"
+            className="font-bold text-brand-blue-700 hover:underline"
             target="_blank"
             rel="noopener noreferrer"
           >

--- a/components/programs/beauty/FeaturedHostPartners.tsx
+++ b/components/programs/beauty/FeaturedHostPartners.tsx
@@ -1,4 +1,7 @@
 import Image from 'next/image';
+import Link from 'next/link';
+import { ExternalLink, MapPin, Navigation, Phone } from 'lucide-react';
+import HostShopShowcase from '@/components/programs/beauty/HostShopShowcase';
 import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
 
 function programLabel(program: string) {
@@ -8,117 +11,175 @@ function programLabel(program: string) {
     .replace(/\b\w/g, (letter) => letter.toUpperCase());
 }
 
+function directionsUrl(address: string) {
+  return `https://www.google.com/maps/dir/?api=1&destination=${encodeURIComponent(address)}`;
+}
+
+function phoneHref(phone: string) {
+  return `tel:${phone.replace(/[^0-9+]/g, '')}`;
+}
+
 export default function FeaturedHostPartners() {
   return (
-    <section className="border-y border-slate-200 bg-slate-50 px-4 py-14 sm:px-6 sm:py-16">
-      <div className="mx-auto max-w-6xl">
-        <p className="text-center text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">
-          Training network
-        </p>
-        <h2 className="mt-2 text-center text-3xl font-black tracking-tight text-slate-950 sm:text-4xl">
-          Host barbershops &amp; training partners
-        </h2>
-        <p className="mx-auto mt-3 max-w-3xl text-center text-base font-medium leading-7 text-slate-700">
-          Indiana host shops supporting hands-on apprenticeship training, supervised workplace learning,
-          and career development.
-        </p>
+    <>
+      <HostShopShowcase />
 
-        <div className="mt-10 grid gap-6 lg:grid-cols-2">
-          {FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => (
-            <article
-              key={shop.name}
-              className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
-            >
-              {shop.media?.length ? (
-                <div
-                  className={
-                    shop.media.length > 1
-                      ? 'grid grid-cols-2 gap-px bg-slate-200'
-                      : 'bg-slate-100'
-                  }
+      <section className="border-y border-slate-200 bg-slate-50 px-4 py-14 sm:px-6 sm:py-16" id="host-shops">
+        <div className="mx-auto max-w-6xl">
+          <p className="text-center text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">
+            Training network & local businesses
+          </p>
+          <h2 className="mt-2 text-center text-3xl font-black tracking-tight text-slate-950 sm:text-4xl">
+            Visit, book, and train with our host-shop network
+          </h2>
+          <p className="mx-auto mt-3 max-w-3xl text-center text-base font-medium leading-7 text-slate-700">
+            Each participating shop is a real local business. Use the contact, website, and map links below to support the shops, explore services, or learn about future apprenticeship opportunities.
+          </p>
+
+          <div className="mt-10 grid gap-6 lg:grid-cols-2">
+            {FEATURED_BEAUTY_HOST_PARTNERS.map((shop) => {
+              const image = shop.media?.[0];
+              const fullAddress = `${shop.address}, ${shop.city}, ${shop.state} ${shop.zip}`;
+              return (
+                <article
+                  key={shop.slug}
+                  className="overflow-hidden rounded-3xl border border-slate-200 bg-white shadow-sm"
                 >
-                  {shop.media.map((media) => (
-                    <div
-                      key={media.src}
-                      className={`relative overflow-hidden bg-slate-100 ${
-                        shop.media && shop.media.length > 1 ? 'aspect-[4/5]' : 'aspect-[4/3]'
-                      }`}
-                    >
+                  {image ? (
+                    <div className="relative aspect-[16/10] overflow-hidden bg-slate-100">
                       <Image
-                        src={media.src}
-                        alt={media.alt}
+                        src={image.src}
+                        alt={image.alt}
                         fill
                         sizes="(max-width: 1024px) 100vw, 50vw"
-                        className={media.kind === 'flyer' ? 'object-contain bg-white p-2' : 'object-cover'}
+                        className={image.kind === 'flyer' ? 'object-contain bg-white p-3' : 'object-cover'}
                       />
                     </div>
-                  ))}
-                </div>
-              ) : null}
+                  ) : null}
 
-              <div className="p-6 sm:p-7">
-                <div className="flex flex-wrap items-start justify-between gap-3">
-                  <div>
-                    <h3 className="text-2xl font-black tracking-tight text-slate-950">
-                      {shop.dba ?? shop.name}
-                    </h3>
-                    {shop.dba ? (
-                      <p className="mt-1 text-sm font-semibold text-slate-600">Legal name: {shop.name}</p>
-                    ) : null}
-                  </div>
-                  <span className="rounded-full bg-brand-blue-50 px-3 py-1 text-xs font-extrabold uppercase tracking-wide text-brand-blue-800">
-                    {shop.city}, {shop.state}
-                  </span>
-                </div>
+                  <div className="p-6 sm:p-7">
+                    <div className="flex flex-wrap items-start justify-between gap-3">
+                      <div>
+                        <h3 className="text-2xl font-black tracking-tight text-slate-950">
+                          {shop.dba ?? shop.name}
+                        </h3>
+                        {shop.dba ? (
+                          <p className="mt-1 text-sm font-semibold text-slate-600">Legal name: {shop.name}</p>
+                        ) : null}
+                      </div>
+                      <span className="rounded-full bg-brand-blue-50 px-3 py-1 text-xs font-extrabold uppercase tracking-wide text-brand-blue-800">
+                        {shop.city}, {shop.state}
+                      </span>
+                    </div>
 
-                {shop.note ? (
-                  <p className="mt-4 text-sm font-medium leading-6 text-slate-700">{shop.note}</p>
-                ) : null}
+                    <p className="mt-4 text-sm font-medium leading-6 text-slate-700">
+                      {shop.marketingBlurb ?? shop.note}
+                    </p>
 
-                {shop.phone ? (
-                  <p className="mt-3 text-sm font-bold text-slate-800">Phone: {shop.phone}</p>
-                ) : null}
+                    <div className="mt-5 space-y-3 border-y border-slate-100 py-5">
+                      <p className="flex items-start gap-2 text-sm font-bold text-slate-800">
+                        <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-brand-red-700" aria-hidden="true" />
+                        <span>{fullAddress}</span>
+                      </p>
+                      {shop.phone ? (
+                        <a
+                          href={phoneHref(shop.phone)}
+                          className="flex items-center gap-2 text-sm font-bold text-slate-800 hover:text-brand-red-700"
+                        >
+                          <Phone className="h-4 w-4 text-brand-red-700" aria-hidden="true" />
+                          {shop.phone}
+                        </a>
+                      ) : (
+                        <p className="text-sm font-semibold text-slate-600">
+                          Direct public phone not yet verified — use the shop contact link below.
+                        </p>
+                      )}
+                    </div>
 
-                <div className="mt-5 flex flex-wrap gap-2">
-                  {shop.programs.map((program) => (
-                    <span
-                      key={program}
-                      className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-700"
-                    >
-                      {programLabel(program)}
-                    </span>
-                  ))}
-                </div>
+                    <div className="mt-5 flex flex-wrap gap-2">
+                      {shop.programs.map((program) => (
+                        <span
+                          key={program}
+                          className="rounded-full border border-slate-200 bg-slate-50 px-3 py-1 text-xs font-bold text-slate-700"
+                        >
+                          {programLabel(program)}
+                        </span>
+                      ))}
+                    </div>
 
-                {(shop.resourceUrl || shop.websiteUrl) && (
-                  <div className="mt-6 flex flex-wrap gap-3 border-t border-slate-100 pt-5">
-                    {shop.websiteUrl ? (
-                      <a
-                        href={shop.websiteUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
-                      >
-                        Visit shop website
-                      </a>
-                    ) : null}
-                    {shop.resourceUrl ? (
-                      <a
-                        href={shop.resourceUrl}
-                        target="_blank"
-                        rel="noopener noreferrer"
+                    <div className="mt-6 flex flex-wrap gap-3">
+                      <Link
+                        href={`/host-shops/${shop.slug}`}
                         className="inline-flex min-h-10 items-center justify-center rounded-xl bg-brand-red-600 px-4 py-2 text-sm font-extrabold text-white transition hover:bg-brand-red-700"
                       >
-                        {shop.resourceLabel ?? 'View shop document'}
+                        Shop profile
+                      </Link>
+                      <a
+                        href={directionsUrl(fullAddress)}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        className="inline-flex min-h-10 items-center justify-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
+                      >
+                        <Navigation className="h-4 w-4" aria-hidden="true" /> Map & directions
                       </a>
-                    ) : null}
+                      {shop.websiteUrl ? (
+                        <a
+                          href={shop.websiteUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-10 items-center justify-center gap-2 rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
+                        >
+                          {shop.websiteLabel ?? 'Visit shop website'} <ExternalLink className="h-4 w-4" />
+                        </a>
+                      ) : null}
+                      {shop.bookingUrl ? (
+                        <a
+                          href={shop.bookingUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
+                        >
+                          Book services
+                        </a>
+                      ) : null}
+                      {shop.socialUrl ? (
+                        <a
+                          href={shop.socialUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
+                        >
+                          {shop.socialLabel ?? 'Photos & social'}
+                        </a>
+                      ) : null}
+                      {shop.onlineListingUrl ? (
+                        <a
+                          href={shop.onlineListingUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-slate-300 px-4 py-2 text-sm font-extrabold text-slate-900 transition hover:bg-slate-50"
+                        >
+                          {shop.onlineListingLabel ?? 'View shop listing'}
+                        </a>
+                      ) : null}
+                      {shop.resourceUrl ? (
+                        <a
+                          href={shop.resourceUrl}
+                          target="_blank"
+                          rel="noopener noreferrer"
+                          className="inline-flex min-h-10 items-center justify-center rounded-xl border border-brand-red-200 bg-brand-red-50 px-4 py-2 text-sm font-extrabold text-brand-red-800 transition hover:bg-brand-red-100"
+                        >
+                          {shop.resourceLabel ?? 'View shop document'}
+                        </a>
+                      ) : null}
+                    </div>
                   </div>
-                )}
-              </div>
-            </article>
-          ))}
+                </article>
+              );
+            })}
+          </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </>
   );
 }

--- a/components/programs/beauty/HostShopShowcase.tsx
+++ b/components/programs/beauty/HostShopShowcase.tsx
@@ -1,0 +1,159 @@
+'use client';
+
+import Image from 'next/image';
+import Link from 'next/link';
+import { ChevronLeft, ChevronRight, ExternalLink, MapPin, Pause, Play, Scissors } from 'lucide-react';
+import { useEffect, useMemo, useState } from 'react';
+import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
+
+const ROTATION_MS = 6500;
+
+export default function HostShopShowcase() {
+  const shops = useMemo(() => FEATURED_BEAUTY_HOST_PARTNERS, []);
+  const [activeIndex, setActiveIndex] = useState(0);
+  const [paused, setPaused] = useState(false);
+  const [reduceMotion, setReduceMotion] = useState(false);
+
+  useEffect(() => {
+    const query = window.matchMedia('(prefers-reduced-motion: reduce)');
+    const sync = () => setReduceMotion(query.matches);
+    sync();
+    query.addEventListener('change', sync);
+    return () => query.removeEventListener('change', sync);
+  }, []);
+
+  useEffect(() => {
+    if (paused || reduceMotion || shops.length < 2) return;
+    const timer = window.setInterval(() => {
+      setActiveIndex((current) => (current + 1) % shops.length);
+    }, ROTATION_MS);
+    return () => window.clearInterval(timer);
+  }, [paused, reduceMotion, shops.length]);
+
+  if (!shops.length) return null;
+
+  const shop = shops[activeIndex];
+  const image = shop.media?.[0];
+  const externalUrl = shop.websiteUrl ?? shop.onlineListingUrl ?? shop.socialUrl;
+  const externalLabel = shop.websiteLabel ?? shop.onlineListingLabel ?? shop.socialLabel ?? 'Visit shop online';
+
+  function go(delta: number) {
+    setActiveIndex((current) => (current + delta + shops.length) % shops.length);
+  }
+
+  return (
+    <section aria-labelledby="host-shop-showcase-heading" className="bg-slate-950 px-4 py-12 text-white sm:px-6 sm:py-16">
+      <div className="mx-auto max-w-6xl">
+        <div className="mb-7 flex flex-col gap-4 sm:flex-row sm:items-end sm:justify-between">
+          <div>
+            <p className="text-xs font-extrabold uppercase tracking-[0.18em] text-red-300">Meet the host-shop network</p>
+            <h2 id="host-shop-showcase-heading" className="mt-2 text-3xl font-black tracking-tight sm:text-4xl">
+              Train in real shops. Discover the businesses behind the apprenticeship.
+            </h2>
+            <p className="mt-3 max-w-3xl text-base leading-7 text-slate-300">
+              This rotating showcase introduces approved host shops, where they are located, and how to visit, book, or learn more.
+            </p>
+          </div>
+          <button
+            type="button"
+            onClick={() => setPaused((value) => !value)}
+            className="inline-flex min-h-11 items-center justify-center gap-2 self-start rounded-xl border border-white/25 px-4 py-2 text-sm font-bold text-white hover:bg-white/10 sm:self-auto"
+            aria-label={paused ? 'Resume host shop slideshow' : 'Pause host shop slideshow'}
+          >
+            {paused ? <Play className="h-4 w-4" /> : <Pause className="h-4 w-4" />}
+            {paused ? 'Play' : 'Pause'}
+          </button>
+        </div>
+
+        <div className="overflow-hidden rounded-3xl border border-white/10 bg-slate-900">
+          <div className="grid min-h-[430px] lg:grid-cols-[1.15fr_0.85fr]">
+            <div className="relative min-h-[300px] overflow-hidden bg-slate-800 lg:min-h-[430px]">
+              {image ? (
+                <Image
+                  key={image.src}
+                  src={image.src}
+                  alt={image.alt}
+                  fill
+                  priority={activeIndex === 0}
+                  sizes="(max-width: 1024px) 100vw, 58vw"
+                  className={image.kind === 'flyer' ? 'object-contain bg-white p-4' : 'object-cover'}
+                />
+              ) : (
+                <div className="absolute inset-0 flex flex-col items-center justify-center bg-gradient-to-br from-slate-800 via-slate-900 to-black px-8 text-center">
+                  <Scissors className="h-14 w-14 text-red-300" aria-hidden="true" />
+                  <p className="mt-5 text-3xl font-black">{shop.dba ?? shop.name}</p>
+                  <p className="mt-2 text-slate-300">{shop.city}, {shop.state}</p>
+                </div>
+              )}
+            </div>
+
+            <div className="flex flex-col justify-center p-7 sm:p-9 lg:p-10" aria-live="polite">
+              <p className="text-xs font-extrabold uppercase tracking-[0.16em] text-red-300">
+                Featured host shop {activeIndex + 1} of {shops.length}
+              </p>
+              <h3 className="mt-3 text-3xl font-black tracking-tight">{shop.dba ?? shop.name}</h3>
+              {shop.dba ? <p className="mt-1 text-sm text-slate-400">Legal name: {shop.name}</p> : null}
+              <p className="mt-5 text-base leading-7 text-slate-300">{shop.marketingBlurb ?? shop.note}</p>
+              <p className="mt-5 flex items-start gap-2 text-sm font-semibold text-slate-200">
+                <MapPin className="mt-0.5 h-4 w-4 shrink-0 text-red-300" aria-hidden="true" />
+                <span>{shop.address}, {shop.city}, {shop.state} {shop.zip}</span>
+              </p>
+
+              <div className="mt-7 flex flex-wrap gap-3">
+                <Link
+                  href={`/host-shops/${shop.slug}`}
+                  className="inline-flex min-h-11 items-center justify-center rounded-xl bg-red-600 px-5 py-2.5 text-sm font-extrabold text-white hover:bg-red-500"
+                >
+                  Explore this host shop
+                </Link>
+                {externalUrl ? (
+                  <a
+                    href={externalUrl}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="inline-flex min-h-11 items-center justify-center gap-2 rounded-xl border border-white/25 px-5 py-2.5 text-sm font-extrabold text-white hover:bg-white/10"
+                  >
+                    {externalLabel} <ExternalLink className="h-4 w-4" />
+                  </a>
+                ) : null}
+              </div>
+            </div>
+          </div>
+
+          <div className="flex flex-wrap items-center justify-between gap-4 border-t border-white/10 px-5 py-4 sm:px-7">
+            <div className="flex gap-2" aria-label="Choose a host shop slide">
+              {shops.map((item, index) => (
+                <button
+                  key={item.slug}
+                  type="button"
+                  onClick={() => setActiveIndex(index)}
+                  className={`h-2.5 rounded-full transition-all ${index === activeIndex ? 'w-8 bg-red-400' : 'w-2.5 bg-white/30 hover:bg-white/50'}`}
+                  aria-label={`Show ${item.dba ?? item.name}`}
+                  aria-current={index === activeIndex ? 'true' : undefined}
+                />
+              ))}
+            </div>
+            <div className="flex gap-2">
+              <button
+                type="button"
+                onClick={() => go(-1)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 hover:bg-white/10"
+                aria-label="Previous host shop"
+              >
+                <ChevronLeft className="h-5 w-5" />
+              </button>
+              <button
+                type="button"
+                onClick={() => go(1)}
+                className="inline-flex h-10 w-10 items-center justify-center rounded-full border border-white/20 hover:bg-white/10"
+                aria-label="Next host shop"
+              >
+                <ChevronRight className="h-5 w-5" />
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/programs/beauty/HostShopShowcase.tsx
+++ b/components/programs/beauty/HostShopShowcase.tsx
@@ -2,7 +2,7 @@
 
 import Image from 'next/image';
 import Link from 'next/link';
-import { ChevronLeft, ChevronRight, ExternalLink, MapPin, Pause, Play, Scissors } from 'lucide-react';
+import { ChevronLeft, ChevronRight, ExternalLink, MapPin, Pause, Play } from 'lucide-react';
 import { useEffect, useMemo, useState } from 'react';
 import { FEATURED_BEAUTY_HOST_PARTNERS } from '@/lib/apprenticeship-programs/host-partners';
 
@@ -79,10 +79,9 @@ export default function HostShopShowcase() {
                   className={image.kind === 'flyer' ? 'object-contain bg-white p-4' : 'object-cover'}
                 />
               ) : (
-                <div className="absolute inset-0 flex flex-col items-center justify-center bg-gradient-to-br from-slate-800 via-slate-900 to-black px-8 text-center">
-                  <Scissors className="h-14 w-14 text-red-300" aria-hidden="true" />
-                  <p className="mt-5 text-3xl font-black">{shop.dba ?? shop.name}</p>
-                  <p className="mt-2 text-slate-300">{shop.city}, {shop.state}</p>
+                <div className="absolute inset-0 flex flex-col justify-end bg-[radial-gradient(circle_at_top_left,rgba(185,28,28,0.32),transparent_42%),linear-gradient(145deg,#1e293b,#020617)] px-8 py-10 sm:px-12 sm:py-12">
+                  <p className="max-w-xl text-4xl font-black tracking-tight sm:text-5xl">{shop.dba ?? shop.name}</p>
+                  <p className="mt-3 text-lg font-semibold text-slate-300">Local business • {shop.city}, {shop.state}</p>
                 </div>
               )}
             </div>

--- a/lib/apprenticeship-programs/host-partners.ts
+++ b/lib/apprenticeship-programs/host-partners.ts
@@ -1,6 +1,6 @@
 /**
  * Featured host / training partners shown on marketing pages.
- * Update when new shops are approved in admin.
+ * Keep this public-facing dataset limited to verified business contact details.
  */
 export type FeaturedHostPartnerMedia = {
   src: string;
@@ -9,44 +9,70 @@ export type FeaturedHostPartnerMedia = {
 };
 
 export type FeaturedHostPartner = {
+  slug: string;
   name: string;
   dba?: string;
+  businessType?: 'BarberShop' | 'HairSalon';
   city: string;
   state: string;
+  zip: string;
+  address: string;
   programs: string[];
   note?: string;
+  marketingBlurb?: string;
   media?: FeaturedHostPartnerMedia[];
   resourceUrl?: string;
   resourceLabel?: string;
   websiteUrl?: string;
+  websiteLabel?: string;
+  bookingUrl?: string;
+  socialUrl?: string;
+  socialLabel?: string;
+  onlineListingUrl?: string;
+  onlineListingLabel?: string;
   phone?: string;
 };
 
 export const FEATURED_BEAUTY_HOST_PARTNERS: FeaturedHostPartner[] = [
   {
+    slug: 'kountry-kutz-barbershop',
     name: 'Kountry Kutz Barbershop',
+    businessType: 'BarberShop',
     city: 'New Palestine',
     state: 'IN',
+    zip: '46163',
+    address: '56 W Main St, Suite A',
+    phone: '(463) 710-6199',
     programs: ['barber-apprenticeship'],
-    note: 'DOL-registered host barbershop partner.',
+    note: 'Approved barber apprenticeship host shop in downtown New Palestine.',
+    marketingBlurb:
+      'A family-oriented Main Street barbershop serving New Palestine with classic cuts, modern grooming, and an apprenticeship training environment.',
+    // Keep one visible image only. The former interior/top image is intentionally not shown.
     media: [
       {
-        src: '/images/partners/kountry-kutz-interior.webp',
-        alt: 'Interior of Kountry Kutz Barbershop with barber stations',
-        kind: 'photo',
-      },
-      {
         src: '/images/partners/kountry-kutz-apprenticeship-flyer.webp',
-        alt: 'Kountry Kutz barber apprenticeship site announcement',
+        alt: 'Kountry Kutz approved barber apprenticeship site announcement',
         kind: 'flyer',
       },
     ],
+    websiteUrl: 'https://kountrykutzbarbershop.com',
+    websiteLabel: 'Visit Kountry Kutz website',
+    socialUrl: 'https://linktr.ee/kountrykutz',
+    socialLabel: 'Photos, video & social',
   },
   {
+    slug: 'cals-kutz-studio',
     name: "Cal's Kutz Studio",
+    businessType: 'BarberShop',
     city: 'Indianapolis',
     state: 'IN',
+    zip: '46268',
+    address: '6240 La Pas Trl',
+    phone: '(317) 201-4841',
     programs: ['barber-apprenticeship'],
+    note: 'Indianapolis barber studio and approved apprenticeship host shop.',
+    marketingBlurb:
+      'A full-service Indianapolis barber studio offering precision cuts, grooming, hair-loss consultation, and professional mentorship in a working shop environment.',
     media: [
       {
         src: '/images/partners/cals-kutz-confidence-restored.webp',
@@ -54,64 +80,117 @@ export const FEATURED_BEAUTY_HOST_PARTNERS: FeaturedHostPartner[] = [
         kind: 'flyer',
       },
     ],
+    websiteUrl: 'https://booksy.com/en-us/211056_cal-s-kutz-studio_barber-shop_19577_indianapolis',
+    websiteLabel: 'Book / view Cal’s Kutz online',
+    socialUrl: 'https://www.instagram.com/calskutzstudio/',
+    socialLabel: 'View Cal’s Kutz photos',
   },
   {
-    name: 'Razors Image Barbershop',
+    slug: 'razors-image-barbershop',
+    name: "Razor's Image Barbershop",
+    businessType: 'BarberShop',
     city: 'Bloomington',
     state: 'IN',
+    zip: '47408',
+    address: '155 S Kingston Dr',
+    phone: '(812) 287-7166',
     programs: ['barber-apprenticeship'],
-    note: 'Approved barber apprenticeship host shop.',
+    note: 'Approved barber apprenticeship host shop in Bloomington.',
+    marketingBlurb:
+      'A multicultural Bloomington barbershop focused on professional grooming, customer service, hair and scalp care, and hands-on barber development.',
+    // One visible photo only. The apprenticeship flyer remains available as a document resource.
     media: [
       {
         src: '/images/partners/razors-image-storefront.webp',
         alt: "Razor's Image Barbershop storefront in Bloomington, Indiana",
         kind: 'photo',
       },
-      {
-        src: '/images/partners/razors-image-apprenticeship-flyer.webp',
-        alt: "Razor's Image barber apprenticeship program flyer",
-        kind: 'flyer',
-      },
     ],
-    resourceUrl: 'https://acrobat.adobe.com/id/urn:aaid:sc:VA6C2:8be7070f-ef4e-42b8-b646-1806801ac9b3',
-    resourceLabel: "View Razor's Image document",
+    resourceUrl:
+      'https://acrobat.adobe.com/id/urn:aaid:sc:VA6C2:8be7070f-ef4e-42b8-b646-1806801ac9b3',
+    resourceLabel: "View Razor's Image apprenticeship document",
     websiteUrl: 'https://razorsimage.com',
+    websiteLabel: "Visit Razor's Image website",
+    bookingUrl: 'https://razorsimage.com/schedule-now/',
+    socialUrl: 'https://www.instagram.com/razors.image/',
+    socialLabel: "View Razor's Image photos",
   },
   {
+    slug: 'b-52s-barber-shop',
     name: "B-52's Barber Shop LLC",
+    dba: 'B-52s Barbershop',
+    businessType: 'BarberShop',
     city: 'New Castle',
     state: 'IN',
+    zip: '47362',
+    address: '314 Parkview Dr, Suite C',
+    phone: '(765) 374-9869',
     programs: ['barber-apprenticeship'],
+    note: 'Traditional New Castle barbershop and apprenticeship host shop.',
+    marketingBlurb:
+      'A traditional New Castle barbershop known for classic barber services including haircuts, razor line-ups, fades, and straight-razor shaves.',
+    onlineListingUrl: 'https://www.bestprosintown.com/in/new-castle/b-52s-barber-shop-/',
+    onlineListingLabel: 'View B-52s shop profile & photos',
   },
   {
+    slug: 'style-and-scissor-salon',
     name: 'Style and Scissor Salon',
-    dba: 'Corinne Yvette Meid — Style and Scissor Salon',
+    dba: 'Style and Scissor Salon & Barber',
+    businessType: 'HairSalon',
     city: 'Sullivan',
     state: 'IN',
+    zip: '47882',
+    address: '10 E Washington St',
+    phone: '(812) 638-2090',
     programs: [
       'barber-apprenticeship',
       'cosmetology-apprenticeship',
       'nail-technician-apprenticeship',
     ],
-    note: '10 E Washington St, Sullivan, IN 47882 — host salon partner.',
+    note: 'Sullivan host salon partner supporting barber and beauty apprenticeship pathways.',
+    marketingBlurb:
+      'A community salon and barber shop in downtown Sullivan offering hair services and traditional barbering in a local, client-focused setting.',
+    // No card image is assigned; the previously submitted Style and Scissor image was intentionally excluded.
+    onlineListingUrl: 'https://www.fresha.com/pl/lvp/style-and-scissor-salon-west-hopewell-street-farmersburg-l1E0B7',
+    onlineListingLabel: 'View Style and Scissor details',
   },
   {
+    slug: 'generations-hair-llc',
     name: 'Generations Hair LLC',
+    businessType: 'HairSalon',
     city: 'Martinsville',
     state: 'IN',
+    zip: '46151',
+    address: '134 N Sycamore St',
     programs: ['barber-apprenticeship'],
-    note: 'Located inside Cat Eye Collective — 134 N Sycamore St, Martinsville, IN 46151.',
+    note: 'Located inside Cat Eye Collective in Martinsville.',
+    marketingBlurb:
+      'An independent Martinsville hair business located inside Cat Eye Collective and participating in the Elevate apprenticeship host-shop network.',
+    socialUrl: 'https://www.instagram.com/midwesternmanes/',
+    socialLabel: 'Contact / view shop photos',
   },
   {
+    slug: 'salon-saloon',
     name: 'Salon Saloon LLC',
     dba: 'Salon Saloon',
+    businessType: 'HairSalon',
     city: 'South Bend',
     state: 'IN',
-    programs: ['barber-apprenticeship'],
-    note: '1740 S Bend Ave., Suite 1, South Bend, IN 46637.',
+    zip: '46637',
+    address: '1740 S Bend Ave, Suite A',
     phone: '(269) 240-7923',
+    programs: ['barber-apprenticeship'],
+    note: 'South Bend host salon partner at its current South Bend Avenue location.',
+    marketingBlurb:
+      'A South Bend salon offering appointment-based hair services while participating in Elevate’s growing apprenticeship host-shop network.',
+    websiteUrl: 'https://tory-103460.square.site/',
+    websiteLabel: 'Book / view Salon Saloon online',
   },
 ];
+
+export function getFeaturedHostPartnerBySlug(slug: string) {
+  return FEATURED_BEAUTY_HOST_PARTNERS.find((shop) => shop.slug === slug);
+}
 
 export const PARTNER_BRAND_ALIASES = {
   prestigeInstitute: 'Elevate Prestige Barber and Beauty Institute',


### PR DESCRIPTION
Rebuilds the public host-shop marketing experience from current main.

Includes:
- rotating autoplay host-shop showcase with pause/previous/next controls and reduced-motion support
- removes the former Kountry Kutz top/interior image from the visible media set
- Razor's Image uses exactly one visible storefront photo; apprenticeship flyer remains document-only
- verified public addresses and phone numbers where available
- map/directions, call, website, booking, social, and public listing CTAs
- Kountry Kutz official site plus photos/video/social discovery link
- Cal's Kutz Booksy and Instagram promotion
- dedicated /host-shops directory
- dedicated SEO profile for every listed host shop
- BarberShop/HairSalon JSON-LD and canonical metadata
- all host-shop profiles added to XML sitemap
- workforce map rebuilt to show every current host shop instead of only the old subset

Generations Hair LLC: public address/social contact are included; no direct public phone was found, so no number is fabricated.

This PR is intentionally draft until production review/deploy approval.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add barber host shop directory, rotating showcase, maps, and SEO profiles to marketing site
> - Adds `/host-shops` directory page listing all featured host partners with address, phone, and external links, and `/host-shops/[slug]` profile pages with Google Maps embed, LD+JSON schema, and Open Graph metadata.
> - Adds a `HostShopShowcase` auto-rotating carousel to the `FeaturedHostPartners` section with pause/play and reduced-motion support.
> - Extends the `FeaturedHostPartner` type and dataset in [host-partners.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/574/files#diff-bf48e5323a07a4ffc0175988693d2766f1dbec395d7976ffd16af649f19ae564) with `slug`, `address`, `zip`, `marketingBlurb`, `businessType`, and external URL fields; adds `getFeaturedHostPartnerBySlug`.
> - Updates `BarberWorkforceNetworkMap` to include host shop pins alongside support locations, with address, phone, directions, and profile links.
> - Adds `/host-shops` and all slug routes to [sitemap.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/574/files#diff-e6e8cdf908bf22e44c4f6fb801583d481ba51341eef99df7cc3fb8b6a5051b5c) with weekly change frequency and 0.82 priority.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bb968c8. (Automatic summaries will resume when PR exits draft mode or review begins).</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->