### PR TITLE
Sync current main orchestration into consolidated release

### DIFF
--- a/apps/admin/app/api/internal/orchestration/process/route.ts
+++ b/apps/admin/app/api/internal/orchestration/process/route.ts
@@ -1,0 +1,51 @@
+import { timingSafeEqual } from 'node:crypto';
+import { NextRequest, NextResponse } from 'next/server';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { processPendingPlatformEvents } from '@/lib/platform/orchestration/dispatcher';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const maxDuration = 60;
+
+function safeEqual(left: string, right: string): boolean {
+  const a = Buffer.from(left);
+  const b = Buffer.from(right);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+function authorized(request: NextRequest, secret: string): boolean {
+  const auth = request.headers.get('authorization') || '';
+  const bearer = auth.startsWith('Bearer ') ? auth.slice(7).trim() : '';
+  const headerSecret = request.headers.get('x-cron-secret') || '';
+  return (!!bearer && safeEqual(bearer, secret)) || (!!headerSecret && safeEqual(headerSecret, secret));
+}
+
+export async function POST(request: NextRequest) {
+  try {
+    await hydrateProcessEnv();
+  } catch (error) {
+    logger.error('[orchestration/process] secret hydration failed', error instanceof Error ? error : undefined);
+  }
+
+  const secret = process.env.CRON_SECRET || '';
+  if (!secret || !authorized(request, secret)) {
+    return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
+  }
+
+  const requested = Number(request.nextUrl.searchParams.get('limit') || '20');
+  const limit = Number.isFinite(requested) ? Math.max(1, Math.min(Math.floor(requested), 100)) : 20;
+
+  try {
+    const result = await processPendingPlatformEvents(limit);
+    return NextResponse.json(result, {
+      status: result.failed > 0 ? 207 : 200,
+      headers: { 'Cache-Control': 'no-store, max-age=0' },
+    });
+  } catch (error) {
+    logger.error('[orchestration/process] batch failed', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Orchestration batch failed' }, { status: 500 });
+  }
+}

--- a/apps/marketing/app/api/apps/upgrade/route.ts
+++ b/apps/marketing/app/api/apps/upgrade/route.ts
@@ -3,6 +3,10 @@ import { createClient } from '@/lib/supabase/server';
 import { getStripe } from '@/lib/stripe/client';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { getIndividualAppCatalog } from '@/lib/apps/individual-app-plans';
+import { individualAppPriceLookupKey } from '@/lib/platform/orchestration/commerce';
+import { resolveCanonicalStripePrice } from '@/lib/stripe/resolve-canonical-price';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -41,11 +45,28 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
   }
 
+  const lookupKey = individualAppPriceLookupKey(catalog.slug, plan.id);
+  let stripePrice;
+  try {
+    stripePrice = await resolveCanonicalStripePrice(stripe, {
+      lookupKey,
+      unitAmount: Math.round(plan.priceMonthly * 100),
+      recurringInterval: 'month',
+    });
+  } catch (error) {
+    const message = error instanceof Error ? error.message : 'Stripe catalog is not configured';
+    return NextResponse.json(
+      { error: 'Subscription catalog is temporarily unavailable', detail: message },
+      { status: 503 },
+    );
+  }
+
   const metadata = {
     checkout_type: 'individual_app',
     user_id: user.id,
     app_slug: catalog.slug,
     plan_id: plan.id,
+    price_lookup_key: lookupKey,
   };
 
   const session = await stripe.checkout.sessions.create({
@@ -55,29 +76,37 @@ export async function POST(request: NextRequest) {
     allow_promotion_codes: true,
     metadata,
     subscription_data: { metadata },
-    line_items: [
-      {
-        price_data: {
-          currency: 'usd',
-          product_data: {
-            name: `${catalog.displayName} — ${plan.name}`,
-            metadata: {
-              app_slug: catalog.slug,
-              plan_id: plan.id,
-            },
-          },
-          unit_amount: Math.round(plan.priceMonthly * 100),
-          recurring: { interval: 'month' },
-        },
-        quantity: 1,
-      },
-    ],
+    line_items: [{ price: stripePrice.id, quantity: 1 }],
     success_url: `${SITE_URL}/store/apps/subscription-success?session_id={CHECKOUT_SESSION_ID}`,
     cancel_url: `${SITE_URL}/store/apps/${catalog.slug}?checkout=cancelled`,
   });
 
   if (!session.url) {
     return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
+  }
+
+  try {
+    const admin = await requireAdminClient();
+    await emitPlatformEvent(admin, {
+      eventType: PlatformEventType.COMMERCE_CHECKOUT_CREATED,
+      category: 'commerce',
+      source: 'marketing.api.apps.upgrade',
+      actorId: user.id,
+      actorType: 'user',
+      subjectType: 'individual_app_subscription',
+      subjectId: session.id,
+      correlationId: session.id,
+      idempotencyKey: `stripe-checkout-created:${session.id}`,
+      dispatch: false,
+      payload: {
+        app_slug: catalog.slug,
+        plan_id: plan.id,
+        stripe_price_id: stripePrice.id,
+        price_lookup_key: lookupKey,
+      },
+    });
+  } catch {
+    // Checkout must not fail because audit/event telemetry is unavailable.
   }
 
   return NextResponse.json({ checkoutUrl: session.url });

--- a/apps/marketing/app/api/apps/upgrade/route.ts
+++ b/apps/marketing/app/api/apps/upgrade/route.ts
@@ -7,6 +7,7 @@ import { individualAppPriceLookupKey } from '@/lib/platform/orchestration/commer
 import { resolveCanonicalStripePrice } from '@/lib/stripe/resolve-canonical-price';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+import { syncIndividualAppLifecycle } from '@/lib/platform/subscription-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -31,19 +32,13 @@ export async function POST(request: NextRequest) {
   const planId = typeof body.plan === 'string' ? body.plan : '';
 
   const catalog = getIndividualAppCatalog(appSlug);
-  if (!catalog) {
-    return NextResponse.json({ error: 'Unknown app' }, { status: 400 });
-  }
+  if (!catalog) return NextResponse.json({ error: 'Unknown app' }, { status: 400 });
 
   const plan = catalog.plans.find((candidate) => candidate.id === planId);
-  if (!plan) {
-    return NextResponse.json({ error: 'Unknown subscription plan' }, { status: 400 });
-  }
+  if (!plan) return NextResponse.json({ error: 'Unknown subscription plan' }, { status: 400 });
 
   const stripe = getStripe();
-  if (!stripe) {
-    return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
-  }
+  if (!stripe) return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
 
   const lookupKey = individualAppPriceLookupKey(catalog.slug, plan.id);
   let stripePrice;
@@ -54,9 +49,11 @@ export async function POST(request: NextRequest) {
       recurringInterval: 'month',
     });
   } catch (error) {
-    const message = error instanceof Error ? error.message : 'Stripe catalog is not configured';
     return NextResponse.json(
-      { error: 'Subscription catalog is temporarily unavailable', detail: message },
+      {
+        error: 'Subscription catalog is temporarily unavailable',
+        detail: error instanceof Error ? error.message : 'Stripe catalog is not configured',
+      },
       { status: 503 },
     );
   }
@@ -68,6 +65,74 @@ export async function POST(request: NextRequest) {
     plan_id: plan.id,
     price_lookup_key: lookupKey,
   };
+
+  const admin = await requireAdminClient();
+  const { data: existing } = await admin
+    .from('user_app_subscriptions')
+    .select('id,status,plan,stripe_subscription_id')
+    .eq('user_id', user.id)
+    .eq('app_slug', catalog.slug)
+    .maybeSingle();
+
+  if (existing?.stripe_subscription_id && ['active', 'trial'].includes(existing.status || '')) {
+    try {
+      const current = await stripe.subscriptions.retrieve(existing.stripe_subscription_id);
+      if (['active', 'trialing'].includes(current.status)) {
+        const item = current.items.data[0];
+        if (!item) {
+          return NextResponse.json({ error: 'The existing Stripe subscription has no billable item.' }, { status: 409 });
+        }
+
+        const updated = item.price.id === stripePrice.id
+          ? current
+          : await stripe.subscriptions.update(current.id, {
+              items: [{ id: item.id, price: stripePrice.id, quantity: 1 }],
+              metadata: { ...current.metadata, ...metadata },
+              proration_behavior: 'create_prorations',
+              payment_behavior: 'error_if_incomplete',
+            });
+
+        if (item.price.id === stripePrice.id && current.metadata?.plan_id !== plan.id) {
+          await stripe.subscriptions.update(current.id, {
+            metadata: { ...current.metadata, ...metadata },
+          });
+        }
+
+        const synchronized = await stripe.subscriptions.retrieve(current.id);
+        await syncIndividualAppLifecycle(admin, synchronized);
+
+        await emitPlatformEvent(admin, {
+          eventType: PlatformEventType.BILLING_SUBSCRIPTION_UPDATED,
+          category: 'billing',
+          source: 'marketing.api.apps.upgrade',
+          actorId: user.id,
+          actorType: 'user',
+          subjectType: 'individual_app_subscription',
+          subjectId: current.id,
+          correlationId: current.id,
+          idempotencyKey: `app-plan-change:${current.id}:${plan.id}:${stripePrice.id}`,
+          dispatch: false,
+          payload: {
+            app_slug: catalog.slug,
+            previous_plan: existing.plan,
+            plan_id: plan.id,
+            stripe_price_id: stripePrice.id,
+          },
+        });
+
+        return NextResponse.json({
+          checkoutUrl: `/apps/${catalog.slug}?subscription=updated&plan=${encodeURIComponent(plan.id)}`,
+          updated: true,
+        });
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : 'Existing subscription could not be updated';
+      return NextResponse.json(
+        { error: 'We could not change the current subscription without creating a duplicate.', detail: message },
+        { status: 409 },
+      );
+    }
+  }
 
   const session = await stripe.checkout.sessions.create({
     mode: 'subscription',
@@ -81,12 +146,9 @@ export async function POST(request: NextRequest) {
     cancel_url: `${SITE_URL}/store/apps/${catalog.slug}?checkout=cancelled`,
   });
 
-  if (!session.url) {
-    return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
-  }
+  if (!session.url) return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
 
   try {
-    const admin = await requireAdminClient();
     await emitPlatformEvent(admin, {
       eventType: PlatformEventType.COMMERCE_CHECKOUT_CREATED,
       category: 'commerce',

--- a/apps/marketing/app/api/host-shop/checkout/route.ts
+++ b/apps/marketing/app/api/host-shop/checkout/route.ts
@@ -1,0 +1,203 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { getStripe } from '@/lib/stripe/client';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { resolveCanonicalStripePrice } from '@/lib/stripe/resolve-canonical-price';
+import { HOST_SHOP_PRICE_LOOKUP_KEYS } from '@/lib/platform/orchestration/commerce';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const SITE_URL = 'https://www.elevateforhumanity.org';
+const APPLICATION_FEE_CENTS = 5000;
+
+type CheckoutBody = {
+  businessName?: string;
+  businessType?: string;
+  contactName?: string;
+  contactEmail?: string;
+  contactPhone?: string;
+  licenseNumber?: string;
+  address?: string;
+  courseSlug?: string;
+};
+
+function clean(value: unknown, max = 240): string {
+  return typeof value === 'string' ? value.trim().slice(0, max) : '';
+}
+
+function validEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(value);
+}
+
+export async function POST(request: NextRequest) {
+  await hydrateProcessEnv();
+
+  let body: CheckoutBody;
+  try {
+    body = await request.json();
+  } catch {
+    return NextResponse.json({ error: 'Invalid request body' }, { status: 400 });
+  }
+
+  const businessName = clean(body.businessName);
+  const businessType = clean(body.businessType, 80);
+  const contactName = clean(body.contactName);
+  const contactEmail = clean(body.contactEmail, 320).toLowerCase();
+  const contactPhone = clean(body.contactPhone, 40);
+  const licenseNumber = clean(body.licenseNumber, 120);
+  const address = clean(body.address, 500);
+  const courseSlug = clean(body.courseSlug, 120) || 'barber-apprenticeship';
+
+  if (!businessName || !contactName || !validEmail(contactEmail)) {
+    return NextResponse.json(
+      { error: 'Business name, contact name, and a valid email are required' },
+      { status: 400 },
+    );
+  }
+
+  const stripe = getStripe();
+  if (!stripe) return NextResponse.json({ error: 'Payment service is unavailable' }, { status: 503 });
+
+  let price;
+  try {
+    price = await resolveCanonicalStripePrice(stripe, {
+      lookupKey: HOST_SHOP_PRICE_LOOKUP_KEYS.application_fee,
+      unitAmount: APPLICATION_FEE_CENTS,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Host Shop application fee is temporarily unavailable',
+        detail: error instanceof Error ? error.message : 'Price not configured',
+      },
+      { status: 503 },
+    );
+  }
+
+  const db = await requireAdminClient();
+  const cutoff = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { data: existing } = await db
+    .from('host_shop_applications')
+    .select('id,stripe_session_id,application_fee_status,created_at')
+    .eq('email', contactEmail)
+    .eq('status', 'drafted')
+    .eq('application_fee_status', 'pending')
+    .gte('created_at', cutoff)
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (existing?.stripe_session_id) {
+    try {
+      const priorSession = await stripe.checkout.sessions.retrieve(existing.stripe_session_id);
+      if (priorSession.status === 'open' && priorSession.url) {
+        return NextResponse.json({
+          applicationId: existing.id,
+          sessionId: priorSession.id,
+          url: priorSession.url,
+          reused: true,
+        });
+      }
+    } catch {
+      // Expired/missing Stripe session: create a replacement for the same draft.
+    }
+  }
+
+  let applicationId = existing?.id as string | undefined;
+  if (!applicationId) {
+    const { data: created, error } = await db
+      .from('host_shop_applications')
+      .insert({
+        shop_name: businessName,
+        business_name: businessName,
+        owner_name: contactName,
+        email: contactEmail,
+        contact_email: contactEmail,
+        phone: contactPhone || null,
+        address: address || null,
+        course_slug: courseSlug,
+        license_info: licenseNumber ? { license_number: licenseNumber } : {},
+        intake: businessType ? { business_type: businessType } : {},
+        status: 'drafted',
+        application_fee_status: 'pending',
+        application_fee_amount_cents: APPLICATION_FEE_CENTS,
+      })
+      .select('id')
+      .single();
+
+    if (error || !created) {
+      logger.error('[host-shop/checkout] draft application creation failed', error ?? undefined);
+      return NextResponse.json({ error: 'Could not start the Host Shop application' }, { status: 500 });
+    }
+    applicationId = created.id;
+  }
+
+  try {
+    const session = await stripe.checkout.sessions.create(
+      {
+        mode: 'payment',
+        line_items: [{ price: price.id, quantity: 1 }],
+        customer_email: contactEmail,
+        client_reference_id: applicationId,
+        metadata: {
+          type: 'host_shop_application_fee',
+          checkout_type: 'host_shop_application_fee',
+          application_id: applicationId,
+          price_lookup_key: HOST_SHOP_PRICE_LOOKUP_KEYS.application_fee,
+        },
+        payment_intent_data: {
+          metadata: {
+            type: 'host_shop_application_fee',
+            application_id: applicationId,
+          },
+        },
+        success_url: `${SITE_URL}/host-shop/apply/success?session_id={CHECKOUT_SESSION_ID}`,
+        cancel_url: `${SITE_URL}/host-shop/apply?application_id=${encodeURIComponent(applicationId)}&checkout=cancelled`,
+        billing_address_collection: 'required',
+        automatic_tax: { enabled: false },
+      },
+      { idempotencyKey: `host-shop-application-fee:${applicationId}` },
+    );
+
+    const { error: updateError } = await db
+      .from('host_shop_applications')
+      .update({ stripe_session_id: session.id, updated_at: new Date().toISOString() })
+      .eq('id', applicationId);
+    if (updateError) {
+      logger.error('[host-shop/checkout] failed to persist Stripe session', updateError, {
+        applicationId,
+        sessionId: session.id,
+      });
+    }
+
+    try {
+      await emitPlatformEvent(db, {
+        eventType: PlatformEventType.COMMERCE_CHECKOUT_CREATED,
+        category: 'commerce',
+        source: 'marketing.api.host-shop.checkout',
+        subjectType: 'host_shop_application',
+        subjectId: applicationId,
+        correlationId: session.id,
+        idempotencyKey: `host-shop-application-checkout:${session.id}`,
+        dispatch: false,
+        payload: {
+          application_id: applicationId,
+          amount_cents: APPLICATION_FEE_CENTS,
+          stripe_price_id: price.id,
+        },
+      });
+    } catch {
+      // Event telemetry cannot invalidate a valid payment session.
+    }
+
+    return NextResponse.json({ applicationId, sessionId: session.id, url: session.url });
+  } catch (error) {
+    logger.error('[host-shop/checkout] Stripe session creation failed', error instanceof Error ? error : undefined, {
+      applicationId,
+    });
+    return NextResponse.json({ error: 'Failed to start payment' }, { status: 502 });
+  }
+}

--- a/apps/marketing/app/api/host-shop/subscription/checkout/route.ts
+++ b/apps/marketing/app/api/host-shop/subscription/checkout/route.ts
@@ -17,6 +17,7 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 
 const SITE_URL = 'https://www.elevateforhumanity.org';
+const HOST_SHOP_DASHBOARD_URL = 'https://app.elevateforhumanity.org/host-shop/dashboard';
 
 export async function POST(request: NextRequest) {
   await hydrateProcessEnv();
@@ -140,7 +141,7 @@ export async function POST(request: NextRequest) {
       });
       await syncHostShopSubscriptionLifecycle(admin, updated);
       return NextResponse.json({
-        url: '/host-shop/dashboard/subscription?subscription=updated',
+        url: `${HOST_SHOP_DASHBOARD_URL}?subscription=updated`,
         sessionId: null,
         updated: true,
       });
@@ -161,7 +162,7 @@ export async function POST(request: NextRequest) {
     metadata,
     subscription_data: { metadata },
     success_url: `${SITE_URL}/host-shop/subscription/success?session_id={CHECKOUT_SESSION_ID}`,
-    cancel_url: `${SITE_URL}/host-shop/dashboard/subscription?checkout=cancelled`,
+    cancel_url: `${HOST_SHOP_DASHBOARD_URL}?checkout=cancelled`,
     billing_address_collection: 'required',
   });
 

--- a/apps/marketing/app/api/host-shop/subscription/checkout/route.ts
+++ b/apps/marketing/app/api/host-shop/subscription/checkout/route.ts
@@ -1,0 +1,183 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { getStripe } from '@/lib/stripe/client';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { resolveCanonicalStripePrice } from '@/lib/stripe/resolve-canonical-price';
+import { HOST_SHOP_PRICE_LOOKUP_KEYS } from '@/lib/platform/orchestration/commerce';
+import {
+  HOST_SHOP_TIER_AMOUNTS,
+  HOST_SHOP_TIER_LABELS,
+  isHostShopTier,
+  syncHostShopSubscriptionLifecycle,
+} from '@/lib/platform/orchestration/host-shop-subscription';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+const SITE_URL = 'https://www.elevateforhumanity.org';
+
+export async function POST(request: NextRequest) {
+  await hydrateProcessEnv();
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id || !user.email) {
+    return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
+  }
+
+  const body = await request.json().catch(() => ({}));
+  const tier = body.tier;
+  const requestedPartnerId = typeof body.partnerId === 'string' ? body.partnerId : '';
+  if (!isHostShopTier(tier)) {
+    return NextResponse.json({ error: 'Invalid host shop tier' }, { status: 400 });
+  }
+
+  const admin = await requireAdminClient();
+  let membershipQuery = admin
+    .from('partner_users')
+    .select('partner_id,role,status')
+    .eq('user_id', user.id);
+  if (requestedPartnerId) membershipQuery = membershipQuery.eq('partner_id', requestedPartnerId);
+  const { data: memberships, error: membershipError } = await membershipQuery;
+  if (membershipError) return NextResponse.json({ error: 'Could not resolve host shop account' }, { status: 500 });
+
+  const activeMemberships = (memberships ?? []).filter((row) => !row.status || row.status === 'active');
+  if (activeMemberships.length !== 1) {
+    return NextResponse.json(
+      { error: activeMemberships.length ? 'Select exactly one host shop account' : 'No active host shop account is linked to this login' },
+      { status: 409 },
+    );
+  }
+
+  const partnerId = activeMemberships[0].partner_id as string;
+  const { data: partner } = await admin
+    .from('partners')
+    .select('id,name,dba,shop_name,owner_name,contact_name,contact_email,contact_phone,phone,status,approval_status')
+    .eq('id', partnerId)
+    .maybeSingle();
+  if (!partner) return NextResponse.json({ error: 'Host shop partner record not found' }, { status: 404 });
+  if (partner.approval_status && partner.approval_status !== 'approved') {
+    return NextResponse.json({ error: 'Host shop approval is required before subscribing' }, { status: 403 });
+  }
+
+  const { data: shop } = await admin
+    .from('shops')
+    .select('id,name,email,phone,active')
+    .eq('partner_id', partnerId)
+    .eq('active', true)
+    .maybeSingle();
+
+  let { data: partnership } = await admin
+    .from('host_shop_partnerships')
+    .select('id,partner_tier,subscription_status,stripe_subscription_id')
+    .eq('partner_id', partnerId)
+    .maybeSingle();
+
+  if (!partnership) {
+    const { data: created, error: createError } = await admin
+      .from('host_shop_partnerships')
+      .insert({
+        partner_id: partnerId,
+        shop_id: shop?.id ?? null,
+        owner_id: user.id,
+        business_name: partner.shop_name || partner.dba || partner.name,
+        contact_name: partner.contact_name || partner.owner_name,
+        contact_email: partner.contact_email || user.email,
+        contact_phone: partner.contact_phone || partner.phone || shop?.phone || null,
+        status: 'pending',
+        partner_tier: 'free',
+        subscription_status: 'inactive',
+        portal_access_enabled: false,
+      })
+      .select('id,partner_tier,subscription_status,stripe_subscription_id')
+      .single();
+    if (createError || !created) {
+      return NextResponse.json({ error: 'Could not create host shop billing profile' }, { status: 500 });
+    }
+    partnership = created;
+  }
+
+  const stripe = getStripe();
+  if (!stripe) return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
+
+  const lookupKey = HOST_SHOP_PRICE_LOOKUP_KEYS[`${tier}_monthly` as keyof typeof HOST_SHOP_PRICE_LOOKUP_KEYS];
+  let price;
+  try {
+    price = await resolveCanonicalStripePrice(stripe, {
+      lookupKey,
+      unitAmount: HOST_SHOP_TIER_AMOUNTS[tier],
+      recurringInterval: 'month',
+    });
+  } catch (error) {
+    return NextResponse.json(
+      { error: 'Host shop subscription catalog is temporarily unavailable', detail: error instanceof Error ? error.message : 'Price not found' },
+      { status: 503 },
+    );
+  }
+
+  const metadata = {
+    type: 'host_shop_subscription',
+    checkout_type: 'host_shop_subscription',
+    tier,
+    user_id: user.id,
+    partnership_id: partnership.id,
+    partner_id: partnerId,
+    shop_id: shop?.id ?? '',
+    price_lookup_key: lookupKey,
+  };
+
+  if (partnership.stripe_subscription_id && ['active', 'trialing'].includes(partnership.subscription_status || '')) {
+    try {
+      const current = await stripe.subscriptions.retrieve(partnership.stripe_subscription_id);
+      const item = current.items.data[0];
+      if (!item) return NextResponse.json({ error: 'Existing subscription has no billable item' }, { status: 409 });
+      const updated = await stripe.subscriptions.update(current.id, {
+        items: [{ id: item.id, price: price.id, quantity: 1 }],
+        metadata: { ...current.metadata, ...metadata },
+        proration_behavior: 'create_prorations',
+        payment_behavior: 'error_if_incomplete',
+      });
+      await syncHostShopSubscriptionLifecycle(admin, updated);
+      return NextResponse.json({
+        url: '/host-shop/dashboard/subscription?subscription=updated',
+        sessionId: null,
+        updated: true,
+      });
+    } catch (error) {
+      return NextResponse.json(
+        { error: 'Could not change the existing host shop subscription without creating a duplicate', detail: error instanceof Error ? error.message : 'Update failed' },
+        { status: 409 },
+      );
+    }
+  }
+
+  const session = await stripe.checkout.sessions.create({
+    mode: 'subscription',
+    line_items: [{ price: price.id, quantity: 1 }],
+    customer_email: user.email,
+    client_reference_id: user.id,
+    allow_promotion_codes: true,
+    metadata,
+    subscription_data: { metadata },
+    success_url: `${SITE_URL}/host-shop/subscription/success?session_id={CHECKOUT_SESSION_ID}`,
+    cancel_url: `${SITE_URL}/host-shop/dashboard/subscription?checkout=cancelled`,
+    billing_address_collection: 'required',
+  });
+
+  await emitPlatformEvent(admin, {
+    eventType: PlatformEventType.COMMERCE_CHECKOUT_CREATED,
+    category: 'commerce',
+    source: 'marketing.api.host-shop.subscription.checkout',
+    actorId: user.id,
+    actorType: 'user',
+    subjectType: 'host_shop_partnership',
+    subjectId: partnership.id,
+    correlationId: session.id,
+    idempotencyKey: `host-shop-checkout-created:${session.id}`,
+    dispatch: false,
+    payload: { partner_id: partnerId, shop_id: shop?.id ?? null, tier, stripe_price_id: price.id, price_lookup_key: lookupKey },
+  });
+
+  return NextResponse.json({ sessionId: session.id, url: session.url, tierLabel: HOST_SHOP_TIER_LABELS[tier] });
+}

--- a/apps/marketing/app/api/host-shop/subscription/webhook/route.ts
+++ b/apps/marketing/app/api/host-shop/subscription/webhook/route.ts
@@ -1,0 +1,63 @@
+import type Stripe from 'stripe';
+import { NextRequest, NextResponse } from 'next/server';
+import { getStripe } from '@/lib/stripe/client';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import {
+  constructStripeEventWithAnySecret,
+  getCanonicalStripeWebhookSecrets,
+} from '@/lib/stripe/construct-webhook-event';
+import { syncHostShopSubscriptionLifecycle } from '@/lib/platform/orchestration/host-shop-subscription';
+import { logger } from '@/lib/logger';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const maxDuration = 60;
+
+function invoiceSubscriptionId(invoice: Stripe.Invoice): string | null {
+  const raw = invoice as unknown as { subscription?: string | { id?: string } | null };
+  return typeof raw.subscription === 'string' ? raw.subscription : raw.subscription?.id ?? null;
+}
+
+export async function POST(request: NextRequest) {
+  await hydrateProcessEnv();
+  const stripe = getStripe();
+  if (!stripe) return NextResponse.json({ error: 'Stripe not configured' }, { status: 503 });
+
+  const signature = request.headers.get('stripe-signature');
+  if (!signature) return NextResponse.json({ error: 'Missing signature' }, { status: 400 });
+
+  const body = await request.text();
+  let event: Stripe.Event;
+  try {
+    event = constructStripeEventWithAnySecret(stripe, body, signature, getCanonicalStripeWebhookSecrets());
+  } catch (error) {
+    logger.error('[host-shop/subscription/webhook] signature verification failed', error instanceof Error ? error : undefined);
+    return NextResponse.json({ error: 'Invalid signature' }, { status: 400 });
+  }
+
+  const admin = await requireAdminClient();
+  try {
+    if (
+      event.type === 'customer.subscription.created' ||
+      event.type === 'customer.subscription.updated' ||
+      event.type === 'customer.subscription.deleted'
+    ) {
+      await syncHostShopSubscriptionLifecycle(admin, event.data.object as Stripe.Subscription);
+    } else if (event.type === 'invoice.payment_failed' || event.type === 'invoice.payment_succeeded') {
+      const subscriptionId = invoiceSubscriptionId(event.data.object as Stripe.Invoice);
+      if (subscriptionId) {
+        const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+        await syncHostShopSubscriptionLifecycle(admin, subscription);
+      }
+    }
+  } catch (error) {
+    logger.error('[host-shop/subscription/webhook] processing failed', error instanceof Error ? error : undefined, {
+      eventId: event.id,
+      eventType: event.type,
+    });
+    return NextResponse.json({ error: 'Processing failed' }, { status: 500 });
+  }
+
+  return NextResponse.json({ received: true });
+}

--- a/apps/marketing/app/api/store/platform-checkout/route.ts
+++ b/apps/marketing/app/api/store/platform-checkout/route.ts
@@ -22,6 +22,7 @@ import {
   resolveCanonicalStripePrice,
 } from '@/lib/stripe/resolve-canonical-price';
 import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+import { syncPlatformSubscriptionLifecycle } from '@/lib/platform/subscription-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -47,9 +48,7 @@ export async function POST(request: NextRequest) {
     : [];
 
   const plan = getBasePlan(planId);
-  if (!plan) {
-    return NextResponse.json({ error: 'Invalid subscription plan' }, { status: 400 });
-  }
+  if (!plan) return NextResponse.json({ error: 'Invalid subscription plan' }, { status: 400 });
 
   const addons = addonSlugs.map(getAddOn);
   if (addons.some((addon) => !addon)) {
@@ -60,10 +59,7 @@ export async function POST(request: NextRequest) {
   const tenantId = await resolveTenantIdForUser(user.id);
   if (!tenantId) {
     return NextResponse.json(
-      {
-        error: 'Start your organization trial first so the subscription can be attached to the correct workspace.',
-        trialUrl: '/store/trial',
-      },
+      { error: 'Start your organization trial first so the subscription can be attached to the correct workspace.', trialUrl: '/store/trial' },
       { status: 409 },
     );
   }
@@ -71,18 +67,13 @@ export async function POST(request: NextRequest) {
   const billingOrganizationId = await resolveBillingOrganizationId(tenantId, admin);
   if (!billingOrganizationId) {
     return NextResponse.json(
-      {
-        error: 'Your workspace is not linked to a billing organization yet.',
-        trialUrl: '/store/trial',
-      },
+      { error: 'Your workspace is not linked to a billing organization yet.', trialUrl: '/store/trial' },
       { status: 409 },
     );
   }
 
   const stripe = getStripe();
-  if (!stripe) {
-    return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
-  }
+  if (!stripe) return NextResponse.json({ error: 'Stripe is not configured' }, { status: 503 });
 
   const recurringInterval = interval === 'annual' ? 'year' : 'month';
   const baseLookupKey = platformPlanPriceLookupKey(plan.id, interval);
@@ -104,16 +95,12 @@ export async function POST(request: NextRequest) {
     );
   }
 
-  const lineItems: Array<{ price: string; quantity: number }> = [
-    { price: basePrice.id, quantity: 1 },
-  ];
-
+  const resolvedAddonPrices: Array<{ slug: string; code: string; priceId: string }> = [];
   for (const addon of addons) {
     if (!addon) continue;
     const addonCode = normalizeAddonCode(addon.slug);
     const amount = interval === 'annual' ? addonPriceCents(addon) * 12 : addonPriceCents(addon);
     const lookupKey = platformAddonPriceLookupKey(addonCode, interval);
-
     try {
       const price = await ensureCanonicalStripePrice(stripe, {
         lookupKey,
@@ -121,11 +108,7 @@ export async function POST(request: NextRequest) {
         recurringInterval,
         productName: `Elevate Add-on — ${addon.name} (${interval === 'annual' ? 'Annual' : 'Monthly'})`,
         nickname: `${addon.name} ${interval}`,
-        productMetadata: {
-          type: 'platform_addon',
-          addon_code: addonCode,
-          addon_slug: addon.slug,
-        },
+        productMetadata: { type: 'platform_addon', addon_code: addonCode, addon_slug: addon.slug },
         priceMetadata: {
           checkout_type: 'platform_saas',
           addon_code: addonCode,
@@ -133,7 +116,7 @@ export async function POST(request: NextRequest) {
           billing_interval: interval,
         },
       });
-      lineItems.push({ price: price.id, quantity: 1 });
+      resolvedAddonPrices.push({ slug: addon.slug, code: addonCode, priceId: price.id });
     } catch (error) {
       return NextResponse.json(
         {
@@ -156,9 +139,79 @@ export async function POST(request: NextRequest) {
     base_price_lookup_key: baseLookupKey,
   };
 
+  const { data: existing } = await admin
+    .from('organization_subscriptions')
+    .select('status,stripe_subscription_id,plan_type')
+    .eq('organization_id', billingOrganizationId)
+    .maybeSingle();
+
+  if (existing?.stripe_subscription_id && ['active', 'trialing'].includes(existing.status || '')) {
+    try {
+      const current = await stripe.subscriptions.retrieve(existing.stripe_subscription_id);
+      if (['active', 'trialing'].includes(current.status)) {
+        const currentItems = current.items.data;
+        if (!currentItems.length) {
+          return NextResponse.json({ error: 'The existing Stripe subscription has no billable items.' }, { status: 409 });
+        }
+
+        const itemUpdates: any[] = [
+          { id: currentItems[0].id, price: basePrice.id, quantity: 1 },
+          ...currentItems.slice(1).map((item) => ({ id: item.id, deleted: true })),
+          ...resolvedAddonPrices.map((addon) => ({ price: addon.priceId, quantity: 1 })),
+        ];
+
+        const updated = await stripe.subscriptions.update(current.id, {
+          items: itemUpdates,
+          metadata: { ...current.metadata, ...metadata },
+          proration_behavior: 'create_prorations',
+          payment_behavior: 'error_if_incomplete',
+        });
+
+        await syncPlatformSubscriptionLifecycle(admin, updated);
+        await emitPlatformEvent(admin, {
+          eventType: PlatformEventType.BILLING_SUBSCRIPTION_UPDATED,
+          category: 'billing',
+          source: 'marketing.api.store.platform-checkout',
+          actorId: user.id,
+          actorType: 'user',
+          tenantId,
+          subjectType: 'organization_subscription',
+          subjectId: updated.id,
+          correlationId: updated.id,
+          idempotencyKey: `platform-plan-change:${updated.id}:${plan.id}:${interval}:${addonSlugs.join(',')}`,
+          dispatch: false,
+          payload: {
+            previous_plan: existing.plan_type,
+            plan_id: plan.id,
+            billing_interval: interval,
+            addon_slugs: addonSlugs,
+            base_price_id: basePrice.id,
+            addon_price_ids: resolvedAddonPrices.map((item) => item.priceId),
+          },
+        });
+
+        return NextResponse.json({
+          checkoutUrl: `/store/plans?subscription=updated&plan=${encodeURIComponent(plan.id)}`,
+          updated: true,
+        });
+      }
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error: 'We could not change the current subscription without creating a duplicate.',
+          detail: error instanceof Error ? error.message : 'Existing subscription update failed',
+        },
+        { status: 409 },
+      );
+    }
+  }
+
   const session = await stripe.checkout.sessions.create({
     mode: 'subscription',
-    line_items: lineItems,
+    line_items: [
+      { price: basePrice.id, quantity: 1 },
+      ...resolvedAddonPrices.map((addon) => ({ price: addon.priceId, quantity: 1 })),
+    ],
     customer_email: user.email,
     allow_promotion_codes: true,
     client_reference_id: user.id,
@@ -168,9 +221,7 @@ export async function POST(request: NextRequest) {
     cancel_url: `${SITE_URL}/store/plans?checkout=cancelled`,
   });
 
-  if (!session.url) {
-    return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
-  }
+  if (!session.url) return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
 
   try {
     await emitPlatformEvent(admin, {
@@ -191,6 +242,7 @@ export async function POST(request: NextRequest) {
         addon_slugs: addonSlugs,
         base_price_id: basePrice.id,
         base_price_lookup_key: baseLookupKey,
+        addon_price_ids: resolvedAddonPrices.map((item) => item.priceId),
       },
     });
   } catch {

--- a/apps/marketing/app/api/store/platform-checkout/route.ts
+++ b/apps/marketing/app/api/store/platform-checkout/route.ts
@@ -10,6 +10,18 @@ import {
   addonPriceCents,
   type BillingInterval,
 } from '@/lib/store/platform-pricing';
+import { resolveTenantIdForUser } from '@/lib/platform/resolve-tenant-for-user';
+import { resolveBillingOrganizationId } from '@/lib/platform/organization-features';
+import { normalizeAddonCode } from '@/lib/platform/feature-catalog';
+import {
+  platformAddonPriceLookupKey,
+  platformPlanPriceLookupKey,
+} from '@/lib/platform/orchestration/commerce';
+import {
+  ensureCanonicalStripePrice,
+  resolveCanonicalStripePrice,
+} from '@/lib/stripe/resolve-canonical-price';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -45,24 +57,22 @@ export async function POST(request: NextRequest) {
   }
 
   const admin = await requireAdminClient();
-  if (!admin) {
-    return NextResponse.json({ error: 'Billing service unavailable' }, { status: 503 });
-  }
-
-  const { data: organization, error: orgError } = await admin
-    .from('organizations')
-    .select('id, name, contact_email')
-    .eq('contact_email', user.email.toLowerCase())
-    .maybeSingle();
-
-  if (orgError) {
-    return NextResponse.json({ error: 'Could not resolve your organization' }, { status: 500 });
-  }
-
-  if (!organization?.id) {
+  const tenantId = await resolveTenantIdForUser(user.id);
+  if (!tenantId) {
     return NextResponse.json(
       {
         error: 'Start your organization trial first so the subscription can be attached to the correct workspace.',
+        trialUrl: '/store/trial',
+      },
+      { status: 409 },
+    );
+  }
+
+  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, admin);
+  if (!billingOrganizationId) {
+    return NextResponse.json(
+      {
+        error: 'Your workspace is not linked to a billing organization yet.',
         trialUrl: '/store/trial',
       },
       { status: 409 },
@@ -75,45 +85,75 @@ export async function POST(request: NextRequest) {
   }
 
   const recurringInterval = interval === 'annual' ? 'year' : 'month';
-  const lineItems: any[] = [
-    {
-      price_data: {
-        currency: 'usd',
-        product_data: {
-          name: `Elevate Platform — ${plan.name}`,
-          metadata: { plan_id: plan.id },
-        },
-        unit_amount: priceCents(plan, interval),
-        recurring: { interval: recurringInterval },
+  const baseLookupKey = platformPlanPriceLookupKey(plan.id, interval);
+
+  let basePrice;
+  try {
+    basePrice = await resolveCanonicalStripePrice(stripe, {
+      lookupKey: baseLookupKey,
+      unitAmount: priceCents(plan, interval),
+      recurringInterval,
+    });
+  } catch (error) {
+    return NextResponse.json(
+      {
+        error: 'Platform subscription catalog is temporarily unavailable',
+        detail: error instanceof Error ? error.message : 'Base plan price could not be resolved',
       },
-      quantity: 1,
-    },
+      { status: 503 },
+    );
+  }
+
+  const lineItems: Array<{ price: string; quantity: number }> = [
+    { price: basePrice.id, quantity: 1 },
   ];
 
   for (const addon of addons) {
     if (!addon) continue;
+    const addonCode = normalizeAddonCode(addon.slug);
     const amount = interval === 'annual' ? addonPriceCents(addon) * 12 : addonPriceCents(addon);
-    lineItems.push({
-      price_data: {
-        currency: 'usd',
-        product_data: {
-          name: `Elevate Add-on — ${addon.name}`,
-          metadata: { addon_slug: addon.slug },
+    const lookupKey = platformAddonPriceLookupKey(addonCode, interval);
+
+    try {
+      const price = await ensureCanonicalStripePrice(stripe, {
+        lookupKey,
+        unitAmount: amount,
+        recurringInterval,
+        productName: `Elevate Add-on — ${addon.name} (${interval === 'annual' ? 'Annual' : 'Monthly'})`,
+        nickname: `${addon.name} ${interval}`,
+        productMetadata: {
+          type: 'platform_addon',
+          addon_code: addonCode,
+          addon_slug: addon.slug,
         },
-        unit_amount: amount,
-        recurring: { interval: recurringInterval },
-      },
-      quantity: 1,
-    });
+        priceMetadata: {
+          checkout_type: 'platform_saas',
+          addon_code: addonCode,
+          addon_slug: addon.slug,
+          billing_interval: interval,
+        },
+      });
+      lineItems.push({ price: price.id, quantity: 1 });
+    } catch (error) {
+      return NextResponse.json(
+        {
+          error: `The ${addon.name} billing option is temporarily unavailable`,
+          detail: error instanceof Error ? error.message : 'Add-on price could not be resolved',
+        },
+        { status: 503 },
+      );
+    }
   }
 
   const metadata = {
     checkout_type: 'platform_saas',
     user_id: user.id,
-    tenant_id: organization.id,
+    tenant_id: tenantId,
+    billing_organization_id: billingOrganizationId,
     plan_id: plan.id,
     billing_interval: interval,
     addon_slugs: addonSlugs.join(','),
+    base_price_lookup_key: baseLookupKey,
   };
 
   const session = await stripe.checkout.sessions.create({
@@ -130,6 +170,31 @@ export async function POST(request: NextRequest) {
 
   if (!session.url) {
     return NextResponse.json({ error: 'Stripe did not return a checkout URL' }, { status: 502 });
+  }
+
+  try {
+    await emitPlatformEvent(admin, {
+      eventType: PlatformEventType.COMMERCE_CHECKOUT_CREATED,
+      category: 'commerce',
+      source: 'marketing.api.store.platform-checkout',
+      actorId: user.id,
+      actorType: 'user',
+      tenantId,
+      subjectType: 'platform_subscription_checkout',
+      subjectId: session.id,
+      correlationId: session.id,
+      idempotencyKey: `platform-checkout-created:${session.id}`,
+      dispatch: false,
+      payload: {
+        plan_id: plan.id,
+        billing_interval: interval,
+        addon_slugs: addonSlugs,
+        base_price_id: basePrice.id,
+        base_price_lookup_key: baseLookupKey,
+      },
+    });
+  } catch {
+    // Audit/event telemetry must not invalidate an otherwise valid Stripe checkout.
   }
 
   return NextResponse.json({ checkoutUrl: session.url });

--- a/apps/marketing/app/host-shop/apply/success/page.tsx
+++ b/apps/marketing/app/host-shop/apply/success/page.tsx
@@ -1,0 +1,125 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { getStripe } from '@/lib/stripe/client';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const metadata = { title: 'Host Shop Application Submitted | Elevate', robots: { index: false, follow: false } };
+
+const APPLICATION_FEE_CENTS = 5000;
+
+export default async function HostShopApplicationSuccess({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>;
+}) {
+  const { session_id: sessionId } = await searchParams;
+  if (!sessionId) redirect('/host-shop/apply');
+
+  await hydrateProcessEnv();
+  const stripe = getStripe();
+  if (!stripe) return <Failure message="Payment verification is temporarily unavailable." />;
+
+  let session;
+  try {
+    session = await stripe.checkout.sessions.retrieve(sessionId);
+  } catch {
+    return <Failure message="Stripe could not find this payment session." />;
+  }
+
+  const applicationId = session.metadata?.application_id || session.client_reference_id || '';
+  const paymentIntentId = typeof session.payment_intent === 'string' ? session.payment_intent : session.payment_intent?.id ?? null;
+  if (
+    session.status !== 'complete' ||
+    session.payment_status !== 'paid' ||
+    session.mode !== 'payment' ||
+    session.metadata?.checkout_type !== 'host_shop_application_fee' ||
+    !applicationId ||
+    session.amount_total !== APPLICATION_FEE_CENTS ||
+    session.currency !== 'usd'
+  ) {
+    return <Failure message="This Host Shop application fee has not been verified as paid." />;
+  }
+
+  const db = await requireAdminClient();
+  const { data: application } = await db
+    .from('host_shop_applications')
+    .select('id,status,application_fee_status,stripe_session_id')
+    .eq('id', applicationId)
+    .maybeSingle();
+  if (!application) return <Failure message="The Host Shop application attached to this payment was not found." />;
+
+  const now = new Date().toISOString();
+  if (application.application_fee_status !== 'paid' || application.status === 'drafted') {
+    const { error } = await db
+      .from('host_shop_applications')
+      .update({
+        status: application.status === 'drafted' ? 'submitted' : application.status,
+        submitted_at: application.status === 'drafted' ? now : undefined,
+        application_fee_status: 'paid',
+        application_fee_amount_cents: APPLICATION_FEE_CENTS,
+        application_fee_paid_at: now,
+        stripe_session_id: session.id,
+        stripe_payment_intent_id: paymentIntentId,
+        updated_at: now,
+      })
+      .eq('id', applicationId);
+    if (error) return <Failure message="Payment was verified, but the Host Shop application could not be synchronized." />;
+  }
+
+  try {
+    await emitPlatformEvent(db, {
+      eventType: PlatformEventType.APPLICATION_SUBMITTED,
+      category: 'application',
+      source: 'marketing.host-shop.apply.success',
+      subjectType: 'host_shop_application',
+      subjectId: applicationId,
+      correlationId: session.id,
+      idempotencyKey: `host-shop-application-submitted:${applicationId}`,
+      payload: {
+        application_id: applicationId,
+        fee_paid: true,
+        amount_cents: APPLICATION_FEE_CENTS,
+      },
+    });
+  } catch {
+    // The database row is authoritative; the event can be replayed separately.
+  }
+
+  return (
+    <main className="min-h-[65vh] bg-slate-50 px-4 py-16">
+      <div className="mx-auto max-w-xl rounded-2xl border border-emerald-200 bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-black uppercase tracking-widest text-emerald-700">Payment verified</p>
+        <h1 className="mt-3 text-3xl font-black text-slate-950">Host Shop application submitted</h1>
+        <p className="mt-4 leading-7 text-slate-600">
+          Your $50 application fee and application are linked to the same record. You do not need to submit or pay again.
+        </p>
+        <div className="mt-8 flex flex-wrap justify-center gap-3">
+          <Link href="/host-shops" className="rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
+            View Host Shops
+          </Link>
+          <Link href="/contact" className="rounded-xl border border-slate-300 px-6 py-3 font-bold text-slate-700">
+            Contact Support
+          </Link>
+        </div>
+      </div>
+    </main>
+  );
+}
+
+function Failure({ message }: { message: string }) {
+  return (
+    <main className="min-h-[65vh] bg-slate-50 px-4 py-16">
+      <div className="mx-auto max-w-xl rounded-2xl border border-amber-200 bg-white p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-black text-slate-950">Application payment verification pending</h1>
+        <p className="mt-3 text-slate-600">{message}</p>
+        <Link href="/contact" className="mt-6 inline-flex rounded-xl bg-slate-950 px-5 py-3 font-bold text-white">
+          Contact Support
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/marketing/app/host-shop/apply/success/page.tsx
+++ b/apps/marketing/app/host-shop/apply/success/page.tsx
@@ -54,18 +54,20 @@ export default async function HostShopApplicationSuccess({
 
   const now = new Date().toISOString();
   if (application.application_fee_status !== 'paid' || application.status === 'drafted') {
+    const update: Record<string, unknown> = {
+      status: application.status === 'drafted' ? 'submitted' : application.status,
+      application_fee_status: 'paid',
+      application_fee_amount_cents: APPLICATION_FEE_CENTS,
+      application_fee_paid_at: now,
+      stripe_session_id: session.id,
+      stripe_payment_intent_id: paymentIntentId,
+      updated_at: now,
+    };
+    if (application.status === 'drafted') update.submitted_at = now;
+
     const { error } = await db
       .from('host_shop_applications')
-      .update({
-        status: application.status === 'drafted' ? 'submitted' : application.status,
-        submitted_at: application.status === 'drafted' ? now : undefined,
-        application_fee_status: 'paid',
-        application_fee_amount_cents: APPLICATION_FEE_CENTS,
-        application_fee_paid_at: now,
-        stripe_session_id: session.id,
-        stripe_payment_intent_id: paymentIntentId,
-        updated_at: now,
-      })
+      .update(update)
       .eq('id', applicationId);
     if (error) return <Failure message="Payment was verified, but the Host Shop application could not be synchronized." />;
   }
@@ -98,8 +100,8 @@ export default async function HostShopApplicationSuccess({
           Your $50 application fee and application are linked to the same record. You do not need to submit or pay again.
         </p>
         <div className="mt-8 flex flex-wrap justify-center gap-3">
-          <Link href="/host-shops" className="rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
-            View Host Shops
+          <Link href="/apprenticeships" className="rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
+            View Apprenticeships
           </Link>
           <Link href="/contact" className="rounded-xl border border-slate-300 px-6 py-3 font-bold text-slate-700">
             Contact Support

--- a/apps/marketing/app/host-shop/subscription/success/page.tsx
+++ b/apps/marketing/app/host-shop/subscription/success/page.tsx
@@ -10,13 +10,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const metadata = { title: 'Host Shop Subscription Confirmed | Elevate', robots: { index: false, follow: false } };
 
+const HOST_SHOP_DASHBOARD_URL = 'https://app.elevateforhumanity.org/host-shop/dashboard';
+
 export default async function HostShopSubscriptionSuccess({
   searchParams,
 }: {
   searchParams: Promise<{ session_id?: string }>;
 }) {
   const { session_id: sessionId } = await searchParams;
-  if (!sessionId) redirect('/host-shop/dashboard/subscription');
+  if (!sessionId) redirect(HOST_SHOP_DASHBOARD_URL);
 
   await hydrateProcessEnv();
   const supabase = await createClient();
@@ -65,7 +67,7 @@ export default async function HostShopSubscriptionSuccess({
         <p className="text-sm font-black uppercase tracking-widest text-emerald-700">Subscription confirmed</p>
         <h1 className="mt-3 text-3xl font-black text-slate-950">Host Shop access is synchronized</h1>
         <p className="mt-4 leading-7 text-slate-600">Your Stripe subscription and Elevate Host Shop partnership now use the same billing status.</p>
-        <Link href="https://app.elevateforhumanity.org/host-shop/dashboard" className="mt-8 inline-flex rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
+        <Link href={HOST_SHOP_DASHBOARD_URL} className="mt-8 inline-flex rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
           Open Host Shop Dashboard
         </Link>
       </div>
@@ -79,8 +81,8 @@ function Failure({ message }: { message: string }) {
       <div className="mx-auto max-w-xl rounded-2xl border border-amber-200 bg-white p-8 text-center shadow-sm">
         <h1 className="text-2xl font-black text-slate-950">Subscription verification pending</h1>
         <p className="mt-3 text-slate-600">{message}</p>
-        <Link href="/host-shop/dashboard/subscription" className="mt-6 inline-flex rounded-xl bg-slate-950 px-5 py-3 font-bold text-white">
-          Return to subscription settings
+        <Link href={HOST_SHOP_DASHBOARD_URL} className="mt-6 inline-flex rounded-xl bg-slate-950 px-5 py-3 font-bold text-white">
+          Return to Host Shop Dashboard
         </Link>
       </div>
     </main>

--- a/apps/marketing/app/host-shop/subscription/success/page.tsx
+++ b/apps/marketing/app/host-shop/subscription/success/page.tsx
@@ -1,0 +1,88 @@
+import Link from 'next/link';
+import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { getStripe } from '@/lib/stripe/client';
+import { hydrateProcessEnv } from '@/lib/secrets';
+import { syncHostShopSubscriptionLifecycle } from '@/lib/platform/orchestration/host-shop-subscription';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+export const metadata = { title: 'Host Shop Subscription Confirmed | Elevate', robots: { index: false, follow: false } };
+
+export default async function HostShopSubscriptionSuccess({
+  searchParams,
+}: {
+  searchParams: Promise<{ session_id?: string }>;
+}) {
+  const { session_id: sessionId } = await searchParams;
+  if (!sessionId) redirect('/host-shop/dashboard/subscription');
+
+  await hydrateProcessEnv();
+  const supabase = await createClient();
+  const { data: { user } } = await supabase.auth.getUser();
+  if (!user?.id) {
+    redirect(`/login?redirect=${encodeURIComponent(`/host-shop/subscription/success?session_id=${sessionId}`)}`);
+  }
+
+  const stripe = getStripe();
+  if (!stripe) return <Failure message="Billing verification is temporarily unavailable." />;
+
+  try {
+    const session = await stripe.checkout.sessions.retrieve(sessionId);
+    if (
+      session.status !== 'complete' ||
+      session.mode !== 'subscription' ||
+      session.client_reference_id !== user.id ||
+      session.metadata?.checkout_type !== 'host_shop_subscription'
+    ) {
+      return <Failure message="This checkout could not be verified for the signed-in Host Shop account." />;
+    }
+
+    const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null;
+    if (!subscriptionId) return <Failure message="Stripe did not attach a recurring subscription to this checkout." />;
+
+    const subscription = await stripe.subscriptions.retrieve(subscriptionId);
+    if (!['active', 'trialing'].includes(subscription.status)) {
+      return <Failure message={`Stripe subscription status is ${subscription.status}, so portal access was not activated.`} />;
+    }
+    if (
+      subscription.metadata?.user_id !== user.id ||
+      subscription.metadata?.checkout_type !== 'host_shop_subscription'
+    ) {
+      return <Failure message="Stripe subscription identity does not match this Host Shop login." />;
+    }
+
+    const admin = await requireAdminClient();
+    await syncHostShopSubscriptionLifecycle(admin, subscription);
+  } catch {
+    return <Failure message="Your payment was verified, but Host Shop access could not be synchronized. Contact support before purchasing again." />;
+  }
+
+  return (
+    <main className="min-h-[65vh] bg-slate-50 px-4 py-16">
+      <div className="mx-auto max-w-xl rounded-2xl border border-emerald-200 bg-white p-8 text-center shadow-sm">
+        <p className="text-sm font-black uppercase tracking-widest text-emerald-700">Subscription confirmed</p>
+        <h1 className="mt-3 text-3xl font-black text-slate-950">Host Shop access is synchronized</h1>
+        <p className="mt-4 leading-7 text-slate-600">Your Stripe subscription and Elevate Host Shop partnership now use the same billing status.</p>
+        <Link href="https://app.elevateforhumanity.org/host-shop/dashboard" className="mt-8 inline-flex rounded-xl bg-slate-950 px-6 py-3 font-bold text-white">
+          Open Host Shop Dashboard
+        </Link>
+      </div>
+    </main>
+  );
+}
+
+function Failure({ message }: { message: string }) {
+  return (
+    <main className="min-h-[65vh] bg-slate-50 px-4 py-16">
+      <div className="mx-auto max-w-xl rounded-2xl border border-amber-200 bg-white p-8 text-center shadow-sm">
+        <h1 className="text-2xl font-black text-slate-950">Subscription verification pending</h1>
+        <p className="mt-3 text-slate-600">{message}</p>
+        <Link href="/host-shop/dashboard/subscription" className="mt-6 inline-flex rounded-xl bg-slate-950 px-5 py-3 font-bold text-white">
+          Return to subscription settings
+        </Link>
+      </div>
+    </main>
+  );
+}

--- a/apps/marketing/app/store/apps/subscription-success/page.tsx
+++ b/apps/marketing/app/store/apps/subscription-success/page.tsx
@@ -5,6 +5,7 @@ import { requireAdminClient } from '@/lib/supabase/admin';
 import { getStripe } from '@/lib/stripe/client';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { getIndividualAppCatalog } from '@/lib/apps/individual-app-plans';
+import { syncIndividualAppLifecycle } from '@/lib/platform/subscription-lifecycle';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -75,59 +76,30 @@ export default async function IndividualAppSubscriptionSuccess({
   }
 
   const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null;
-  const customerId = typeof session.customer === 'string' ? session.customer : null;
   if (!subscriptionId) {
     return <ErrorState message="Stripe did not attach a recurring subscription to this checkout." />;
   }
 
-  let periodStart: string | null = null;
-  let periodEnd: string | null = null;
   try {
     const stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
-    const raw = stripeSubscription as unknown as {
-      current_period_start?: number;
-      current_period_end?: number;
-      status?: string;
-    };
-    if (raw.current_period_start) periodStart = new Date(raw.current_period_start * 1000).toISOString();
-    if (raw.current_period_end) periodEnd = new Date(raw.current_period_end * 1000).toISOString();
-    if (raw.status && !['active', 'trialing'].includes(raw.status)) {
-      return <ErrorState message={`Stripe subscription status is ${raw.status}, so access was not activated.`} />;
+    if (!['active', 'trialing'].includes(stripeSubscription.status)) {
+      return <ErrorState message={`Stripe subscription status is ${stripeSubscription.status}, so access was not activated.`} />;
     }
+
+    const subscriptionMetadata = stripeSubscription.metadata || {};
+    if (
+      subscriptionMetadata.checkout_type !== 'individual_app' ||
+      subscriptionMetadata.user_id !== user.id ||
+      subscriptionMetadata.app_slug !== catalog.slug ||
+      subscriptionMetadata.plan_id !== plan.id
+    ) {
+      return <ErrorState message="Stripe subscription metadata does not match this purchase." />;
+    }
+
+    const admin = await requireAdminClient();
+    await syncIndividualAppLifecycle(admin, stripeSubscription);
   } catch {
-    return <ErrorState message="The recurring Stripe subscription could not be verified." />;
-  }
-
-  const admin = await requireAdminClient();
-  const { data: existing, error: readError } = await admin
-    .from('user_app_subscriptions')
-    .select('id')
-    .eq('user_id', user.id)
-    .eq('app_slug', catalog.slug)
-    .maybeSingle();
-
-  if (readError) return <ErrorState message="We could not read the app subscription record." />;
-
-  const payload = {
-    user_id: user.id,
-    gov: catalog.slug,
-    app_slug: catalog.slug,
-    plan: plan.id,
-    status: 'active',
-    trial_ends_at: null,
-    current_period_start: periodStart,
-    current_period_end: periodEnd,
-    stripe_subscription_id: subscriptionId,
-    stripe_customer_id: customerId,
-    updated_at: new Date().toISOString(),
-  };
-
-  const writeResult = existing?.id
-    ? await admin.from('user_app_subscriptions').update(payload).eq('id', existing.id)
-    : await admin.from('user_app_subscriptions').insert(payload);
-
-  if (writeResult.error) {
-    return <ErrorState message="Your payment was verified, but the app entitlement could not be saved. Please contact support before purchasing again." />;
+    return <ErrorState message="Your payment was verified, but the app entitlement could not be synchronized. Please contact support before purchasing again." />;
   }
 
   redirect(`/apps/${catalog.slug}?subscription=active`);

--- a/apps/marketing/app/store/subscription-success/page.tsx
+++ b/apps/marketing/app/store/subscription-success/page.tsx
@@ -4,7 +4,9 @@ import { CheckCircle, ArrowRight, CreditCard, PlusCircle } from 'lucide-react';
 import { getStripe } from '@/lib/stripe/client';
 import { hydrateProcessEnv } from '@/lib/secrets';
 import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
 import { ADD_ON_MARKETPLACE, getBasePlan } from '@/lib/store/platform-pricing';
+import { syncPlatformSubscriptionLifecycle } from '@/lib/platform/subscription-lifecycle';
 
 export const dynamic = 'force-dynamic';
 export const metadata = {
@@ -47,9 +49,34 @@ export default async function SubscriptionSuccessPage({
 
   const planId = session.metadata?.plan_id ?? '';
   const plan = getBasePlan(planId);
-  const purchasedAddons = new Set((session.metadata?.addon_slugs || '').split(',').map((value) => value.trim()).filter(Boolean));
-  const planFeatures = new Set(plan?.features || []);
+  if (!plan) return <Failure message="The purchased platform plan is not in the current Store catalog." />;
 
+  const subscriptionId = typeof session.subscription === 'string' ? session.subscription : null;
+  if (!subscriptionId) {
+    return <Failure message="Stripe did not attach a recurring subscription to this checkout." />;
+  }
+
+  try {
+    const stripeSubscription = await stripe.subscriptions.retrieve(subscriptionId);
+    if (!['active', 'trialing'].includes(stripeSubscription.status)) {
+      return <Failure message={`Stripe subscription status is ${stripeSubscription.status}, so platform access was not activated.`} />;
+    }
+    if (
+      stripeSubscription.metadata?.checkout_type !== 'platform_saas' ||
+      stripeSubscription.metadata?.user_id !== user.id ||
+      stripeSubscription.metadata?.plan_id !== plan.id
+    ) {
+      return <Failure message="Stripe subscription metadata does not match this platform purchase." />;
+    }
+
+    const admin = await requireAdminClient();
+    await syncPlatformSubscriptionLifecycle(admin, stripeSubscription);
+  } catch {
+    return <Failure message="Your payment was verified, but platform access could not be synchronized. Please contact support before purchasing again." />;
+  }
+
+  const purchasedAddons = new Set((session.metadata?.addon_slugs || '').split(',').map((value) => value.trim()).filter(Boolean));
+  const planFeatures = new Set(plan.features || []);
   const recommendedAddons = ADD_ON_MARKETPLACE.filter((addon) => {
     if (purchasedAddons.has(addon.slug)) return false;
     if (addon.features.length > 0 && addon.features.every((feature) => planFeatures.has(feature))) return false;
@@ -65,7 +92,7 @@ export default async function SubscriptionSuccessPage({
           </div>
           <h1 className="text-center text-3xl font-black text-slate-950">Subscription confirmed</h1>
           <p className="mt-3 text-center text-slate-600">
-            Stripe confirmed your {plan?.name || planId || 'platform'} subscription. Your organization access is synchronized by the Store fulfillment flow.
+            Stripe confirmed your {plan.name} subscription and Elevate synchronized the workspace entitlements before showing this confirmation.
           </p>
 
           <div className="mt-8 rounded-xl bg-slate-50 p-5 text-sm text-slate-700">
@@ -82,16 +109,10 @@ export default async function SubscriptionSuccessPage({
             >
               Open Platform <ArrowRight className="h-4 w-4" />
             </a>
-            <Link
-              href="/store/plans"
-              className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold text-slate-800 hover:bg-slate-50"
-            >
+            <Link href="/store/plans" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold text-slate-800 hover:bg-slate-50">
               Manage plan options
             </Link>
-            <Link
-              href="/store/apps"
-              className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold text-slate-800 hover:bg-slate-50"
-            >
+            <Link href="/store/apps" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-semibold text-slate-800 hover:bg-slate-50">
               Search full Store
             </Link>
           </div>

--- a/components/navigation/DashboardDropdown.tsx
+++ b/components/navigation/DashboardDropdown.tsx
@@ -34,7 +34,7 @@ interface Dashboard {
   order_index: number;
 }
 
-interface DashboardDefinition extends Omit<Dashboard, 'href' | 'roles'> {}
+type DashboardDefinition = Omit<Dashboard, 'href' | 'roles'>;
 
 interface Props {
   className?: string;

--- a/lib/platform/fulfillment.ts
+++ b/lib/platform/fulfillment.ts
@@ -1,44 +1,66 @@
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@/lib/supabase';
-import { getOrganizationFeatures } from '@/lib/platform/organization-features';
+import {
+  getOrganizationFeatures,
+  resolveBillingOrganizationId,
+} from '@/lib/platform/organization-features';
 import { syncLicenseFromSaasEntitlements } from '@/lib/platform/sync-license-from-saas';
 import { normalizeAddonCode } from '@/lib/platform/feature-catalog';
 import type { BasePlanId, BillingInterval } from '@/lib/store/platform-pricing';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
 
 export interface PlatformSaasCheckoutMetadata {
   user_id: string;
+  /** Canonical tenants.id, never organizations.id. */
   tenant_id?: string;
   plan_id: BasePlanId;
   billing_interval: BillingInterval;
   addon_slugs?: string;
   stripe_subscription_id?: string;
   stripe_customer_id?: string;
+  current_period_start?: string;
   current_period_end?: string;
 }
 
+function databaseBillingInterval(interval: BillingInterval): 'month' | 'year' {
+  return interval === 'annual' ? 'year' : 'month';
+}
+
 /**
- * Apply plan + add-ons to organization_subscriptions, addon_subscriptions,
- * and sync licenses.features for existing middleware.
+ * Apply the purchased platform plan to the billing organization and add-ons to
+ * the canonical tenant. This function is the checkout fulfillment boundary and
+ * must never treat organizations.id and tenants.id as interchangeable.
  */
 export async function fulfillPlatformSaasSubscription(
   adminSupabase: SupabaseClient,
   meta: PlatformSaasCheckoutMetadata,
 ): Promise<{ ok: boolean; error?: string }> {
-  const organizationId = meta.tenant_id;
-  if (!organizationId) {
+  const tenantId = meta.tenant_id;
+  if (!tenantId) {
     logger.warn('platform_saas fulfillment: no tenant_id', { user_id: meta.user_id });
-    return { ok: false, error: 'No organization linked to this account' };
+    return { ok: false, error: 'No tenant linked to this account' };
   }
 
-  const addonSlugs = (meta.addon_slugs || '')
-    .split(',')
-    .map((s) => s.trim())
-    .filter(Boolean)
-    .map(normalizeAddonCode);
+  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, adminSupabase);
+  if (!billingOrganizationId) {
+    logger.warn('platform_saas fulfillment: billing organization not found', {
+      user_id: meta.user_id,
+      tenant_id: tenantId,
+    });
+    return { ok: false, error: 'No billing organization linked to this workspace' };
+  }
+
+  const addonSlugs = [...new Set(
+    (meta.addon_slugs || '')
+      .split(',')
+      .map((s) => s.trim())
+      .filter(Boolean)
+      .map(normalizeAddonCode),
+  )];
 
   const { data: planRow, error: planErr } = await adminSupabase
     .from('subscription_plans')
-    .select('id, monthly_price')
+    .select('id, slug, monthly_price')
     .eq('slug', meta.plan_id)
     .eq('active', true)
     .maybeSingle();
@@ -47,44 +69,73 @@ export async function fulfillPlatformSaasSubscription(
     return { ok: false, error: planErr?.message ?? 'Plan not found in catalog' };
   }
 
-  const periodEnd = meta.current_period_end ?? null;
-
+  const now = new Date().toISOString();
   const { error: subErr } = await adminSupabase.from('organization_subscriptions').upsert(
     {
-      organization_id: organizationId,
+      organization_id: billingOrganizationId,
       plan_id: planRow.id,
+      plan_type: planRow.slug,
       stripe_subscription_id: meta.stripe_subscription_id ?? null,
       stripe_customer_id: meta.stripe_customer_id ?? null,
-      billing_interval: meta.billing_interval,
+      billing_interval: databaseBillingInterval(meta.billing_interval),
       status: 'active',
-      current_period_end: periodEnd,
-      updated_at: new Date().toISOString(),
-      metadata: { plan_slug: meta.plan_id, addon_slugs: addonSlugs },
+      current_period_start: meta.current_period_start ?? null,
+      current_period_end: meta.current_period_end ?? null,
+      updated_at: now,
+      metadata: {
+        tenant_id: tenantId,
+        plan_slug: meta.plan_id,
+        addon_slugs: addonSlugs,
+      },
     },
     { onConflict: 'organization_id' },
   );
 
   if (subErr) {
-    logger.error('organization_subscriptions upsert failed', subErr);
+    logger.error('organization_subscriptions upsert failed', subErr, {
+      tenantId,
+      billingOrganizationId,
+    });
     return { ok: false, error: subErr.message };
   }
 
+  // The checkout represents the desired full add-on set on the platform
+  // subscription. Retire previously selected add-ons before reactivating the
+  // current set so downgrades/removals do not leave stale entitlements behind.
+  await adminSupabase
+    .from('addon_subscriptions')
+    .update({ active: false, canceled_at: now, updated_at: now })
+    .eq('organization_id', tenantId);
+
+  await adminSupabase
+    .from('organization_addons')
+    .update({ status: 'inactive' })
+    .eq('tenant_id', tenantId);
+
   for (const code of addonSlugs) {
-    const { data: catalog } = await adminSupabase
+    const { data: catalog, error: catalogError } = await adminSupabase
       .from('saas_addon_catalog')
-      .select('monthly_price')
+      .select('code, monthly_price, active')
       .eq('code', code)
       .maybeSingle();
 
+    if (catalogError || !catalog?.active) {
+      logger.warn('platform_saas fulfillment: add-on unavailable', {
+        code,
+        error: catalogError?.message,
+      });
+      continue;
+    }
+
     const { error: addonErr } = await adminSupabase.from('addon_subscriptions').upsert(
       {
-        organization_id: organizationId,
+        organization_id: tenantId,
         addon_code: code,
-        monthly_price: catalog?.monthly_price ?? null,
+        monthly_price: catalog.monthly_price ?? null,
         active: true,
-        activated_at: new Date().toISOString(),
+        activated_at: now,
         canceled_at: null,
-        updated_at: new Date().toISOString(),
+        updated_at: now,
       },
       { onConflict: 'organization_id,addon_code' },
     );
@@ -95,23 +146,43 @@ export async function fulfillPlatformSaasSubscription(
 
     await adminSupabase.from('organization_addons').upsert(
       {
-        tenant_id: organizationId,
+        tenant_id: tenantId,
         addon_slug: code,
         status: 'active',
-        activated_at: new Date().toISOString(),
+        activated_at: now,
       },
       { onConflict: 'tenant_id,addon_slug' },
     );
   }
 
-  const entitlements = await getOrganizationFeatures(organizationId, adminSupabase);
+  const entitlements = await getOrganizationFeatures(tenantId, adminSupabase);
 
-  await syncLicenseFromSaasEntitlements(adminSupabase, organizationId, entitlements, {
+  await syncLicenseFromSaasEntitlements(adminSupabase, tenantId, entitlements, {
     planSlug: meta.plan_id,
     billingInterval: meta.billing_interval,
     stripeSubscriptionId: meta.stripe_subscription_id,
     stripeCustomerId: meta.stripe_customer_id,
   });
+
+  if (meta.stripe_subscription_id) {
+    await emitPlatformEvent(adminSupabase, {
+      eventType: PlatformEventType.ENTITLEMENT_REFRESHED,
+      category: 'entitlement',
+      source: 'platform.fulfillment',
+      actorId: meta.user_id || null,
+      actorType: 'user',
+      tenantId,
+      subjectType: 'tenant',
+      subjectId: tenantId,
+      correlationId: meta.stripe_subscription_id,
+      idempotencyKey: `platform-checkout-entitlement:${meta.stripe_subscription_id}:${meta.plan_id}:${addonSlugs.join(',')}`,
+      payload: {
+        plan_slug: meta.plan_id,
+        addon_codes: addonSlugs,
+        features: entitlements.features,
+      },
+    });
+  }
 
   return { ok: true };
 }

--- a/lib/platform/fulfillment.ts
+++ b/lib/platform/fulfillment.ts
@@ -2,7 +2,7 @@ import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@/lib/supabase';
 import {
   getOrganizationFeatures,
-  resolveBillingOrganizationId,
+  resolveOrganizationIdentity,
 } from '@/lib/platform/organization-features';
 import { syncLicenseFromSaasEntitlements } from '@/lib/platform/sync-license-from-saas';
 import { normalizeAddonCode } from '@/lib/platform/feature-catalog';
@@ -11,7 +11,6 @@ import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestrati
 
 export interface PlatformSaasCheckoutMetadata {
   user_id: string;
-  /** Canonical tenants.id, never organizations.id. */
   tenant_id?: string;
   plan_id: BasePlanId;
   billing_interval: BillingInterval;
@@ -26,22 +25,18 @@ function databaseBillingInterval(interval: BillingInterval): 'month' | 'year' {
   return interval === 'annual' ? 'year' : 'month';
 }
 
-/**
- * Apply the purchased platform plan to the billing organization and add-ons to
- * the canonical tenant. This function is the checkout fulfillment boundary and
- * must never treat organizations.id and tenants.id as interchangeable.
- */
 export async function fulfillPlatformSaasSubscription(
   adminSupabase: SupabaseClient,
   meta: PlatformSaasCheckoutMetadata,
 ): Promise<{ ok: boolean; error?: string }> {
-  const tenantId = meta.tenant_id;
-  if (!tenantId) {
+  if (!meta.tenant_id) {
     logger.warn('platform_saas fulfillment: no tenant_id', { user_id: meta.user_id });
     return { ok: false, error: 'No tenant linked to this account' };
   }
 
-  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, adminSupabase);
+  const identity = await resolveOrganizationIdentity(meta.tenant_id, adminSupabase);
+  const tenantId = identity.tenantId;
+  const billingOrganizationId = identity.billingOrganizationId;
   if (!billingOrganizationId) {
     logger.warn('platform_saas fulfillment: billing organization not found', {
       user_id: meta.user_id,
@@ -82,31 +77,20 @@ export async function fulfillPlatformSaasSubscription(
       current_period_start: meta.current_period_start ?? null,
       current_period_end: meta.current_period_end ?? null,
       updated_at: now,
-      metadata: {
-        tenant_id: tenantId,
-        plan_slug: meta.plan_id,
-        addon_slugs: addonSlugs,
-      },
+      metadata: { tenant_id: tenantId, plan_slug: meta.plan_id, addon_slugs: addonSlugs },
     },
     { onConflict: 'organization_id' },
   );
 
   if (subErr) {
-    logger.error('organization_subscriptions upsert failed', subErr, {
-      tenantId,
-      billingOrganizationId,
-    });
+    logger.error('organization_subscriptions upsert failed', subErr, { tenantId, billingOrganizationId });
     return { ok: false, error: subErr.message };
   }
 
-  // The checkout represents the desired full add-on set on the platform
-  // subscription. Retire previously selected add-ons before reactivating the
-  // current set so downgrades/removals do not leave stale entitlements behind.
   await adminSupabase
     .from('addon_subscriptions')
     .update({ active: false, canceled_at: now, updated_at: now })
     .eq('organization_id', tenantId);
-
   await adminSupabase
     .from('organization_addons')
     .update({ status: 'inactive' })
@@ -118,12 +102,8 @@ export async function fulfillPlatformSaasSubscription(
       .select('code, monthly_price, active')
       .eq('code', code)
       .maybeSingle();
-
     if (catalogError || !catalog?.active) {
-      logger.warn('platform_saas fulfillment: add-on unavailable', {
-        code,
-        error: catalogError?.message,
-      });
+      logger.warn('platform_saas fulfillment: add-on unavailable', { code, error: catalogError?.message });
       continue;
     }
 
@@ -139,29 +119,21 @@ export async function fulfillPlatformSaasSubscription(
       },
       { onConflict: 'organization_id,addon_code' },
     );
-
-    if (addonErr) {
-      logger.warn('addon_subscriptions upsert failed', { code, addonErr });
-    }
+    if (addonErr) logger.warn('addon_subscriptions upsert failed', { code, addonErr });
 
     await adminSupabase.from('organization_addons').upsert(
-      {
-        tenant_id: tenantId,
-        addon_slug: code,
-        status: 'active',
-        activated_at: now,
-      },
+      { tenant_id: tenantId, addon_slug: code, status: 'active', activated_at: now },
       { onConflict: 'tenant_id,addon_slug' },
     );
   }
 
   const entitlements = await getOrganizationFeatures(tenantId, adminSupabase);
-
   await syncLicenseFromSaasEntitlements(adminSupabase, tenantId, entitlements, {
     planSlug: meta.plan_id,
     billingInterval: meta.billing_interval,
     stripeSubscriptionId: meta.stripe_subscription_id,
     stripeCustomerId: meta.stripe_customer_id,
+    active: true,
   });
 
   if (meta.stripe_subscription_id) {
@@ -176,11 +148,7 @@ export async function fulfillPlatformSaasSubscription(
       subjectId: tenantId,
       correlationId: meta.stripe_subscription_id,
       idempotencyKey: `platform-checkout-entitlement:${meta.stripe_subscription_id}:${meta.plan_id}:${addonSlugs.join(',')}`,
-      payload: {
-        plan_slug: meta.plan_id,
-        addon_codes: addonSlugs,
-        features: entitlements.features,
-      },
+      payload: { plan_slug: meta.plan_id, addon_codes: addonSlugs, features: entitlements.features },
     });
   }
 

--- a/lib/platform/handle-subscription-webhook.ts
+++ b/lib/platform/handle-subscription-webhook.ts
@@ -9,47 +9,14 @@ import {
   syncIndividualAppLifecycle,
   syncPlatformSubscriptionLifecycle,
 } from '@/lib/platform/subscription-lifecycle';
-
-function subscriptionPeriod(subscription: Stripe.Subscription) {
-  const firstItem = subscription.items?.data?.[0];
-  return {
-    start: firstItem?.current_period_start
-      ? new Date(firstItem.current_period_start * 1000).toISOString()
-      : null,
-    end: firstItem?.current_period_end
-      ? new Date(firstItem.current_period_end * 1000).toISOString()
-      : null,
-  };
-}
-
-async function persistGenericSubscription(db: any, subscription: Stripe.Subscription) {
-  const period = subscriptionPeriod(subscription);
-  await db.from('subscriptions').upsert(
-    {
-      stripe_subscription_id: subscription.id,
-      customer_id:
-        typeof subscription.customer === 'string'
-          ? subscription.customer
-          : subscription.customer?.id,
-      status: subscription.status,
-      current_period_start: period.start,
-      current_period_end: period.end,
-      cancel_at_period_end: subscription.cancel_at_period_end,
-      canceled_at: subscription.canceled_at
-        ? new Date(subscription.canceled_at * 1000).toISOString()
-        : null,
-      created_at: new Date(subscription.created * 1000).toISOString(),
-      metadata: subscription.metadata,
-      updated_at: new Date().toISOString(),
-    },
-    { onConflict: 'stripe_subscription_id' },
-  );
-}
+import { syncHostShopSubscriptionLifecycle } from '@/lib/platform/orchestration/host-shop-subscription';
 
 async function syncAllSubscriptionState(db: any, subscription: Stripe.Subscription) {
-  await persistGenericSubscription(db, subscription);
+  // Domain tables are authoritative. Do not mirror into the legacy generic
+  // `subscriptions` table: that creates a competing source of truth.
   await syncPlatformSubscriptionLifecycle(db, subscription);
   await syncIndividualAppLifecycle(db, subscription);
+  await syncHostShopSubscriptionLifecycle(db, subscription);
 }
 
 async function persistInvoice(db: any, invoice: Stripe.Invoice, status: 'paid' | 'failed') {
@@ -97,8 +64,11 @@ async function persistInvoice(db: any, invoice: Stripe.Invoice, status: 'paid' |
 
 /**
  * Canonical subscription webhook processor used by Marketing and LMS.
- * Stripe should still point to one public endpoint, but duplicate app routes now
- * execute exactly the same lifecycle logic and cannot drift independently.
+ *
+ * All recurring product families flow through this one handler. Individual
+ * lifecycle helpers ignore subscriptions outside their metadata namespace, so
+ * each Stripe event has exactly one domain owner while sharing verification,
+ * invoice auditing, retries, and logging.
  */
 export async function handleSubscriptionWebhook(request: NextRequest) {
   const payload = Buffer.from(await request.arrayBuffer()).toString();
@@ -123,7 +93,6 @@ export async function handleSubscriptionWebhook(request: NextRequest) {
   }
 
   const db = await requireAdminClient();
-  if (!db) return NextResponse.json({ error: 'Database unavailable' }, { status: 503 });
 
   try {
     switch (event.type) {
@@ -137,6 +106,7 @@ export async function handleSubscriptionWebhook(request: NextRequest) {
           subscriptionId: subscription.id,
           status: subscription.status,
           checkoutType: subscription.metadata?.checkout_type,
+          type: subscription.metadata?.type,
         });
         break;
       }

--- a/lib/platform/orchestration/commerce.ts
+++ b/lib/platform/orchestration/commerce.ts
@@ -1,4 +1,5 @@
 import type { IndividualAppSlug, IndividualPlanId } from '@/lib/apps/individual-app-plans';
+import type { BasePlanId, BillingInterval as PlatformBillingInterval } from '@/lib/store/platform-pricing';
 
 export type BillingInterval = 'month' | 'year' | 'week' | 'one_time';
 
@@ -18,13 +19,27 @@ export function individualAppPriceLookupKey(
   return canonicalPriceLookupKey(['app', appSlug, plan, 'monthly']);
 }
 
+export function platformPlanPriceLookupKey(
+  plan: BasePlanId,
+  interval: PlatformBillingInterval,
+): string {
+  return canonicalPriceLookupKey(['platform', plan, interval]);
+}
+
+export function platformAddonPriceLookupKey(
+  addonSlug: string,
+  interval: PlatformBillingInterval,
+): string {
+  return canonicalPriceLookupKey(['platform', 'addon', addonSlug, interval]);
+}
+
 export const PLATFORM_PRICE_LOOKUP_KEYS = {
-  solo_monthly: canonicalPriceLookupKey(['platform', 'solo', 'monthly']),
-  solo_annual: canonicalPriceLookupKey(['platform', 'solo', 'annual']),
-  business_monthly: canonicalPriceLookupKey(['platform', 'business', 'monthly']),
-  business_annual: canonicalPriceLookupKey(['platform', 'business', 'annual']),
-  professional_monthly: canonicalPriceLookupKey(['platform', 'professional', 'monthly']),
-  professional_annual: canonicalPriceLookupKey(['platform', 'professional', 'annual']),
+  solo_monthly: platformPlanPriceLookupKey('solo', 'monthly'),
+  solo_annual: platformPlanPriceLookupKey('solo', 'annual'),
+  business_monthly: platformPlanPriceLookupKey('business', 'monthly'),
+  business_annual: platformPlanPriceLookupKey('business', 'annual'),
+  professional_monthly: platformPlanPriceLookupKey('professional', 'monthly'),
+  professional_annual: platformPlanPriceLookupKey('professional', 'annual'),
 } as const;
 
 export const HOST_SHOP_PRICE_LOOKUP_KEYS = {

--- a/lib/platform/orchestration/commerce.ts
+++ b/lib/platform/orchestration/commerce.ts
@@ -1,0 +1,40 @@
+import type { IndividualAppSlug, IndividualPlanId } from '@/lib/apps/individual-app-plans';
+
+export type BillingInterval = 'month' | 'year' | 'week' | 'one_time';
+
+function normalizeKeyPart(value: string): string {
+  return value.trim().toLowerCase().replace(/[^a-z0-9]+/g, '_').replace(/^_+|_+$/g, '');
+}
+
+/** Stable Stripe lookup key. Checkout code must resolve a Price by this key. */
+export function canonicalPriceLookupKey(parts: string[]): string {
+  return ['elevate', ...parts.map(normalizeKeyPart)].join('_');
+}
+
+export function individualAppPriceLookupKey(
+  appSlug: IndividualAppSlug,
+  plan: IndividualPlanId,
+): string {
+  return canonicalPriceLookupKey(['app', appSlug, plan, 'monthly']);
+}
+
+export const PLATFORM_PRICE_LOOKUP_KEYS = {
+  solo_monthly: canonicalPriceLookupKey(['platform', 'solo', 'monthly']),
+  solo_annual: canonicalPriceLookupKey(['platform', 'solo', 'annual']),
+  business_monthly: canonicalPriceLookupKey(['platform', 'business', 'monthly']),
+  business_annual: canonicalPriceLookupKey(['platform', 'business', 'annual']),
+  professional_monthly: canonicalPriceLookupKey(['platform', 'professional', 'monthly']),
+  professional_annual: canonicalPriceLookupKey(['platform', 'professional', 'annual']),
+} as const;
+
+export const HOST_SHOP_PRICE_LOOKUP_KEYS = {
+  bronze_monthly: canonicalPriceLookupKey(['host_shop', 'bronze', 'monthly']),
+  silver_monthly: canonicalPriceLookupKey(['host_shop', 'silver', 'monthly']),
+  gold_monthly: canonicalPriceLookupKey(['host_shop', 'gold', 'monthly']),
+  platinum_monthly: canonicalPriceLookupKey(['host_shop', 'platinum', 'monthly']),
+  application_fee: canonicalPriceLookupKey(['host_shop', 'application', 'one_time']),
+} as const;
+
+export const TUITION_PRICE_LOOKUP_KEYS = {
+  barber_weekly: canonicalPriceLookupKey(['tuition', 'barber_apprenticeship', 'weekly']),
+} as const;

--- a/lib/platform/orchestration/dispatcher.ts
+++ b/lib/platform/orchestration/dispatcher.ts
@@ -1,0 +1,341 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { executeWorkflow } from '@/lib/workflows/engine';
+import { getOrganizationFeatures } from '@/lib/platform/organization-features';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+
+type PlatformEventRow = {
+  id: string;
+  event_type: string;
+  category: string;
+  severity: string;
+  source?: string | null;
+  actor_id?: string | null;
+  actor_type?: string | null;
+  subject_id?: string | null;
+  subject_type?: string | null;
+  tenant_id?: string | null;
+  correlation_id?: string | null;
+  idempotency_key?: string | null;
+  payload?: Record<string, unknown> | null;
+  message?: string | null;
+  attempts?: number | null;
+  created_at?: string | null;
+};
+
+type WorkflowTriggerRow = {
+  id: string;
+  workflow_id: string;
+  event_filter?: Record<string, unknown> | null;
+};
+
+export interface OrchestrationProcessResult {
+  claimed: number;
+  processed: number;
+  failed: number;
+  workflowRuns: number;
+  eventIds: string[];
+}
+
+function matchesFilterValue(actual: string | null | undefined, expected: unknown): boolean {
+  if (expected === undefined || expected === null || expected === '') return true;
+  if (Array.isArray(expected)) return expected.map(String).includes(String(actual ?? ''));
+  return String(actual ?? '') === String(expected);
+}
+
+function triggerMatches(event: PlatformEventRow, trigger: WorkflowTriggerRow): boolean {
+  const filter = trigger.event_filter ?? {};
+  return (
+    matchesFilterValue(event.event_type, filter.event_type) &&
+    matchesFilterValue(event.category, filter.category) &&
+    matchesFilterValue(event.subject_type, filter.subject_type) &&
+    matchesFilterValue(event.source, filter.source)
+  );
+}
+
+async function hydrateEventContext(db: Awaited<ReturnType<typeof requireAdminClient>>, event: PlatformEventRow) {
+  const base: Record<string, unknown> = {
+    event_id: event.id,
+    event_type: event.event_type,
+    category: event.category,
+    source: event.source ?? null,
+    actor_id: event.actor_id ?? null,
+    subject_id: event.subject_id ?? null,
+    subject_type: event.subject_type ?? null,
+    tenant_id: event.tenant_id ?? null,
+    correlation_id: event.correlation_id ?? event.id,
+    payload: event.payload ?? {},
+  };
+
+  if (!event.subject_id || !event.subject_type) return base;
+
+  if (event.subject_type === 'application' || event.subject_type === 'host_shop_application') {
+    const table = event.subject_type === 'application' ? 'applications' : 'host_shop_applications';
+    const fields = event.subject_type === 'application'
+      ? 'id,user_id,first_name,last_name,email,phone,status,program_id,program_slug,program_interest,reference_number,source,funding_source,funding_type'
+      : 'id,shop_name,business_name,owner_name,email,contact_email,phone,status,course_slug,approved_at,stripe_session_id';
+    const { data } = await db.from(table).select(fields).eq('id', event.subject_id).maybeSingle();
+    if (data) return { ...base, ...data, record: data };
+  }
+
+  if (event.subject_type === 'program_enrollment') {
+    const { data } = await db
+      .from('program_enrollments')
+      .select('id,user_id,student_id,email,full_name,phone,status,enrollment_state,program_id,program_slug,course_id,tenant_id,host_shop_id,orientation_completed_at,funding_source,next_required_action')
+      .eq('id', event.subject_id)
+      .maybeSingle();
+    if (data) return { ...base, ...data, record: data };
+  }
+
+  if (event.subject_type === 'certificate') {
+    const { data } = await db
+      .from('certificates')
+      .select('id,user_id,student_id,student_email,student_name,course_id,course_title,course_name,program_id,program_name,enrollment_id,certificate_number,verification_url,certificate_url,tenant_id,status,issued_at')
+      .eq('id', event.subject_id)
+      .maybeSingle();
+    if (data) return { ...base, ...data, record: data };
+  }
+
+  if (event.subject_type === 'exam_session') {
+    const { data } = await db
+      .from('exam_sessions')
+      .select('id,tenant_id,student_id,student_name,student_email,provider,exam_name,exam_code,status,program_slug,is_retest,created_at')
+      .eq('id', event.subject_id)
+      .maybeSingle();
+    if (data) return { ...base, ...data, record: data };
+  }
+
+  if (event.subject_type === 'individual_app') {
+    const appSlug = event.subject_id;
+    const userId = event.actor_id;
+    if (userId) {
+      const { data } = await db
+        .from('user_app_subscriptions')
+        .select('id,user_id,app_slug,plan,status,trial_ends_at,current_period_end,stripe_subscription_id,stripe_customer_id')
+        .eq('user_id', userId)
+        .eq('app_slug', appSlug)
+        .maybeSingle();
+      if (data) return { ...base, ...data, record: data };
+    }
+  }
+
+  if (event.subject_type === 'tenant' && event.subject_id) {
+    const entitlements = await getOrganizationFeatures(event.subject_id, db);
+    return { ...base, entitlements };
+  }
+
+  return base;
+}
+
+async function handleProvisioningRequested(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  event: PlatformEventRow,
+  context: Record<string, unknown>,
+): Promise<void> {
+  const payload = (event.payload ?? {}) as Record<string, unknown>;
+  const kind = String(payload.kind ?? 'workspace');
+
+  if (event.subject_type === 'individual_app') {
+    const status = String(context.status ?? '');
+    if (!['active', 'trial'].includes(status)) {
+      throw new Error(`Cannot provision ${event.subject_id}: subscription status is ${status || 'missing'}`);
+    }
+  }
+
+  if (event.subject_type === 'tenant' && event.subject_id) {
+    const entitlements = await getOrganizationFeatures(event.subject_id, db);
+    if (!entitlements.features.length) {
+      throw new Error(`Cannot provision tenant ${event.subject_id}: no active entitlements`);
+    }
+  }
+
+  const { error } = await db.from('provisioning_events').insert({
+    tenant_id: event.tenant_id ?? (event.subject_type === 'tenant' ? event.subject_id : null),
+    correlation_id: event.correlation_id ?? event.id,
+    step: kind,
+    status: 'completed',
+    metadata: {
+      source_event_id: event.id,
+      subject_type: event.subject_type,
+      subject_id: event.subject_id,
+      app_slug: payload.app_slug ?? null,
+      plan: payload.plan ?? payload.plan_slug ?? null,
+      automated: true,
+    },
+    environment: process.env.NODE_ENV ?? 'production',
+  });
+  if (error) throw error;
+
+  await emitPlatformEvent(db, {
+    eventType: PlatformEventType.PROVISIONING_COMPLETED,
+    category: 'provisioning',
+    source: 'platform.orchestration.dispatcher',
+    actorId: event.actor_id ?? null,
+    actorType: event.actor_type ?? 'system',
+    tenantId: event.tenant_id ?? null,
+    subjectType: event.subject_type ?? 'workspace',
+    subjectId: event.subject_id ?? event.id,
+    correlationId: event.correlation_id ?? event.id,
+    idempotencyKey: `provisioning-completed:${event.id}`,
+    dispatch: false,
+    payload: { kind, source_event_id: event.id },
+  });
+}
+
+async function runCoreOrchestration(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  event: PlatformEventRow,
+  context: Record<string, unknown>,
+): Promise<void> {
+  switch (event.event_type) {
+    case PlatformEventType.PROVISIONING_REQUESTED:
+      await handleProvisioningRequested(db, event, context);
+      break;
+    default:
+      // Most domain routes already own their immediate atomic side effects.
+      // The dispatcher coordinates optional cross-system workflows without
+      // duplicating those canonical writes.
+      break;
+  }
+}
+
+async function runMatchingWorkflows(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  event: PlatformEventRow,
+  context: Record<string, unknown>,
+): Promise<number> {
+  const { data: triggers, error: triggerError } = await db
+    .from('workflow_triggers')
+    .select('id,workflow_id,event_filter')
+    .eq('trigger_type', 'event')
+    .eq('enabled', true);
+  if (triggerError) throw triggerError;
+
+  const matching = (triggers ?? []).filter((row) => triggerMatches(event, row as WorkflowTriggerRow));
+  if (!matching.length) return 0;
+
+  const workflowIds = [...new Set(matching.map((row) => row.workflow_id))];
+  const { data: workflows, error: workflowError } = await db
+    .from('workflows')
+    .select('id,status,tenant_id')
+    .in('id', workflowIds);
+  if (workflowError) throw workflowError;
+
+  const activeIds = new Set(
+    (workflows ?? [])
+      .filter((workflow) =>
+        workflow.status === 'active' &&
+        (!workflow.tenant_id || !event.tenant_id || workflow.tenant_id === event.tenant_id),
+      )
+      .map((workflow) => workflow.id),
+  );
+
+  let runs = 0;
+  for (const trigger of matching) {
+    if (!activeIds.has(trigger.workflow_id)) continue;
+
+    const { data: existingRun } = await db
+      .from('workflow_runs')
+      .select('id,status')
+      .eq('platform_event_id', event.id)
+      .eq('workflow_id', trigger.workflow_id)
+      .maybeSingle();
+    if (existingRun) continue;
+
+    const result = await executeWorkflow(
+      trigger.workflow_id,
+      'event',
+      context,
+      trigger.id,
+      event.correlation_id ?? event.id,
+      event.tenant_id ?? undefined,
+    );
+
+    if (result.runId) {
+      await db
+        .from('workflow_runs')
+        .update({ platform_event_id: event.id })
+        .eq('id', result.runId);
+      runs++;
+    }
+
+    if (result.status === 'failed') {
+      throw new Error(result.error || `Workflow ${trigger.workflow_id} failed`);
+    }
+  }
+
+  return runs;
+}
+
+async function markProcessed(db: Awaited<ReturnType<typeof requireAdminClient>>, eventId: string) {
+  const { error } = await db
+    .from('platform_events')
+    .update({
+      processing_status: 'processed',
+      processed_at: new Date().toISOString(),
+      resolved: true,
+      locked_at: null,
+      last_error: null,
+    })
+    .eq('id', eventId);
+  if (error) throw error;
+}
+
+async function markFailed(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  event: PlatformEventRow,
+  errorMessage: string,
+) {
+  const attempts = Math.max(1, Number(event.attempts ?? 1));
+  const retryMinutes = Math.min(60, Math.pow(2, Math.max(0, attempts - 1)));
+  const retryAt = new Date(Date.now() + retryMinutes * 60_000).toISOString();
+  await db
+    .from('platform_events')
+    .update({
+      processing_status: 'failed',
+      available_at: retryAt,
+      locked_at: null,
+      last_error: errorMessage.slice(0, 4000),
+      resolved: false,
+    })
+    .eq('id', event.id);
+}
+
+export async function processPendingPlatformEvents(limit = 20): Promise<OrchestrationProcessResult> {
+  const db = await requireAdminClient();
+  const boundedLimit = Math.max(1, Math.min(limit, 100));
+  const { data: claimed, error } = await db.rpc('claim_platform_events_v1', { p_limit: boundedLimit });
+  if (error) throw error;
+
+  const events = (claimed ?? []) as PlatformEventRow[];
+  const result: OrchestrationProcessResult = {
+    claimed: events.length,
+    processed: 0,
+    failed: 0,
+    workflowRuns: 0,
+    eventIds: events.map((event) => event.id),
+  };
+
+  for (const event of events) {
+    try {
+      const context = await hydrateEventContext(db, event);
+      await runCoreOrchestration(db, event, context);
+      result.workflowRuns += await runMatchingWorkflows(db, event, context);
+      await markProcessed(db, event.id);
+      result.processed++;
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger.error('[orchestration] event processing failed', error instanceof Error ? error : undefined, {
+        eventId: event.id,
+        eventType: event.event_type,
+        attempts: event.attempts,
+      });
+      await markFailed(db, event, message);
+      result.failed++;
+    }
+  }
+
+  return result;
+}

--- a/lib/platform/orchestration/events.ts
+++ b/lib/platform/orchestration/events.ts
@@ -1,0 +1,195 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '@/lib/logger';
+
+export const PlatformEventType = {
+  IDENTITY_AUTHENTICATED: 'identity.authenticated',
+  IDENTITY_ROLE_CHANGED: 'identity.role_changed',
+  COMMERCE_CHECKOUT_CREATED: 'commerce.checkout_created',
+  COMMERCE_CHECKOUT_COMPLETED: 'commerce.checkout_completed',
+  BILLING_SUBSCRIPTION_ACTIVATED: 'billing.subscription_activated',
+  BILLING_SUBSCRIPTION_UPDATED: 'billing.subscription_updated',
+  BILLING_SUBSCRIPTION_PAST_DUE: 'billing.subscription_past_due',
+  BILLING_SUBSCRIPTION_CANCELED: 'billing.subscription_canceled',
+  BILLING_PAYMENT_FAILED: 'billing.payment_failed',
+  ENTITLEMENT_REFRESHED: 'entitlement.refreshed',
+  ENTITLEMENT_GRANTED: 'entitlement.granted',
+  ENTITLEMENT_REVOKED: 'entitlement.revoked',
+  PROVISIONING_REQUESTED: 'provisioning.requested',
+  PROVISIONING_COMPLETED: 'provisioning.completed',
+  PROVISIONING_FAILED: 'provisioning.failed',
+  APPLICATION_SUBMITTED: 'application.submitted',
+  APPLICATION_APPROVED: 'application.approved',
+  ENROLLMENT_CONFIRMED: 'enrollment.confirmed',
+  ORIENTATION_COMPLETED: 'orientation.completed',
+  COURSE_COMPLETED: 'course.completed',
+  CERTIFICATE_ISSUED: 'certificate.issued',
+  HOST_SHOP_APPROVED: 'host_shop.approved',
+  APPRENTICE_ASSIGNED: 'apprentice.assigned',
+  TESTING_REGISTRATION_CREATED: 'testing.registration_created',
+  WORKFLOW_TRIGGERED: 'workflow.triggered',
+} as const;
+
+export type PlatformEventTypeValue =
+  (typeof PlatformEventType)[keyof typeof PlatformEventType];
+
+export type PlatformEventCategory =
+  | 'identity'
+  | 'commerce'
+  | 'billing'
+  | 'entitlement'
+  | 'provisioning'
+  | 'application'
+  | 'enrollment'
+  | 'lms'
+  | 'credential'
+  | 'workforce'
+  | 'testing'
+  | 'workflow'
+  | 'ai'
+  | 'deployment';
+
+export type PlatformEventSeverity = 'info' | 'warning' | 'error' | 'critical';
+export type PlatformEventProcessingStatus =
+  | 'observed'
+  | 'pending'
+  | 'processing'
+  | 'processed'
+  | 'failed';
+
+export interface EmitPlatformEventInput {
+  eventType: PlatformEventTypeValue | string;
+  category: PlatformEventCategory;
+  source: string;
+  subjectType?: string | null;
+  subjectId?: string | null;
+  actorId?: string | null;
+  actorType?: string | null;
+  tenantId?: string | null;
+  correlationId?: string | null;
+  idempotencyKey?: string | null;
+  payload?: Record<string, unknown>;
+  message?: string | null;
+  severity?: PlatformEventSeverity;
+  dispatch?: boolean;
+  availableAt?: string | null;
+}
+
+export interface PlatformEventWriteResult {
+  id: string | null;
+  duplicate: boolean;
+}
+
+/**
+ * Canonical durable event writer for cross-platform orchestration.
+ *
+ * Business flows should write one stable event here rather than directly
+ * triggering multiple downstream systems. Consumers can process `pending`
+ * events idempotently; telemetry-only events remain `observed`.
+ */
+export async function emitPlatformEvent(
+  db: SupabaseClient,
+  input: EmitPlatformEventInput,
+): Promise<PlatformEventWriteResult> {
+  const row = {
+    event_type: input.eventType,
+    category: input.category,
+    severity: input.severity ?? 'info',
+    source: input.source,
+    actor_id: input.actorId ?? null,
+    actor_type: input.actorType ?? null,
+    subject_id: input.subjectId ?? null,
+    subject_type: input.subjectType ?? null,
+    tenant_id: input.tenantId ?? null,
+    correlation_id: input.correlationId ?? null,
+    idempotency_key: input.idempotencyKey ?? null,
+    payload: input.payload ?? {},
+    message: input.message ?? null,
+    resolved: false,
+    processing_status: input.dispatch === false ? 'observed' : 'pending',
+    available_at: input.availableAt ?? new Date().toISOString(),
+  };
+
+  const { data, error } = await db
+    .from('platform_events')
+    .insert(row)
+    .select('id')
+    .maybeSingle();
+
+  if (!error) {
+    return { id: data?.id ?? null, duplicate: false };
+  }
+
+  if (error.code === '23505' && input.idempotencyKey) {
+    const { data: existing } = await db
+      .from('platform_events')
+      .select('id')
+      .eq('idempotency_key', input.idempotencyKey)
+      .maybeSingle();
+    return { id: existing?.id ?? null, duplicate: true };
+  }
+
+  logger.error('[orchestration] platform event insert failed', error, {
+    eventType: input.eventType,
+    category: input.category,
+    source: input.source,
+    correlationId: input.correlationId,
+  });
+  throw error;
+}
+
+export async function markPlatformEventProcessing(
+  db: SupabaseClient,
+  eventId: string,
+): Promise<void> {
+  const { error } = await db
+    .from('platform_events')
+    .update({
+      processing_status: 'processing',
+      attempts: 1,
+      last_error: null,
+    })
+    .eq('id', eventId)
+    .eq('processing_status', 'pending');
+  if (error) throw error;
+}
+
+export async function markPlatformEventProcessed(
+  db: SupabaseClient,
+  eventId: string,
+): Promise<void> {
+  const { error } = await db
+    .from('platform_events')
+    .update({
+      processing_status: 'processed',
+      processed_at: new Date().toISOString(),
+      resolved: true,
+      last_error: null,
+    })
+    .eq('id', eventId);
+  if (error) throw error;
+}
+
+export async function markPlatformEventFailed(
+  db: SupabaseClient,
+  eventId: string,
+  errorMessage: string,
+  retryAt?: Date,
+): Promise<void> {
+  const { data: current } = await db
+    .from('platform_events')
+    .select('attempts')
+    .eq('id', eventId)
+    .maybeSingle();
+
+  const attempts = Number(current?.attempts ?? 0) + 1;
+  const { error } = await db
+    .from('platform_events')
+    .update({
+      processing_status: 'failed',
+      attempts,
+      last_error: errorMessage.slice(0, 4000),
+      available_at: (retryAt ?? new Date(Date.now() + 5 * 60_000)).toISOString(),
+    })
+    .eq('id', eventId);
+  if (error) throw error;
+}

--- a/lib/platform/orchestration/host-shop-subscription.ts
+++ b/lib/platform/orchestration/host-shop-subscription.ts
@@ -1,0 +1,180 @@
+import type Stripe from 'stripe';
+import type { SupabaseClient } from '@/lib/supabase';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
+import { logger } from '@/lib/logger';
+
+export type HostShopTier = 'bronze' | 'silver' | 'gold' | 'platinum';
+
+export const HOST_SHOP_TIER_AMOUNTS: Record<HostShopTier, number> = {
+  bronze: 14900,
+  silver: 29900,
+  gold: 49900,
+  platinum: 99900,
+};
+
+export const HOST_SHOP_TIER_LABELS: Record<HostShopTier, string> = {
+  bronze: 'Bronze Host Partner',
+  silver: 'Silver Growth Partner',
+  gold: 'Gold Business Accelerator',
+  platinum: 'Platinum Elite Partner',
+};
+
+export function isHostShopTier(value: unknown): value is HostShopTier {
+  return typeof value === 'string' && value in HOST_SHOP_TIER_AMOUNTS;
+}
+
+function periodStart(subscription: Stripe.Subscription): string | null {
+  const raw = subscription as unknown as { current_period_start?: number };
+  return raw.current_period_start ? new Date(raw.current_period_start * 1000).toISOString() : null;
+}
+
+function periodEnd(subscription: Stripe.Subscription): string | null {
+  const raw = subscription as unknown as { current_period_end?: number };
+  return raw.current_period_end ? new Date(raw.current_period_end * 1000).toISOString() : null;
+}
+
+function customerId(subscription: Stripe.Subscription): string | null {
+  return typeof subscription.customer === 'string'
+    ? subscription.customer
+    : subscription.customer?.id ?? null;
+}
+
+function mappedStatus(status: Stripe.Subscription.Status): {
+  subscriptionStatus: string;
+  partnershipStatus: string;
+  hasAccess: boolean;
+} {
+  if (status === 'active' || status === 'trialing') {
+    return { subscriptionStatus: status, partnershipStatus: 'active', hasAccess: true };
+  }
+  if (status === 'canceled' || status === 'incomplete_expired') {
+    return { subscriptionStatus: 'canceled', partnershipStatus: 'expired', hasAccess: false };
+  }
+  return { subscriptionStatus: status, partnershipStatus: 'suspended', hasAccess: false };
+}
+
+function billingEvent(status: Stripe.Subscription.Status): string {
+  if (status === 'active' || status === 'trialing') return PlatformEventType.BILLING_SUBSCRIPTION_ACTIVATED;
+  if (status === 'canceled' || status === 'incomplete_expired') return PlatformEventType.BILLING_SUBSCRIPTION_CANCELED;
+  if (status === 'past_due' || status === 'unpaid' || status === 'incomplete') return PlatformEventType.BILLING_SUBSCRIPTION_PAST_DUE;
+  return PlatformEventType.BILLING_SUBSCRIPTION_UPDATED;
+}
+
+export async function syncHostShopSubscriptionLifecycle(
+  db: SupabaseClient,
+  subscription: Stripe.Subscription,
+): Promise<void> {
+  const metadata = subscription.metadata || {};
+  if (metadata.type !== 'host_shop_subscription' && metadata.checkout_type !== 'host_shop_subscription') return;
+
+  const partnershipId = metadata.partnership_id || '';
+  const partnerId = metadata.partner_id || '';
+  const shopId = metadata.shop_id || '';
+  const ownerId = metadata.user_id || metadata.owner_id || '';
+  const tier = metadata.tier;
+  if (!isHostShopTier(tier)) {
+    logger.error('[host-shop] subscription missing canonical tier', undefined, {
+      subscriptionId: subscription.id,
+      tier,
+    });
+    return;
+  }
+
+  let query = db.from('host_shop_partnerships').select('id,partner_tier,subscription_status');
+  if (partnershipId) query = query.eq('id', partnershipId);
+  else if (partnerId) query = query.eq('partner_id', partnerId);
+  else if (shopId) query = query.eq('shop_id', shopId);
+  else {
+    logger.error('[host-shop] subscription has no partnership identity', undefined, { subscriptionId: subscription.id });
+    return;
+  }
+
+  const { data: existing } = await query.maybeSingle();
+  if (!existing?.id) {
+    logger.error('[host-shop] partnership not found for subscription', undefined, {
+      subscriptionId: subscription.id,
+      partnershipId,
+      partnerId,
+      shopId,
+    });
+    return;
+  }
+
+  const state = mappedStatus(subscription.status);
+  const now = new Date().toISOString();
+  const { error } = await db
+    .from('host_shop_partnerships')
+    .update({
+      partner_tier: state.hasAccess ? tier : 'free',
+      stripe_customer_id: customerId(subscription),
+      stripe_subscription_id: subscription.id,
+      subscription_status: state.subscriptionStatus,
+      subscription_start_date: periodStart(subscription),
+      current_period_end: periodEnd(subscription),
+      subscription_end_date: state.hasAccess ? null : now,
+      status: state.partnershipStatus,
+      portal_access_enabled: state.hasAccess,
+      portal_access_at: state.hasAccess ? now : null,
+      owner_id: ownerId || null,
+      updated_at: now,
+      metadata: {
+        billing_authority: 'stripe',
+        stripe_subscription_id: subscription.id,
+        tier,
+        partner_id: partnerId || null,
+        shop_id: shopId || null,
+      },
+    })
+    .eq('id', existing.id);
+
+  if (error) throw error;
+
+  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}:${tier}`;
+  await emitPlatformEvent(db, {
+    eventType: billingEvent(subscription.status),
+    category: 'billing',
+    source: 'stripe.host-shop-subscription',
+    actorId: ownerId || null,
+    actorType: ownerId ? 'user' : 'system',
+    subjectType: 'host_shop_partnership',
+    subjectId: existing.id,
+    correlationId: subscription.id,
+    idempotencyKey: `billing:host-shop:${eventKey}`,
+    payload: {
+      partner_id: partnerId || null,
+      shop_id: shopId || null,
+      tier,
+      status: state.subscriptionStatus,
+    },
+  });
+
+  await emitPlatformEvent(db, {
+    eventType: state.hasAccess ? PlatformEventType.ENTITLEMENT_GRANTED : PlatformEventType.ENTITLEMENT_REVOKED,
+    category: 'entitlement',
+    source: 'stripe.host-shop-subscription',
+    actorId: ownerId || null,
+    actorType: ownerId ? 'user' : 'system',
+    subjectType: 'host_shop_partnership',
+    subjectId: existing.id,
+    correlationId: subscription.id,
+    idempotencyKey: `entitlement:host-shop:${eventKey}`,
+    payload: { tier, portal_access: state.hasAccess },
+  });
+
+  const previouslyAccessible = existing.subscription_status === 'active' || existing.subscription_status === 'trialing';
+  const tierChanged = existing.partner_tier !== tier;
+  if (state.hasAccess && (!previouslyAccessible || tierChanged)) {
+    await emitPlatformEvent(db, {
+      eventType: PlatformEventType.PROVISIONING_REQUESTED,
+      category: 'provisioning',
+      source: 'stripe.host-shop-subscription',
+      actorId: ownerId || null,
+      actorType: ownerId ? 'user' : 'system',
+      subjectType: 'host_shop_partnership',
+      subjectId: existing.id,
+      correlationId: subscription.id,
+      idempotencyKey: `provisioning:host-shop:${subscription.id}:${tier}`,
+      payload: { kind: 'host_shop_workspace', tier, partner_id: partnerId || null, shop_id: shopId || null },
+    });
+  }
+}

--- a/lib/platform/orchestration/surfaces.ts
+++ b/lib/platform/orchestration/surfaces.ts
@@ -1,0 +1,163 @@
+import { PlatformFeature, type PlatformFeatureKey } from '@/lib/platform/features';
+
+export type PlatformRuntime = 'marketing' | 'lms' | 'admin';
+export type PlatformSurfaceScope =
+  | 'public'
+  | 'individual_app'
+  | 'organization'
+  | 'role'
+  | 'platform_admin';
+
+export interface PlatformSurfaceContract {
+  key: string;
+  label: string;
+  runtime: PlatformRuntime;
+  entryPath: string;
+  scope: PlatformSurfaceScope;
+  requiredFeature?: PlatformFeatureKey;
+  subscriptionSlug?: string;
+  provisioningKind?: string;
+}
+
+/**
+ * One route/capability contract for every major product surface.
+ * Navigation, commercial access, provisioning and smoke tests should resolve
+ * from this registry instead of inventing independent route/feature maps.
+ */
+export const PLATFORM_SURFACES: Record<string, PlatformSurfaceContract> = {
+  store: {
+    key: 'store', label: 'Store', runtime: 'marketing', entryPath: '/store', scope: 'public',
+  },
+  website_builder: {
+    key: 'website_builder', label: 'Website Builder', runtime: 'marketing',
+    entryPath: '/apps/website-builder', scope: 'individual_app',
+    requiredFeature: PlatformFeature.WEBSITE_BUILDER,
+    subscriptionSlug: 'website-builder', provisioningKind: 'website_workspace',
+  },
+  sam_gov: {
+    key: 'sam_gov', label: 'SAM.gov Manager', runtime: 'marketing',
+    entryPath: '/apps/sam-gov', scope: 'individual_app',
+    requiredFeature: PlatformFeature.SAM_GOV_MANAGER,
+    subscriptionSlug: 'sam-gov', provisioningKind: 'sam_gov_workspace',
+  },
+  grants: {
+    key: 'grants', label: 'Grants Discovery', runtime: 'marketing',
+    entryPath: '/apps/grants', scope: 'individual_app',
+    requiredFeature: PlatformFeature.GRANTS_DISCOVERY,
+    subscriptionSlug: 'grants', provisioningKind: 'grants_workspace',
+  },
+  crm: {
+    key: 'crm', label: 'CRM', runtime: 'admin', entryPath: '/crm', scope: 'organization',
+    requiredFeature: PlatformFeature.CRM, provisioningKind: 'crm_workspace',
+  },
+  bookings: {
+    key: 'bookings', label: 'Bookings', runtime: 'admin', entryPath: '/bookings', scope: 'organization',
+    requiredFeature: PlatformFeature.BOOKING,
+  },
+  forms: {
+    key: 'forms', label: 'Forms', runtime: 'admin', entryPath: '/forms', scope: 'organization',
+    requiredFeature: PlatformFeature.FORMS,
+  },
+  email_marketing: {
+    key: 'email_marketing', label: 'Email Marketing', runtime: 'admin',
+    entryPath: '/marketing', scope: 'organization', requiredFeature: PlatformFeature.EMAIL_MARKETING,
+  },
+  automations: {
+    key: 'automations', label: 'Automations', runtime: 'admin',
+    entryPath: '/automations', scope: 'organization', requiredFeature: PlatformFeature.AUTOMATIONS,
+  },
+  invoicing: {
+    key: 'invoicing', label: 'Invoicing', runtime: 'admin',
+    entryPath: '/billing', scope: 'organization', requiredFeature: PlatformFeature.INVOICING,
+  },
+  analytics: {
+    key: 'analytics', label: 'Analytics', runtime: 'admin',
+    entryPath: '/analytics', scope: 'organization', requiredFeature: PlatformFeature.ANALYTICS,
+  },
+  lms: {
+    key: 'lms', label: 'Learning Management System', runtime: 'lms',
+    entryPath: '/dashboard', scope: 'organization', requiredFeature: PlatformFeature.LMS,
+    provisioningKind: 'lms_workspace',
+  },
+  course_builder: {
+    key: 'course_builder', label: 'Course Builder', runtime: 'lms',
+    entryPath: '/studio/courses', scope: 'organization', requiredFeature: PlatformFeature.COURSE_BUILDER,
+    provisioningKind: 'course_workspace',
+  },
+  course_factory: {
+    key: 'course_factory', label: 'AI Course Factory', runtime: 'lms',
+    entryPath: '/studio/course-factory', scope: 'organization', requiredFeature: PlatformFeature.COURSE_FACTORY,
+  },
+  student_management: {
+    key: 'student_management', label: 'Student Management', runtime: 'admin',
+    entryPath: '/students', scope: 'organization', requiredFeature: PlatformFeature.STUDENT_MANAGEMENT,
+  },
+  instructor_tools: {
+    key: 'instructor_tools', label: 'Instructor Tools', runtime: 'lms',
+    entryPath: '/instructor', scope: 'role', requiredFeature: PlatformFeature.INSTRUCTOR_TOOLS,
+  },
+  workforce: {
+    key: 'workforce', label: 'Workforce', runtime: 'admin',
+    entryPath: '/workforce', scope: 'organization', requiredFeature: PlatformFeature.WORKFORCE,
+  },
+  apprenticeship: {
+    key: 'apprenticeship', label: 'Apprenticeship Management', runtime: 'lms',
+    entryPath: '/apprentice', scope: 'organization', requiredFeature: PlatformFeature.APPRENTICESHIP,
+    provisioningKind: 'apprenticeship_workspace',
+  },
+  employer_portal: {
+    key: 'employer_portal', label: 'Employer Portal', runtime: 'lms',
+    entryPath: '/employer/dashboard', scope: 'role', requiredFeature: PlatformFeature.EMPLOYER_PORTAL,
+  },
+  host_shop_portal: {
+    key: 'host_shop_portal', label: 'Host Shop Portal', runtime: 'lms',
+    entryPath: '/host-shop/dashboard', scope: 'role', requiredFeature: PlatformFeature.APPRENTICESHIP,
+  },
+  testing_center: {
+    key: 'testing_center', label: 'Testing Center', runtime: 'admin',
+    entryPath: '/testing-center', scope: 'organization', requiredFeature: PlatformFeature.TESTING_CENTER,
+    provisioningKind: 'testing_center_workspace',
+  },
+  compliance: {
+    key: 'compliance', label: 'Compliance', runtime: 'admin',
+    entryPath: '/compliance', scope: 'organization', requiredFeature: PlatformFeature.COMPLIANCE,
+  },
+  media_studio: {
+    key: 'media_studio', label: 'Media Studio', runtime: 'admin',
+    entryPath: '/studio/media', scope: 'organization', requiredFeature: PlatformFeature.MEDIA_STUDIO,
+  },
+  ai_paris: {
+    key: 'ai_paris', label: 'PARIS', runtime: 'admin',
+    entryPath: '/ai/paris', scope: 'organization', requiredFeature: PlatformFeature.AI_PARIS,
+  },
+  ai_ellie: {
+    key: 'ai_ellie', label: 'ELLIE', runtime: 'admin',
+    entryPath: '/ai/ellie', scope: 'organization', requiredFeature: PlatformFeature.AI_ELLIE,
+  },
+  ai_lizzy: {
+    key: 'ai_lizzy', label: 'LIZZY', runtime: 'admin',
+    entryPath: '/ai/lizzy', scope: 'organization', requiredFeature: PlatformFeature.AI_LIZZY,
+  },
+  ai_zora: {
+    key: 'ai_zora', label: 'ZORA', runtime: 'admin',
+    entryPath: '/ai/zora', scope: 'organization', requiredFeature: PlatformFeature.AI_ZORA,
+  },
+  dev_studio: {
+    key: 'dev_studio', label: 'Dev Studio', runtime: 'admin',
+    entryPath: '/studio', scope: 'platform_admin', requiredFeature: PlatformFeature.DEV_STUDIO,
+  },
+};
+
+export function getPlatformSurface(key: string): PlatformSurfaceContract | null {
+  return PLATFORM_SURFACES[key] ?? null;
+}
+
+export function getPlatformSurfaceByPath(
+  runtime: PlatformRuntime,
+  pathname: string,
+): PlatformSurfaceContract | null {
+  const candidates = Object.values(PLATFORM_SURFACES)
+    .filter((surface) => surface.runtime === runtime && pathname.startsWith(surface.entryPath))
+    .sort((a, b) => b.entryPath.length - a.entryPath.length);
+  return candidates[0] ?? null;
+}

--- a/lib/platform/organization-features.ts
+++ b/lib/platform/organization-features.ts
@@ -2,7 +2,6 @@ import type { SupabaseClient } from '@/lib/supabase';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import {
   ADDON_FEATURE_FALLBACK,
-  FEATURES,
   PLAN_FEATURE_FALLBACK,
   PLAN_LIMITS_FALLBACK,
   normalizeAddonCode,
@@ -12,7 +11,10 @@ import {
 } from '@/lib/platform/feature-catalog';
 
 export interface OrganizationEntitlements {
+  /** Canonical SaaS tenant id (tenants.id). */
   organizationId: string;
+  /** Billing organization id (organizations.id) when one is mapped to the tenant. */
+  billingOrganizationId: string | null;
   planSlug: string | null;
   planName: string | null;
   status: string | null;
@@ -33,6 +35,8 @@ export class FeatureUpgradeRequiredError extends Error {
   }
 }
 
+const ACCESSIBLE_SUBSCRIPTION_STATUSES = new Set(['active', 'trialing']);
+
 function addFeature(featureSet: Set<FeatureCode>, raw: string | null | undefined) {
   if (!raw) return;
   const normalized = normalizeFeatureCode(raw);
@@ -46,35 +50,72 @@ function applyAddonFallback(featureSet: Set<FeatureCode>, addonCode: string) {
 }
 
 /**
- * Load merged feature codes for an organization (tenant).
- * DB plan/add-on definitions are preferred; code-side fallbacks keep recently
- * introduced capabilities usable during catalog migration/deployment windows.
+ * Convert the canonical SaaS tenant id (tenants.id) to the billing organization
+ * id (organizations.id). Legacy callers that already pass organizations.id are
+ * also supported so the migration is backward compatible.
+ */
+export async function resolveBillingOrganizationId(
+  tenantOrOrganizationId: string,
+  client?: SupabaseClient,
+): Promise<string | null> {
+  const supabase = client ?? (await requireAdminClient());
+  if (!supabase) return null;
+
+  const { data: byTenant } = await supabase
+    .from('organizations')
+    .select('id')
+    .eq('tenant_id', tenantOrOrganizationId)
+    .maybeSingle();
+  if (byTenant?.id) return byTenant.id as string;
+
+  const { data: byId } = await supabase
+    .from('organizations')
+    .select('id')
+    .eq('id', tenantOrOrganizationId)
+    .maybeSingle();
+  return (byId?.id as string | undefined) ?? null;
+}
+
+/**
+ * Load merged feature codes for a canonical SaaS tenant.
+ *
+ * Billing plan rows live under organizations.id while add-ons and licenses are
+ * keyed by tenants.id. This function is the normalization boundary: callers
+ * always pass the tenant id and never need to know which persistence model a
+ * commercial subsystem historically used.
  */
 export async function getOrganizationFeatures(
-  organizationId: string,
+  tenantId: string,
   client?: SupabaseClient,
 ): Promise<OrganizationEntitlements> {
   const supabase = client ?? (await requireAdminClient());
   if (!supabase) {
-    return emptyEntitlements(organizationId);
+    return emptyEntitlements(tenantId);
   }
 
-  const { data: orgSub } = await supabase
-    .from('organization_subscriptions')
-    .select(
-      'status, current_period_end, billing_interval, plan_id, subscription_plans ( slug, name, limits )',
-    )
-    .eq('organization_id', organizationId)
-    .maybeSingle();
+  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, supabase);
+
+  let orgSub: any = null;
+  if (billingOrganizationId) {
+    const { data } = await supabase
+      .from('organization_subscriptions')
+      .select(
+        'status, current_period_end, billing_interval, plan_id, subscription_plans ( slug, name, limits )',
+      )
+      .eq('organization_id', billingOrganizationId)
+      .maybeSingle();
+    orgSub = data;
+  }
 
   const planJoin = orgSub?.subscription_plans;
   const planRow = Array.isArray(planJoin) ? planJoin[0] : planJoin;
   const planSlug = planRow?.slug ?? null;
   const planId = orgSub?.plan_id as string | undefined;
+  const subscriptionHasAccess = ACCESSIBLE_SUBSCRIPTION_STATUSES.has(orgSub?.status ?? '');
 
   const featureSet = new Set<FeatureCode>();
 
-  if (planId) {
+  if (subscriptionHasAccess && planId) {
     const { data: planFeatureRows } = await supabase
       .from('plan_features')
       .select('features ( code )')
@@ -89,14 +130,20 @@ export async function getOrganizationFeatures(
     }
   }
 
-  if (featureSet.size === 0 && planSlug && planSlug in PLAN_FEATURE_FALLBACK) {
+  if (
+    subscriptionHasAccess &&
+    featureSet.size === 0 &&
+    planSlug &&
+    planSlug in PLAN_FEATURE_FALLBACK
+  ) {
     PLAN_FEATURE_FALLBACK[planSlug].forEach((c) => featureSet.add(c));
   }
 
+  // Add-ons are tenant-keyed and may be sold independently of a base plan.
   const { data: addonRows } = await supabase
     .from('addon_subscriptions')
     .select('addon_code, saas_addon_catalog ( feature_codes )')
-    .eq('organization_id', organizationId)
+    .eq('organization_id', tenantId)
     .eq('active', true);
 
   const activeAddonCodes: string[] = [];
@@ -112,7 +159,7 @@ export async function getOrganizationFeatures(
   const { data: legacyAddons } = await supabase
     .from('organization_addons')
     .select('addon_slug')
-    .eq('tenant_id', organizationId)
+    .eq('tenant_id', tenantId)
     .eq('status', 'active');
 
   for (const leg of legacyAddons ?? []) {
@@ -128,11 +175,14 @@ export async function getOrganizationFeatures(
     if (!dbFeatureCodes.length) applyAddonFallback(featureSet, code);
   }
 
-  if (featureSet.size === 0) {
+  // A legacy/manual license is a compatibility source only when there is no
+  // recurring organization subscription. It must never resurrect features for
+  // a canceled or past-due Stripe subscription.
+  if (featureSet.size === 0 && !orgSub) {
     const { data: license } = await supabase
       .from('licenses')
       .select('features')
-      .eq('tenant_id', organizationId)
+      .eq('tenant_id', tenantId)
       .eq('status', 'active')
       .maybeSingle();
     for (const f of (license?.features as string[]) ?? []) addFeature(featureSet, f);
@@ -143,7 +193,8 @@ export async function getOrganizationFeatures(
     (planSlug && PLAN_LIMITS_FALLBACK[planSlug] ? PLAN_LIMITS_FALLBACK[planSlug] : { users: 1 });
 
   return {
-    organizationId,
+    organizationId: tenantId,
+    billingOrganizationId,
     planSlug,
     planName: planRow?.name ?? null,
     status: orgSub?.status ?? null,
@@ -154,9 +205,10 @@ export async function getOrganizationFeatures(
   };
 }
 
-function emptyEntitlements(organizationId: string): OrganizationEntitlements {
+function emptyEntitlements(tenantId: string): OrganizationEntitlements {
   return {
-    organizationId,
+    organizationId: tenantId,
+    billingOrganizationId: null,
     planSlug: null,
     planName: null,
     status: null,
@@ -177,11 +229,11 @@ export function organizationHasFeature(
 }
 
 export async function requireFeature(
-  organizationId: string,
+  tenantId: string,
   feature: string,
   client?: SupabaseClient,
 ): Promise<OrganizationEntitlements> {
-  const entitlements = await getOrganizationFeatures(organizationId, client);
+  const entitlements = await getOrganizationFeatures(tenantId, client);
   if (!organizationHasFeature(entitlements, feature)) {
     throw new FeatureUpgradeRequiredError(feature);
   }

--- a/lib/platform/organization-features.ts
+++ b/lib/platform/organization-features.ts
@@ -24,6 +24,11 @@ export interface OrganizationEntitlements {
   currentPeriodEnd: string | null;
 }
 
+export interface OrganizationIdentity {
+  tenantId: string;
+  billingOrganizationId: string | null;
+}
+
 export class FeatureUpgradeRequiredError extends Error {
   readonly statusCode = 403;
   readonly feature: string;
@@ -50,50 +55,71 @@ function applyAddonFallback(featureSet: Set<FeatureCode>, addonCode: string) {
 }
 
 /**
- * Convert the canonical SaaS tenant id (tenants.id) to the billing organization
- * id (organizations.id). Legacy callers that already pass organizations.id are
- * also supported so the migration is backward compatible.
+ * Normalize either identifier used historically by billing:
+ * - tenants.id (canonical application identity)
+ * - organizations.id (legacy Stripe metadata / billing identity)
  */
+export async function resolveOrganizationIdentity(
+  tenantOrOrganizationId: string,
+  client?: SupabaseClient,
+): Promise<OrganizationIdentity> {
+  const supabase = client ?? (await requireAdminClient());
+  if (!supabase) {
+    return { tenantId: tenantOrOrganizationId, billingOrganizationId: null };
+  }
+
+  const { data: byTenant } = await supabase
+    .from('organizations')
+    .select('id, tenant_id')
+    .eq('tenant_id', tenantOrOrganizationId)
+    .maybeSingle();
+  if (byTenant?.id) {
+    return {
+      tenantId: (byTenant.tenant_id as string | null) ?? tenantOrOrganizationId,
+      billingOrganizationId: byTenant.id as string,
+    };
+  }
+
+  const { data: byOrganization } = await supabase
+    .from('organizations')
+    .select('id, tenant_id')
+    .eq('id', tenantOrOrganizationId)
+    .maybeSingle();
+  if (byOrganization?.id) {
+    return {
+      tenantId: (byOrganization.tenant_id as string | null) ?? tenantOrOrganizationId,
+      billingOrganizationId: byOrganization.id as string,
+    };
+  }
+
+  return { tenantId: tenantOrOrganizationId, billingOrganizationId: null };
+}
+
 export async function resolveBillingOrganizationId(
   tenantOrOrganizationId: string,
   client?: SupabaseClient,
 ): Promise<string | null> {
-  const supabase = client ?? (await requireAdminClient());
-  if (!supabase) return null;
-
-  const { data: byTenant } = await supabase
-    .from('organizations')
-    .select('id')
-    .eq('tenant_id', tenantOrOrganizationId)
-    .maybeSingle();
-  if (byTenant?.id) return byTenant.id as string;
-
-  const { data: byId } = await supabase
-    .from('organizations')
-    .select('id')
-    .eq('id', tenantOrOrganizationId)
-    .maybeSingle();
-  return (byId?.id as string | undefined) ?? null;
+  const identity = await resolveOrganizationIdentity(tenantOrOrganizationId, client);
+  return identity.billingOrganizationId;
 }
 
 /**
- * Load merged feature codes for a canonical SaaS tenant.
- *
- * Billing plan rows live under organizations.id while add-ons and licenses are
- * keyed by tenants.id. This function is the normalization boundary: callers
- * always pass the tenant id and never need to know which persistence model a
- * commercial subsystem historically used.
+ * Load merged feature codes for a SaaS tenant. Legacy organizations.id callers
+ * are normalized at this boundary so downstream feature checks always operate
+ * on tenants.id.
  */
 export async function getOrganizationFeatures(
-  tenantId: string,
+  tenantOrOrganizationId: string,
   client?: SupabaseClient,
 ): Promise<OrganizationEntitlements> {
   const supabase = client ?? (await requireAdminClient());
   if (!supabase) {
-    return emptyEntitlements(tenantId);
+    return emptyEntitlements(tenantOrOrganizationId);
   }
 
-  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, supabase);
+  const identity = await resolveOrganizationIdentity(tenantOrOrganizationId, supabase);
+  const tenantId = identity.tenantId;
+  const billingOrganizationId = identity.billingOrganizationId;
 
   let orgSub: any = null;
   if (billingOrganizationId) {

--- a/lib/platform/subscription-lifecycle.ts
+++ b/lib/platform/subscription-lifecycle.ts
@@ -1,14 +1,67 @@
 import type Stripe from 'stripe';
 import { logger } from '@/lib/logger';
 import type { SupabaseClient } from '@/lib/supabase';
-import { getOrganizationFeatures } from '@/lib/platform/organization-features';
+import {
+  getOrganizationFeatures,
+  resolveBillingOrganizationId,
+} from '@/lib/platform/organization-features';
 import { syncLicenseFromSaasEntitlements } from '@/lib/platform/sync-license-from-saas';
+import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
 
-const ACCESS_STATUSES = new Set(['active', 'trialing']);
+const ACCESS_STATUSES = new Set<Stripe.Subscription.Status>(['active', 'trialing']);
+
+function periodStart(subscription: Stripe.Subscription): string | null {
+  const raw = subscription as unknown as { current_period_start?: number };
+  return raw.current_period_start
+    ? new Date(raw.current_period_start * 1000).toISOString()
+    : null;
+}
 
 function periodEnd(subscription: Stripe.Subscription): string | null {
   const raw = subscription as unknown as { current_period_end?: number };
-  return raw.current_period_end ? new Date(raw.current_period_end * 1000).toISOString() : null;
+  return raw.current_period_end
+    ? new Date(raw.current_period_end * 1000).toISOString()
+    : null;
+}
+
+function customerId(subscription: Stripe.Subscription): string | null {
+  return typeof subscription.customer === 'string'
+    ? subscription.customer
+    : subscription.customer?.id ?? null;
+}
+
+function organizationStatus(status: Stripe.Subscription.Status): string {
+  if (status === 'active' || status === 'trialing') return status;
+  if (status === 'past_due' || status === 'unpaid') return status;
+  if (status === 'canceled' || status === 'incomplete_expired') return 'canceled';
+  return 'past_due';
+}
+
+function individualAppStatus(status: Stripe.Subscription.Status): string {
+  if (ACCESS_STATUSES.has(status)) return 'active';
+  if (status === 'past_due' || status === 'unpaid' || status === 'incomplete') return 'past_due';
+  if (status === 'canceled' || status === 'incomplete_expired') return 'canceled';
+  return 'inactive';
+}
+
+function billingInterval(raw: string | undefined): 'month' | 'year' | null {
+  if (!raw) return null;
+  if (raw === 'month' || raw === 'monthly') return 'month';
+  if (raw === 'year' || raw === 'annual' || raw === 'annually' || raw === 'yearly') return 'year';
+  return null;
+}
+
+function lifecycleEventType(status: Stripe.Subscription.Status): string {
+  if (status === 'active' || status === 'trialing') {
+    return PlatformEventType.BILLING_SUBSCRIPTION_ACTIVATED;
+  }
+  if (status === 'past_due' || status === 'unpaid' || status === 'incomplete') {
+    return PlatformEventType.BILLING_SUBSCRIPTION_PAST_DUE;
+  }
+  if (status === 'canceled' || status === 'incomplete_expired') {
+    return PlatformEventType.BILLING_SUBSCRIPTION_CANCELED;
+  }
+  return PlatformEventType.BILLING_SUBSCRIPTION_UPDATED;
 }
 
 export async function syncPlatformSubscriptionLifecycle(
@@ -19,28 +72,67 @@ export async function syncPlatformSubscriptionLifecycle(
   const tenantId = metadata.tenant_id;
   if (!tenantId || metadata.checkout_type !== 'platform_saas') return;
 
+  const billingOrganizationId = await resolveBillingOrganizationId(tenantId, db);
+  if (!billingOrganizationId) {
+    logger.error('platform subscription lifecycle could not resolve billing organization', undefined, {
+      tenantId,
+      subscriptionId: subscription.id,
+    });
+    return;
+  }
+
+  const planSlug = metadata.plan_id || metadata.plan_slug || 'professional';
+  const { data: planRow } = await db
+    .from('subscription_plans')
+    .select('id, slug')
+    .eq('slug', planSlug)
+    .eq('active', true)
+    .maybeSingle();
+
+  if (!planRow?.id) {
+    logger.error('platform subscription lifecycle could not resolve plan', undefined, {
+      tenantId,
+      billingOrganizationId,
+      subscriptionId: subscription.id,
+      planSlug,
+    });
+    return;
+  }
+
+  const { data: previous } = await db
+    .from('organization_subscriptions')
+    .select('status, stripe_subscription_id')
+    .eq('organization_id', billingOrganizationId)
+    .maybeSingle();
+
+  const status = organizationStatus(subscription.status);
   const hasAccess = ACCESS_STATUSES.has(subscription.status);
-  const status = hasAccess
-    ? 'active'
-    : subscription.status === 'past_due' || subscription.status === 'unpaid'
-      ? 'past_due'
-      : subscription.status === 'canceled'
-        ? 'canceled'
-        : subscription.status;
+  const interval = billingInterval(metadata.billing_interval);
+  const now = new Date().toISOString();
 
   const { error } = await db
     .from('organization_subscriptions')
-    .update({
-      status,
-      current_period_end: periodEnd(subscription),
-      updated_at: new Date().toISOString(),
-    })
-    .eq('organization_id', tenantId)
-    .eq('stripe_subscription_id', subscription.id);
+    .upsert(
+      {
+        organization_id: billingOrganizationId,
+        stripe_subscription_id: subscription.id,
+        stripe_customer_id: customerId(subscription),
+        plan_id: planRow.id,
+        plan_type: planRow.slug,
+        billing_interval: interval,
+        status,
+        current_period_start: periodStart(subscription),
+        current_period_end: periodEnd(subscription),
+        cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+        updated_at: now,
+      },
+      { onConflict: 'organization_id' },
+    );
 
   if (error) {
-    logger.error('platform subscription lifecycle update failed', error, {
+    logger.error('platform subscription lifecycle upsert failed', error, {
       tenantId,
+      billingOrganizationId,
       subscriptionId: subscription.id,
       status,
     });
@@ -51,7 +143,7 @@ export async function syncPlatformSubscriptionLifecycle(
   if (!hasAccess) {
     await db
       .from('addon_subscriptions')
-      .update({ active: false, canceled_at: new Date().toISOString(), updated_at: new Date().toISOString() })
+      .update({ active: false, canceled_at: now, updated_at: now })
       .eq('organization_id', tenantId);
     await db
       .from('organization_addons')
@@ -61,12 +153,65 @@ export async function syncPlatformSubscriptionLifecycle(
 
   const entitlements = await getOrganizationFeatures(tenantId, db);
   await syncLicenseFromSaasEntitlements(db, tenantId, entitlements, {
-    planSlug: metadata.plan_id,
-    billingInterval: metadata.billing_interval,
+    planSlug: planRow.slug,
+    billingInterval: interval ?? undefined,
     stripeSubscriptionId: subscription.id,
-    stripeCustomerId:
-      typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id,
+    stripeCustomerId: customerId(subscription) ?? undefined,
   });
+
+  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}`;
+  await emitPlatformEvent(db, {
+    eventType: lifecycleEventType(subscription.status),
+    category: 'billing',
+    source: 'stripe.subscription',
+    subjectType: 'organization_subscription',
+    subjectId: subscription.id,
+    tenantId,
+    correlationId: subscription.id,
+    idempotencyKey: `billing:${eventKey}`,
+    payload: {
+      billing_organization_id: billingOrganizationId,
+      plan_slug: planRow.slug,
+      status,
+      stripe_status: subscription.status,
+      current_period_end: periodEnd(subscription),
+    },
+  });
+
+  await emitPlatformEvent(db, {
+    eventType: PlatformEventType.ENTITLEMENT_REFRESHED,
+    category: 'entitlement',
+    source: 'stripe.subscription',
+    subjectType: 'tenant',
+    subjectId: tenantId,
+    tenantId,
+    correlationId: subscription.id,
+    idempotencyKey: `entitlement:${eventKey}`,
+    payload: {
+      features: entitlements.features,
+      plan_slug: entitlements.planSlug,
+      subscription_status: entitlements.status,
+    },
+  });
+
+  const previouslyAccessible = previous?.status === 'active' || previous?.status === 'trialing';
+  if (hasAccess && !previouslyAccessible) {
+    await emitPlatformEvent(db, {
+      eventType: PlatformEventType.PROVISIONING_REQUESTED,
+      category: 'provisioning',
+      source: 'stripe.subscription',
+      subjectType: 'tenant',
+      subjectId: tenantId,
+      tenantId,
+      correlationId: subscription.id,
+      idempotencyKey: `provisioning:platform:${subscription.id}`,
+      payload: {
+        kind: 'platform_workspace',
+        plan_slug: planRow.slug,
+        features: entitlements.features,
+      },
+    });
+  }
 }
 
 export async function syncIndividualAppLifecycle(
@@ -78,27 +223,95 @@ export async function syncIndividualAppLifecycle(
 
   const userId = metadata.user_id;
   const appSlug = metadata.app_slug;
+  const plan = metadata.plan_id || 'starter';
   if (!userId || !appSlug) return;
 
-  const hasAccess = ACCESS_STATUSES.has(subscription.status);
-  const status = hasAccess
-    ? 'active'
-    : subscription.status === 'past_due' || subscription.status === 'unpaid'
-      ? 'past_due'
-      : subscription.status === 'canceled'
-        ? 'canceled'
-        : 'inactive';
-
-  await db
+  const { data: previous } = await db
     .from('user_app_subscriptions')
-    .update({
-      status,
-      stripe_subscription_id: subscription.id,
-      stripe_customer_id:
-        typeof subscription.customer === 'string' ? subscription.customer : subscription.customer?.id,
-      current_period_end: periodEnd(subscription),
-      updated_at: new Date().toISOString(),
-    })
+    .select('status, plan, stripe_subscription_id')
     .eq('user_id', userId)
-    .eq('app_slug', appSlug);
+    .eq('app_slug', appSlug)
+    .maybeSingle();
+
+  const status = individualAppStatus(subscription.status);
+  const hasAccess = ACCESS_STATUSES.has(subscription.status);
+  const now = new Date().toISOString();
+
+  const { error } = await db
+    .from('user_app_subscriptions')
+    .upsert(
+      {
+        user_id: userId,
+        app_slug: appSlug,
+        plan,
+        status,
+        stripe_subscription_id: subscription.id,
+        stripe_customer_id: customerId(subscription),
+        current_period_start: periodStart(subscription),
+        current_period_end: periodEnd(subscription),
+        updated_at: now,
+      },
+      { onConflict: 'user_id,app_slug' },
+    );
+
+  if (error) {
+    logger.error('individual app subscription lifecycle upsert failed', error, {
+      userId,
+      appSlug,
+      subscriptionId: subscription.id,
+      status,
+    });
+    return;
+  }
+
+  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}`;
+  await emitPlatformEvent(db, {
+    eventType: lifecycleEventType(subscription.status),
+    category: 'billing',
+    source: 'stripe.subscription',
+    actorId: userId,
+    actorType: 'user',
+    subjectType: 'individual_app_subscription',
+    subjectId: subscription.id,
+    correlationId: subscription.id,
+    idempotencyKey: `billing:individual-app:${eventKey}`,
+    payload: {
+      app_slug: appSlug,
+      plan,
+      status,
+      stripe_status: subscription.status,
+      current_period_end: periodEnd(subscription),
+    },
+  });
+
+  await emitPlatformEvent(db, {
+    eventType: hasAccess
+      ? PlatformEventType.ENTITLEMENT_GRANTED
+      : PlatformEventType.ENTITLEMENT_REVOKED,
+    category: 'entitlement',
+    source: 'stripe.subscription',
+    actorId: userId,
+    actorType: 'user',
+    subjectType: 'individual_app',
+    subjectId: appSlug,
+    correlationId: subscription.id,
+    idempotencyKey: `entitlement:individual-app:${eventKey}`,
+    payload: { app_slug: appSlug, plan, status },
+  });
+
+  const previouslyAccessible = previous?.status === 'active' || previous?.status === 'trial';
+  if (hasAccess && !previouslyAccessible) {
+    await emitPlatformEvent(db, {
+      eventType: PlatformEventType.PROVISIONING_REQUESTED,
+      category: 'provisioning',
+      source: 'stripe.subscription',
+      actorId: userId,
+      actorType: 'user',
+      subjectType: 'individual_app',
+      subjectId: appSlug,
+      correlationId: subscription.id,
+      idempotencyKey: `provisioning:individual-app:${subscription.id}`,
+      payload: { kind: `${appSlug}_workspace`, app_slug: appSlug, plan },
+    });
+  }
 }

--- a/lib/platform/subscription-lifecycle.ts
+++ b/lib/platform/subscription-lifecycle.ts
@@ -6,6 +6,8 @@ import {
   resolveBillingOrganizationId,
 } from '@/lib/platform/organization-features';
 import { syncLicenseFromSaasEntitlements } from '@/lib/platform/sync-license-from-saas';
+import { normalizeAddonCode } from '@/lib/platform/feature-catalog';
+import type { BasePlanId, BillingInterval } from '@/lib/store/platform-pricing';
 import { emitPlatformEvent, PlatformEventType } from '@/lib/platform/orchestration/events';
 
 const ACCESS_STATUSES = new Set<Stripe.Subscription.Status>(['active', 'trialing']);
@@ -44,11 +46,14 @@ function individualAppStatus(status: Stripe.Subscription.Status): string {
   return 'inactive';
 }
 
-function billingInterval(raw: string | undefined): 'month' | 'year' | null {
-  if (!raw) return null;
-  if (raw === 'month' || raw === 'monthly') return 'month';
-  if (raw === 'year' || raw === 'annual' || raw === 'annually' || raw === 'yearly') return 'year';
-  return null;
+function codeBillingInterval(raw: string | undefined): BillingInterval {
+  return raw === 'year' || raw === 'annual' || raw === 'annually' || raw === 'yearly'
+    ? 'annual'
+    : 'monthly';
+}
+
+function databaseBillingInterval(interval: BillingInterval): 'month' | 'year' {
+  return interval === 'annual' ? 'year' : 'month';
 }
 
 function lifecycleEventType(status: Stripe.Subscription.Status): string {
@@ -62,6 +67,89 @@ function lifecycleEventType(status: Stripe.Subscription.Status): string {
     return PlatformEventType.BILLING_SUBSCRIPTION_CANCELED;
   }
   return PlatformEventType.BILLING_SUBSCRIPTION_UPDATED;
+}
+
+function purchasedAddonCodes(metadata: Stripe.Metadata): string[] {
+  return [...new Set(
+    String(metadata.addon_slugs || '')
+      .split(',')
+      .map((value) => value.trim())
+      .filter(Boolean)
+      .map(normalizeAddonCode),
+  )];
+}
+
+async function syncPlatformAddons(
+  db: SupabaseClient,
+  tenantId: string,
+  addonCodes: string[],
+  hasAccess: boolean,
+  now: string,
+): Promise<void> {
+  await db
+    .from('addon_subscriptions')
+    .update({ active: false, canceled_at: now, updated_at: now })
+    .eq('organization_id', tenantId);
+
+  await db
+    .from('organization_addons')
+    .update({ status: 'inactive' })
+    .eq('tenant_id', tenantId);
+
+  if (!hasAccess || !addonCodes.length) return;
+
+  const { data: catalogRows, error: catalogError } = await db
+    .from('saas_addon_catalog')
+    .select('code, monthly_price, active')
+    .in('code', addonCodes)
+    .eq('active', true);
+
+  if (catalogError) {
+    logger.error('platform subscription add-on catalog lookup failed', catalogError, {
+      tenantId,
+      addonCodes,
+    });
+    return;
+  }
+
+  const catalog = new Map((catalogRows ?? []).map((row) => [row.code, row]));
+  for (const code of addonCodes) {
+    const row = catalog.get(code);
+    if (!row) {
+      logger.warn('platform subscription ignored unknown/inactive add-on', { tenantId, code });
+      continue;
+    }
+
+    const { error: addonError } = await db.from('addon_subscriptions').upsert(
+      {
+        organization_id: tenantId,
+        addon_code: code,
+        monthly_price: row.monthly_price ?? null,
+        active: true,
+        activated_at: now,
+        canceled_at: null,
+        updated_at: now,
+      },
+      { onConflict: 'organization_id,addon_code' },
+    );
+    if (addonError) {
+      logger.error('platform subscription add-on upsert failed', addonError, { tenantId, code });
+      continue;
+    }
+
+    const { error: legacyError } = await db.from('organization_addons').upsert(
+      {
+        tenant_id: tenantId,
+        addon_slug: code,
+        status: 'active',
+        activated_at: now,
+      },
+      { onConflict: 'tenant_id,addon_slug' },
+    );
+    if (legacyError) {
+      logger.warn('platform subscription legacy add-on sync failed', { tenantId, code, legacyError });
+    }
+  }
 }
 
 export async function syncPlatformSubscriptionLifecycle(
@@ -89,7 +177,7 @@ export async function syncPlatformSubscriptionLifecycle(
     .eq('active', true)
     .maybeSingle();
 
-  if (!planRow?.id) {
+  if (!planRow?.id || !['solo', 'business', 'professional'].includes(planRow.slug)) {
     logger.error('platform subscription lifecycle could not resolve plan', undefined, {
       tenantId,
       billingOrganizationId,
@@ -99,15 +187,17 @@ export async function syncPlatformSubscriptionLifecycle(
     return;
   }
 
+  const canonicalPlan = planRow.slug as BasePlanId;
   const { data: previous } = await db
     .from('organization_subscriptions')
-    .select('status, stripe_subscription_id')
+    .select('status, stripe_subscription_id, plan_type')
     .eq('organization_id', billingOrganizationId)
     .maybeSingle();
 
   const status = organizationStatus(subscription.status);
   const hasAccess = ACCESS_STATUSES.has(subscription.status);
-  const interval = billingInterval(metadata.billing_interval);
+  const interval = codeBillingInterval(metadata.billing_interval);
+  const addonCodes = purchasedAddonCodes(metadata);
   const now = new Date().toISOString();
 
   const { error } = await db
@@ -118,12 +208,18 @@ export async function syncPlatformSubscriptionLifecycle(
         stripe_subscription_id: subscription.id,
         stripe_customer_id: customerId(subscription),
         plan_id: planRow.id,
-        plan_type: planRow.slug,
-        billing_interval: interval,
+        plan_type: canonicalPlan,
+        billing_interval: databaseBillingInterval(interval),
         status,
         current_period_start: periodStart(subscription),
         current_period_end: periodEnd(subscription),
         cancel_at_period_end: subscription.cancel_at_period_end ?? false,
+        metadata: {
+          tenant_id: tenantId,
+          plan_slug: canonicalPlan,
+          addon_codes: addonCodes,
+          stripe_status: subscription.status,
+        },
         updated_at: now,
       },
       { onConflict: 'organization_id' },
@@ -139,27 +235,18 @@ export async function syncPlatformSubscriptionLifecycle(
     return;
   }
 
-  // Add-ons sold on the same Stripe subscription follow the base subscription lifecycle.
-  if (!hasAccess) {
-    await db
-      .from('addon_subscriptions')
-      .update({ active: false, canceled_at: now, updated_at: now })
-      .eq('organization_id', tenantId);
-    await db
-      .from('organization_addons')
-      .update({ status: 'inactive' })
-      .eq('tenant_id', tenantId);
-  }
+  await syncPlatformAddons(db, tenantId, addonCodes, hasAccess, now);
 
   const entitlements = await getOrganizationFeatures(tenantId, db);
   await syncLicenseFromSaasEntitlements(db, tenantId, entitlements, {
-    planSlug: planRow.slug,
-    billingInterval: interval ?? undefined,
+    planSlug: canonicalPlan,
+    billingInterval: interval,
     stripeSubscriptionId: subscription.id,
     stripeCustomerId: customerId(subscription) ?? undefined,
+    active: hasAccess,
   });
 
-  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}`;
+  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}:${canonicalPlan}:${addonCodes.join(',')}`;
   await emitPlatformEvent(db, {
     eventType: lifecycleEventType(subscription.status),
     category: 'billing',
@@ -171,7 +258,8 @@ export async function syncPlatformSubscriptionLifecycle(
     idempotencyKey: `billing:${eventKey}`,
     payload: {
       billing_organization_id: billingOrganizationId,
-      plan_slug: planRow.slug,
+      plan_slug: canonicalPlan,
+      addon_codes: addonCodes,
       status,
       stripe_status: subscription.status,
       current_period_end: periodEnd(subscription),
@@ -190,12 +278,14 @@ export async function syncPlatformSubscriptionLifecycle(
     payload: {
       features: entitlements.features,
       plan_slug: entitlements.planSlug,
+      addon_codes: entitlements.activeAddonCodes,
       subscription_status: entitlements.status,
     },
   });
 
   const previouslyAccessible = previous?.status === 'active' || previous?.status === 'trialing';
-  if (hasAccess && !previouslyAccessible) {
+  const planChanged = Boolean(previous?.plan_type && previous.plan_type !== canonicalPlan);
+  if (hasAccess && (!previouslyAccessible || planChanged)) {
     await emitPlatformEvent(db, {
       eventType: PlatformEventType.PROVISIONING_REQUESTED,
       category: 'provisioning',
@@ -204,10 +294,11 @@ export async function syncPlatformSubscriptionLifecycle(
       subjectId: tenantId,
       tenantId,
       correlationId: subscription.id,
-      idempotencyKey: `provisioning:platform:${subscription.id}`,
+      idempotencyKey: `provisioning:platform:${subscription.id}:${canonicalPlan}:${addonCodes.join(',')}`,
       payload: {
         kind: 'platform_workspace',
-        plan_slug: planRow.slug,
+        plan_slug: canonicalPlan,
+        addon_codes: addonCodes,
         features: entitlements.features,
       },
     });
@@ -264,7 +355,7 @@ export async function syncIndividualAppLifecycle(
     return;
   }
 
-  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}`;
+  const eventKey = `${subscription.id}:${subscription.status}:${periodEnd(subscription) ?? 'none'}:${plan}`;
   await emitPlatformEvent(db, {
     eventType: lifecycleEventType(subscription.status),
     category: 'billing',
@@ -300,7 +391,8 @@ export async function syncIndividualAppLifecycle(
   });
 
   const previouslyAccessible = previous?.status === 'active' || previous?.status === 'trial';
-  if (hasAccess && !previouslyAccessible) {
+  const planChanged = Boolean(previous?.plan && previous.plan !== plan);
+  if (hasAccess && (!previouslyAccessible || planChanged)) {
     await emitPlatformEvent(db, {
       eventType: PlatformEventType.PROVISIONING_REQUESTED,
       category: 'provisioning',
@@ -310,7 +402,7 @@ export async function syncIndividualAppLifecycle(
       subjectType: 'individual_app',
       subjectId: appSlug,
       correlationId: subscription.id,
-      idempotencyKey: `provisioning:individual-app:${subscription.id}`,
+      idempotencyKey: `provisioning:individual-app:${subscription.id}:${plan}`,
       payload: { kind: `${appSlug}_workspace`, app_slug: appSlug, plan },
     });
   }

--- a/lib/platform/sync-license-from-saas.ts
+++ b/lib/platform/sync-license-from-saas.ts
@@ -5,6 +5,8 @@ import type { OrganizationEntitlements } from '@/lib/platform/organization-featu
 
 /**
  * Keep licenses.features in sync for middleware that still reads licenses table.
+ * The SaaS subscription remains authoritative; compatibility licenses must never
+ * resurrect access after recurring billing is past due or canceled.
  */
 export async function syncLicenseFromSaasEntitlements(
   adminSupabase: SupabaseClient,
@@ -15,22 +17,28 @@ export async function syncLicenseFromSaasEntitlements(
     billingInterval: BillingInterval;
     stripeSubscriptionId?: string;
     stripeCustomerId?: string;
+    active?: boolean;
   },
 ): Promise<void> {
+  const active = opts.active !== false;
   const tier = licenseTierForPlan(opts.planSlug, opts.billingInterval);
-  const features = entitlements.features.map((f) => (f === 'bookings' ? 'booking' : f));
+  const features = active
+    ? entitlements.features.map((f) => (f === 'bookings' ? 'booking' : f))
+    : [];
 
   const payload = {
     tier,
-    status: 'active',
+    status: active ? 'active' : 'suspended',
     features,
-    max_users: entitlements.limits.users ?? 1,
+    max_users: active ? entitlements.limits.users ?? 1 : 0,
     stripe_subscription_id: opts.stripeSubscriptionId ?? null,
     stripe_customer_id: opts.stripeCustomerId ?? null,
     metadata: {
       saas_plan_slug: opts.planSlug,
-      limits: entitlements.limits,
-      addon_codes: entitlements.activeAddonCodes,
+      limits: active ? entitlements.limits : { users: 0 },
+      addon_codes: active ? entitlements.activeAddonCodes : [],
+      subscription_authority: 'organization_subscriptions',
+      billing_access: active,
     },
     updated_at: new Date().toISOString(),
   };

--- a/lib/stripe/resolve-canonical-price.ts
+++ b/lib/stripe/resolve-canonical-price.ts
@@ -1,0 +1,58 @@
+import type Stripe from 'stripe';
+
+export interface CanonicalPriceExpectation {
+  lookupKey: string;
+  unitAmount: number;
+  currency?: string;
+  recurringInterval?: 'day' | 'week' | 'month' | 'year';
+}
+
+/**
+ * Resolve a pre-created Stripe Price by stable lookup_key and verify that it
+ * still matches the code-side commercial catalog. This prevents Checkout from
+ * creating duplicate products/prices and fails closed on catalog drift.
+ */
+export async function resolveCanonicalStripePrice(
+  stripe: Stripe,
+  expectation: CanonicalPriceExpectation,
+): Promise<Stripe.Price> {
+  const prices = await stripe.prices.list({
+    lookup_keys: [expectation.lookupKey],
+    active: true,
+    limit: 2,
+  });
+
+  if (prices.data.length !== 1) {
+    throw new Error(
+      `Stripe catalog misconfigured for ${expectation.lookupKey}: expected exactly one active price, found ${prices.data.length}`,
+    );
+  }
+
+  const price = prices.data[0];
+  const expectedCurrency = expectation.currency ?? 'usd';
+  if (price.currency !== expectedCurrency) {
+    throw new Error(
+      `Stripe catalog drift for ${expectation.lookupKey}: expected ${expectedCurrency}, got ${price.currency}`,
+    );
+  }
+
+  if (price.unit_amount !== expectation.unitAmount) {
+    throw new Error(
+      `Stripe catalog drift for ${expectation.lookupKey}: expected ${expectation.unitAmount}, got ${price.unit_amount ?? 'null'}`,
+    );
+  }
+
+  if (expectation.recurringInterval) {
+    if (price.recurring?.interval !== expectation.recurringInterval) {
+      throw new Error(
+        `Stripe catalog drift for ${expectation.lookupKey}: expected ${expectation.recurringInterval} recurrence, got ${price.recurring?.interval ?? 'none'}`,
+      );
+    }
+  } else if (price.recurring) {
+    throw new Error(
+      `Stripe catalog drift for ${expectation.lookupKey}: expected one-time price, got recurring`,
+    );
+  }
+
+  return price;
+}

--- a/lib/stripe/resolve-canonical-price.ts
+++ b/lib/stripe/resolve-canonical-price.ts
@@ -7,28 +7,17 @@ export interface CanonicalPriceExpectation {
   recurringInterval?: 'day' | 'week' | 'month' | 'year';
 }
 
-/**
- * Resolve a pre-created Stripe Price by stable lookup_key and verify that it
- * still matches the code-side commercial catalog. This prevents Checkout from
- * creating duplicate products/prices and fails closed on catalog drift.
- */
-export async function resolveCanonicalStripePrice(
-  stripe: Stripe,
+export interface CanonicalPriceProvisioning extends CanonicalPriceExpectation {
+  productName: string;
+  productMetadata?: Record<string, string>;
+  priceMetadata?: Record<string, string>;
+  nickname?: string;
+}
+
+function verifyCanonicalStripePrice(
+  price: Stripe.Price,
   expectation: CanonicalPriceExpectation,
-): Promise<Stripe.Price> {
-  const prices = await stripe.prices.list({
-    lookup_keys: [expectation.lookupKey],
-    active: true,
-    limit: 2,
-  });
-
-  if (prices.data.length !== 1) {
-    throw new Error(
-      `Stripe catalog misconfigured for ${expectation.lookupKey}: expected exactly one active price, found ${prices.data.length}`,
-    );
-  }
-
-  const price = prices.data[0];
+): Stripe.Price {
   const expectedCurrency = expectation.currency ?? 'usd';
   if (price.currency !== expectedCurrency) {
     throw new Error(
@@ -55,4 +44,83 @@ export async function resolveCanonicalStripePrice(
   }
 
   return price;
+}
+
+/**
+ * Resolve a pre-created Stripe Price by stable lookup_key and verify that it
+ * still matches the code-side commercial catalog. This prevents Checkout from
+ * creating duplicate products/prices and fails closed on catalog drift.
+ */
+export async function resolveCanonicalStripePrice(
+  stripe: Stripe,
+  expectation: CanonicalPriceExpectation,
+): Promise<Stripe.Price> {
+  const prices = await stripe.prices.list({
+    lookup_keys: [expectation.lookupKey],
+    active: true,
+    limit: 2,
+  });
+
+  if (prices.data.length !== 1) {
+    throw new Error(
+      `Stripe catalog misconfigured for ${expectation.lookupKey}: expected exactly one active price, found ${prices.data.length}`,
+    );
+  }
+
+  return verifyCanonicalStripePrice(prices.data[0], expectation);
+}
+
+/**
+ * Resolve an existing canonical Price or create it exactly once when a catalog
+ * item is intentionally lazy-provisioned (currently SaaS add-ons). Stripe
+ * enforces lookup-key uniqueness; a concurrent creation race re-resolves the
+ * winning Price instead of creating an unbounded duplicate chain.
+ */
+export async function ensureCanonicalStripePrice(
+  stripe: Stripe,
+  provisioning: CanonicalPriceProvisioning,
+): Promise<Stripe.Price> {
+  const existing = await stripe.prices.list({
+    lookup_keys: [provisioning.lookupKey],
+    active: true,
+    limit: 2,
+  });
+  if (existing.data.length === 1) {
+    return verifyCanonicalStripePrice(existing.data[0], provisioning);
+  }
+  if (existing.data.length > 1) {
+    throw new Error(
+      `Stripe catalog misconfigured for ${provisioning.lookupKey}: found ${existing.data.length} active prices`,
+    );
+  }
+
+  try {
+    const created = await stripe.prices.create({
+      currency: provisioning.currency ?? 'usd',
+      unit_amount: provisioning.unitAmount,
+      lookup_key: provisioning.lookupKey,
+      nickname: provisioning.nickname,
+      recurring: provisioning.recurringInterval
+        ? { interval: provisioning.recurringInterval }
+        : undefined,
+      metadata: provisioning.priceMetadata,
+      product_data: {
+        name: provisioning.productName,
+        metadata: provisioning.productMetadata,
+      },
+    });
+    return verifyCanonicalStripePrice(created, provisioning);
+  } catch (error) {
+    // Concurrent checkout may have created the lookup key first. Re-resolve
+    // before surfacing an error so the checkout remains idempotent.
+    const raced = await stripe.prices.list({
+      lookup_keys: [provisioning.lookupKey],
+      active: true,
+      limit: 2,
+    });
+    if (raced.data.length === 1) {
+      return verifyCanonicalStripePrice(raced.data[0], provisioning);
+    }
+    throw error;
+  }
 }

--- a/lib/workflows/engine.ts
+++ b/lib/workflows/engine.ts
@@ -33,8 +33,6 @@ interface RunContext {
   triggerPayload: Record<string, unknown>;
 }
 
-// ── Interpolation ─────────────────────────────────────────────────────────────
-
 function interpolate(v: unknown, payload: Record<string, unknown>): unknown {
   if (typeof v === 'string') {
     return v.replace(/\{\{(\w+(?:\.\w+)*)\}\}/g, (_, path: string) => {
@@ -55,8 +53,6 @@ function interpolate(v: unknown, payload: Record<string, unknown>): unknown {
 function interpolateObj(obj: Record<string, unknown>, payload: Record<string, unknown>): Record<string, unknown> {
   return interpolate(obj, payload) as Record<string, unknown>;
 }
-
-// ── Step executors ────────────────────────────────────────────────────────────
 
 async function execSendNotification(config: Record<string, unknown>, ctx: RunContext) {
   const db = await requireAdminClient();
@@ -129,7 +125,7 @@ function execCondition(config: Record<string, unknown>, conditionExpr: string | 
   const expr = (config.condition_expr as string | undefined) ?? conditionExpr;
   if (!expr) return { ok: true, output: { condition: 'passed', reason: 'no_expression' } };
   const match = expr.trim().match(/^([\w.]+)\s*(==|!=|>=|<=|>|<|contains|exists)\s*(.*)$/);
-  if (!match) return { ok: true, output: { condition: 'passed', reason: 'unparseable' } };
+  if (!match) return { ok: false, output: { error: `Unsupported condition expression: ${expr}` } };
   const [, path, op, rawExpected] = match;
   const expected = rawExpected.trim().replace(/^["']|["']$/g, '');
   const actual = path.split('.').reduce<unknown>((obj, key) =>
@@ -148,9 +144,11 @@ function execCondition(config: Record<string, unknown>, conditionExpr: string | 
     case '<=':       passed = !isNaN(actualNum) && !isNaN(expectedNum) && actualNum <= expectedNum; break;
     case 'contains': passed = actualStr.includes(expected); break;
     case 'exists':   passed = actual !== undefined && actual !== null && actual !== ''; break;
-    default:         passed = true;
+    default:         passed = false;
   }
-  return { ok: passed, output: { condition: passed ? 'passed' : 'failed', expr, actual: actualStr, expected } };
+  return passed
+    ? { ok: true, output: { condition: 'passed', expr, actual: actualStr, expected } }
+    : { ok: false, output: { error: `Condition failed: ${expr}`, condition: 'failed', expr, actual: actualStr, expected } };
 }
 
 async function execCreateRecord(config: Record<string, unknown>, ctx: RunContext) {
@@ -202,9 +200,12 @@ async function execAiAction(config: Record<string, unknown>, ctx: RunContext) {
       const db = await requireAdminClient();
       let matchObj: Record<string, unknown>;
       try { matchObj = typeof persistMatch === 'string' ? JSON.parse(persistMatch) : persistMatch; }
-      catch { matchObj = {}; }
-      await db.from(persistTable).update({ [persistField]: response }).match(interpolateObj(matchObj, ctx.triggerPayload))
-        .then(undefined, (err) => logger.warn('[workflow/ai_action] persist failed', { run_id: ctx.runId, error: String(err) }));
+      catch { return { ok: false, output: { error: 'ai_action persist_match must be valid JSON' } }; }
+      const { error } = await db
+        .from(persistTable)
+        .update({ [persistField]: response })
+        .match(interpolateObj(matchObj, ctx.triggerPayload));
+      if (error) return { ok: false, output: { error: error.message } };
     }
     return { ok: true, output: { response } };
   } catch (err: unknown) {
@@ -223,8 +224,11 @@ async function execStep(step: WorkflowStep, ctx: RunContext): Promise<{ ok: bool
     case 'update_record':     return execUpdateRecord(step.action_config, ctx);
     case 'ai_action':         return execAiAction(step.action_config, ctx);
     default:
-      logger.warn('[workflow/engine] unknown action_type', { action_type: step.action_type, run_id: ctx.runId });
-      return { ok: true, output: { note: `action_type '${step.action_type}' not implemented` } };
+      logger.error('[workflow/engine] unsupported action_type', new Error(`Unsupported action_type: ${step.action_type}`), {
+        action_type: step.action_type,
+        run_id: ctx.runId,
+      });
+      return { ok: false, output: { error: `action_type '${step.action_type}' is not implemented` } };
   }
 }
 
@@ -244,7 +248,6 @@ async function execStepWithRetry(
     lastResult = await execStep(step, ctx);
     if (lastResult.ok) return { ...lastResult, attempts };
   }
-  // Dead-letter
   await db.from('workflow_dead_letters').insert({
     workflow_id: ctx.workflowId,
     run_id: ctx.runId,
@@ -264,8 +267,6 @@ async function execStepWithRetry(
   });
   return { ...lastResult, attempts };
 }
-
-// ── Main executor ─────────────────────────────────────────────────────────────
 
 export async function executeWorkflow(
   workflowId: string,

--- a/supabase/migrations/20260810053000_upgrade_platform_events_for_orchestration.sql
+++ b/supabase/migrations/20260810053000_upgrade_platform_events_for_orchestration.sql
@@ -1,0 +1,28 @@
+alter table public.platform_events
+  add column if not exists source text,
+  add column if not exists correlation_id text,
+  add column if not exists idempotency_key text,
+  add column if not exists tenant_id uuid,
+  add column if not exists processing_status text not null default 'observed',
+  add column if not exists attempts integer not null default 0,
+  add column if not exists available_at timestamptz not null default now(),
+  add column if not exists last_error text;
+
+create unique index if not exists platform_events_idempotency_key_uidx
+  on public.platform_events (idempotency_key)
+  where idempotency_key is not null;
+
+create index if not exists platform_events_pending_idx
+  on public.platform_events (processing_status, available_at, created_at)
+  where processing_status in ('pending','processing','failed');
+
+create index if not exists platform_events_correlation_idx
+  on public.platform_events (correlation_id, created_at desc)
+  where correlation_id is not null;
+
+create index if not exists platform_events_tenant_idx
+  on public.platform_events (tenant_id, created_at desc)
+  where tenant_id is not null;
+
+comment on table public.platform_events is
+  'Canonical cross-platform event ledger for identity, commerce, billing, entitlement, provisioning, workflow, LMS, workforce, and AI orchestration.';

--- a/supabase/migrations/20260810054500_enforce_subscription_identity_keys.sql
+++ b/supabase/migrations/20260810054500_enforce_subscription_identity_keys.sql
@@ -1,0 +1,5 @@
+alter table public.user_app_subscriptions
+  add constraint user_app_subscriptions_user_app_key unique (user_id, app_slug);
+
+alter table public.organization_subscriptions
+  add constraint organization_subscriptions_organization_key unique (organization_id);

--- a/supabase/migrations/20260810055200_align_organization_subscription_plan_contract.sql
+++ b/supabase/migrations/20260810055200_align_organization_subscription_plan_contract.sql
@@ -1,0 +1,21 @@
+alter table public.organization_subscriptions
+  add column if not exists plan_id uuid references public.subscription_plans(id),
+  add column if not exists billing_interval text;
+
+update public.organization_subscriptions os
+set plan_id = sp.id
+from public.subscription_plans sp
+where os.plan_id is null and sp.slug = os.plan_type;
+
+alter table public.organization_subscriptions drop constraint if exists valid_plan_type;
+alter table public.organization_subscriptions
+  add constraint valid_plan_type check (
+    plan_type = any (array['free'::text,'starter'::text,'solo'::text,'business'::text,'professional'::text,'enterprise'::text,'custom'::text])
+  );
+
+alter table public.organization_subscriptions
+  add constraint organization_subscriptions_billing_interval_check
+  check (billing_interval is null or billing_interval = any (array['month'::text,'year'::text]));
+
+create index if not exists organization_subscriptions_plan_id_idx
+  on public.organization_subscriptions(plan_id);

--- a/supabase/migrations/20260810061000_install_domain_orchestration_event_triggers.sql
+++ b/supabase/migrations/20260810061000_install_domain_orchestration_event_triggers.sql
@@ -1,0 +1,202 @@
+create or replace function public.enqueue_platform_event_v1(
+  p_event_type text,
+  p_category text,
+  p_source text,
+  p_subject_type text,
+  p_subject_id text,
+  p_actor_id uuid default null,
+  p_tenant_id uuid default null,
+  p_correlation_id text default null,
+  p_idempotency_key text default null,
+  p_payload jsonb default '{}'::jsonb,
+  p_message text default null,
+  p_severity text default 'info'
+) returns uuid
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_id uuid;
+begin
+  insert into public.platform_events (
+    event_type, category, severity, source, actor_id, actor_type,
+    subject_id, subject_type, tenant_id, correlation_id, idempotency_key,
+    payload, message, resolved, processing_status, available_at
+  ) values (
+    p_event_type, p_category, p_severity, p_source, p_actor_id,
+    case when p_actor_id is null then 'system' else 'user' end,
+    p_subject_id, p_subject_type, p_tenant_id, p_correlation_id,
+    p_idempotency_key, coalesce(p_payload, '{}'::jsonb), p_message,
+    false, 'pending', now()
+  )
+  on conflict (idempotency_key) where idempotency_key is not null do nothing
+  returning id into v_id;
+
+  if v_id is null and p_idempotency_key is not null then
+    select id into v_id
+    from public.platform_events
+    where idempotency_key = p_idempotency_key
+    limit 1;
+  end if;
+
+  return v_id;
+end;
+$$;
+
+revoke all on function public.enqueue_platform_event_v1(text,text,text,text,text,uuid,uuid,text,text,jsonb,text,text) from public;
+grant execute on function public.enqueue_platform_event_v1(text,text,text,text,text,uuid,uuid,text,text,jsonb,text,text) to service_role;
+
+create or replace function public.capture_domain_orchestration_event_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_user text;
+  v_course text;
+begin
+  if tg_table_name = 'applications' then
+    if tg_op = 'INSERT' and new.status = 'submitted' then
+      perform public.enqueue_platform_event_v1(
+        'application.submitted','application','db.trigger.applications','application',new.id::text,
+        new.user_id,null,new.id::text,'application-submitted:' || new.id::text,
+        jsonb_build_object('program_id',new.program_id,'program_slug',coalesce(new.program_slug,new.pathway_slug,new.program_interest),'source',new.source)
+      );
+    elsif tg_op = 'UPDATE' then
+      if old.status is distinct from new.status and new.status = 'submitted' then
+        perform public.enqueue_platform_event_v1(
+          'application.submitted','application','db.trigger.applications','application',new.id::text,
+          new.user_id,null,new.id::text,'application-submitted:' || new.id::text,
+          jsonb_build_object('program_id',new.program_id,'program_slug',coalesce(new.program_slug,new.pathway_slug,new.program_interest),'source',new.source)
+        );
+      end if;
+      if old.status is distinct from new.status and new.status = 'approved' then
+        perform public.enqueue_platform_event_v1(
+          'application.approved','application','db.trigger.applications','application',new.id::text,
+          coalesce(new.reviewer_id,new.eligibility_verified_by,new.funding_verified_by),null,new.id::text,
+          'application-approved:' || new.id::text,
+          jsonb_build_object('user_id',new.user_id,'program_id',new.program_id,'program_slug',coalesce(new.program_slug,new.pathway_slug,new.program_interest),'funding_source',coalesce(new.funding_source,new.recommended_funding_source))
+        );
+      end if;
+    end if;
+
+  elsif tg_table_name = 'program_enrollments' then
+    if tg_op = 'INSERT' and (new.status = 'active' or new.enrollment_state in ('active','enrolled')) then
+      perform public.enqueue_platform_event_v1(
+        'enrollment.confirmed','enrollment','db.trigger.program_enrollments','program_enrollment',new.id::text,
+        coalesce(new.user_id,new.student_id),new.tenant_id,new.id::text,'enrollment-confirmed:' || new.id::text,
+        jsonb_build_object('program_id',new.program_id,'program_slug',new.program_slug,'course_id',new.course_id,'funding_source',new.funding_source)
+      );
+    elsif tg_op = 'UPDATE' then
+      if (old.status is distinct from new.status or old.enrollment_state is distinct from new.enrollment_state)
+         and (new.status = 'active' or new.enrollment_state in ('active','enrolled')) then
+        perform public.enqueue_platform_event_v1(
+          'enrollment.confirmed','enrollment','db.trigger.program_enrollments','program_enrollment',new.id::text,
+          coalesce(new.user_id,new.student_id),new.tenant_id,new.id::text,'enrollment-confirmed:' || new.id::text,
+          jsonb_build_object('program_id',new.program_id,'program_slug',new.program_slug,'course_id',new.course_id,'funding_source',new.funding_source)
+        );
+      end if;
+      if old.orientation_completed_at is null and new.orientation_completed_at is not null then
+        perform public.enqueue_platform_event_v1(
+          'orientation.completed','enrollment','db.trigger.program_enrollments','program_enrollment',new.id::text,
+          coalesce(new.user_id,new.student_id),new.tenant_id,new.id::text,'orientation-completed:' || new.id::text,
+          jsonb_build_object('program_id',new.program_id,'program_slug',new.program_slug)
+        );
+      end if;
+      if old.host_shop_id is distinct from new.host_shop_id and new.host_shop_id is not null then
+        perform public.enqueue_platform_event_v1(
+          'apprentice.assigned','workforce','db.trigger.program_enrollments','program_enrollment',new.id::text,
+          coalesce(new.user_id,new.student_id),new.tenant_id,new.id::text,'apprentice-assigned:' || new.id::text || ':' || new.host_shop_id::text,
+          jsonb_build_object('host_shop_id',new.host_shop_id,'program_id',new.program_id,'program_slug',new.program_slug)
+        );
+      end if;
+    end if;
+
+  elsif tg_table_name = 'course_enrollments' then
+    if (tg_op = 'INSERT' and (new.completed_at is not null or new.status = 'completed'))
+       or (tg_op = 'UPDATE' and ((old.completed_at is null and new.completed_at is not null) or (old.status is distinct from new.status and new.status = 'completed'))) then
+      v_user := coalesce(new.student_id::text,new.id::text);
+      v_course := coalesce(new.course_id::text,new.id::text);
+      perform public.enqueue_platform_event_v1(
+        'course.completed','lms','db.trigger.course_enrollments','course',v_course,
+        new.student_id,null,new.id::text,'course-completed:' || v_user || ':' || v_course,
+        jsonb_build_object('enrollment_id',new.id,'student_id',new.student_id,'course_id',new.course_id,'score',new.score)
+      );
+    end if;
+
+  elsif tg_table_name = 'course_progress' then
+    if (tg_op = 'INSERT' and (new.completed_at is not null or new.status = 'completed' or coalesce(new.progress_percentage,0) >= 100))
+       or (tg_op = 'UPDATE' and ((old.completed_at is null and new.completed_at is not null) or (old.status is distinct from new.status and new.status = 'completed') or (coalesce(old.progress_percentage,0) < 100 and coalesce(new.progress_percentage,0) >= 100))) then
+      v_user := coalesce(new.user_id::text,new.id::text);
+      v_course := coalesce(new.course_id::text,new.id::text);
+      perform public.enqueue_platform_event_v1(
+        'course.completed','lms','db.trigger.course_progress','course',v_course,
+        new.user_id,null,new.id::text,'course-completed:' || v_user || ':' || v_course,
+        jsonb_build_object('progress_id',new.id,'enrollment_id',new.enrollment_id,'user_id',new.user_id,'course_id',new.course_id,'progress_percentage',new.progress_percentage)
+      );
+    end if;
+
+  elsif tg_table_name = 'certificates' then
+    if tg_op = 'INSERT' then
+      perform public.enqueue_platform_event_v1(
+        'certificate.issued','credential','db.trigger.certificates','certificate',new.id::text,
+        coalesce(new.user_id,new.student_id),new.tenant_id,new.id::text,'certificate-issued:' || new.id::text,
+        jsonb_build_object('course_id',new.course_id,'program_id',new.program_id,'enrollment_id',new.enrollment_id,'certificate_number',new.certificate_number)
+      );
+    end if;
+
+  elsif tg_table_name = 'host_shop_applications' then
+    if (tg_op = 'INSERT' and new.status = 'approved')
+       or (tg_op = 'UPDATE' and old.status is distinct from new.status and new.status = 'approved') then
+      perform public.enqueue_platform_event_v1(
+        'host_shop.approved','workforce','db.trigger.host_shop_applications','host_shop_application',new.id::text,
+        null,null,new.id::text,'host-shop-approved:' || new.id::text,
+        jsonb_build_object('course_slug',new.course_slug,'stripe_session_id',new.stripe_session_id)
+      );
+    end if;
+
+  elsif tg_table_name = 'exam_sessions' then
+    if tg_op = 'INSERT' then
+      perform public.enqueue_platform_event_v1(
+        'testing.registration_created','testing','db.trigger.exam_sessions','exam_session',new.id::text,
+        new.student_id,new.tenant_id,new.id::text,'testing-registration:' || new.id::text,
+        jsonb_build_object('provider',new.provider::text,'exam_code',new.exam_code,'program_slug',new.program_slug,'is_retest',new.is_retest)
+      );
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.capture_domain_orchestration_event_v1() from public;
+
+drop trigger if exists orchestration_applications_v1 on public.applications;
+create trigger orchestration_applications_v1 after insert or update on public.applications
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_program_enrollments_v1 on public.program_enrollments;
+create trigger orchestration_program_enrollments_v1 after insert or update on public.program_enrollments
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_course_enrollments_v1 on public.course_enrollments;
+create trigger orchestration_course_enrollments_v1 after insert or update on public.course_enrollments
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_course_progress_v1 on public.course_progress;
+create trigger orchestration_course_progress_v1 after insert or update on public.course_progress
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_certificates_v1 on public.certificates;
+create trigger orchestration_certificates_v1 after insert on public.certificates
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_host_shop_applications_v1 on public.host_shop_applications;
+create trigger orchestration_host_shop_applications_v1 after insert or update on public.host_shop_applications
+for each row execute function public.capture_domain_orchestration_event_v1();
+
+drop trigger if exists orchestration_exam_sessions_v1 on public.exam_sessions;
+create trigger orchestration_exam_sessions_v1 after insert on public.exam_sessions
+for each row execute function public.capture_domain_orchestration_event_v1();

--- a/supabase/migrations/20260810062500_align_workflow_engine_runtime_contract.sql
+++ b/supabase/migrations/20260810062500_align_workflow_engine_runtime_contract.sql
@@ -1,0 +1,15 @@
+alter table public.workflow_runs
+  add column if not exists duration_ms integer,
+  add column if not exists retry_count integer not null default 0,
+  add column if not exists platform_event_id uuid references public.platform_events(id) on delete set null;
+
+alter table public.workflow_step_logs
+  add column if not exists attempts integer not null default 1;
+
+create index if not exists workflow_runs_platform_event_id_idx
+  on public.workflow_runs(platform_event_id)
+  where platform_event_id is not null;
+
+create unique index if not exists workflow_runs_event_workflow_uidx
+  on public.workflow_runs(platform_event_id, workflow_id)
+  where platform_event_id is not null;

--- a/supabase/migrations/20260810063200_align_workflow_dead_letter_columns.sql
+++ b/supabase/migrations/20260810063200_align_workflow_dead_letter_columns.sql
@@ -1,0 +1,2 @@
+alter table public.workflow_dead_letters rename column last_error to error;
+alter table public.workflow_dead_letters rename column payload to trigger_payload;

--- a/supabase/migrations/20260810064500_add_atomic_platform_event_claiming.sql
+++ b/supabase/migrations/20260810064500_add_atomic_platform_event_claiming.sql
@@ -1,0 +1,42 @@
+alter table public.platform_events
+  add column if not exists locked_at timestamptz;
+
+create or replace function public.claim_platform_events_v1(p_limit integer default 20)
+returns setof public.platform_events
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  return query
+  with candidates as (
+    select pe.id
+    from public.platform_events pe
+    where (
+      (pe.processing_status in ('pending','failed') and pe.available_at <= now())
+      or (pe.processing_status = 'processing' and pe.locked_at < now() - interval '10 minutes')
+    )
+      and pe.attempts < 5
+    order by pe.created_at asc
+    for update skip locked
+    limit greatest(1, least(coalesce(p_limit,20),100))
+  ), claimed as (
+    update public.platform_events pe
+    set processing_status = 'processing',
+        attempts = pe.attempts + 1,
+        locked_at = now(),
+        last_error = null
+    from candidates c
+    where pe.id = c.id
+    returning pe.*
+  )
+  select * from claimed;
+end;
+$$;
+
+revoke all on function public.claim_platform_events_v1(integer) from public;
+grant execute on function public.claim_platform_events_v1(integer) to service_role;
+
+create index if not exists platform_events_claim_idx
+  on public.platform_events(processing_status, available_at, locked_at, attempts, created_at)
+  where processing_status in ('pending','failed','processing');

--- a/supabase/migrations/20260810071500_route_individual_app_subscriptions_through_store_rpc.sql
+++ b/supabase/migrations/20260810071500_route_individual_app_subscriptions_through_store_rpc.sql
@@ -1,0 +1,144 @@
+create or replace function public.upsert_store_subscription(
+  p_user_id uuid,
+  p_stripe_subscription_id text,
+  p_stripe_customer_id text,
+  p_stripe_price_id text,
+  p_status text,
+  p_cancel_at_period_end boolean,
+  p_current_period_start timestamptz,
+  p_current_period_end timestamptz,
+  p_canceled_at timestamptz default null,
+  p_ended_at timestamptz default null,
+  p_trial_start timestamptz default null,
+  p_trial_end timestamptz default null,
+  p_metadata jsonb default null
+) returns jsonb
+language plpgsql
+security definer
+set search_path = ''
+as $$
+declare
+  v_subscription_id uuid;
+  v_product_id uuid;
+  v_checkout_type text := coalesce(p_metadata ->> 'checkout_type', '');
+  v_app_slug text := coalesce(p_metadata ->> 'app_slug', '');
+  v_plan text := coalesce(p_metadata ->> 'plan_id', 'starter');
+  v_app_status text;
+  v_had_access boolean := false;
+  v_has_access boolean := false;
+begin
+  if coalesce(auth.jwt() ->> 'role', '') <> 'service_role' then
+    raise exception 'Service role required';
+  end if;
+
+  if p_status not in (
+    'incomplete', 'incomplete_expired', 'trialing', 'active',
+    'past_due', 'canceled', 'unpaid', 'paused'
+  ) then
+    raise exception 'Unsupported store subscription status: %', p_status;
+  end if;
+
+  if v_checkout_type = 'individual_app' then
+    if v_app_slug not in ('website-builder','sam-gov','grants') then
+      raise exception 'Unsupported individual app slug: %', v_app_slug;
+    end if;
+    if v_plan not in ('starter','professional','enterprise') then
+      raise exception 'Unsupported individual app plan: %', v_plan;
+    end if;
+
+    select status in ('active','trial') into v_had_access
+    from public.user_app_subscriptions
+    where user_id = p_user_id and app_slug = v_app_slug;
+    v_had_access := coalesce(v_had_access, false);
+
+    v_app_status := case
+      when p_status in ('active','trialing') then 'active'
+      when p_status in ('past_due','unpaid','incomplete') then 'past_due'
+      when p_status in ('canceled','incomplete_expired') then 'canceled'
+      else 'inactive'
+    end;
+    v_has_access := v_app_status = 'active';
+
+    insert into public.user_app_subscriptions (
+      user_id, app_slug, plan, status,
+      stripe_subscription_id, stripe_customer_id,
+      current_period_start, current_period_end,
+      trial_ends_at, updated_at
+    ) values (
+      p_user_id, v_app_slug, v_plan, v_app_status,
+      p_stripe_subscription_id, p_stripe_customer_id,
+      p_current_period_start, p_current_period_end,
+      p_trial_end, now()
+    )
+    on conflict (user_id, app_slug)
+    do update set
+      plan = excluded.plan,
+      status = excluded.status,
+      stripe_subscription_id = excluded.stripe_subscription_id,
+      stripe_customer_id = excluded.stripe_customer_id,
+      current_period_start = excluded.current_period_start,
+      current_period_end = excluded.current_period_end,
+      trial_ends_at = coalesce(excluded.trial_ends_at, public.user_app_subscriptions.trial_ends_at),
+      updated_at = now()
+    returning id into v_subscription_id;
+
+    perform public.enqueue_platform_event_v1(
+      case
+        when p_status in ('active','trialing') then 'billing.subscription_activated'
+        when p_status in ('past_due','unpaid','incomplete') then 'billing.subscription_past_due'
+        when p_status in ('canceled','incomplete_expired') then 'billing.subscription_canceled'
+        else 'billing.subscription_updated'
+      end,
+      'billing','db.rpc.upsert_store_subscription','individual_app_subscription',
+      p_stripe_subscription_id,p_user_id,null,p_stripe_subscription_id,
+      'billing:individual-app:' || p_stripe_subscription_id || ':' || p_status || ':' || coalesce(p_current_period_end::text,'none'),
+      jsonb_build_object('app_slug',v_app_slug,'plan',v_plan,'status',v_app_status,'stripe_status',p_status,'stripe_price_id',p_stripe_price_id,'current_period_end',p_current_period_end)
+    );
+
+    perform public.enqueue_platform_event_v1(
+      case when v_has_access then 'entitlement.granted' else 'entitlement.revoked' end,
+      'entitlement','db.rpc.upsert_store_subscription','individual_app',v_app_slug,
+      p_user_id,null,p_stripe_subscription_id,
+      'entitlement:individual-app:' || p_stripe_subscription_id || ':' || p_status || ':' || coalesce(p_current_period_end::text,'none'),
+      jsonb_build_object('app_slug',v_app_slug,'plan',v_plan,'status',v_app_status)
+    );
+
+    if v_has_access and not v_had_access then
+      perform public.enqueue_platform_event_v1(
+        'provisioning.requested','provisioning','db.rpc.upsert_store_subscription','individual_app',v_app_slug,
+        p_user_id,null,p_stripe_subscription_id,'provisioning:individual-app:' || p_stripe_subscription_id,
+        jsonb_build_object('kind',v_app_slug || '_workspace','app_slug',v_app_slug,'plan',v_plan)
+      );
+    end if;
+
+    return jsonb_build_object('success',true,'subscription_id',v_subscription_id,'subscription_type','individual_app');
+  end if;
+
+  select sp.store_product_id into v_product_id
+  from public.store_prices sp
+  where sp.stripe_price_id = p_stripe_price_id and sp.is_active = true
+  limit 1;
+
+  if v_product_id is null then
+    raise exception 'Active store price not found';
+  end if;
+
+  insert into public.store_subscriptions (
+    user_id,stripe_subscription_id,stripe_customer_id,stripe_price_id,store_product_id,status,
+    cancel_at_period_end,current_period_start,current_period_end,canceled_at,ended_at,trial_start,trial_end,metadata,updated_at
+  ) values (
+    p_user_id,p_stripe_subscription_id,p_stripe_customer_id,p_stripe_price_id,v_product_id,p_status,
+    p_cancel_at_period_end,p_current_period_start,p_current_period_end,p_canceled_at,p_ended_at,p_trial_start,p_trial_end,
+    coalesce(p_metadata,'{}'::jsonb),now()
+  )
+  on conflict (stripe_subscription_id) where stripe_subscription_id is not null
+  do update set
+    user_id=excluded.user_id,stripe_customer_id=excluded.stripe_customer_id,stripe_price_id=excluded.stripe_price_id,
+    store_product_id=excluded.store_product_id,status=excluded.status,cancel_at_period_end=excluded.cancel_at_period_end,
+    current_period_start=excluded.current_period_start,current_period_end=excluded.current_period_end,canceled_at=excluded.canceled_at,
+    ended_at=excluded.ended_at,trial_start=excluded.trial_start,trial_end=excluded.trial_end,metadata=excluded.metadata,updated_at=now()
+  returning id into v_subscription_id;
+
+  return jsonb_build_object('success',true,'subscription_id',v_subscription_id,'subscription_type','store');
+end;
+$$;

--- a/supabase/migrations/20260810074500_canonicalize_host_shop_subscription_identity.sql
+++ b/supabase/migrations/20260810074500_canonicalize_host_shop_subscription_identity.sql
@@ -1,0 +1,20 @@
+alter table public.host_shop_partnerships
+  add column if not exists partner_id uuid references public.partners(id) on delete set null,
+  add column if not exists shop_id uuid references public.shops(id) on delete set null,
+  add column if not exists owner_id uuid references auth.users(id) on delete set null;
+
+create unique index if not exists host_shop_partnerships_partner_uidx
+  on public.host_shop_partnerships(partner_id)
+  where partner_id is not null;
+
+create unique index if not exists host_shop_partnerships_shop_uidx
+  on public.host_shop_partnerships(shop_id)
+  where shop_id is not null;
+
+create unique index if not exists host_shop_partnerships_stripe_subscription_uidx
+  on public.host_shop_partnerships(stripe_subscription_id)
+  where stripe_subscription_id is not null;
+
+create index if not exists host_shop_partnerships_owner_idx
+  on public.host_shop_partnerships(owner_id)
+  where owner_id is not null;

--- a/supabase/migrations/20260810081500_wire_certificate_issued_workflow.sql
+++ b/supabase/migrations/20260810081500_wire_certificate_issued_workflow.sql
@@ -1,0 +1,29 @@
+do $$
+declare
+  v_workflow_id uuid;
+begin
+  select id into v_workflow_id from public.workflows where workflow_key='cert_issued' limit 1;
+  if v_workflow_id is null then
+    raise exception 'Certificate workflow not found';
+  end if;
+
+  delete from public.workflow_triggers where workflow_id=v_workflow_id and trigger_type='event';
+  delete from public.workflow_steps where workflow_id=v_workflow_id;
+
+  insert into public.workflow_triggers(workflow_id,trigger_type,event_filter,enabled)
+  values (v_workflow_id,'event',jsonb_build_object('event_type','certificate.issued','subject_type','certificate'),true);
+
+  insert into public.workflow_steps(workflow_id,step_order,action_type,action_config,is_condition,enabled)
+  values (
+    v_workflow_id,
+    1,
+    'send_email',
+    jsonb_build_object(
+      'to','{{student_email}}',
+      'subject','Your Elevate certificate is ready',
+      'html','<h2>Congratulations {{student_name}}</h2><p>Your certificate for <strong>{{course_title}}</strong> has been issued.</p><p>Certificate number: <strong>{{certificate_number}}</strong></p><p><a href="{{verification_url}}">Verify your certificate</a></p>'
+    ),
+    false,
+    true
+  );
+end $$;

--- a/supabase/migrations/20260810084500_harden_host_shop_application_fee_contract.sql
+++ b/supabase/migrations/20260810084500_harden_host_shop_application_fee_contract.sql
@@ -1,0 +1,17 @@
+alter table public.host_shop_applications
+  add column if not exists application_fee_status text not null default 'not_required',
+  add column if not exists application_fee_amount_cents integer,
+  add column if not exists stripe_payment_intent_id text,
+  add column if not exists application_fee_paid_at timestamptz;
+
+alter table public.host_shop_applications
+  add constraint host_shop_applications_fee_status_check
+  check (application_fee_status = any (array['not_required'::text,'pending'::text,'paid'::text,'refunded'::text,'failed'::text]));
+
+create unique index if not exists host_shop_applications_stripe_session_uidx
+  on public.host_shop_applications(stripe_session_id)
+  where stripe_session_id is not null;
+
+create unique index if not exists host_shop_applications_payment_intent_uidx
+  on public.host_shop_applications(stripe_payment_intent_id)
+  where stripe_payment_intent_id is not null;


### PR DESCRIPTION
Synchronizes the already-merged, fully-green #580 orchestration/subscription layer into the consolidated release branch before final portal/marketing merge. This prevents the release branch from shipping partial subscription-lifecycle files without the corresponding orchestration modules.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate platform orchestration with subscription lifecycle, event system, and canonical Stripe pricing
> - Introduces a durable `platform_events` table with idempotency, tenancy, processing lifecycle (claim/retry/dead-letter), and DB-level domain triggers that enqueue events on state changes to applications, enrollments, certificates, and more.
> - Adds `syncPlatformSubscriptionLifecycle` and `syncHostShopSubscriptionLifecycle` handlers that persist subscription state to `organization_subscriptions`/`host_shop_partnerships` by billing organization, manage tenant-scoped add-ons, sync compatibility licenses, and emit billing/entitlement/provisioning events.
> - Replaces inline Stripe `price_data` with canonical lookup-key-based price resolution (`resolveCanonicalStripePrice`, `ensureCanonicalStripePrice`) across platform, individual app, and host shop checkout endpoints; updates existing active/trialing subscriptions in-place instead of always creating new Checkout sessions.
> - Adds new API routes for host shop subscription checkout, host shop application fee checkout, and an authenticated internal endpoint (`/api/internal/orchestration/process`) to process pending platform events in bounded batches.
> - Introduces `resolveOrganizationIdentity` to separate tenant identity from billing organization identity; `getOrganizationFeatures` now gates plan-derived features on accessible subscription statuses and no longer grants features for canceled/past-due subscriptions.
> - Adds database migrations enforcing unique constraints on `organization_subscriptions(organization_id)`, `user_app_subscriptions(user_id, app_slug)`, and Stripe IDs across `host_shop_partnerships` and `host_shop_applications`.
> - Risk: canceled or past-due subscriptions no longer contribute plan features; column renames in `workflow_dead_letters` (`last_error`→`error`, `payload`→`trigger_payload`) will break existing queries using old names.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78235c2.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->