### PR TITLE
feat: bring Rise Forward Foundation into primary website journey

### DIFF
--- a/apps/marketing/app/apply/student/page.tsx
+++ b/apps/marketing/app/apply/student/page.tsx
@@ -292,6 +292,39 @@ export default async function StudentApplicationPage({
         </div>
       </section>
 
+      <section className="border-b border-emerald-200 bg-emerald-50 px-4 py-14" aria-labelledby="foundation-support-title">
+        <div className="mx-auto max-w-5xl">
+          <div className="grid gap-8 lg:grid-cols-[0.9fr_1.1fr] lg:items-start">
+            <div>
+              <p className="mb-2 text-xs font-black uppercase tracking-widest text-emerald-800">Support Beyond Tuition</p>
+              <h2 id="foundation-support-title" className="text-2xl font-extrabold text-slate-950 sm:text-3xl">
+                Rise Forward Foundation may help connect eligible participants to additional support.
+              </h2>
+              <p className="mt-4 text-sm leading-6 text-slate-700">
+                Selfish Inc. d/b/a Rise Forward Foundation works alongside Elevate as a nonprofit community-support partner. Available support is separate from tuition funding and depends on the Foundation's programs, resources, and participant eligibility.
+              </p>
+              <Link href="/rise-forward-foundation" className="mt-6 inline-flex min-h-11 items-center rounded-xl bg-emerald-800 px-5 py-3 text-sm font-black text-white hover:bg-emerald-900">
+                Learn About Rise Forward Foundation
+              </Link>
+            </div>
+            <div className="grid gap-3 sm:grid-cols-3">
+              <article className="rounded-2xl border border-emerald-200 bg-white p-5">
+                <h3 className="text-sm font-black text-slate-950">Training costs</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">Public or third-party funding must be separately approved by the responsible funder for the participant and program.</p>
+              </article>
+              <article className="rounded-2xl border border-emerald-200 bg-white p-5">
+                <h3 className="text-sm font-black text-slate-950">Wraparound resources</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">Eligible participants may be referred for available community resources, financial-capability support, or other barrier-reduction services.</p>
+              </article>
+              <article className="rounded-2xl border border-emerald-200 bg-white p-5">
+                <h3 className="text-sm font-black text-slate-950">No automatic benefit</h3>
+                <p className="mt-2 text-sm leading-6 text-slate-700">Submitting this application does not guarantee a voucher, reimbursement, books, equipment, counseling, or another specific charitable benefit.</p>
+              </article>
+            </div>
+          </div>
+        </div>
+      </section>
+
       <section id="application-form" className="px-4 py-14">
         <div className="mx-auto max-w-4xl">
           <div className="mb-8">

--- a/apps/marketing/app/page.tsx
+++ b/apps/marketing/app/page.tsx
@@ -9,6 +9,7 @@ import { HomeApprenticeshipInfra } from '@/components/home/HomeApprenticeshipInf
 import { HomeFunding } from '@/components/home/HomeFunding';
 import { HomeEmployerStrip } from '@/components/home/HomeEmployerStrip';
 import { HomeFinalCTA } from '@/components/home/HomeFinalCTA';
+import { HomeFoundationPartner } from '@/components/home/HomeFoundationPartner';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { ParisFloatingButton } from '@/components/paris/ParisFloatingButton';
 import StructuredData from '@/components/StructuredData';
@@ -61,6 +62,7 @@ export default function HomePage() {
       <StructuredData />
       <HomeHeroVideo banner={banner} />
       <MarqueeBanner />
+      <HomeFoundationPartner />
       <HomeCareerPathways />
       <HomeHowItWorks />
       <HomeFunding />

--- a/apps/marketing/app/programs/selfish-inc/page.tsx
+++ b/apps/marketing/app/programs/selfish-inc/page.tsx
@@ -1,0 +1,7 @@
+import { permanentRedirect } from 'next/navigation';
+
+export const dynamic = 'force-static';
+
+export default function LegacySelfishIncPage() {
+  permanentRedirect('/rise-forward-foundation');
+}

--- a/apps/marketing/app/rise-forward-foundation/page.tsx
+++ b/apps/marketing/app/rise-forward-foundation/page.tsx
@@ -1,0 +1,171 @@
+import type { Metadata } from 'next';
+import Link from 'next/link';
+import {
+  ArrowRight,
+  BadgeDollarSign,
+  BriefcaseBusiness,
+  HandHeart,
+  HeartHandshake,
+  Landmark,
+  ShieldCheck,
+  TreePine,
+  Users,
+} from 'lucide-react';
+import { LEGAL_PARTNER_LINE } from '@/lib/config/legal-entity';
+
+export const metadata: Metadata = {
+  title: 'Rise Forward Foundation | Selfish Inc. Community Support Partner',
+  description:
+    'Learn how Selfish Inc. d/b/a Rise Forward Foundation works alongside Elevate for Humanity to support eligible participants with community-resource navigation and wraparound services.',
+  alternates: {
+    canonical: 'https://www.elevateforhumanity.org/rise-forward-foundation',
+  },
+};
+
+const supportAreas = [
+  {
+    icon: HandHeart,
+    title: 'Barrier-reduction support',
+    text: 'Resource navigation and supportive-service referrals that may help eligible participants address barriers to completing training or entering employment.',
+  },
+  {
+    icon: BadgeDollarSign,
+    title: 'Financial capability & tax support',
+    text: 'Community-facing financial-literacy, tax-support, and related services when available through the Foundation or its partner network.',
+  },
+  {
+    icon: Users,
+    title: 'Community connection',
+    text: 'Connections to community programs, nonprofit resources, workshops, outreach, and support networks based on availability and eligibility.',
+  },
+  {
+    icon: HeartHandshake,
+    title: 'Career-readiness support',
+    text: 'Supportive resources that complement training and career services without replacing employer hiring decisions or public-funding eligibility rules.',
+  },
+] as const;
+
+export default function RiseForwardFoundationPage() {
+  return (
+    <main className="min-h-screen bg-white text-slate-950">
+      <section className="border-b border-emerald-900 bg-slate-950 px-4 py-16 text-white sm:py-20">
+        <div className="mx-auto grid max-w-6xl gap-10 lg:grid-cols-[0.95fr_1.05fr] lg:items-center">
+          <div>
+            <div className="inline-flex items-center gap-2 rounded-full border border-emerald-400/30 bg-emerald-400/10 px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-emerald-300">
+              <TreePine className="h-4 w-4" /> Selfish Inc. d/b/a Rise Forward Foundation
+            </div>
+            <h1 className="mt-5 max-w-4xl text-4xl font-black tracking-tight sm:text-5xl lg:text-6xl">
+              Support beyond the classroom.
+            </h1>
+            <p className="mt-5 max-w-3xl text-base font-medium leading-7 text-slate-300 sm:text-lg">
+              Elevate for Humanity focuses on career training, credentials, apprenticeship, and employer pathways. Rise Forward Foundation supports the broader mission by helping eligible participants connect with community and wraparound resources that can reduce barriers to progress.
+            </p>
+            <div className="mt-8 flex flex-wrap gap-3">
+              <Link href="/apply/student" className="inline-flex min-h-12 items-center gap-2 rounded-xl bg-emerald-500 px-6 py-3 font-black text-slate-950 hover:bg-emerald-400">
+                Apply for Training <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link href="/eligibility/quiz" className="inline-flex min-h-12 items-center rounded-xl border border-white/30 px-6 py-3 font-black text-white hover:bg-white/10">
+                Check Funding Eligibility
+              </Link>
+            </div>
+          </div>
+
+          <div className="rounded-3xl border border-white/15 bg-white/5 p-7 sm:p-8">
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-emerald-300">How the partnership works</p>
+            <div className="mt-5 space-y-4">
+              <div className="rounded-2xl bg-white p-5 text-slate-950">
+                <p className="text-xs font-black uppercase tracking-wide text-brand-red-700">Elevate for Humanity</p>
+                <p className="mt-2 font-black">Training, credentials, apprenticeship, career preparation, employer connections.</p>
+              </div>
+              <div className="rounded-2xl border border-white/15 p-5">
+                <div className="flex items-center gap-2"><Landmark className="h-5 w-5 text-cyan-300" /><p className="font-black">Workforce & public funding</p></div>
+                <p className="mt-2 text-sm leading-6 text-slate-300">When available, the applicable agency—not Elevate or the Foundation—determines participant eligibility, approved costs, and funding authorization.</p>
+              </div>
+              <div className="rounded-2xl border border-emerald-400/25 bg-emerald-400/10 p-5">
+                <div className="flex items-center gap-2"><HandHeart className="h-5 w-5 text-emerald-300" /><p className="font-black">Rise Forward Foundation</p></div>
+                <p className="mt-2 text-sm leading-6 text-slate-200">Community and wraparound support based on available programs, resources, and participant eligibility.</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-4 py-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="max-w-3xl">
+            <p className="text-xs font-black uppercase tracking-[0.18em] text-emerald-700">The dual-engine model</p>
+            <h2 className="mt-3 text-3xl font-black text-slate-950 sm:text-4xl">Two organizations. One participant-centered mission.</h2>
+            <p className="mt-4 text-base font-medium leading-7 text-slate-700">
+              A credential can open a door, but transportation, finances, family responsibilities, wellness, and other barriers can still affect completion. The partnership is designed to keep training and community support connected while maintaining clear legal and funding responsibilities.
+            </p>
+          </div>
+
+          <div className="mt-10 grid gap-5 md:grid-cols-2">
+            {supportAreas.map(({ icon: Icon, title, text }) => (
+              <article key={title} className="rounded-3xl border border-slate-200 bg-slate-50 p-6">
+                <Icon className="h-7 w-7 text-emerald-700" />
+                <h3 className="mt-4 text-xl font-black text-slate-950">{title}</h3>
+                <p className="mt-2 text-sm font-medium leading-6 text-slate-700">{text}</p>
+              </article>
+            ))}
+          </div>
+        </div>
+      </section>
+
+      <section className="border-y border-slate-200 bg-slate-50 px-4 py-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="rounded-3xl border border-slate-200 bg-white p-7 sm:p-9">
+            <div className="flex items-start gap-4">
+              <ShieldCheck className="mt-1 h-8 w-8 shrink-0 text-brand-blue-700" />
+              <div>
+                <h2 className="text-2xl font-black text-slate-950">Clear responsibility. Clear disclosures.</h2>
+                <p className="mt-3 max-w-4xl text-sm font-medium leading-6 text-slate-700">
+                  Public workforce funding, charitable support, and career training are separate functions. Applying to Elevate does not guarantee WIOA, Workforce Ready Grant, another voucher, or a specific Foundation benefit. Each source has its own eligibility, availability, documentation, and authorization requirements.
+                </p>
+                <p className="mt-4 text-sm font-bold text-slate-900">Legal partner: {LEGAL_PARTNER_LINE}</p>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="px-4 py-16">
+        <div className="mx-auto max-w-6xl">
+          <div className="grid gap-6 lg:grid-cols-3">
+            <div className="rounded-3xl bg-slate-950 p-7 text-white">
+              <BriefcaseBusiness className="h-7 w-7 text-cyan-300" />
+              <p className="mt-4 text-xs font-black uppercase tracking-[0.16em] text-cyan-300">Step 1</p>
+              <h3 className="mt-2 text-xl font-black">Choose a career pathway</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">Review the exact program, credential goal, requirements, tuition, schedule, and funding disclosure.</p>
+            </div>
+            <div className="rounded-3xl bg-slate-950 p-7 text-white">
+              <Landmark className="h-7 w-7 text-cyan-300" />
+              <p className="mt-4 text-xs font-black uppercase tracking-[0.16em] text-cyan-300">Step 2</p>
+              <h3 className="mt-2 text-xl font-black">Verify funding separately</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">If third-party funding is requested, obtain the required eligibility decision and written authorization from the responsible agency.</p>
+            </div>
+            <div className="rounded-3xl bg-slate-950 p-7 text-white">
+              <HandHeart className="h-7 w-7 text-emerald-300" />
+              <p className="mt-4 text-xs font-black uppercase tracking-[0.16em] text-emerald-300">Step 3</p>
+              <h3 className="mt-2 text-xl font-black">Connect to available support</h3>
+              <p className="mt-2 text-sm leading-6 text-slate-300">Eligible participants may be connected to Rise Forward Foundation or other community resources for available wraparound support.</p>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="bg-emerald-900 px-4 py-16 text-center text-white">
+        <div className="mx-auto max-w-3xl">
+          <h2 className="text-3xl font-black">Training is the pathway. Support helps people stay on it.</h2>
+          <p className="mt-4 text-base font-medium leading-7 text-emerald-50">
+            Start with the career program that fits your goal, verify the funding path that applies to you, and ask about available supportive resources during the enrollment process.
+          </p>
+          <div className="mt-7 flex flex-wrap justify-center gap-3">
+            <Link href="/programs" className="rounded-xl bg-white px-6 py-3 font-black text-emerald-950 hover:bg-emerald-50">Explore Programs</Link>
+            <Link href="/contact" className="rounded-xl border border-white/40 px-6 py-3 font-black text-white hover:bg-white/10">Contact Admissions</Link>
+          </div>
+        </div>
+      </section>
+    </main>
+  );
+}

--- a/components/home/HomeFoundationPartner.tsx
+++ b/components/home/HomeFoundationPartner.tsx
@@ -1,0 +1,91 @@
+import Link from 'next/link';
+import {
+  ArrowRight,
+  BriefcaseBusiness,
+  GraduationCap,
+  HandHeart,
+  Landmark,
+  ShieldCheck,
+} from 'lucide-react';
+import { LEGAL_PARTNER_LINE } from '@/lib/config/legal-entity';
+
+const pillars = [
+  {
+    icon: GraduationCap,
+    eyebrow: 'Career Training',
+    title: 'Elevate for Humanity',
+    description:
+      'Career and technical training, Registered Apprenticeship pathways, credentials, career preparation, and employer connections.',
+  },
+  {
+    icon: Landmark,
+    eyebrow: 'Training Funding',
+    title: 'Workforce & Public Programs',
+    description:
+      'Eligible participants may qualify for approved workforce or public funding. The responsible funding agency determines eligibility, covered costs, and authorization.',
+  },
+  {
+    icon: HandHeart,
+    eyebrow: 'Wraparound Support',
+    title: 'Selfish Inc. / Rise Forward Foundation',
+    description:
+      'Community-resource navigation and supportive services designed to help eligible participants address barriers that can interfere with training, employment, and economic stability.',
+  },
+] as const;
+
+export function HomeFoundationPartner() {
+  return (
+    <section className="border-b border-slate-200 bg-white px-4 py-14 sm:py-16" aria-labelledby="foundation-partner-title">
+      <div className="mx-auto max-w-6xl">
+        <div className="mx-auto max-w-4xl text-center">
+          <span className="inline-flex items-center gap-2 rounded-full bg-emerald-50 px-4 py-2 text-xs font-black uppercase tracking-[0.18em] text-emerald-800">
+            <ShieldCheck className="h-4 w-4" /> Training + funding + support
+          </span>
+          <h2 id="foundation-partner-title" className="mt-4 text-3xl font-black tracking-tight text-slate-950 sm:text-4xl">
+            Two Organizations. One Complete Mission.
+          </h2>
+          <p className="mx-auto mt-4 max-w-3xl text-base font-medium leading-7 text-slate-700 sm:text-lg">
+            Elevate for Humanity focuses on skills, credentials, apprenticeship, and employment pathways. Selfish Inc. d/b/a Rise Forward Foundation supports the broader mission through community and wraparound resources. Public funding, when available, remains controlled by the applicable funding agency.
+          </p>
+        </div>
+
+        <div className="mt-10 grid gap-5 lg:grid-cols-3">
+          {pillars.map(({ icon: Icon, eyebrow, title, description }) => (
+            <article key={title} className="rounded-3xl border border-slate-200 bg-slate-50 p-6 shadow-sm">
+              <div className="flex h-12 w-12 items-center justify-center rounded-2xl bg-slate-950 text-white">
+                <Icon className="h-6 w-6" />
+              </div>
+              <p className="mt-5 text-xs font-black uppercase tracking-[0.16em] text-brand-red-700">{eyebrow}</p>
+              <h3 className="mt-2 text-xl font-black text-slate-950">{title}</h3>
+              <p className="mt-3 text-sm font-medium leading-6 text-slate-700">{description}</p>
+            </article>
+          ))}
+        </div>
+
+        <div className="mt-8 rounded-3xl bg-slate-950 p-6 text-white sm:p-8">
+          <div className="grid gap-6 lg:grid-cols-[1fr_auto] lg:items-center">
+            <div>
+              <div className="flex items-center gap-2 text-emerald-300">
+                <BriefcaseBusiness className="h-5 w-5" />
+                <p className="text-xs font-black uppercase tracking-[0.18em]">One participant journey</p>
+              </div>
+              <h3 className="mt-3 text-2xl font-black text-white">Career goal → funding review → training → support → credential → employment</h3>
+              <p className="mt-3 max-w-3xl text-sm font-medium leading-6 text-slate-300">
+                Support is based on program availability and participant eligibility. No website statement, application, or referral guarantees public funding or a specific charitable benefit.
+              </p>
+              <p className="mt-3 text-xs font-semibold text-slate-400">Foundation partner: {LEGAL_PARTNER_LINE}</p>
+            </div>
+            <div className="flex flex-col gap-3 sm:flex-row lg:flex-col">
+              <Link href="/rise-forward-foundation" className="inline-flex min-h-12 items-center justify-center gap-2 rounded-xl bg-emerald-500 px-5 py-3 font-black text-slate-950 hover:bg-emerald-400">
+                Explore Rise Forward <ArrowRight className="h-4 w-4" />
+              </Link>
+              <Link href="/eligibility/quiz" className="inline-flex min-h-12 items-center justify-center rounded-xl border border-white/30 px-5 py-3 font-black text-white hover:bg-white/10">
+                Check Funding Eligibility
+              </Link>
+            </div>
+          </div>
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/components/site-footer.tsx
+++ b/components/site-footer.tsx
@@ -3,6 +3,7 @@
 import Link from 'next/link';
 import { siteConfig } from '@/content/site';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { LEGAL_ENTITY_OPERATING_LINE } from '@/lib/config/legal-entity';
 import { ROUTES } from '@/lib/navigation/routes';
 import { PORTAL_MAP } from '@/lib/routing/portal-map';
 import { Mail, Phone, MapPin, Facebook, Twitter, Linkedin, Instagram, ExternalLink } from 'lucide-react';
@@ -36,6 +37,12 @@ export function SiteFooter() {
           <div>
             <p className="text-lg font-black text-slate-950">{siteConfig.name}</p>
             <p className="mt-2 text-base leading-7 text-slate-700">{siteConfig.description}</p>
+            <p className="mt-4 rounded-xl border border-emerald-200 bg-emerald-50 p-3 text-sm font-semibold leading-6 text-emerald-950">
+              Career programs are supported by our nonprofit partner, Selfish Inc. d/b/a Rise Forward Foundation, through available community and wraparound resources. Support is subject to eligibility and program availability.
+            </p>
+            <Link href="/rise-forward-foundation" className="mt-3 inline-flex text-sm font-black text-emerald-800 hover:underline">
+              Learn about Rise Forward Foundation
+            </Link>
             <div className="mt-5 flex gap-3">
               <a href="https://facebook.com/elevateforhumanity" target="_blank" rel="noopener noreferrer" className="flex h-10 w-10 items-center justify-center rounded-full bg-blue-700 text-white hover:bg-blue-800" aria-label="Facebook"><Facebook className="h-5 w-5" /></a>
               <a href="https://twitter.com/elevatefh" target="_blank" rel="noopener noreferrer" className="flex h-10 w-10 items-center justify-center rounded-full bg-sky-600 text-white hover:bg-sky-700" aria-label="Twitter"><Twitter className="h-5 w-5" /></a>
@@ -85,6 +92,7 @@ export function SiteFooter() {
         <div className="mt-10 grid gap-9 border-t border-slate-200 pt-10 md:grid-cols-5">
           <FooterGroup title="About">
             <li><Link href={ROUTES.about} className={linkClass}>About / Mission</Link></li>
+            <li><Link href="/rise-forward-foundation" className="text-base font-bold text-emerald-800 hover:underline">Rise Forward Foundation</Link></li>
             <li><Link href={ROUTES.aboutApprovals} className={linkClass}>Approvals</Link></li>
             <li><Link href={ROUTES.apprenticeshipSponsor} className={linkClass}>Apprenticeship Sponsor of Record</Link></li>
             <li><Link href={ROUTES.successStories} className={linkClass}>Success Stories</Link></li>
@@ -122,6 +130,9 @@ export function SiteFooter() {
         </div>
 
         <div className="mt-10 border-t border-slate-200 pt-6">
+          <p className="mb-5 text-sm font-semibold leading-6 text-slate-700">
+            <span className="font-black text-slate-950">Operating structure:</span> {LEGAL_ENTITY_OPERATING_LINE}. Training, public funding, and charitable support remain separate functions with separate eligibility and authorization requirements.
+          </p>
           <div className="flex flex-col gap-4 md:flex-row md:items-center md:justify-between">
             <div className="flex flex-wrap gap-4 text-sm font-medium text-slate-700">
               <Link href="/privacy" className="hover:text-slate-950 hover:underline">Privacy Policy</Link>

--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -55,6 +55,11 @@ export const NAV_ITEMS: NavItem[] = [
     ],
   },
   {
+    id: 'foundation',
+    name: 'Foundation',
+    href: '/rise-forward-foundation',
+  },
+  {
     id: 'employers',
     name: 'Employers',
     href: ROUTES.employers,
@@ -97,6 +102,7 @@ export const NAV_ITEMS: NavItem[] = [
     href: ROUTES.about,
     subItems: [
       { name: 'Mission', href: ROUTES.about, isSectionLink: true },
+      { name: 'Rise Forward Foundation', href: '/rise-forward-foundation', isSectionLink: true },
       { name: 'Approvals', href: ROUTES.aboutApprovals, isSectionLink: true },
       { name: 'Apprenticeship Sponsor of Record', href: ROUTES.apprenticeshipSponsor, isSectionLink: true },
       { name: 'Testing Center', href: ROUTES.testing, isSectionLink: true },


### PR DESCRIPTION
## What this changes
- Adds a homepage section immediately after the hero/marquee explaining the Elevate + public funding + Rise Forward support model.
- Adds `/rise-forward-foundation` as a dedicated public page.
- Adds **Foundation** as a direct top-level navigation item and also links it from About.
- Adds persistent nonprofit-partner and legal-operating-structure disclosure in the global footer.
- Adds a **Support Beyond Tuition** section to the canonical student application flow.
- Restores old `/programs/selfish-inc` inbound links with a permanent redirect to the new canonical Foundation page.

## Compliance guardrails
Copy intentionally avoids promising $0 out-of-pocket tuition, guaranteed WIOA/WRG funding, or automatic books/gear/counseling benefits. Public funding and charitable support are described as eligibility/availability dependent and legally distinct from training.

## Logo asset
The ChatGPT File Library contains the Selfish Inc. / Rise Forward Foundation tree logo embedded in the Humanitarian Hub concept-board images, but no standalone logo file was discoverable. This PR uses a neutral tree mark/text lockup rather than fabricating or extracting a potentially altered logo. Once the standalone PNG/SVG is supplied, it can be dropped into the page without changing the content architecture.

No deployment triggered.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add Rise Forward Foundation as a named section throughout the marketing site
> - Creates a new `/rise-forward-foundation` page ([page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/592/files#diff-c788f659f15297263a8e3bce535542142603ed458ae529a60a82937ece0eca96)) with SEO metadata, partnership details, and CTAs to `/apply/student`, `/eligibility/quiz`, `/programs`, and `/contact`.
> - Adds a `HomeFoundationPartner` section to the homepage ([HomeFoundationPartner.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/592/files#diff-71e78e1dfcdd788493f0c910dabeae56566ee980ee9533a4add96502259265b0)) between the marquee banner and career pathways, with three pillar cards and links to the foundation page.
> - Inserts a foundation-support info block with feature cards on the student application page ([page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/592/files#diff-097d5484301691296f9b27321feae4d13f03fd088a8a9ad4ac99479f1e0d95e5)).
> - Updates the site footer ([site-footer.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/592/files#diff-eedcf459879d71e3226ad4a1bdea3bde70ece6d4344eea2163a8cb6883fb4d87)) with foundation disclosures, operating structure text, and a link to the foundation page.
> - Adds a top-level "Foundation" nav item and an About submenu entry in [navigation.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/592/files#diff-4a50adcb0dcec63dfc56096cd65044e1ed4a673603fe2b895267d3bd3232f47b); redirects `/programs/selfish-inc` to `/rise-forward-foundation` with a 308.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 9065f33.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->