### PR TITLE
fix(header): keep desktop navigation on laptop widths

### DIFF
--- a/components/site/Header.tsx
+++ b/components/site/Header.tsx
@@ -18,7 +18,7 @@ export default function Header() {
       data-site-header
       data-header-owner="marketing-root"
     >
-      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-3 lg:gap-2 lg:px-3 xl:gap-3 xl:px-4 2xl:px-6">
+      <div className="mx-auto grid h-full w-full max-w-screen-2xl grid-cols-[auto_minmax(0,1fr)_auto] items-center gap-2 px-3 min-[900px]:gap-1 min-[900px]:px-2 xl:gap-3 xl:px-4 2xl:px-6">
         <Link
           href="/"
           className="flex min-w-0 flex-shrink-0 items-center gap-2"
@@ -30,14 +30,14 @@ export default function Header() {
           </span>
         </Link>
 
-        {/* One canonical desktop navigation row. No second desktop menu,
-            no horizontal scrolling strip, and no duplicated header shell. */}
-        <div className="hidden min-w-0 justify-center overflow-visible lg:flex">
+        {/* One canonical desktop navigation row. Keep it available on compact
+            laptop viewports instead of falling back to the mobile drawer. */}
+        <div className="hidden min-w-0 justify-center overflow-visible min-[900px]:flex">
           <HeaderDesktopNav items={NAV_ITEMS} />
         </div>
 
         <div className="flex min-w-0 flex-shrink-0 flex-nowrap items-center justify-end gap-1.5">
-          <div className="hidden flex-nowrap items-center gap-1 lg:flex">
+          <div className="hidden flex-nowrap items-center gap-1 min-[900px]:flex">
             <Link
               href={ROUTES.login}
               className="inline-flex whitespace-nowrap px-1.5 py-2 text-[13px] font-semibold text-slate-800 hover:text-slate-950 xl:px-2 xl:text-sm"
@@ -52,8 +52,8 @@ export default function Header() {
             </Link>
           </div>
 
-          {/* Phones and tablets below 1024px use the dedicated mobile drawer. */}
-          <div className="flex flex-nowrap items-center gap-1 lg:hidden">
+          {/* Phones and compact tablets below 900px use the dedicated drawer. */}
+          <div className="flex flex-nowrap items-center gap-1 min-[900px]:hidden">
             <span className="hidden whitespace-nowrap text-sm font-bold text-slate-700 sm:inline" aria-hidden="true">
               Menu
             </span>

--- a/tests/unit/site-header.test.tsx
+++ b/tests/unit/site-header.test.tsx
@@ -29,4 +29,10 @@ describe('SiteHeader', () => {
     expect(src).toContain('HeaderDesktopNav');
     expect(src).toContain('NAV_ITEMS');
   });
+
+  it('keeps compact laptop widths on desktop navigation', () => {
+    expect(src).toContain('min-[900px]:flex');
+    expect(src).toContain('min-[900px]:hidden');
+    expect(src).toContain('below 900px use the dedicated drawer');
+  });
 });


### PR DESCRIPTION
Fixes the marketing header breakpoint that caused laptop/desktop users to receive the hamburger navigation when the CSS viewport dropped below 1024px.

Changes:
- switch canonical desktop nav at 900px instead of 1024px
- keep Sign In / Apply aligned with the same breakpoint
- reserve hamburger drawer for phones and compact tablets below 900px
- tighten header spacing in the compact desktop range
- add regression coverage in the site-header static test

Scope is limited to the canonical marketing header and its regression test; no legacy header or parallel navigation implementation was introduced.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show desktop navigation at 900px viewport width instead of 1024px in site header
> Lowers the breakpoint for the desktop nav in [Header.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/593/files#diff-ab1fe96a19fb5a4115ecc8932848cfad8d945af1a39528b95ecf35d3e7f1caca) from Tailwind's `lg` (1024px) to a custom `min-[900px]` breakpoint. Spacing and padding at the new breakpoint are also reduced to fit compact laptop viewports. A unit test in [site-header.test.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/593/files#diff-7cd4fe6a548b590357d00816220ba16b05aeaeafea8dcfc0988fdbe7036e4043) verifies the new classnames are present.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 939701e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->