### PR TITLE
fix(marketing): consolidate header navigation before production rebuild

### DIFF
--- a/lib/navigation.ts
+++ b/lib/navigation.ts
@@ -67,7 +67,6 @@ export const NAV_ITEMS: NavItem[] = [
       { name: 'Hire Graduates', href: ROUTES.employersHireGraduates, isSectionLink: true },
       { name: 'Become a Host Site', href: ROUTES.apprenticeshipsHostShop, isSectionLink: true },
       { name: 'Post a Job', href: ROUTES.employersPostJob, isSectionLink: true },
-      { name: 'Employer Portal', href: ROUTES.employerPortal, isSectionLink: true, isAuth: true },
       { name: 'Workforce Agency Tools', href: ROUTES.forAgencies, isSectionLink: true },
       { name: 'Request Demo', href: ROUTES.storeDemo, isSectionLink: true },
     ],
@@ -102,7 +101,6 @@ export const NAV_ITEMS: NavItem[] = [
     href: ROUTES.about,
     subItems: [
       { name: 'Mission', href: ROUTES.about, isSectionLink: true },
-      { name: 'Rise Forward Foundation', href: '/rise-forward-foundation', isSectionLink: true },
       { name: 'Approvals', href: ROUTES.aboutApprovals, isSectionLink: true },
       { name: 'Apprenticeship Sponsor of Record', href: ROUTES.apprenticeshipSponsor, isSectionLink: true },
       { name: 'Testing Center', href: ROUTES.testing, isSectionLink: true },


### PR DESCRIPTION
Removes two redundant public navigation destinations before the next Marketing production build:
- keep Rise Forward Foundation as a top-level Foundation destination instead of duplicating it under About
- keep Employer Portal under Portals instead of duplicating it under Employers

This branch is based on current main at 082c09bf, which already contains the 900px desktop-header breakpoint and the latest PR #596/#597 work. No LMS/Admin behavior is changed.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Remove 'Employer Portal' and 'Rise Forward Foundation' from header navigation
> Removes two submenu entries from the `NAV_ITEMS` constant in [lib/navigation.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/598/files#diff-4a50adcb0dcec63dfc56096cd65044e1ed4a673603fe2b895267d3bd3232f47b): 'Employer Portal' under Employers and 'Rise Forward Foundation' under About. These links will no longer appear in the site header navigation.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized bc2ff5e.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->