### PR TITLE
feat: make Website Builder imports store-aware

### DIFF
--- a/apps/marketing/app/api/apps/website-builder/import/route.ts
+++ b/apps/marketing/app/api/apps/website-builder/import/route.ts
@@ -12,7 +12,15 @@ export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
 export const maxDuration = 60;
 
+async function isPlatformAdmin(userId: string) {
+  const supabase = await createClient();
+  const { data } = await supabase.from('profiles').select('role').eq('id', userId).maybeSingle();
+  return data?.role === 'admin' || data?.role === 'super_admin';
+}
+
 async function hasIndividualWebsiteImport(userId: string) {
+  if (await isPlatformAdmin(userId)) return true;
+
   const supabase = await createClient();
   const { data: appSub } = await supabase
     .from('user_app_subscriptions')

--- a/apps/marketing/app/api/apps/website-builder/sites/route.ts
+++ b/apps/marketing/app/api/apps/website-builder/sites/route.ts
@@ -16,6 +16,10 @@ function stringValue(value: unknown, fallback = '', max = 1200) {
   return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : fallback;
 }
 
+function optionalString(value: unknown, max = 1200) {
+  return typeof value === 'string' && value.trim() ? value.trim().slice(0, max) : undefined;
+}
+
 function normalizeProvidedConfig(
   provided: unknown,
   fallback: TenantSiteConfig,
@@ -23,13 +27,37 @@ function normalizeProvidedConfig(
   if (!provided || typeof provided !== 'object' || Array.isArray(provided)) return fallback;
   const incoming = provided as Record<string, any>;
 
+  const products = Array.isArray(incoming.products)
+    ? incoming.products.slice(0, 60).map((item: any) => ({
+        name: stringValue(item?.name, 'Product', 180),
+        description: stringValue(item?.description, '', 1800),
+        price: optionalString(item?.price, 40),
+        compareAtPrice: optionalString(item?.compareAtPrice, 40),
+        image: optionalString(item?.image, 1600),
+        imageAlt: optionalString(item?.imageAlt, 220),
+        href: optionalString(item?.href, 1600),
+        category: optionalString(item?.category, 120),
+        badge: optionalString(item?.badge, 80),
+      }))
+    : fallback.products;
+
   return {
     ...fallback,
+    template:
+      incoming.template && typeof incoming.template === 'object' && !Array.isArray(incoming.template)
+        ? {
+            ...fallback.template,
+            ...incoming.template,
+            id: stringValue(incoming.template.id, fallback.template.id, 80),
+            name: stringValue(incoming.template.name, fallback.template.name, 120),
+          }
+        : fallback.template,
     branding: {
       ...fallback.branding,
       ...(incoming.branding && typeof incoming.branding === 'object' ? incoming.branding : {}),
       logoText: stringValue(incoming.branding?.logoText, fallback.branding.logoText, 120),
       tagline: stringValue(incoming.branding?.tagline, fallback.branding.tagline || '', 240),
+      logoImage: optionalString(incoming.branding?.logoImage, 1600),
     },
     homepage: {
       ...fallback.homepage,
@@ -37,10 +65,15 @@ function normalizeProvidedConfig(
       heroTitle: stringValue(incoming.homepage?.heroTitle, fallback.homepage.heroTitle, 180),
       heroSubtitle: stringValue(incoming.homepage?.heroSubtitle, fallback.homepage.heroSubtitle, 500),
       heroCtaText: stringValue(incoming.homepage?.heroCtaText, fallback.homepage.heroCtaText, 80),
+      heroCtaHref: optionalString(incoming.homepage?.heroCtaHref, 600),
+      heroImage: optionalString(incoming.homepage?.heroImage, 1600),
+      heroImageAlt: optionalString(incoming.homepage?.heroImageAlt, 220),
+      announcement: optionalString(incoming.homepage?.announcement, 240),
       features: Array.isArray(incoming.homepage?.features)
         ? incoming.homepage.features.slice(0, 12).map((item: any) => ({
             title: stringValue(item?.title, 'Service', 120),
             description: stringValue(item?.description, '', 500),
+            image: optionalString(item?.image, 1600),
           }))
         : fallback.homepage.features,
     },
@@ -50,12 +83,26 @@ function normalizeProvidedConfig(
           description: stringValue(item?.description, '', 1000),
           duration: stringValue(item?.duration, '', 80),
           level: stringValue(item?.level, '', 80),
+          image: optionalString(item?.image, 1600),
         }))
       : fallback.programs,
+    products,
+    contact:
+      incoming.contact && typeof incoming.contact === 'object' && !Array.isArray(incoming.contact)
+        ? {
+            email: optionalString(incoming.contact.email, 180),
+            phone: optionalString(incoming.contact.phone, 80),
+            address: optionalString(incoming.contact.address, 300),
+            bookingUrl: optionalString(incoming.contact.bookingUrl, 1600),
+            hours: Array.isArray(incoming.contact.hours)
+              ? incoming.contact.hours.map((value: unknown) => stringValue(value, '', 120)).filter(Boolean).slice(0, 14)
+              : undefined,
+          }
+        : fallback.contact,
     navigation: Array.isArray(incoming.navigation)
-      ? incoming.navigation.slice(0, 12).map((item: any) => ({
+      ? incoming.navigation.slice(0, 16).map((item: any) => ({
           label: stringValue(item?.label, 'Page', 60),
-          href: stringValue(item?.href, '/', 240),
+          href: stringValue(item?.href, '/', 1600),
         }))
       : fallback.navigation,
     footer: {
@@ -79,6 +126,12 @@ function normalizeProvidedConfig(
   };
 }
 
+async function getAdminRole(userId: string) {
+  const supabase = await createClient();
+  const { data } = await supabase.from('profiles').select('role').eq('id', userId).maybeSingle();
+  return data?.role === 'admin' || data?.role === 'super_admin';
+}
+
 export async function POST(request: NextRequest) {
   const supabase = await createClient();
   const {
@@ -87,6 +140,7 @@ export async function POST(request: NextRequest) {
 
   if (!user?.id) return NextResponse.json({ error: 'Authentication required' }, { status: 401 });
 
+  const adminTesting = await getAdminRole(user.id);
   const { data: subscription } = await supabase
     .from('user_app_subscriptions')
     .select('plan, status, trial_ends_at')
@@ -94,15 +148,15 @@ export async function POST(request: NextRequest) {
     .eq('app_slug', 'website-builder')
     .maybeSingle();
 
-  if (!subscription || !['trial', 'active'].includes(subscription.status || '')) {
+  if (!adminTesting && (!subscription || !['trial', 'active'].includes(subscription.status || ''))) {
     return NextResponse.json({ error: 'Website Builder subscription required' }, { status: 403 });
   }
 
-  if (subscription.status === 'trial' && subscription.trial_ends_at && new Date(subscription.trial_ends_at) < new Date()) {
+  if (!adminTesting && subscription?.status === 'trial' && subscription.trial_ends_at && new Date(subscription.trial_ends_at) < new Date()) {
     return NextResponse.json({ error: 'Website Builder trial has expired' }, { status: 403 });
   }
 
-  const plan = subscription.plan || 'starter';
+  const plan = adminTesting ? 'enterprise' : (subscription?.plan || 'starter');
   const limit = PLAN_SITE_LIMITS[plan] ?? 1;
   if (limit !== null) {
     const { count } = await supabase

--- a/components/tenant/PublicTenantSite.tsx
+++ b/components/tenant/PublicTenantSite.tsx
@@ -1,16 +1,72 @@
 'use client';
 
 import Link from 'next/link';
-import type { PublishedTenantSite } from '@/lib/tenant/site-types';
+import type { PublishedTenantSite, TenantSiteProduct } from '@/lib/tenant/site-types';
 
-type PageKey = 'home' | 'programs' | 'about' | 'contact';
+type PageKey = 'home' | 'catalog' | 'about' | 'contact';
+
+function isExternalHref(href: string) {
+  return /^https?:\/\//i.test(href);
+}
 
 function resolvePage(pathname: string): PageKey {
   const p = pathname.replace(/\/$/, '') || '/';
-  if (p === '/programs') return 'programs';
+  if (p === '/programs' || p === '/shop' || p === '/products') return 'catalog';
   if (p === '/about') return 'about';
   if (p === '/contact') return 'contact';
   return 'home';
+}
+
+function money(value?: string) {
+  if (!value) return '';
+  const parsed = Number(value.replace(/[^0-9.]/g, ''));
+  if (!Number.isFinite(parsed)) return value;
+  return new Intl.NumberFormat('en-US', { style: 'currency', currency: 'USD' }).format(parsed);
+}
+
+function ProductCard({ product, accent, textColor }: { product: TenantSiteProduct; accent: string; textColor: string }) {
+  const content = (
+    <article className="group h-full overflow-hidden rounded-3xl border border-black/10 bg-white shadow-sm transition hover:-translate-y-1 hover:shadow-xl">
+      <div className="aspect-square overflow-hidden bg-slate-100">
+        {product.image ? (
+          // Remote source images are intentionally preserved during migration.
+          // eslint-disable-next-line @next/next/no-img-element
+          <img
+            src={product.image}
+            alt={product.imageAlt || product.name}
+            className="h-full w-full object-cover transition duration-500 group-hover:scale-[1.03]"
+            loading="lazy"
+          />
+        ) : (
+          <div className="flex h-full items-center justify-center px-6 text-center text-sm font-bold text-slate-500">
+            {product.name}
+          </div>
+        )}
+      </div>
+      <div className="p-5">
+        {product.badge ? (
+          <span className="mb-3 inline-flex rounded-full px-3 py-1 text-xs font-black" style={{ backgroundColor: `${accent}18`, color: accent }}>
+            {product.badge}
+          </span>
+        ) : null}
+        <h3 className="text-lg font-black leading-snug" style={{ color: textColor }}>{product.name}</h3>
+        {product.description ? <p className="mt-2 line-clamp-3 text-sm font-medium leading-6 text-slate-600">{product.description}</p> : null}
+        <div className="mt-4 flex items-baseline gap-2">
+          {product.price ? <span className="text-lg font-black" style={{ color: accent }}>{money(product.price)}</span> : null}
+          {product.compareAtPrice && product.compareAtPrice !== product.price ? (
+            <span className="text-sm font-semibold text-slate-400 line-through">{money(product.compareAtPrice)}</span>
+          ) : null}
+        </div>
+        {product.href ? <p className="mt-4 text-sm font-black" style={{ color: accent }}>View product →</p> : null}
+      </div>
+    </article>
+  );
+
+  if (!product.href) return content;
+  if (isExternalHref(product.href)) {
+    return <a href={product.href} target="_blank" rel="noreferrer" className="block h-full">{content}</a>;
+  }
+  return <Link href={product.href} className="block h-full">{content}</Link>;
 }
 
 export function PublicTenantSite({
@@ -22,34 +78,49 @@ export function PublicTenantSite({
 }) {
   const { config } = site;
   const page = resolvePage(pathname);
-  const primary = config.branding.primaryColor;
+  const primary = config.branding.primaryColor || '#7c3f58';
+  const secondary = config.branding.secondaryColor || '#475569';
+  const accent = config.branding.accentColor || primary;
+  const background = config.branding.backgroundColor || config.template.colors?.background || '#ffffff';
+  const textColor = config.branding.textColor || config.template.colors?.text || '#0f172a';
+  const headingFont = config.template.fonts?.heading || 'inherit';
+  const bodyFont = config.template.fonts?.body || 'inherit';
+  const isStore = config.meta?.siteKind === 'store' || Boolean(config.products?.length);
+  const products = config.products || [];
+  const catalogHref = isStore ? '/shop' : '/programs';
+  const ctaHref = config.homepage.heroCtaHref || catalogHref;
 
   return (
-    <div className="min-h-screen bg-white text-slate-900">
-      <header className="border-b border-slate-200 bg-white sticky top-0 z-20">
-        <div className="max-w-6xl mx-auto px-4 py-4 flex items-center justify-between gap-4">
-          <Link href="/" className="font-bold text-lg" style={{ color: primary }}>
-            {config.branding.logoText}
+    <div className="min-h-screen" style={{ backgroundColor: background, color: textColor, fontFamily: bodyFont }}>
+      {config.homepage.announcement ? (
+        <div className="px-4 py-2 text-center text-sm font-black text-white" style={{ backgroundColor: primary }}>
+          {config.homepage.announcement}
+        </div>
+      ) : null}
+
+      <header className="sticky top-0 z-20 border-b border-black/10 bg-white/95 backdrop-blur">
+        <div className="mx-auto flex max-w-7xl items-center justify-between gap-5 px-4 py-4 sm:px-6">
+          <Link href="/" className="flex min-w-0 items-center gap-3">
+            {config.branding.logoImage ? (
+              // eslint-disable-next-line @next/next/no-img-element
+              <img src={config.branding.logoImage} alt={`${config.branding.logoText} logo`} className="h-10 w-auto max-w-36 object-contain" />
+            ) : null}
+            <span className="truncate text-lg font-black" style={{ color: primary, fontFamily: headingFont }}>
+              {config.branding.logoText}
+            </span>
           </Link>
-          <nav className="flex flex-wrap gap-4 text-sm font-medium">
-            {config.navigation.map((item) => (
-              <Link
-                key={item.href}
-                href={item.href}
-                className={
-                  resolvePage(item.href) === page ? 'text-slate-900' : 'text-slate-600 hover:text-slate-900'
-                }
-              >
-                {item.label}
-              </Link>
-            ))}
+          <nav className="hidden items-center gap-5 text-sm font-bold md:flex">
+            {config.navigation.slice(0, 7).map((item) => {
+              const active = !isExternalHref(item.href) && resolvePage(item.href) === page;
+              const className = active ? 'font-black' : 'text-slate-600 hover:text-slate-950';
+              if (isExternalHref(item.href)) {
+                return <a key={`${item.label}-${item.href}`} href={item.href} target="_blank" rel="noreferrer" className={className}>{item.label}</a>;
+              }
+              return <Link key={`${item.label}-${item.href}`} href={item.href} className={className} style={active ? { color: primary } : undefined}>{item.label}</Link>;
+            })}
           </nav>
-          <Link
-            href="/admin"
-            className="hidden sm:inline-flex px-3 py-1.5 rounded-lg text-sm font-medium text-white"
-            style={{ backgroundColor: primary }}
-          >
-            Admin
+          <Link href={catalogHref} className="shrink-0 rounded-full px-4 py-2 text-sm font-black text-white" style={{ backgroundColor: primary }}>
+            {isStore ? 'Shop now' : 'Explore'}
           </Link>
         </div>
       </header>
@@ -57,71 +128,176 @@ export function PublicTenantSite({
       <main>
         {page === 'home' && (
           <>
-            <section className="px-4 py-16 md:py-24 bg-slate-50">
-              <div className="max-w-4xl mx-auto text-center">
-                <p className="text-sm font-semibold uppercase tracking-wide text-slate-600 mb-3">
-                  {config.branding.tagline}
-                </p>
-                <h1 className="text-3xl md:text-5xl font-bold text-slate-900 mb-4">
-                  {config.homepage.heroTitle}
-                </h1>
-                <p className="text-lg text-slate-600 mb-8 max-w-2xl mx-auto">
-                  {config.homepage.heroSubtitle}
-                </p>
-                <Link
-                  href="/programs"
-                  className="inline-flex px-6 py-3 rounded-lg font-semibold text-white"
-                  style={{ backgroundColor: primary }}
-                >
-                  {config.homepage.heroCtaText}
-                </Link>
+            <section className="overflow-hidden border-b border-black/5">
+              <div className={`mx-auto grid max-w-7xl items-center gap-10 px-5 py-14 sm:px-6 md:py-20 ${config.homepage.heroImage ? 'lg:grid-cols-[0.95fr_1.05fr]' : ''}`}>
+                <div className={config.homepage.heroImage ? '' : 'mx-auto max-w-4xl text-center'}>
+                  {config.branding.tagline ? (
+                    <p className="mb-4 text-sm font-black uppercase tracking-[0.18em]" style={{ color: secondary }}>{config.branding.tagline}</p>
+                  ) : null}
+                  <h1 className="text-4xl font-black leading-[1.05] tracking-tight sm:text-5xl lg:text-6xl" style={{ fontFamily: headingFont }}>
+                    {config.homepage.heroTitle}
+                  </h1>
+                  <p className={`mt-5 text-lg font-medium leading-8 text-slate-600 ${config.homepage.heroImage ? 'max-w-2xl' : 'mx-auto max-w-3xl'}`}>
+                    {config.homepage.heroSubtitle}
+                  </p>
+                  <div className={`mt-8 flex flex-wrap gap-3 ${config.homepage.heroImage ? '' : 'justify-center'}`}>
+                    {isExternalHref(ctaHref) ? (
+                      <a href={ctaHref} target="_blank" rel="noreferrer" className="rounded-full px-7 py-3.5 font-black text-white shadow-lg" style={{ backgroundColor: primary }}>
+                        {config.homepage.heroCtaText}
+                      </a>
+                    ) : (
+                      <Link href={ctaHref} className="rounded-full px-7 py-3.5 font-black text-white shadow-lg" style={{ backgroundColor: primary }}>
+                        {config.homepage.heroCtaText}
+                      </Link>
+                    )}
+                    {config.contact?.bookingUrl ? (
+                      <a href={config.contact.bookingUrl} target="_blank" rel="noreferrer" className="rounded-full border-2 bg-white px-7 py-3.5 font-black" style={{ borderColor: primary, color: primary }}>
+                        Book a consultation
+                      </a>
+                    ) : null}
+                  </div>
+                </div>
+
+                {config.homepage.heroImage ? (
+                  <div className="relative min-h-[420px] overflow-hidden rounded-[2rem] bg-slate-100 shadow-2xl">
+                    {/* eslint-disable-next-line @next/next/no-img-element */}
+                    <img
+                      src={config.homepage.heroImage}
+                      alt={config.homepage.heroImageAlt || config.homepage.heroTitle}
+                      className="absolute inset-0 h-full w-full object-cover"
+                    />
+                    <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/55 to-transparent p-6 pt-24 text-white">
+                      <p className="text-sm font-black uppercase tracking-[0.16em]">{isStore ? 'Shop the collection' : config.branding.logoText}</p>
+                    </div>
+                  </div>
+                ) : null}
               </div>
             </section>
-            <section className="max-w-6xl mx-auto px-4 py-12 grid md:grid-cols-3 gap-8">
-              {config.homepage.features.map((f) => (
-                <div key={f.title} className="rounded-xl border border-slate-200 p-6">
-                  <h2 className="font-bold text-lg mb-2">{f.title}</h2>
-                  <p className="text-slate-600 text-sm">{f.description}</p>
+
+            {config.homepage.features.length ? (
+              <section className="mx-auto grid max-w-7xl gap-5 px-5 py-12 sm:px-6 md:grid-cols-2 lg:grid-cols-4">
+                {config.homepage.features.slice(0, 8).map((feature) => (
+                  <article key={feature.title} className="overflow-hidden rounded-3xl border border-black/10 bg-white shadow-sm">
+                    {feature.image ? (
+                      <div className="aspect-[16/10] overflow-hidden bg-slate-100">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={feature.image} alt={feature.title} className="h-full w-full object-cover" loading="lazy" />
+                      </div>
+                    ) : null}
+                    <div className="p-6">
+                      <h2 className="text-lg font-black" style={{ fontFamily: headingFont }}>{feature.title}</h2>
+                      <p className="mt-2 text-sm font-medium leading-6 text-slate-600">{feature.description}</p>
+                    </div>
+                  </article>
+                ))}
+              </section>
+            ) : null}
+
+            {isStore && products.length ? (
+              <section className="border-y border-black/5 bg-white/60 py-14">
+                <div className="mx-auto max-w-7xl px-5 sm:px-6">
+                  <div className="flex flex-wrap items-end justify-between gap-4">
+                    <div>
+                      <p className="text-sm font-black uppercase tracking-[0.18em]" style={{ color: accent }}>Featured products</p>
+                      <h2 className="mt-2 text-3xl font-black" style={{ fontFamily: headingFont }}>Shop the Curvature collection</h2>
+                    </div>
+                    <Link href="/shop" className="font-black" style={{ color: primary }}>View all products →</Link>
+                  </div>
+                  <div className="mt-8 grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                    {products.slice(0, 8).map((product) => <ProductCard key={`${product.name}-${product.href || ''}`} product={product} accent={accent} textColor={textColor} />)}
+                  </div>
                 </div>
-              ))}
-            </section>
+              </section>
+            ) : null}
           </>
         )}
-        {page === 'programs' && (
-          <section className="max-w-6xl mx-auto px-4 py-12">
-            <h1 className="text-3xl font-bold mb-8">Training Programs</h1>
-            <div className="grid md:grid-cols-2 lg:grid-cols-3 gap-6">
-              {config.programs.map((prog) => (
-                <article key={prog.name} className="border border-slate-200 rounded-xl p-6">
-                  <h2 className="font-bold text-lg mb-2">{prog.name}</h2>
-                  <p className="text-slate-600 text-sm mb-4">{prog.description}</p>
-                </article>
-              ))}
-            </div>
-          </section>
-        )}
-        {page === 'about' && (
-          <section className="max-w-3xl mx-auto px-4 py-12">
-            <h1 className="text-3xl font-bold mb-4">About {config.branding.logoText}</h1>
-            <p className="text-slate-600 leading-relaxed">{config.footer.description}</p>
-          </section>
-        )}
-        {page === 'contact' && (
-          <section className="max-w-3xl mx-auto px-4 py-12">
-            <h1 className="text-3xl font-bold mb-4">Contact</h1>
-            {config.footer.contactEmail && (
-              <p className="text-slate-800">
-                Email:{' '}
-                <a href={`mailto:${config.footer.contactEmail}`} className="underline font-medium">
-                  {config.footer.contactEmail}
-                </a>
+
+        {page === 'catalog' && (
+          <section className="mx-auto max-w-7xl px-5 py-14 sm:px-6">
+            <div className="max-w-3xl">
+              <p className="text-sm font-black uppercase tracking-[0.18em]" style={{ color: accent }}>{isStore ? 'Curvature shop' : 'Programs'}</p>
+              <h1 className="mt-2 text-4xl font-black" style={{ fontFamily: headingFont }}>{isStore ? 'Wellness products' : 'Training programs'}</h1>
+              <p className="mt-3 text-base font-medium leading-7 text-slate-600">
+                {isStore ? 'Browse products imported from the original Curvature storefront. Review product details before purchasing.' : 'Explore available programs and services.'}
               </p>
+            </div>
+            {isStore ? (
+              <div className="mt-9 grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+                {products.map((product) => <ProductCard key={`${product.name}-${product.href || ''}`} product={product} accent={accent} textColor={textColor} />)}
+              </div>
+            ) : (
+              <div className="mt-9 grid gap-6 md:grid-cols-2 lg:grid-cols-3">
+                {config.programs.map((prog) => (
+                  <article key={prog.name} className="overflow-hidden rounded-3xl border border-black/10 bg-white shadow-sm">
+                    {prog.image ? (
+                      <div className="aspect-[16/10] overflow-hidden bg-slate-100">
+                        {/* eslint-disable-next-line @next/next/no-img-element */}
+                        <img src={prog.image} alt={prog.name} className="h-full w-full object-cover" loading="lazy" />
+                      </div>
+                    ) : null}
+                    <div className="p-6">
+                      <h2 className="text-xl font-black" style={{ fontFamily: headingFont }}>{prog.name}</h2>
+                      <p className="mt-2 text-sm font-medium leading-6 text-slate-600">{prog.description}</p>
+                    </div>
+                  </article>
+                ))}
+              </div>
             )}
           </section>
         )}
+
+        {page === 'about' && (
+          <section className="mx-auto max-w-4xl px-5 py-16 sm:px-6">
+            <p className="text-sm font-black uppercase tracking-[0.18em]" style={{ color: accent }}>About</p>
+            <h1 className="mt-2 text-4xl font-black" style={{ fontFamily: headingFont }}>About {config.branding.logoText}</h1>
+            <p className="mt-6 text-lg font-medium leading-8 text-slate-600">{config.footer.description}</p>
+          </section>
+        )}
+
+        {page === 'contact' && (
+          <section className="mx-auto max-w-4xl px-5 py-16 sm:px-6">
+            <p className="text-sm font-black uppercase tracking-[0.18em]" style={{ color: accent }}>Contact</p>
+            <h1 className="mt-2 text-4xl font-black" style={{ fontFamily: headingFont }}>Connect with {config.branding.logoText}</h1>
+            <div className="mt-8 grid gap-5 sm:grid-cols-2">
+              {(config.contact?.email || config.footer.contactEmail) ? (
+                <a href={`mailto:${config.contact?.email || config.footer.contactEmail}`} className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">Email</p>
+                  <p className="mt-2 font-black" style={{ color: primary }}>{config.contact?.email || config.footer.contactEmail}</p>
+                </a>
+              ) : null}
+              {config.contact?.phone ? (
+                <a href={`tel:${config.contact.phone}`} className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm">
+                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">Phone</p>
+                  <p className="mt-2 font-black" style={{ color: primary }}>{config.contact.phone}</p>
+                </a>
+              ) : null}
+              {config.contact?.bookingUrl ? (
+                <a href={config.contact.bookingUrl} target="_blank" rel="noreferrer" className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm sm:col-span-2">
+                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">Appointments</p>
+                  <p className="mt-2 text-lg font-black" style={{ color: primary }}>Book consultation services →</p>
+                </a>
+              ) : null}
+              {config.contact?.hours?.length ? (
+                <div className="rounded-3xl border border-black/10 bg-white p-6 shadow-sm sm:col-span-2">
+                  <p className="text-xs font-black uppercase tracking-wider text-slate-500">Hours</p>
+                  <div className="mt-3 space-y-1 text-sm font-semibold text-slate-700">
+                    {config.contact.hours.map((line) => <p key={line}>{line}</p>)}
+                  </div>
+                </div>
+              ) : null}
+            </div>
+          </section>
+        )}
       </main>
-      <footer className="border-t border-slate-200 mt-12 py-8 bg-slate-50 text-center text-sm text-slate-600">
-        <p>{config.footer.description}</p>
+
+      <footer className="mt-12 border-t border-black/10 bg-white/80 py-10">
+        <div className="mx-auto flex max-w-7xl flex-col gap-4 px-5 sm:px-6 md:flex-row md:items-center md:justify-between">
+          <div>
+            <p className="font-black" style={{ color: primary, fontFamily: headingFont }}>{config.branding.logoText}</p>
+            <p className="mt-1 max-w-2xl text-sm font-medium leading-6 text-slate-600">{config.footer.description}</p>
+          </div>
+          <Link href={catalogHref} className="font-black" style={{ color: primary }}>{isStore ? 'Shop products →' : 'Explore programs →'}</Link>
+        </div>
       </footer>
     </div>
   );

--- a/lib/tenant/site-types.ts
+++ b/lib/tenant/site-types.ts
@@ -1,3 +1,23 @@
+export type TenantSiteProduct = {
+  name: string;
+  description?: string;
+  price?: string;
+  compareAtPrice?: string;
+  image?: string;
+  imageAlt?: string;
+  href?: string;
+  category?: string;
+  badge?: string;
+};
+
+export type TenantSiteContact = {
+  email?: string;
+  phone?: string;
+  address?: string;
+  bookingUrl?: string;
+  hours?: string[];
+};
+
 export type TenantSiteConfig = {
   template: {
     id: string;
@@ -14,19 +34,27 @@ export type TenantSiteConfig = {
     textColor?: string;
     logoText: string;
     tagline?: string;
+    logoImage?: string;
   };
   homepage: {
     heroTitle: string;
     heroSubtitle: string;
     heroCtaText: string;
-    features: Array<{ title: string; description: string }>;
+    heroCtaHref?: string;
+    heroImage?: string;
+    heroImageAlt?: string;
+    announcement?: string;
+    features: Array<{ title: string; description: string; image?: string }>;
   };
   programs: Array<{
     name: string;
     description: string;
     duration?: string;
     level?: string;
+    image?: string;
   }>;
+  products?: TenantSiteProduct[];
+  contact?: TenantSiteContact;
   stats?: {
     students?: number;
     completionRate?: string;

--- a/lib/websites/import-site-service.ts
+++ b/lib/websites/import-site-service.ts
@@ -2,12 +2,23 @@ import * as cheerio from 'cheerio';
 import { aiChat } from '@/lib/ai/ai-service';
 import { logger } from '@/lib/logger';
 
+export interface ScrapedWebsiteProduct {
+  name: string;
+  description: string;
+  price?: string;
+  compareAtPrice?: string;
+  image?: string;
+  href: string;
+  category?: string;
+}
+
 export interface ScrapedWebsiteData {
   success: boolean;
   error?: string;
   title: string;
   description: string;
   logo?: string;
+  heroImage?: string;
   colors: string[];
   fonts: string[];
   navigation: Array<{ label: string; href: string }>;
@@ -20,10 +31,12 @@ export interface ScrapedWebsiteData {
   }>;
   images: string[];
   programs: Array<{ name: string; description: string }>;
+  products: ScrapedWebsiteProduct[];
   contactInfo: {
     email?: string;
     phone?: string;
     address?: string;
+    bookingUrl?: string;
   };
 }
 
@@ -54,6 +67,128 @@ export function assertSafePublicImportUrl(url: URL) {
   }
 }
 
+function toAbsoluteUrl(value: string | undefined, baseUrl: string): string | undefined {
+  if (!value) return undefined;
+  const trimmed = value.trim();
+  if (!trimmed || trimmed.startsWith('data:')) return undefined;
+  try {
+    return new URL(trimmed, baseUrl).href;
+  } catch {
+    return undefined;
+  }
+}
+
+function bestImageSrc($: cheerio.CheerioAPI, el: any, baseUrl: string): string | undefined {
+  const node = $(el);
+  const src = node.attr('src') || node.attr('data-src') || node.attr('data-original');
+  if (src) return toAbsoluteUrl(src, baseUrl);
+
+  const srcset = node.attr('srcset') || node.attr('data-srcset');
+  if (srcset) {
+    const candidates = srcset
+      .split(',')
+      .map((candidate) => candidate.trim().split(/\s+/)[0])
+      .filter(Boolean);
+    return toAbsoluteUrl(candidates[candidates.length - 1], baseUrl);
+  }
+  return undefined;
+}
+
+function currencyValues(text: string): string[] {
+  return [...text.matchAll(/\$\s*([0-9]+(?:\.[0-9]{1,2})?)/g)].map((match) => match[1]);
+}
+
+function productContainer($: cheerio.CheerioAPI, anchor: any) {
+  const node = $(anchor);
+  return node.closest('article, li, .grid__item, .card-wrapper, .product-card-wrapper, .product-item, .product-card').first();
+}
+
+function collectProductsFromHtml(
+  html: string,
+  pageUrl: string,
+  existing: ScrapedWebsiteProduct[] = [],
+): ScrapedWebsiteProduct[] {
+  const $ = cheerio.load(html);
+  const byHref = new Map(existing.map((product) => [product.href, product]));
+
+  $('a[href*="/products/"]').each((_, anchor) => {
+    const rawHref = $(anchor).attr('href');
+    const href = toAbsoluteUrl(rawHref, pageUrl);
+    if (!href) return;
+
+    const normalizedHref = href.split('?')[0].split('#')[0];
+    const container = productContainer($, anchor);
+    const scope = container.length ? container : $(anchor).parent();
+    const heading = scope.find('h1, h2, h3, .card__heading, .product-title, .product__title').first().text().trim();
+    const anchorText = $(anchor).text().replace(/\s+/g, ' ').trim();
+    const name = (heading || anchorText).replace(/\s+/g, ' ').trim().slice(0, 180);
+    if (!name || name.length < 2) return;
+
+    const scopeText = scope.text().replace(/\s+/g, ' ').trim();
+    const prices = currencyValues(scopeText);
+    const imageEl = scope.find('img').first();
+    const image = imageEl.length ? bestImageSrc($, imageEl, pageUrl) : undefined;
+    const previous = byHref.get(normalizedHref);
+
+    byHref.set(normalizedHref, {
+      name: previous?.name || name,
+      description: previous?.description || '',
+      price: previous?.price || prices[prices.length - 1] || prices[0],
+      compareAtPrice: previous?.compareAtPrice || (prices.length > 1 ? prices[0] : undefined),
+      image: previous?.image || image,
+      href: normalizedHref,
+      category: previous?.category,
+    });
+  });
+
+  return [...byHref.values()].slice(0, 40);
+}
+
+async function enrichProduct(product: ScrapedWebsiteProduct, origin: string): Promise<ScrapedWebsiteProduct> {
+  try {
+    const productUrl = new URL(product.href);
+    if (productUrl.origin !== origin) return product;
+    assertSafePublicImportUrl(productUrl);
+
+    const response = await fetch(productUrl.href, {
+      headers: { 'User-Agent': 'Mozilla/5.0 (compatible; ElevateWebsiteImporter/1.0)' },
+      redirect: 'follow',
+      signal: AbortSignal.timeout(10000),
+    });
+    if (!response.ok || !(response.headers.get('content-type') || '').includes('text/html')) return product;
+
+    const html = (await response.text()).slice(0, 1_500_000);
+    const $ = cheerio.load(html);
+    const name = $('h1').first().text().replace(/\s+/g, ' ').trim() || product.name;
+    const description = $(
+      '.product__description, .product-description, [class*="product__description"], [class*="product-description"]',
+    )
+      .first()
+      .text()
+      .replace(/\s+/g, ' ')
+      .trim()
+      .slice(0, 1600);
+    const text = $('main').text().replace(/\s+/g, ' ');
+    const prices = currencyValues(text);
+    const image =
+      toAbsoluteUrl($('meta[property="og:image"]').attr('content'), productUrl.href) ||
+      bestImageSrc($, $('main img').first(), productUrl.href) ||
+      product.image;
+
+    return {
+      ...product,
+      name: name.slice(0, 180),
+      description: description || product.description,
+      price: product.price || prices[prices.length - 1] || prices[0],
+      compareAtPrice: product.compareAtPrice || (prices.length > 1 ? prices[0] : undefined),
+      image,
+    };
+  } catch (error) {
+    logger.debug('[website-import] product detail skipped', { url: product.href, error: String(error) });
+    return product;
+  }
+}
+
 export async function importExistingWebsite(
   rawUrl: string,
   includePages: string[] = ['/', '/about', '/programs', '/contact'],
@@ -77,6 +212,7 @@ export async function importExistingWebsite(
       description: scrapedData.description,
       pageCount: scrapedData.pages.length,
       imagesFound: scrapedData.images.length,
+      productsFound: scrapedData.products.length,
       colorsDetected: scrapedData.colors,
     },
     config: {
@@ -86,6 +222,8 @@ export async function importExistingWebsite(
         importedFrom: rawUrl,
         importedAt: new Date().toISOString(),
         previewId,
+        sourceImageCount: scrapedData.images.length,
+        sourceProductCount: scrapedData.products.length,
       },
     },
   };
@@ -102,6 +240,7 @@ async function scrapeSite(baseUrl: string, pages: string[]): Promise<ScrapedWebs
     pages: [],
     images: [],
     programs: [],
+    products: [],
     contactInfo: {},
   };
 
@@ -132,44 +271,54 @@ async function scrapeSite(baseUrl: string, pages: string[]): Promise<ScrapedWebs
       $('meta[property="og:description"]').attr('content') ||
       $('p').first().text().trim().slice(0, 300);
 
-    result.logo = $('img[alt*="logo" i], img[class*="logo" i], header img').first().attr('src');
-    if (result.logo && !result.logo.startsWith('http')) {
-      result.logo = new URL(result.logo, baseUrl).href;
-    }
+    result.logo = toAbsoluteUrl(
+      $('img[alt*="logo" i], img[class*="logo" i], header img').first().attr('src'),
+      baseUrl,
+    );
+    result.heroImage =
+      toAbsoluteUrl($('meta[property="og:image"]').attr('content'), baseUrl) ||
+      bestImageSrc($, $('main img, section img').first(), baseUrl);
 
     $('nav a, header a, .nav a, .menu a, .navigation a').each((_, el) => {
       const href = $(el).attr('href');
-      const label = $(el).text().trim();
-      if (href && label && label.length < 50 && !href.startsWith('#')) result.navigation.push({ label, href });
+      const label = $(el).text().replace(/\s+/g, ' ').trim();
+      if (!href || !label || label.length >= 60 || href.startsWith('#')) return;
+      const absolute = toAbsoluteUrl(href, baseUrl) || href;
+      result.navigation.push({ label, href: absolute });
+      if (/book|appointment|consultation/i.test(label) && /^https?:/i.test(absolute)) {
+        result.contactInfo.bookingUrl = absolute;
+      }
     });
     result.navigation = result.navigation
       .filter((item, index, self) => index === self.findIndex((candidate) => candidate.label === item.label))
-      .slice(0, 12);
+      .slice(0, 16);
 
     const colorRegex = /#[0-9A-Fa-f]{6}|#[0-9A-Fa-f]{3}|rgb\([^)]+\)|rgba\([^)]+\)/g;
     const styleContent = `${$('style').text()} ${$('[style]').map((_, el) => $(el).attr('style')).get().join(' ')}`;
-    result.colors = [...new Set(styleContent.match(colorRegex) || [])].slice(0, 12);
+    result.colors = [...new Set(styleContent.match(colorRegex) || [])].slice(0, 16);
+
+    const fontRegex = /font-family\s*:\s*([^;}]+)/gi;
+    result.fonts = [...styleContent.matchAll(fontRegex)]
+      .map((match) => match[1].replace(/["']/g, '').trim())
+      .filter((value, index, self) => value && self.indexOf(value) === index)
+      .slice(0, 8);
 
     $('img').each((_, el) => {
-      let src = $(el).attr('src') || $(el).attr('data-src');
-      if (!src) return;
-      try {
-        if (!src.startsWith('http')) src = new URL(src, baseUrl).href;
-        result.images.push(src);
-      } catch {
-        // Ignore malformed image URLs.
-      }
+      const src = bestImageSrc($, el, baseUrl);
+      if (src) result.images.push(src);
     });
-    result.images = [...new Set(result.images)].slice(0, 30);
+    result.images = [...new Set(result.images)].slice(0, 80);
 
     $('h2, h3, .card-title, .program-title, .course-title, .service-title').each((_, el) => {
-      const name = $(el).text().trim();
-      const description = $(el).next('p').text().trim() || $(el).parent().find('p').first().text().trim();
+      const name = $(el).text().replace(/\s+/g, ' ').trim();
+      const description = $(el).next('p').text().replace(/\s+/g, ' ').trim() || $(el).parent().find('p').first().text().replace(/\s+/g, ' ').trim();
       if (name && name.length > 3 && name.length < 120) {
-        result.programs.push({ name, description: description.slice(0, 400) });
+        result.programs.push({ name, description: description.slice(0, 500) });
       }
     });
-    result.programs = result.programs.slice(0, 16);
+    result.programs = result.programs.slice(0, 20);
+
+    result.products = collectProductsFromHtml(html, baseUrl);
 
     const emailMatch = html.match(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/);
     if (emailMatch) result.contactInfo.email = emailMatch[0];
@@ -177,7 +326,13 @@ async function scrapeSite(baseUrl: string, pages: string[]): Promise<ScrapedWebs
     if (phoneMatch) result.contactInfo.phone = phoneMatch[0];
 
     const origin = new URL(baseUrl).origin;
-    for (const pagePath of pages.slice(1, 6)) {
+    const discoveredPaths = pages.slice(1, 6);
+    if (/shopify/i.test(html) || $('a[href*="/products/"]').length > 0) {
+      discoveredPaths.push('/collections/all');
+    }
+
+    const uniquePaths = [...new Set(discoveredPaths)];
+    for (const pagePath of uniquePaths) {
       try {
         const pageUrl = new URL(pagePath, baseUrl);
         if (pageUrl.origin !== origin) continue;
@@ -190,18 +345,40 @@ async function scrapeSite(baseUrl: string, pages: string[]): Promise<ScrapedWebs
         if (!pageResponse.ok) continue;
         const pageType = pageResponse.headers.get('content-type') || '';
         if (!pageType.includes('text/html')) continue;
-        const pageHtml = (await pageResponse.text()).slice(0, 1_000_000);
+        const pageHtml = (await pageResponse.text()).slice(0, 1_500_000);
         const page$ = cheerio.load(pageHtml);
+        const pageImages = page$('img')
+          .map((_, el) => bestImageSrc(page$, el, pageUrl.href))
+          .get()
+          .filter(Boolean) as string[];
         result.pages.push({
           url: pageUrl.href,
           title: page$('title').text().trim() || page$('h1').first().text().trim(),
-          headings: page$('h1, h2, h3').map((_, el) => page$(el).text().trim()).get().slice(0, 12),
-          paragraphs: page$('p').map((_, el) => page$(el).text().trim()).get().filter((p) => p.length > 40).slice(0, 8),
-          images: page$('img').map((_, el) => page$(el).attr('src')).get().slice(0, 8),
+          headings: page$('h1, h2, h3').map((_, el) => page$(el).text().replace(/\s+/g, ' ').trim()).get().slice(0, 20),
+          paragraphs: page$('p').map((_, el) => page$(el).text().replace(/\s+/g, ' ').trim()).get().filter((p) => p.length > 40).slice(0, 16),
+          images: pageImages.slice(0, 30),
         });
+        result.images.push(...pageImages);
+        result.products = collectProductsFromHtml(pageHtml, pageUrl.href, result.products);
+
+        const pageText = pageHtml;
+        if (!result.contactInfo.email) {
+          const match = pageText.match(/[a-zA-Z0-9._%+-]+@[a-zA-Z0-9.-]+\.[a-zA-Z]{2,}/);
+          if (match) result.contactInfo.email = match[0];
+        }
+        if (!result.contactInfo.phone) {
+          const match = pageText.match(/(\+?1?[-.\s]?)?\(?\d{3}\)?[-.\s]?\d{3}[-.\s]?\d{4}/);
+          if (match) result.contactInfo.phone = match[0];
+        }
       } catch (error) {
         logger.debug('[website-import] subpage skipped', { error: String(error) });
       }
+    }
+
+    result.images = [...new Set(result.images)].slice(0, 120);
+    if (result.products.length) {
+      const enriched = await Promise.all(result.products.slice(0, 30).map((product) => enrichProduct(product, origin)));
+      result.products = enriched.filter((product) => product.name && product.href);
     }
 
     result.success = true;
@@ -213,38 +390,76 @@ async function scrapeSite(baseUrl: string, pages: string[]): Promise<ScrapedWebs
 }
 
 async function analyzeAndGenerateConfig(scrapedData: ScrapedWebsiteData): Promise<any> {
-  const prompt = `Analyze this public website and generate an Elevate website configuration that preserves the organization's factual content and brand voice.\n\nTitle: ${scrapedData.title}\nDescription: ${scrapedData.description}\nNavigation: ${JSON.stringify(scrapedData.navigation)}\nColors: ${scrapedData.colors.join(', ')}\nServices/programs: ${JSON.stringify(scrapedData.programs.slice(0, 10))}\nContact: ${JSON.stringify(scrapedData.contactInfo)}\nPage titles: ${scrapedData.pages.map((p) => p.title).join(', ')}\n\nReturn ONLY JSON with branding, homepage, programs, navigation, footer, seo and template. Never invent licenses, accreditations, testimonials, ratings, outcomes, addresses or legal claims.`;
+  const sourceProducts = scrapedData.products.slice(0, 30).map((product) => ({
+    name: product.name,
+    description: product.description,
+    price: product.price,
+    compareAtPrice: product.compareAtPrice,
+    image: product.image,
+    href: product.href,
+    category: product.category,
+  }));
+
+  const prompt = `Analyze this public website and generate an Elevate website configuration that preserves the organization's factual content, brand voice, products, imagery and calls to action. Do not collapse a retail or service business into a generic training-provider website.\n\nTitle: ${scrapedData.title}\nDescription: ${scrapedData.description}\nNavigation: ${JSON.stringify(scrapedData.navigation)}\nColors: ${scrapedData.colors.join(', ')}\nFonts: ${scrapedData.fonts.join(', ')}\nHero image: ${scrapedData.heroImage || ''}\nServices/programs: ${JSON.stringify(scrapedData.programs.slice(0, 12))}\nProducts: ${JSON.stringify(sourceProducts)}\nContact: ${JSON.stringify(scrapedData.contactInfo)}\nPage titles: ${scrapedData.pages.map((p) => p.title).join(', ')}\n\nReturn ONLY JSON with template, branding, homepage, programs, products, contact, navigation, footer, seo and meta. Use homepage.heroImage when a source hero image exists. For a retail site set meta.siteKind to "store" and use a shop-focused CTA. Preserve source product names, prices, image URLs and links. Never invent licenses, accreditations, testimonials, ratings, outcomes, addresses, medical claims or legal claims.`;
 
   try {
     const completion = await aiChat({
       messages: [
-        { role: 'system', content: 'You are a website migration expert. Preserve source facts. Return only valid JSON.' },
+        { role: 'system', content: 'You are a website migration expert. Preserve source facts and media. Return only valid JSON.' },
         { role: 'user', content: prompt },
       ],
-      temperature: 0.35,
-      maxTokens: 2400,
+      temperature: 0.3,
+      maxTokens: 5200,
     });
-    return JSON.parse((completion.content || '').replace(/```json\n?|\n?```/g, '').trim());
+    const parsed = JSON.parse((completion.content || '').replace(/```json\n?|\n?```/g, '').trim());
+    return {
+      ...parsed,
+      products: sourceProducts,
+      contact: {
+        ...(parsed.contact || {}),
+        email: scrapedData.contactInfo.email || parsed.contact?.email,
+        phone: scrapedData.contactInfo.phone || parsed.contact?.phone,
+        bookingUrl: scrapedData.contactInfo.bookingUrl || parsed.contact?.bookingUrl,
+      },
+      homepage: {
+        ...(parsed.homepage || {}),
+        heroImage: scrapedData.heroImage || parsed.homepage?.heroImage,
+      },
+      branding: {
+        ...(parsed.branding || {}),
+        logoImage: scrapedData.logo || parsed.branding?.logoImage,
+      },
+      meta: {
+        ...(parsed.meta || {}),
+        siteKind: sourceProducts.length ? 'store' : parsed.meta?.siteKind,
+      },
+    };
   } catch {
+    const isStore = sourceProducts.length > 0;
     return {
       branding: {
-        primaryColor: scrapedData.colors[0] || '#1e40af',
-        secondaryColor: scrapedData.colors[1] || '#3b82f6',
-        accentColor: scrapedData.colors[2] || '#f59e0b',
+        primaryColor: scrapedData.colors[0] || '#7c3f58',
+        secondaryColor: scrapedData.colors[1] || '#6f7f56',
+        accentColor: scrapedData.colors[2] || '#c99048',
         logoText: scrapedData.title.split('|')[0].split('-')[0].trim(),
-        tagline: scrapedData.description.slice(0, 100),
+        logoImage: scrapedData.logo,
+        tagline: scrapedData.description.slice(0, 120),
       },
       homepage: {
         heroTitle: scrapedData.title.split('|')[0].trim(),
         heroSubtitle: scrapedData.description,
-        heroCtaText: 'Get Started',
-        features: scrapedData.programs.slice(0, 3).map((item) => ({ title: item.name, description: item.description })),
+        heroCtaText: isStore ? 'Shop Products' : 'Get Started',
+        heroCtaHref: isStore ? '/shop' : '/programs',
+        heroImage: scrapedData.heroImage,
+        features: scrapedData.programs.slice(0, 4).map((item) => ({ title: item.name, description: item.description })),
       },
-      programs: scrapedData.programs.slice(0, 12).map((item) => ({ name: item.name, description: item.description })),
-      navigation: scrapedData.navigation.slice(0, 8),
-      footer: { description: scrapedData.description.slice(0, 150), contactEmail: scrapedData.contactInfo.email || '' },
+      programs: scrapedData.programs.slice(0, 20).map((item) => ({ name: item.name, description: item.description })),
+      products: sourceProducts,
+      contact: scrapedData.contactInfo,
+      navigation: scrapedData.navigation.slice(0, 12),
+      footer: { description: scrapedData.description.slice(0, 220), contactEmail: scrapedData.contactInfo.email || '' },
       seo: { title: scrapedData.title, description: scrapedData.description, keywords: [] },
-      template: 'professional',
+      meta: { siteKind: isStore ? 'store' : 'business' },
     };
   }
 }

--- a/supabase/migrations/20260811020500_secure_website_builder_credit_rpcs.sql
+++ b/supabase/migrations/20260811020500_secure_website_builder_credit_rpcs.sql
@@ -1,0 +1,88 @@
+create or replace function public.ensure_app_trial_wallet(p_user_id uuid, p_app_slug text, p_trial_credits integer default 500)
+returns integer
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_balance integer;
+  v_role text := auth.role();
+begin
+  if v_role is distinct from 'service_role' then
+    if auth.uid() is null or auth.uid() <> p_user_id then
+      raise exception 'not authorized';
+    end if;
+  end if;
+
+  insert into public.user_app_credit_wallets (
+    user_id, app_slug, balance, lifetime_granted, lifetime_used
+  ) values (
+    p_user_id, p_app_slug, greatest(p_trial_credits, 0), greatest(p_trial_credits, 0), 0
+  )
+  on conflict (user_id, app_slug) do nothing;
+
+  select balance into v_balance
+  from public.user_app_credit_wallets
+  where user_id = p_user_id and app_slug = p_app_slug;
+
+  return coalesce(v_balance, 0);
+end;
+$$;
+
+create or replace function public.consume_app_credits(p_user_id uuid, p_app_slug text, p_operation text, p_cost integer)
+returns table(success boolean, balance integer)
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  v_balance integer;
+  v_next integer;
+  v_role text := auth.role();
+begin
+  if v_role is distinct from 'service_role' then
+    if auth.uid() is null or auth.uid() <> p_user_id then
+      raise exception 'not authorized';
+    end if;
+  end if;
+
+  if p_cost <= 0 then
+    select w.balance into v_balance
+    from public.user_app_credit_wallets w
+    where w.user_id = p_user_id and w.app_slug = p_app_slug;
+    return query select true, coalesce(v_balance, 0);
+    return;
+  end if;
+
+  select w.balance into v_balance
+  from public.user_app_credit_wallets w
+  where w.user_id = p_user_id and w.app_slug = p_app_slug
+  for update;
+
+  if v_balance is null or v_balance < p_cost then
+    return query select false, coalesce(v_balance, 0);
+    return;
+  end if;
+
+  v_next := v_balance - p_cost;
+
+  update public.user_app_credit_wallets
+  set balance = v_next,
+      lifetime_used = lifetime_used + p_cost,
+      updated_at = now()
+  where user_id = p_user_id and app_slug = p_app_slug;
+
+  insert into public.user_app_credit_ledger (
+    user_id, app_slug, operation, credits_delta, balance_after, source
+  ) values (
+    p_user_id, p_app_slug, p_operation, -p_cost, v_next, 'usage'
+  );
+
+  return query select true, v_next;
+end;
+$$;
+
+revoke all on function public.ensure_app_trial_wallet(uuid, text, integer) from public, anon;
+revoke all on function public.consume_app_credits(uuid, text, text, integer) from public, anon;
+grant execute on function public.ensure_app_trial_wallet(uuid, text, integer) to authenticated, service_role;
+grant execute on function public.consume_app_credits(uuid, text, text, integer) to authenticated, service_role;


### PR DESCRIPTION
Upgrades Website Builder import/rebuild flow using Curvature Body Sculpting as the real-world test case.

Changes:
- extend tenant site schema for products, contact details, hero imagery and store metadata
- scrape Shopify-style product catalogs, product pages, prices and source images
- preserve imported product links and media instead of collapsing retail sites into training-program cards
- render imported storefronts with a real shop layout, product cards, pricing, imagery, booking/contact CTAs and template-aware brand styling
- preserve imported template/store fields when creating a site
- allow platform admins to test Website Builder import/create flows without a paid individual Website Builder subscription

No publish/deploy in this PR yet. A Curvature Body Sculpting draft has been created in production data but remains unpublished.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add store-aware product catalog and admin bypass to Website Builder import
> - Extends the Website Builder import pipeline to scrape and enrich product listings from imported sites, detecting prices, images, and product detail pages, then merging them into the generated config.
> - Adds `isPlatformAdmin`/`getAdminRole` checks so users with `admin` or `super_admin` roles bypass subscription and trial constraints; their plan is treated as `enterprise`.
> - Expands `TenantSiteConfig` with new product, contact, hero image, logo, and announcement fields, and updates `normalizeProvidedConfig` to sanitize and cap these inputs.
> - `PublicTenantSite` now renders a full storefront view when `config.meta.siteKind === 'store'` or products are present, including a product catalog page, announcement bar, hero image, contact cards, and external link handling.
> - Adds two `SECURITY DEFINER` RPCs ([migration](https://github.com/elevate-for-humanity/Elevate-lms/pull/587/files#diff-44028e9d691d56540f159216a0311eca44f8bd8c71cb203479634e14e2781de1)) to provision trial credit wallets and atomically consume app credits with ledger recording.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 69ee46b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->