### PR TITLE
fix(home): stop homepage hero poster flicker

### DIFF
--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -27,6 +27,11 @@ export interface HomeHeroVideoProps {
  * Homepage compatibility wrapper.
  * Media playback, mobile source selection, error fallback, narration controls,
  * and route cleanup all live in components/marketing/HeroVideo.
+ *
+ * The homepage intentionally does not pass a poster layer into HeroVideo.
+ * Its dedicated R2 video is the primary hero media; keeping a separate poster
+ * underneath the opacity-faded video caused a visible poster/frame flash on
+ * some browsers during first-frame decoding.
  */
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   const ctas = banner.secondaryCta
@@ -37,7 +42,6 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
     <HeroVideo
       videoSrcDesktop={banner.videoSrcDesktop}
       videoSrcMobile={banner.videoSrcMobile}
-      posterImage={banner.posterImage}
       voiceoverSrc={banner.voiceoverSrc}
       microLabel={banner.microLabel}
       belowHeroHeadline={banner.belowHeroHeadline}


### PR DESCRIPTION
Removes the homepage-only poster layer passed into the canonical HeroVideo renderer. PR #595 introduced a permanently mounted poster under an opacity-faded video; on the homepage that can flash between poster and decoded video frames. The homepage now uses the dedicated video as the sole media layer while retaining all narration, controls, responsive source selection, and hero copy.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove poster image from homepage hero video to fix visible flash on load
> Removes the `posterImage` prop from the `HomeHeroVideo` component so it no longer forwards `banner.posterImage` to `HeroVideo`. This eliminates a visible poster/frame flash that occurred before the video started playing. A comment is added to explain the intentional omission.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1dd4265.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->