### PR TITLE
fix(applications): guarantee submission alerts and Host Shop onboarding

### DIFF
--- a/apps/marketing/app/api/applications/wioa/route.ts
+++ b/apps/marketing/app/api/applications/wioa/route.ts
@@ -5,10 +5,20 @@ import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { withApiAudit } from '@/lib/audit/withApiAudit';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
+
 export const runtime = 'nodejs';
 export const maxDuration = 60;
-
 export const dynamic = 'force-dynamic';
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
 
 async function _POST(req: Request) {
   try {
@@ -22,10 +32,7 @@ async function _POST(req: Request) {
       return NextResponse.json({ error: 'Service temporarily unavailable.' }, { status: 503 });
     }
 
-    // Generate reference number
     const referenceNumber = `EFH-${Date.now().toString(36).toUpperCase()}`;
-
-    // Build comprehensive notes
     const notes = [
       `Reference: ${referenceNumber}`,
       `\n=== ELIGIBILITY ===`,
@@ -64,7 +71,6 @@ async function _POST(req: Request) {
       .filter(Boolean)
       .join('\n');
 
-    // Insert into applications table
     const { data, error }: any = await supabase
       .from('applications')
       .insert({
@@ -81,7 +87,7 @@ async function _POST(req: Request) {
       .select()
       .maybeSingle();
 
-    if (error) {
+    if (error || !data?.id) {
       return NextResponse.json(
         {
           error: `Failed to save application. Please call ${PLATFORM_DEFAULTS.supportPhone} for assistance.`,
@@ -91,93 +97,39 @@ async function _POST(req: Request) {
       );
     }
 
-    // Send confirmation email to applicant
-    try {
-      await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/send-email`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          to: body.email,
-          subject: `Application Received [Ref: ${referenceNumber}] - ${PLATFORM_DEFAULTS.orgName}`,
-          html: `
-            <div style="font-family: Arial, sans-serif; max-width: 600px; margin: 0 auto;">
-              <h2 style="color: #ea580c;">Application Received!</h2>
-              <p>Hi ${body.firstName},</p>
-              <p>We've received your WIOA application for our <strong>${body.program}</strong> program.</p>
+    const applicantName = `${String(body.firstName || '').trim()} ${String(body.lastName || '').trim()}`.trim();
+    const applicantEmail = String(body.email || '').trim().toLowerCase();
+    const safeFirst = escapeHtml(body.firstName);
+    const safeName = escapeHtml(applicantName);
+    const safeEmail = escapeHtml(applicantEmail);
+    const safeProgram = escapeHtml(body.program || 'your selected program');
+    const safeReference = escapeHtml(referenceNumber);
 
-              <div style="background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 20px 0;">
-                <p style="margin: 0 0 8px 0; font-size: 14px; color: #64748b;">Your Reference Number:</p>
-                <p style="margin: 0; font-size: 24px; font-weight: bold; font-family: monospace; color: #0f172a;">${referenceNumber}</p>
-                <p style="margin: 8px 0 0 0; font-size: 12px; color: #64748b;">Save this number to check your application status</p>
-              </div>
-
-              <h3 style="color: #0f172a;">What Happens Next?</h3>
-              <ol style="line-height: 1.8;">
-                <li>We review your application and verify WIOA eligibility</li>
-                <li>An advisor will contact you within 1-2 business days via ${body.preferredContact}</li>
-                <li>We'll discuss program details, funding confirmation, and next steps</li>
-              </ol>
-
-              <div style="background: #f9fafb; border: 1px solid #e5e7eb; border-radius: 8px; padding: 16px; margin: 20px 0;">
-                <h3 style="margin-top: 0; color: #ea580c;">Want to Talk Sooner?</h3>
-                <p>Schedule your advisor call now:</p>
-                <a href="https://calendly.com/elevate4humanityedu" style="display: inline-block; background: #ea580c; color: white; padding: 12px 24px; text-decoration: none; border-radius: 8px; font-weight: bold;">Schedule Call Now</a>
-              </div>
-
-              <p>Questions? Call us at <a href="tel:${PLATFORM_DEFAULTS.supportPhone}" style="color: #ea580c; font-weight: bold;">${PLATFORM_DEFAULTS.supportPhone}</a></p>
-              <p>Best regards,<br><strong>${PLATFORM_DEFAULTS.orgName} Team</strong></p>
-            </div>
-          `,
-        }),
-      });
-    } catch {
-      /* non-fatal */
-    }
-
-    // Send notification to admin
-    try {
-      await fetch(`${process.env.NEXT_PUBLIC_SITE_URL}/api/send-email`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          to: 'elevate4humanityedu@gmail.com',
-          subject: `New WIOA Application [${referenceNumber}]: ${body.firstName} ${body.lastName}`,
-          html: `
-            <h2>New WIOA Application Received</h2>
-            <p><strong>Reference:</strong> ${referenceNumber}</p>
-            <p><strong>Name:</strong> ${body.firstName} ${body.lastName}</p>
-            <p><strong>Email:</strong> ${body.email}</p>
-            <p><strong>Phone:</strong> ${body.phone}</p>
-            <p><strong>Program:</strong> ${body.program}</p>
-            <p><strong>Location:</strong> ${body.city}, ${body.zip}</p>
-            <p><strong>Income:</strong> ${body.annualIncome}</p>
-            <p><strong>Employment:</strong> ${body.employmentStatus}</p>
-            <p><strong>Public Assistance:</strong> ${Array.isArray(body.receivesPublicAssistance) ? body.receivesPublicAssistance.join(', ') : 'None'}</p>
-            <p><strong>Justice Involvement:</strong> ${body.hasJusticeInvolvement ? 'Yes' : 'No'}</p>
-            <p><strong>Barriers:</strong> ${Array.isArray(body.barriers) ? body.barriers.join(', ') : 'None'}</p>
-            <p><a href="${process.env.NEXT_PUBLIC_SITE_URL}/admin/applications">View in Admin Portal</a></p>
-          `,
-        }),
-      });
-    } catch {
-      /* non-fatal */
-    }
+    const notifications = await notifyApplicationSubmission({
+      db: supabase,
+      applicationId: data.id,
+      applicationType: 'wioa',
+      applicantName,
+      applicantEmail,
+      applicantSubject: `WIOA Application Received [${referenceNumber}] | ${PLATFORM_DEFAULTS.orgName}`,
+      applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>WIOA Application Received</h2><p>Hi ${safeFirst},</p><p>We received your WIOA/funding application for <strong>${safeProgram}</strong>.</p><p><strong>Reference:</strong> ${safeReference}</p><h3>What happens next</h3><ol><li>Elevate reviews the application for completeness and funding-readiness.</li><li>A workforce advisor verifies WIOA eligibility and identifies any WorkOne documentation still needed.</li><li>You receive the exact next step for orientation, funding verification, or self-pay options as applicable.</li><li>Program portal/enrollment access is activated when the enrollment/funding requirements for your training path are satisfied.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      staffSubject: `New WIOA Application [${referenceNumber}]: ${applicantName}`,
+      staffHtml: `<h2>New WIOA Application Received</h2><p><strong>Reference:</strong> ${safeReference}</p><p><strong>Name:</strong> ${safeName}</p><p><strong>Email:</strong> ${safeEmail}</p><p><strong>Phone:</strong> ${escapeHtml(body.phone)}</p><p><strong>Program:</strong> ${safeProgram}</p><p><strong>Location:</strong> ${escapeHtml(body.city)}, ${escapeHtml(body.zip)}</p><p><strong>Income:</strong> ${escapeHtml(body.annualIncome)}</p><p><strong>Employment:</strong> ${escapeHtml(body.employmentStatus)}</p><p><strong>Public Assistance:</strong> ${escapeHtml(Array.isArray(body.receivesPublicAssistance) ? body.receivesPublicAssistance.join(', ') : 'None')}</p><p><strong>Justice Involvement:</strong> ${body.hasJusticeInvolvement ? 'Yes' : 'No'}</p><p><strong>Barriers:</strong> ${escapeHtml(Array.isArray(body.barriers) ? body.barriers.join(', ') : 'None')}</p><p>Review in the Admin application queue and assign the appropriate funding/onboarding next action.</p>`,
+      metadata: { reference_number: referenceNumber, program: body.program || null },
+    });
 
     return NextResponse.json(
       {
         ok: true,
         id: data.id,
-        referenceNumber: referenceNumber,
+        referenceNumber,
+        notificationStatus: notifications,
       },
       { status: 200 },
     );
-  } catch (error) {
-    return NextResponse.json(
-      {
-        error: 'Internal server error',
-      },
-      { status: 500 },
-    );
+  } catch {
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
   }
 }
+
 export const POST = withApiAudit('/api/applications/wioa', _POST);

--- a/apps/marketing/app/api/employer/apply/route.ts
+++ b/apps/marketing/app/api/employer/apply/route.ts
@@ -3,6 +3,7 @@ import { getAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -13,6 +14,10 @@ function clean(value: unknown, max = 2000): string {
 
 function validEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;');
 }
 
 export async function POST(request: Request) {
@@ -80,12 +85,30 @@ export async function POST(request: Request) {
       );
     }
 
+    const safeCompany = escapeHtml(companyName);
+    const safeName = escapeHtml(contactName);
+    const safeEmail = escapeHtml(email);
+    const safeRef = escapeHtml(data.id);
+    const notifications = await notifyApplicationSubmission({
+      db: admin,
+      applicationId: data.id,
+      applicationType: 'employer',
+      applicantName: contactName,
+      applicantEmail: email,
+      applicantSubject: 'Employer Partnership Application Received | Elevate for Humanity',
+      applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>Employer Partnership Application Received</h2><p>Hello ${safeName},</p><p>We received the employer partnership application for <strong>${safeCompany}</strong>.</p><p><strong>Reference:</strong> ${safeRef}</p><h3>What happens next</h3><ol><li>Our workforce team reviews your hiring, OJT, WEX, apprenticeship, and training needs.</li><li>If additional employer verification or agreements are needed, we will send the exact next step.</li><li>Once the partnership is approved, your employer/partner portal access and onboarding instructions will be issued to <strong>${safeEmail}</strong>.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      staffSubject: `[EMPLOYER APPLICATION] ${companyName}`,
+      staffHtml: `<h2>New Employer Partnership Application</h2><p><strong>${safeCompany}</strong><br>${safeName}<br>${safeEmail}<br>${escapeHtml(phone || 'No phone')}</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Industry:</strong> ${escapeHtml(industry || 'Not provided')}</p><p><strong>Hiring/workforce needs:</strong> ${escapeHtml(hiringNeeds || 'Not provided')}</p><p>Review the application and initiate employer onboarding when approved.</p>`,
+      metadata: { company_name: companyName, industry },
+    });
+
     return NextResponse.json(
       {
         ok: true,
         applicationId: data.id,
         referenceNumber: data.id,
         applicationType: 'employer',
+        notificationStatus: notifications,
       },
       { status: 201 },
     );

--- a/apps/marketing/app/api/host-shop/apply-multipart/route.ts
+++ b/apps/marketing/app/api/host-shop/apply-multipart/route.ts
@@ -2,8 +2,9 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { logger } from '@/lib/logger';
-import { sendEmail } from '@/lib/email/sendgrid';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
+import { provisionHostShopApplication } from '@/lib/partners/provision-host-shop-application';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -55,6 +56,15 @@ function safeExtension(file: File): string {
   if (file.type === 'image/png') return 'png';
   if (file.type === 'image/webp') return 'webp';
   return 'jpg';
+}
+
+function escapeHtml(value: string): string {
+  return value
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
 }
 
 async function uploadFile(
@@ -235,20 +245,134 @@ export async function POST(request: NextRequest) {
       return NextResponse.json({ ok: false, error: 'We could not save the Host Site application. Please try again.' }, { status: 500 });
     }
 
-    await Promise.allSettled([
-      sendEmail({
-        to: email,
-        subject: 'Host Site Application Received | Elevate for Humanity',
-        html: `<p>Hello ${contactName},</p><p>We received the Host Site application for <strong>${businessName}</strong>.</p><p>Reference: <strong>${data.id}</strong></p><p>Our team will verify licensing, insurance, workers' compensation/exemption documentation, supervisor credentials, worksite capacity, and program fit before approval.</p>`,
-      }),
-      sendEmail({
-        to: process.env.PARTNER_NOTIFICATION_EMAIL || PLATFORM_DEFAULTS.supportEmail,
-        subject: `[HOST SITE APPLICATION] ${businessName}`,
-        html: `<p>New Host Site application.</p><p><strong>${businessName}</strong><br>${contactName}<br>${email}<br>${phone}</p><p>Programs: ${programs.join(', ')}</p><p>Reference: ${data.id}</p>`,
-      }),
-    ]);
+    let provisioned: Awaited<ReturnType<typeof provisionHostShopApplication>> | null = null;
+    let provisioningError: string | null = null;
+    try {
+      provisioned = await provisionHostShopApplication({
+        db,
+        applicationId: data.id,
+        businessName,
+        legalBusinessName,
+        ownerName,
+        contactName,
+        email,
+        phone,
+        address1,
+        address2: address2 || null,
+        city,
+        state,
+        zip,
+        businessType,
+        licenseNumber,
+        supervisorName,
+        supervisorLicenseNumber,
+        supervisorYearsLicensed,
+        workersCompStatus,
+        compensationModel,
+        numberOfEmployees: numberOfEmployees || null,
+        programs,
+        documents: {
+          shopLicense: uploaded.shopLicense,
+          insurance: uploaded.insurance,
+          workersComp: uploaded.workersComp,
+          supervisorLicense: uploaded.supervisorLicense,
+          ein: uploaded.ein,
+          localBusiness: uploaded.localBusiness || null,
+        },
+      });
+    } catch (caught) {
+      provisioningError = caught instanceof Error ? caught.message : String(caught);
+      logger.error('[host-shop/apply-multipart] conditional portal provisioning failed', caught instanceof Error ? caught : undefined, {
+        applicationId: data.id,
+        email,
+      });
+      await db.from('staff_notifications').insert({
+        type: 'host_shop_provisioning_failed',
+        title: `Host Shop portal provisioning failed: ${businessName}`,
+        message: `Application ${data.id} was saved, but conditional portal access could not be provisioned. ${provisioningError}`,
+        severity: 'error',
+        metadata: { application_id: data.id, email, business_name: businessName, error: provisioningError },
+      });
+    }
 
-    return NextResponse.json({ ok: true, applicationId: data.id, referenceNumber: data.id }, { status: 201 });
+    const safeContact = escapeHtml(contactName);
+    const safeBusiness = escapeHtml(businessName);
+    const safeEmail = escapeHtml(email);
+    const safeReference = escapeHtml(data.id);
+    const portalUrl = provisioned?.portalUrl || 'https://app.elevateforhumanity.org/host-shop/login';
+    const accessLink = provisioned?.accessLink || portalUrl;
+    const requestedPrograms = programs.map(escapeHtml).join(', ');
+
+    const applicantHtml = `
+      <div style="font-family:Arial,sans-serif;max-width:640px;margin:0 auto;color:#0f172a">
+        <h2>Host Site Application Received</h2>
+        <p>Hello ${safeContact},</p>
+        <p>Elevate received the Host Site application for <strong>${safeBusiness}</strong>.</p>
+        <p><strong>Reference:</strong> ${safeReference}</p>
+        <p><strong>Programs requested:</strong> ${requestedPrograms}</p>
+        ${provisioned ? `
+          <div style="background:#eff6ff;border:1px solid #bfdbfe;border-radius:10px;padding:18px;margin:20px 0">
+            <h3 style="margin-top:0">Your Host Shop portal is ready for onboarding</h3>
+            <p><strong>Username:</strong> ${safeEmail}</p>
+            <p>For security, Elevate does not email a plaintext password. Use the secure button below to access your account or set your password.</p>
+            <p><a href="${accessLink}" style="display:inline-block;background:#1d4ed8;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:bold">Secure Host Shop Access</a></p>
+            <p>If the secure link expires, use the magic-link option at <a href="${portalUrl}">${portalUrl}</a>.</p>
+          </div>` : `
+          <div style="background:#fff7ed;border:1px solid #fed7aa;border-radius:10px;padding:18px;margin:20px 0">
+            <strong>Your application is saved.</strong> Elevate staff has also been alerted that portal provisioning needs attention. You do not need to submit the application again.
+          </div>`}
+        <h3>What happens next</h3>
+        <ol>
+          <li>Sign in to the Host Shop portal and review your business profile.</li>
+          <li>Complete the Host Site onboarding/MOU items shown in the portal.</li>
+          <li>Elevate reviews the license, insurance, workers' compensation/exemption, supervisor credential, EIN/W-9 record, and worksite capacity you uploaded.</li>
+          <li>Portal access is conditional while compliance review is pending; submission does not mean final Host Site approval.</li>
+          <li>After approval and apprentice matching, assigned apprentices appear in your Host Shop board.</li>
+          <li>The Host Shop supervises on-the-job learning, verifies hours and competencies, and responds to Elevate compliance requests through the portal.</li>
+        </ol>
+        <p>If additional documentation is required, Elevate will identify the exact item in the portal or by email.</p>
+        <p>Questions? Reply to this email or call ${PLATFORM_DEFAULTS.supportPhone}.</p>
+      </div>`;
+
+    const staffHtml = `
+      <h2>New Host Site Application</h2>
+      <p><strong>${safeBusiness}</strong><br>${safeContact}<br>${safeEmail}<br>${escapeHtml(phone)}</p>
+      <p><strong>Reference:</strong> ${safeReference}</p>
+      <p><strong>Programs:</strong> ${requestedPrograms}</p>
+      <p><strong>Supervisor:</strong> ${escapeHtml(supervisorName)} — ${escapeHtml(supervisorLicenseNumber)}</p>
+      <p><strong>Conditional portal provisioning:</strong> ${provisioned ? `completed (Partner ${escapeHtml(provisioned.partnerId)})` : `FAILED — ${escapeHtml(provisioningError || 'unknown error')}`}</p>
+      <p>All required application uploads were saved. Review the Host Shop compliance queue before changing the application to approved.</p>`;
+
+    const notifications = await notifyApplicationSubmission({
+      db,
+      applicationId: data.id,
+      applicationType: 'host_shop',
+      applicantName: contactName,
+      applicantEmail: email,
+      applicantSubject: 'Host Site Application Received + Portal Next Steps | Elevate for Humanity',
+      applicantHtml,
+      staffSubject: `[HOST SITE APPLICATION] ${businessName}`,
+      staffHtml,
+      metadata: {
+        business_name: businessName,
+        programs,
+        partner_id: provisioned?.partnerId || null,
+        portal_provisioned: Boolean(provisioned),
+        provisioning_error: provisioningError,
+      },
+    });
+
+    return NextResponse.json(
+      {
+        ok: true,
+        applicationId: data.id,
+        referenceNumber: data.id,
+        portalProvisioned: Boolean(provisioned),
+        partnerId: provisioned?.partnerId || null,
+        notificationStatus: notifications,
+      },
+      { status: 201 },
+    );
   } catch (error) {
     if (db) await cleanup(db, uploadedPaths);
     logger.error('[host-shop/apply-multipart] unexpected error', error instanceof Error ? error : undefined);

--- a/apps/marketing/app/api/program-holder/apply/route.ts
+++ b/apps/marketing/app/api/program-holder/apply/route.ts
@@ -3,6 +3,7 @@ import { getAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -13,6 +14,10 @@ function clean(value: unknown, max = 2000): string {
 
 function validEmail(value: string): boolean {
   return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;');
 }
 
 export async function POST(request: Request) {
@@ -81,12 +86,31 @@ export async function POST(request: Request) {
       );
     }
 
+    const safeOrganization = escapeHtml(organizationName);
+    const safeName = escapeHtml(contactName);
+    const safeEmail = escapeHtml(email);
+    const safeRef = escapeHtml(data.id);
+    const safePrograms = programTypes.length ? programTypes.map(escapeHtml).join(', ') : 'Not specified';
+    const notifications = await notifyApplicationSubmission({
+      db: admin,
+      applicationId: data.id,
+      applicationType: 'program_holder',
+      applicantName: contactName,
+      applicantEmail: email,
+      applicantSubject: 'Program Holder Application Received | Elevate for Humanity',
+      applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>Program Holder Application Received</h2><p>Hello ${safeName},</p><p>We received the Program Holder application for <strong>${safeOrganization}</strong>.</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Programs/services listed:</strong> ${safePrograms}</p><h3>What happens next</h3><ol><li>Elevate reviews organizational eligibility, program scope, required credentials, and operating documents.</li><li>If documents or an agreement are required, we will send a specific checklist.</li><li>After approval, portal access and Program Holder onboarding instructions will be issued to <strong>${safeEmail}</strong>.</li><li>Approved Program Holders can then manage authorized programs, documents, participants, and reporting from the partner portal.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      staffSubject: `[PROGRAM HOLDER APPLICATION] ${organizationName}`,
+      staffHtml: `<h2>New Program Holder Application</h2><p><strong>${safeOrganization}</strong><br>${safeName}<br>${safeEmail}<br>${escapeHtml(phone || 'No phone')}</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Program types:</strong> ${safePrograms}</p><p><strong>Website:</strong> ${escapeHtml(website || 'Not provided')}</p><p>Review eligibility/documents and initiate Program Holder onboarding when approved.</p>`,
+      metadata: { organization_name: organizationName, program_types: programTypes },
+    });
+
     return NextResponse.json(
       {
         ok: true,
         applicationId: data.id,
         referenceNumber: data.id,
         applicationType: 'program_holder',
+        notificationStatus: notifications,
       },
       { status: 201 },
     );

--- a/apps/marketing/app/api/programs/[program]/inquiry/route.ts
+++ b/apps/marketing/app/api/programs/[program]/inquiry/route.ts
@@ -3,9 +3,18 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError, safeInternalError, safeDbError } from '@/lib/api/safe-error';
-import { sendEmail } from '@/lib/email';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
+
+function escapeHtml(value: unknown): string {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
+}
 
 export async function POST(request: NextRequest, { params }: { params: { program: string } }) {
   const rateLimited = await applyRateLimit(request, 'contact');
@@ -41,21 +50,17 @@ export async function POST(request: NextRequest, { params }: { params: { program
   }
 
   const db = await requireAdminClient();
+  const normalizedEmail = email.toLowerCase().trim();
 
-  // Insert into applications with program context pre-filled
   const { data: application, error } = await db
     .from('applications')
     .insert({
       first_name: firstName.trim(),
       last_name: lastName.trim(),
-      email: email.toLowerCase().trim(),
+      email: normalizedEmail,
       phone: phone?.trim() || null,
-      // The live schema requires a non-blank city, but this short form does not
-      // collect one. Its empty-string default is normalized to NULL by a trigger.
       city: 'Not provided',
       program_interest: slug,
-      // `inquiry` is the record type, not an applications workflow status.
-      // The live applications_status_check constraint accepts `submitted`.
       status: 'submitted',
       application_type: 'inquiry',
       source: body.source || 'program-request-info',
@@ -71,29 +76,24 @@ export async function POST(request: NextRequest, { params }: { params: { program
     .select('id')
     .maybeSingle();
 
-  if (error) return safeDbError(error, 'Failed to save inquiry');
+  if (error || !application?.id) return safeDbError(error, 'Failed to save inquiry');
 
   logger.info('Program inquiry submitted', { slug, applicationId: application.id });
 
-  // Notify internal team
-  try {
-    await sendEmail({
-      to: 'elevate4humanityedu@gmail.com',
-      subject: `Program Inquiry — ${slug}`,
-      html: `
-        <p><strong>Program:</strong> ${slug}</p>
-        <p><strong>Name:</strong> ${firstName} ${lastName}</p>
-        <p><strong>Email:</strong> ${email}</p>
-        ${phone ? `<p><strong>Phone:</strong> ${phone}</p>` : ''}
-        ${message ? `<p><strong>Message:</strong> ${message}</p>` : ''}
-        ${fundingQuestion ? `<p><strong>Funding question:</strong> ${fundingQuestion}</p>` : ''}
-        <p><a href="${PLATFORM_DEFAULTS.siteUrl}/admin/applications/review/${application.id}">View in Admin</a></p>
-      `,
-    });
-  } catch (emailErr) {
-    logger.error('Failed to send inquiry notification email', emailErr);
-    // Non-fatal — inquiry is saved
-  }
+  const fullName = `${firstName.trim()} ${lastName.trim()}`;
+  const programLabel = slug.replace(/-/g, ' ').replace(/\b\w/g, (character) => character.toUpperCase());
+  const notifications = await notifyApplicationSubmission({
+    db,
+    applicationId: application.id,
+    applicationType: 'program_inquiry',
+    applicantName: fullName,
+    applicantEmail: normalizedEmail,
+    applicantSubject: `Information Request Received — ${programLabel} | Elevate for Humanity`,
+    applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>We received your information request</h2><p>Hello ${escapeHtml(firstName)},</p><p>We received your request for information about <strong>${escapeHtml(programLabel)}</strong>.</p><p><strong>Reference:</strong> ${escapeHtml(application.id)}</p><p>This is an information request, not a completed enrollment application. No seat or funding has been reserved yet.</p><h3>What happens next</h3><ol><li>An advisor reviews your question and funding selection.</li><li>We contact you with the correct funding/self-pay path and required documents.</li><li>When you are ready to enroll, complete the full application at <a href="${PLATFORM_DEFAULTS.siteUrl}/apply?program=${encodeURIComponent(slug)}">${PLATFORM_DEFAULTS.siteUrl}/apply</a>.</li></ol><p>Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+    staffSubject: `Program Information Request — ${fullName} — ${programLabel}`,
+    staffHtml: `<h2>Program Information Request</h2><p><strong>Program:</strong> ${escapeHtml(programLabel)}</p><p><strong>Name:</strong> ${escapeHtml(fullName)}</p><p><strong>Email:</strong> ${escapeHtml(normalizedEmail)}</p>${phone ? `<p><strong>Phone:</strong> ${escapeHtml(phone)}</p>` : ''}${message ? `<p><strong>Message:</strong> ${escapeHtml(message)}</p>` : ''}${fundingQuestion ? `<p><strong>Funding question:</strong> ${escapeHtml(fundingQuestion)}</p>` : ''}<p><strong>Reference:</strong> ${escapeHtml(application.id)}</p><p>This is a lead/information request. Follow up and direct the person to the full enrollment application when ready.</p>`,
+    metadata: { program_slug: slug, source: body.source || 'program-request-info' },
+  });
 
-  return NextResponse.json({ success: true, id: application.id });
+  return NextResponse.json({ success: true, id: application.id, notificationStatus: notifications });
 }

--- a/apps/marketing/app/api/programs/[program]/inquiry/route.ts
+++ b/apps/marketing/app/api/programs/[program]/inquiry/route.ts
@@ -2,7 +2,7 @@
 import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
-import { safeError, safeInternalError, safeDbError } from '@/lib/api/safe-error';
+import { safeError, safeDbError } from '@/lib/api/safe-error';
 import { logger } from '@/lib/logger';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';

--- a/apps/marketing/app/api/staff/apply/route.ts
+++ b/apps/marketing/app/api/staff/apply/route.ts
@@ -1,0 +1,104 @@
+import { NextResponse } from 'next/server';
+import { getAdminClient } from '@/lib/supabase/admin';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { logger } from '@/lib/logger';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+import { notifyApplicationSubmission } from '@/lib/applications/submission-notifications';
+
+export const runtime = 'nodejs';
+export const dynamic = 'force-dynamic';
+
+function clean(value: unknown, max = 2000): string {
+  return String(value ?? '').trim().slice(0, max);
+}
+
+function validEmail(value: string): boolean {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]{2,}$/.test(value);
+}
+
+function escapeHtml(value: string): string {
+  return value.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;').replaceAll('"', '&quot;').replaceAll("'", '&#039;');
+}
+
+export async function POST(request: Request) {
+  const limited = await applyRateLimit(request, 'contact');
+  if (limited) return limited;
+
+  try {
+    const body = await request.json();
+    const firstName = clean(body.firstName, 120);
+    const lastName = clean(body.lastName, 120);
+    const email = clean(body.email, 254).toLowerCase();
+    const phone = clean(body.phone, 50);
+    const position = clean(body.position, 120) || 'general';
+    const city = clean(body.city, 120);
+    const experience = clean(body.experience, 5000);
+    const resume = clean(body.resume, 2000);
+
+    if (!firstName || !lastName || !email) {
+      return NextResponse.json({ ok: false, error: 'First name, last name, and email are required.' }, { status: 400 });
+    }
+    if (!validEmail(email)) {
+      return NextResponse.json({ ok: false, error: 'Enter a valid email address.' }, { status: 400 });
+    }
+
+    const db = await getAdminClient();
+    if (!db) {
+      return NextResponse.json({ ok: false, error: `Staff applications are temporarily unavailable. Please call ${PLATFORM_DEFAULTS.supportPhone}.` }, { status: 503 });
+    }
+
+    const fullName = `${firstName} ${lastName}`.trim();
+    const { data, error } = await db
+      .from('application_intake')
+      .insert({
+        application_type: 'staff',
+        source: 'public_form',
+        payload: {
+          first_name: firstName,
+          last_name: lastName,
+          full_name: fullName,
+          email,
+          phone,
+          position,
+          city,
+          experience,
+          resume,
+        },
+      })
+      .select('id, created_at')
+      .maybeSingle();
+
+    if (error || !data?.id) {
+      logger.error('[staff/apply] intake insert failed', error ?? undefined, { email, position });
+      return NextResponse.json({ ok: false, error: 'We could not save the staff application. Please try again.' }, { status: 500 });
+    }
+
+    const safeName = escapeHtml(fullName);
+    const safeEmail = escapeHtml(email);
+    const safePosition = escapeHtml(position);
+    const safeRef = escapeHtml(data.id);
+    const notifications = await notifyApplicationSubmission({
+      db,
+      applicationId: data.id,
+      applicationType: 'staff',
+      applicantName: fullName,
+      applicantEmail: email,
+      applicantSubject: 'Employment Application Received | Elevate for Humanity',
+      applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>Employment Application Received</h2><p>Hello ${safeName},</p><p>We received your application for <strong>${safePosition}</strong>.</p><p><strong>Reference:</strong> ${safeRef}</p><h3>What happens next</h3><ol><li>Our team reviews your experience and the current staffing need.</li><li>If selected for the next stage, we will contact you about an interview and any required credentials/background documentation.</li><li>Staff portal access is only issued after a hiring/authorization decision; no login is required while your application is under review.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      staffSubject: `[STAFF APPLICATION] ${fullName} — ${position}`,
+      staffHtml: `<h2>New Staff Application</h2><p><strong>${safeName}</strong><br>${safeEmail}<br>${escapeHtml(phone || 'No phone')}</p><p><strong>Position:</strong> ${safePosition}</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Experience:</strong> ${escapeHtml(experience || 'Not provided')}</p><p>Review and move the applicant to the hiring/onboarding process if selected.</p>`,
+      metadata: { position, city },
+    });
+
+    return NextResponse.json({
+      ok: true,
+      applicationId: data.id,
+      referenceNumber: data.id,
+      applicationType: 'staff',
+      notificationStatus: notifications,
+    }, { status: 201 });
+  } catch (error) {
+    logger.error('[staff/apply] unexpected error', error instanceof Error ? error : undefined);
+    return NextResponse.json({ ok: false, error: 'Unable to submit the staff application. Please try again.' }, { status: 500 });
+  }
+}

--- a/apps/marketing/app/apply/barber/page.tsx
+++ b/apps/marketing/app/apply/barber/page.tsx
@@ -1,7 +1,7 @@
 import { redirect } from 'next/navigation';
 
 export default function ApplyBarberRedirect() {
-  redirect('/partners/barber-host-shop/apply');
+  redirect('/partners/host-shop/apply?program=barber');
 }
 
 export const metadata = {

--- a/apps/marketing/app/apply/cosmetology/page.tsx
+++ b/apps/marketing/app/apply/cosmetology/page.tsx
@@ -6,5 +6,5 @@ export const metadata: Metadata = {
 };
 
 export default function ApplyCosmetologyRedirect() {
-  redirect('/partners/cosmetology-host-shop');
+  redirect('/partners/host-shop/apply?program=cosmetology');
 }

--- a/apps/marketing/app/apply/staff/StaffApplicationForm.tsx
+++ b/apps/marketing/app/apply/staff/StaffApplicationForm.tsx
@@ -28,21 +28,18 @@ export default function StaffApplicationForm() {
     setResult(null);
 
     try {
-      const res = await fetch('/api/applications', {
+      const res = await fetch('/api/staff/apply', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ ...form, source: 'staff-application' }),
+        body: JSON.stringify(form),
       });
       const data = await res.json();
       if (res.ok && data.ok) {
         setResult({ success: true, message: 'Application received! Our HR team will review and contact you within 3-5 business days.' });
-        const ref = data.referenceNumber || '';
-        const prog = data.program || '';
-        const q = new URLSearchParams();
+        const ref = data.referenceNumber || data.applicationId || '';
+        const q = new URLSearchParams({ type: 'staff' });
         if (ref) q.set('ref', ref);
-        if (prog) q.set('program', prog);
-        const suffix = q.toString() ? '?' + q.toString() : '';
-        setTimeout(() => router.push('/apply/success' + suffix), 2000);
+        setTimeout(() => router.push('/apply/success?' + q.toString()), 2000);
       } else {
         setResult({ success: false, error: data.error || 'Something went wrong.' });
       }

--- a/apps/marketing/app/partners/apply/page.tsx
+++ b/apps/marketing/app/partners/apply/page.tsx
@@ -1,6 +1,6 @@
 import { Metadata } from 'next';
 import Link from 'next/link';
-import { Building2, GraduationCap, Users, Heart, Phone, Mail, ArrowRight } from 'lucide-react';
+import { Building2, GraduationCap, Users, Heart, Phone, Mail } from 'lucide-react';
 
 export const metadata: Metadata = {
   title: 'Apply for Partnership | Elevate for Humanity',
@@ -8,9 +8,9 @@ export const metadata: Metadata = {
 };
 
 const partnershipOptions = [
-  { icon: Building2, title: 'Employer Partnership', desc: 'Hire graduates, sponsor apprenticeships, or participate in OJT reimbursement.', href: '/onboarding/employer' },
-  { icon: GraduationCap, title: 'Training Provider', desc: 'Join our network of credentialed training providers.', href: '/onboarding/provider' },
-  { icon: Users, title: 'Host Shop', desc: 'Host beauty apprentices in your salon or barbershop.', href: '/partners/barber-host-shop/apply' },
+  { icon: Building2, title: 'Employer Partnership', desc: 'Hire graduates, sponsor apprenticeships, or participate in OJT reimbursement.', href: '/apply/employer' },
+  { icon: GraduationCap, title: 'Training Provider', desc: 'Join our network of credentialed training providers.', href: '/apply/program-holder' },
+  { icon: Users, title: 'Host Shop', desc: 'Host beauty apprentices in your salon, barbershop, spa, or nail salon.', href: '/partners/host-shop/apply' },
   { icon: Heart, title: 'Community Partner', desc: 'Refer participants from your organization or community group.', href: '/contact' },
 ];
 
@@ -23,7 +23,7 @@ export default function Page() {
             <span className="bg-white/20 text-white px-4 py-1 rounded-full text-sm font-medium">Partnership Application</span>
           </div>
           <h1 className="text-4xl md:text-5xl font-bold mb-4">Apply to Partner with Elevate</h1>
-          <p className="text-xl text-blue-100 max-w-2xl">Complete our partner application to join the Elevate network. We'll review your application and contact you within 2-3 business days.</p>
+          <p className="text-xl text-blue-100 max-w-2xl">Choose the partnership type that matches your organization. Each option routes to the canonical application for that role so your submission, acknowledgment, review, and onboarding stay in one workflow.</p>
         </div>
       </section>
       
@@ -57,28 +57,28 @@ export default function Page() {
                   <div className="w-8 h-8 bg-brand-blue-600 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">1</div>
                   <div>
                     <h4 className="font-semibold text-slate-900">Submit Application</h4>
-                    <p className="text-slate-600 text-sm">Complete the application form for your partnership type.</p>
+                    <p className="text-slate-600 text-sm">Complete the application for your partnership type and receive a reference/receipt.</p>
                   </div>
                 </div>
                 <div className="flex gap-4">
                   <div className="w-8 h-8 bg-brand-blue-600 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">2</div>
                   <div>
-                    <h4 className="font-semibold text-slate-900">Review Period</h4>
-                    <p className="text-slate-600 text-sm">Our team reviews your application within 2-3 business days.</p>
+                    <h4 className="font-semibold text-slate-900">Review &amp; Verification</h4>
+                    <p className="text-slate-600 text-sm">Elevate reviews the application and any required business, credential, or compliance documentation.</p>
                   </div>
                 </div>
                 <div className="flex gap-4">
                   <div className="w-8 h-8 bg-brand-blue-600 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">3</div>
                   <div>
-                    <h4 className="font-semibold text-slate-900">Onboarding Call</h4>
-                    <p className="text-slate-600 text-sm">We'll schedule a call to discuss next steps and answer questions.</p>
+                    <h4 className="font-semibold text-slate-900">Onboarding</h4>
+                    <p className="text-slate-600 text-sm">You receive the role-specific agreements, portal access, and exact next steps required for approval.</p>
                   </div>
                 </div>
                 <div className="flex gap-4">
                   <div className="w-8 h-8 bg-brand-blue-600 rounded-full flex items-center justify-center flex-shrink-0 text-white font-bold text-sm">4</div>
                   <div>
-                    <h4 className="font-semibold text-slate-900">Get Started</h4>
-                    <p className="text-slate-600 text-sm">Access your partner portal and start connecting with students.</p>
+                    <h4 className="font-semibold text-slate-900">Operate in the Portal</h4>
+                    <p className="text-slate-600 text-sm">Approved partners use the correct portal for apprentices, participants, programs, documents, and reporting.</p>
                   </div>
                 </div>
               </div>

--- a/lib/applications/submission-notifications.ts
+++ b/lib/applications/submission-notifications.ts
@@ -1,0 +1,210 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { sendEmail } from '@/lib/email/sendgrid';
+import { logger } from '@/lib/logger';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+type EmailMessage = {
+  to: string;
+  subject: string;
+  html: string;
+};
+
+export type ApplicationNotificationResult = {
+  applicant: 'sent' | 'failed';
+  staff: 'sent' | 'failed';
+  applicantError?: string;
+  staffError?: string;
+};
+
+type NotifyApplicationSubmissionInput = {
+  db: SupabaseClient;
+  applicationId: string;
+  applicationType: string;
+  applicantName: string;
+  applicantEmail: string;
+  applicantSubject: string;
+  applicantHtml: string;
+  staffSubject: string;
+  staffHtml: string;
+  staffEmail?: string;
+  metadata?: Record<string, unknown>;
+};
+
+async function auditEmail(
+  db: SupabaseClient,
+  input: {
+    applicationId: string;
+    applicationType: string;
+    audience: 'applicant' | 'staff';
+    recipient: string;
+    subject: string;
+    success: boolean;
+    error?: string;
+    metadata?: Record<string, unknown>;
+  },
+) {
+  const now = new Date().toISOString();
+  const { error } = await db.from('email_logs').insert({
+    action: 'application_submission_notification',
+    recipient_email: input.recipient,
+    recipient: input.recipient,
+    to: input.recipient,
+    subject: input.subject,
+    provider: 'sendgrid',
+    status: input.success ? 'sent' : 'failed',
+    error_message: input.error ?? null,
+    error: input.error ?? null,
+    sent_at: input.success ? now : null,
+    details: {
+      application_id: input.applicationId,
+      application_type: input.applicationType,
+      audience: input.audience,
+      ...(input.metadata ?? {}),
+    },
+    metadata: {
+      application_id: input.applicationId,
+      application_type: input.applicationType,
+      audience: input.audience,
+      ...(input.metadata ?? {}),
+    },
+  });
+
+  if (error) {
+    logger.warn('[applications] email audit insert failed', {
+      applicationId: input.applicationId,
+      audience: input.audience,
+      error: error.message,
+    });
+  }
+}
+
+async function sendAndAudit(
+  db: SupabaseClient,
+  message: EmailMessage,
+  context: {
+    applicationId: string;
+    applicationType: string;
+    audience: 'applicant' | 'staff';
+    metadata?: Record<string, unknown>;
+  },
+): Promise<{ success: boolean; error?: string }> {
+  try {
+    const result = await sendEmail(message);
+    const success = result.success === true;
+    const error = success ? undefined : result.error || 'Email provider returned an unsuccessful result.';
+
+    await auditEmail(db, {
+      ...context,
+      recipient: message.to,
+      subject: message.subject,
+      success,
+      error,
+    });
+
+    if (!success) {
+      logger.error('[applications] submission email not sent', undefined, {
+        applicationId: context.applicationId,
+        applicationType: context.applicationType,
+        audience: context.audience,
+        recipient: message.to,
+        error,
+      });
+    }
+
+    return { success, error };
+  } catch (caught) {
+    const error = caught instanceof Error ? caught.message : String(caught);
+    await auditEmail(db, {
+      ...context,
+      recipient: message.to,
+      subject: message.subject,
+      success: false,
+      error,
+    });
+    logger.error('[applications] submission email threw', caught instanceof Error ? caught : undefined, {
+      applicationId: context.applicationId,
+      applicationType: context.applicationType,
+      audience: context.audience,
+      recipient: message.to,
+    });
+    return { success: false, error };
+  }
+}
+
+/**
+ * Canonical submission notification contract for public applications.
+ *
+ * A saved application must always leave an internal database notification, even
+ * when the email provider is unavailable. Applicant/staff email attempts are
+ * audited in email_logs so a successful HTTP submission can never silently hide
+ * an email failure again.
+ */
+export async function notifyApplicationSubmission(
+  input: NotifyApplicationSubmissionInput,
+): Promise<ApplicationNotificationResult> {
+  const staffEmail =
+    input.staffEmail ||
+    process.env.PARTNER_NOTIFICATION_EMAIL ||
+    PLATFORM_DEFAULTS.supportEmail ||
+    'elevate4humanityedu@gmail.com';
+
+  await input.db.from('staff_notifications').insert({
+    type: 'application_submitted',
+    title: input.staffSubject,
+    message: `${input.applicantName} (${input.applicantEmail}) submitted a ${input.applicationType} application. Reference: ${input.applicationId}`,
+    severity: 'info',
+    metadata: {
+      application_id: input.applicationId,
+      application_type: input.applicationType,
+      applicant_name: input.applicantName,
+      applicant_email: input.applicantEmail,
+      ...(input.metadata ?? {}),
+    },
+  }).then(({ error }) => {
+    if (error) {
+      logger.warn('[applications] staff notification insert failed', {
+        applicationId: input.applicationId,
+        applicationType: input.applicationType,
+        error: error.message,
+      });
+    }
+  });
+
+  const [applicant, staff] = await Promise.all([
+    sendAndAudit(
+      input.db,
+      {
+        to: input.applicantEmail,
+        subject: input.applicantSubject,
+        html: input.applicantHtml,
+      },
+      {
+        applicationId: input.applicationId,
+        applicationType: input.applicationType,
+        audience: 'applicant',
+        metadata: input.metadata,
+      },
+    ),
+    sendAndAudit(
+      input.db,
+      {
+        to: staffEmail,
+        subject: input.staffSubject,
+        html: input.staffHtml,
+      },
+      {
+        applicationId: input.applicationId,
+        applicationType: input.applicationType,
+        audience: 'staff',
+        metadata: input.metadata,
+      },
+    ),
+  ]);
+
+  return {
+    applicant: applicant.success ? 'sent' : 'failed',
+    staff: staff.success ? 'sent' : 'failed',
+    ...(applicant.error ? { applicantError: applicant.error } : {}),
+    ...(staff.error ? { staffError: staff.error } : {}),
+  };
+}

--- a/lib/apply/apply-surface-routes.ts
+++ b/lib/apply/apply-surface-routes.ts
@@ -11,69 +11,104 @@ export type ApplySurface = {
   note?: string;
 };
 
-/** Extra program-specific apply URLs (not duplicated in header nav elsewhere). */
+/** Extra program-specific apply URLs. All student/program forms use the canonical applications API. */
 export const PROGRAM_APPLY_LINKS: ApplySurface[] = [
-  { section: 'Program applies', name: 'Barber apprentice apply', href: '/programs/barber-apprenticeship/apply' },
-  { section: 'Program applies', name: 'Cosmetology apprentice apply', href: '/programs/cosmetology-apprenticeship/apply' },
-  { section: 'Program applies', name: 'HVAC technician apply', href: '/programs/hvac-technician/apply' },
-  { section: 'Program applies', name: 'Esthetician apprentice apply', href: '/programs/esthetician-apprenticeship/apply' },
-  { section: 'Program applies', name: 'Nail technician apprentice apply', href: '/programs/nail-technician-apprenticeship/apply' },
-  { section: 'Program applies', name: 'Peer recovery specialist apply', href: '/programs/peer-recovery-specialist/apply' },
-  { section: 'Program applies', name: 'QMA apply', href: '/programs/qma/apply' },
+  { section: 'Program applies', name: 'Barber apprentice apply', href: '/programs/barber-apprenticeship/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'Cosmetology apprentice apply', href: '/programs/cosmetology-apprenticeship/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'HVAC technician apply', href: '/programs/hvac-technician/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'Esthetician apprentice apply', href: '/programs/esthetician-apprenticeship/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'Nail technician apprentice apply', href: '/programs/nail-technician-apprenticeship/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'Peer recovery specialist apply', href: '/programs/peer-recovery-specialist/apply', api: '/api/applications' },
+  { section: 'Program applies', name: 'QMA apply', href: '/programs/qma/apply', api: '/api/applications' },
 ];
 
-/** Host shop applies under partners (esthetician/nail were missing from menu). */
+/** Legacy trade-specific Host Shop links redirect into one universal Host Site application. */
 export const EXTRA_HOST_APPLY_LINKS: ApplySurface[] = [
   {
     section: 'Providers & hosts',
     name: 'Esthetician host shop apply',
     href: '/partners/esthetician-apprenticeship/apply',
+    api: '/api/host-shop/apply-multipart',
+    note: 'Redirects to the universal Host Site application.',
   },
   {
     section: 'Providers & hosts',
     name: 'Nail technician host shop apply',
     href: '/partners/nail-technician-apprenticeship/apply',
+    api: '/api/host-shop/apply-multipart',
+    note: 'Redirects to the universal Host Site application.',
   },
 ];
 
 export const APPLY_AUDIT_SURFACES: ApplySurface[] = [
-  { section: 'Students', name: 'Apply hub', href: '/apply', expectForm: 'IntakeFormInner', api: '/api/intake' },
+  {
+    section: 'Students',
+    name: 'Apply hub',
+    href: '/apply',
+    api: '/api/applications',
+    note: 'Redirects to /apply/student; no parallel short-intake record.',
+  },
   {
     section: 'Students',
     name: 'Student application',
     href: '/apply/student',
     expectForm: 'StudentApplicationForm',
-    api: 'server:submitStudentApplication',
+    api: '/api/applications',
   },
   { section: 'Students', name: 'Enroll hub', href: '/enrollment' },
   { section: 'Students', name: 'Track', href: '/apply/track', api: '/api/applications/track' },
-  { section: 'Employers', name: 'Employer application', href: '/apply/employer', expectForm: 'EmployerApplicationForm' },
-  { section: 'Employers', name: 'Employer onboarding', href: '/onboarding/employer', note: 'Auth required' },
+  {
+    section: 'Employers',
+    name: 'Employer application',
+    href: '/apply/employer',
+    expectForm: 'EmployerApplicationForm',
+    api: '/api/employer/apply',
+  },
+  { section: 'Employers', name: 'Employer onboarding', href: '/onboarding/employer', note: 'Auth required after approval/authorization.' },
   {
     section: 'Providers & hosts',
     name: 'Program holder',
     href: '/apply/program-holder',
     expectForm: 'ProgramHolderForm',
+    api: '/api/program-holder/apply',
+  },
+  {
+    section: 'Providers & hosts',
+    name: 'Universal Host Site application',
+    href: '/partners/host-shop/apply',
+    expectForm: 'UniversalHostSiteApplyPage',
+    api: '/api/host-shop/apply-multipart',
   },
   {
     section: 'Providers & hosts',
     name: 'Barber host apply',
     href: '/partners/barber-host-shop/apply',
-    expectForm: 'Compliance Uploads',
-    api: '/api/partners/barber-host-shop/apply',
+    api: '/api/host-shop/apply-multipart',
+    note: 'Compatibility route redirects to /partners/host-shop/apply.',
   },
   {
     section: 'Providers & hosts',
     name: 'Cosmetology host apply',
     href: '/partners/cosmetology-host-shop/apply',
-    expectForm: 'Compliance Uploads',
-    api: '/api/partners/cosmetology-host-shop/apply',
+    api: '/api/host-shop/apply-multipart',
+    note: 'Compatibility route redirects to /partners/host-shop/apply.',
   },
   ...EXTRA_HOST_APPLY_LINKS,
-  { section: 'Providers & hosts', name: 'Booth rental', href: '/booth-rental/apply', api: '/api/booth-rental/checkout' },
-  { section: 'Providers & hosts', name: 'Create program', href: '/partners/create-program', note: 'CTA → /partners/apply' },
-  { section: 'Staff', name: 'Staff application', href: '/apply/staff', expectForm: 'StaffApplicationForm' },
-  { section: 'Staff', name: 'Instructor onboarding', href: '/onboarding/instructor' },
-  { section: 'Agencies', name: 'Partner application', href: '/partners/apply', expectForm: 'ProviderApplicationForm', api: '/api/provider/apply' },
+  { section: 'Providers & hosts', name: 'Booth rental', href: '/booth-rental/apply', api: '/api/booth-rental/checkout', note: 'Commercial checkout, not an application-review workflow.' },
+  { section: 'Providers & hosts', name: 'Create program', href: '/partners/create-program', note: 'CTA routes into the partner selection flow.' },
+  {
+    section: 'Staff',
+    name: 'Staff application',
+    href: '/apply/staff',
+    expectForm: 'StaffApplicationForm',
+    api: '/api/staff/apply',
+  },
+  { section: 'Staff', name: 'Instructor onboarding', href: '/onboarding/instructor', note: 'Authorized onboarding surface; not a public application.' },
+  {
+    section: 'Agencies',
+    name: 'Partner selection',
+    href: '/partners/apply',
+    note: 'Selector routes users to Employer, Training Provider, Host Shop, or Community pathways; it is not itself a provider application form.',
+  },
   ...PROGRAM_APPLY_LINKS,
 ];

--- a/lib/partners/host-shop-onboarding.ts
+++ b/lib/partners/host-shop-onboarding.ts
@@ -63,34 +63,36 @@ export const HOST_SHOP_ONBOARDING_PATHS: Record<
 
 const DEFAULT_REQUIREMENTS: Record<HostShopProgramType, HostShopDocumentRequirement[]> = {
   barber: [
-    requirement('barber', 'ein_letter', 'IRS EIN Assignment Letter', 'IRS CP 575 or 147C letter confirming the shop EIN.'),
-    requirement('barber', 'w9', 'IRS W-9', 'Completed W-9 for partner payout and tax records.'),
+    requirement('barber', 'ein_letter', 'EIN / W-9 Business Identity Record', 'IRS CP 575/147C EIN verification or an acceptable W-9 business identity record.'),
     requirement('barber', 'barbershop_license', 'Indiana Barbershop License', 'Current Indiana barbershop establishment license.', true),
     requirement('barber', 'workers_comp', "Workers' Compensation Certificate", "Workers' compensation certificate or valid Indiana exemption."),
     requirement('barber', 'liability_insurance', 'General Liability Insurance Certificate', 'Certificate of general liability insurance for the host shop.', true),
     requirement('barber', 'supervisor_license', 'Supervising Barber License', 'Indiana barber license for the direct apprentice supervisor.', true),
+    requirement('barber', 'business_license', 'City/County Business or Occupancy Document', 'Local business license or occupancy document, if applicable.', false, false),
   ],
   cosmetology: [
-    requirement('cosmetology', 'ein_letter', 'IRS EIN Assignment Letter', 'IRS CP 575 or 147C letter confirming the salon EIN.'),
-    requirement('cosmetology', 'w9', 'IRS W-9', 'Completed W-9 for partner payout and tax records.'),
+    requirement('cosmetology', 'ein_letter', 'EIN / W-9 Business Identity Record', 'IRS CP 575/147C EIN verification or an acceptable W-9 business identity record.'),
     requirement('cosmetology', 'salon_license', 'Indiana Cosmetology Salon License', 'Current Indiana cosmetology salon license.', true),
     requirement('cosmetology', 'workers_comp', "Workers' Compensation Certificate", "Workers' compensation certificate or valid Indiana exemption."),
     requirement('cosmetology', 'liability_insurance', 'General Liability Insurance Certificate', 'Certificate of general liability insurance for the host salon.', true),
     requirement('cosmetology', 'supervisor_license', 'Supervising Cosmetologist License', 'Indiana cosmetology license for the designated apprentice supervisor.', true),
+    requirement('cosmetology', 'business_license', 'City/County Business or Occupancy Document', 'Local business license or occupancy document, if applicable.', false, false),
   ],
   nail_technician: [
-    requirement('nail_technician', 'ein_letter', 'IRS EIN Assignment Letter', 'IRS CP 575 or 147C letter confirming the salon EIN.'),
+    requirement('nail_technician', 'ein_letter', 'EIN / W-9 Business Identity Record', 'IRS CP 575/147C EIN verification or an acceptable W-9 business identity record.'),
     requirement('nail_technician', 'salon_license', 'Indiana Nail Salon License', 'Current Indiana nail salon license.', true),
     requirement('nail_technician', 'workers_comp', "Workers' Compensation Certificate", "Workers' compensation certificate or valid Indiana exemption."),
+    requirement('nail_technician', 'liability_insurance', 'General Liability Insurance Certificate', 'Certificate of general liability insurance for the host salon.', true),
     requirement('nail_technician', 'supervisor_license', 'Supervising Nail Technician License', 'Indiana nail technician license for the apprentice supervisor.', true),
-    requirement('nail_technician', 'business_license', 'City/County Business License', 'Local business license or occupancy permit, if applicable.', false),
+    requirement('nail_technician', 'business_license', 'City/County Business License', 'Local business license or occupancy permit, if applicable.', false, false),
   ],
   esthetician: [
-    requirement('esthetician', 'ein_letter', 'IRS EIN Assignment Letter', 'IRS CP 575 or 147C letter confirming the spa EIN.'),
+    requirement('esthetician', 'ein_letter', 'EIN / W-9 Business Identity Record', 'IRS CP 575/147C EIN verification or an acceptable W-9 business identity record.'),
     requirement('esthetician', 'salon_license', 'Indiana Esthetician Establishment License', 'Current Indiana esthetics establishment license.', true),
     requirement('esthetician', 'workers_comp', "Workers' Compensation Certificate", "Workers' compensation certificate or valid Indiana exemption."),
+    requirement('esthetician', 'liability_insurance', 'General Liability Insurance Certificate', 'Certificate of general liability insurance for the host spa.', true),
     requirement('esthetician', 'supervisor_license', 'Supervising Esthetician License', 'Indiana esthetician license for the apprentice supervisor.', true),
-    requirement('esthetician', 'business_license', 'City/County Business License', 'Local business license or occupancy permit, if applicable.', false),
+    requirement('esthetician', 'business_license', 'City/County Business License', 'Local business license or occupancy permit, if applicable.', false, false),
   ],
 };
 
@@ -144,6 +146,47 @@ export function getDefaultHostShopDocumentRequirements(program: HostShopProgramT
   return DEFAULT_REQUIREMENTS[program];
 }
 
+function normalizeLegacyRequirement(
+  raw: Record<string, unknown>,
+  program: HostShopProgramType,
+): Record<string, unknown> | null {
+  const rawType = String(raw.document_type ?? '').trim();
+  if (!rawType || rawType === 'mou') return null;
+
+  let documentType = rawType;
+  if (rawType === 'establishment_license') {
+    documentType = program === 'barber' ? 'barbershop_license' : 'salon_license';
+  } else if (rawType === 'insurance_coi') {
+    documentType = 'liability_insurance';
+  } else if (rawType === 'w9') {
+    // The public Host Site application accepts EIN verification OR W-9 in one
+    // tax-identity upload. Treat the legacy global W-9 requirement as that same
+    // canonical record so the portal does not demand a duplicate upload.
+    documentType = 'ein_letter';
+  }
+
+  const normalized = {
+    ...raw,
+    id: raw.id ?? `${program}-${documentType}`,
+    document_type: documentType,
+    program_id: program,
+  };
+
+  if (documentType === 'ein_letter') {
+    normalized.document_name = 'EIN / W-9 Business Identity Record';
+    normalized.description = 'IRS CP 575/147C EIN verification or an acceptable W-9 business identity record.';
+    normalized.is_required = true;
+  }
+  if (documentType === 'business_license') {
+    // The public application explicitly treats the local business/occupancy
+    // document as optional. Do not turn an optional upload into a second
+    // approval blocker because of an older requirement row.
+    normalized.is_required = false;
+  }
+
+  return normalized;
+}
+
 export function mergeHostShopDocumentRequirements(
   dbRequirements: Array<Record<string, unknown>> | null | undefined,
   program: HostShopProgramType,
@@ -152,10 +195,13 @@ export function mergeHostShopDocumentRequirements(
   const byType = new Map<string, Record<string, unknown>>();
 
   for (const req of defaults) byType.set(req.document_type, req);
-  for (const req of dbRequirements ?? []) {
+  for (const raw of dbRequirements ?? []) {
+    const req = normalizeLegacyRequirement(raw, program);
+    if (!req) continue;
     const documentType = String(req.document_type ?? '');
     if (!documentType) continue;
-    byType.set(documentType, { ...req, id: req.id ?? `${program}-${documentType}` });
+    const existing = byType.get(documentType) ?? {};
+    byType.set(documentType, { ...existing, ...req, id: req.id ?? `${program}-${documentType}` });
   }
   return Array.from(byType.values());
 }

--- a/lib/partners/provision-host-shop-application.ts
+++ b/lib/partners/provision-host-shop-application.ts
@@ -171,6 +171,7 @@ export async function provisionHostShopApplication(
     ? existingPartner.programs.map(String)
     : [];
   const mergedPrograms = [...new Set([...existingPrograms, ...programs])];
+  const alreadyApproved = existingPartner?.approval_status === 'approved';
 
   const partnerPayload = {
     name: input.businessName,
@@ -198,14 +199,11 @@ export async function provisionHostShopApplication(
     partner_type: input.businessType || 'host_shop',
     program_type: primaryProgram,
     programs: mergedPrograms,
-    status: existingPartner?.status === 'active' ? 'active' : 'active',
-    approval_status: existingPartner?.approval_status === 'approved' ? 'approved' : 'pending',
-    account_status:
-      existingPartner?.approval_status === 'approved' || existingPartner?.account_status === 'active'
-        ? 'active'
-        : 'conditional_access',
-    documents_verified: existingPartner?.approval_status === 'approved' ? true : false,
-    onboarding_completed: false,
+    status: 'active',
+    approval_status: alreadyApproved ? 'approved' : 'pending',
+    account_status: alreadyApproved || existingPartner?.account_status === 'active' ? 'active' : 'conditional_access',
+    documents_verified: alreadyApproved,
+    onboarding_completed: alreadyApproved ? undefined : false,
     mou_acknowledged: true,
     updated_at: now,
   };
@@ -217,7 +215,7 @@ export async function provisionHostShopApplication(
   } else {
     const { data, error } = await db
       .from('partners')
-      .insert({ ...partnerPayload, applied_at: now })
+      .insert({ ...partnerPayload, onboarding_completed: false, applied_at: now })
       .select('id')
       .single();
     if (error || !data?.id) throw error || new Error('Host Shop partner insert returned no id.');
@@ -236,7 +234,7 @@ export async function provisionHostShopApplication(
       .maybeSingle();
 
     if (!existingProfile) {
-      await db.from('profiles').insert({
+      const { error } = await db.from('profiles').insert({
         id: identity.userId,
         email,
         full_name: input.contactName,
@@ -245,8 +243,10 @@ export async function provisionHostShopApplication(
         phone: input.phone,
         role: 'partner',
       });
+      if (error) throw error;
     } else if (!['admin', 'super_admin', 'org_admin', 'staff'].includes(String(existingProfile.role || ''))) {
-      await db.from('profiles').update({ role: 'partner' }).eq('id', identity.userId);
+      const { error } = await db.from('profiles').update({ role: 'partner' }).eq('id', identity.userId);
+      if (error) throw error;
     }
 
     const { error: userLinkError } = await db.from('partner_users').upsert(
@@ -263,7 +263,14 @@ export async function provisionHostShopApplication(
 
   for (const programId of programs) {
     const { error } = await db.from('partner_program_access').upsert(
-      { partner_id: partnerId, program_id: programId, revoked_at: null },
+      {
+        partner_id: partnerId,
+        program_id: programId,
+        can_view_apprentices: true,
+        can_enter_progress: true,
+        can_view_reports: true,
+        revoked_at: null,
+      },
       { onConflict: 'partner_id,program_id' },
     );
     if (error) throw error;
@@ -280,12 +287,14 @@ export async function provisionHostShopApplication(
   ] as Array<[string, string]>;
 
   for (const [documentType, path] of docs) {
-    await db
+    const { error: deleteError } = await db
       .from('partner_documents')
       .delete()
       .eq('partner_id', partnerId)
       .eq('document_type', documentType)
       .eq('program_id', primaryProgram);
+    if (deleteError) throw deleteError;
+
     const { error } = await db.from('partner_documents').insert({
       partner_id: partnerId,
       document_type: documentType,
@@ -294,7 +303,7 @@ export async function provisionHostShopApplication(
       display_name: fileName(path),
       file_name: fileName(path),
       file_url: path,
-      status: 'pending',
+      status: alreadyApproved ? 'accepted' : 'pending',
       storage_bucket: 'documents',
     });
     if (error) throw error;
@@ -310,7 +319,7 @@ export async function provisionHostShopApplication(
     contact_name: input.contactName,
     contact_email: email,
     contact_phone: input.phone,
-    status: existingPartner?.approval_status === 'approved' ? 'active' : 'pending',
+    status: alreadyApproved ? 'active' : 'pending',
     partner_tier: 'free',
     portal_access_enabled: true,
     portal_access_at: now,
@@ -319,17 +328,18 @@ export async function provisionHostShopApplication(
       programs,
       source: 'host_shop_application',
       application_id: input.applicationId,
-      conditional_access: existingPartner?.approval_status !== 'approved',
+      conditional_access: !alreadyApproved,
     },
     updated_at: now,
   };
 
-  const { data: existingPartnership } = await db
+  const { data: existingPartnership, error: partnershipLookupError } = await db
     .from('host_shop_partnerships')
     .select('id')
     .or(`application_id.eq.${input.applicationId},partner_id.eq.${partnerId}`)
     .limit(1)
     .maybeSingle();
+  if (partnershipLookupError) throw partnershipLookupError;
 
   if (existingPartnership?.id) {
     const { error } = await db
@@ -341,14 +351,6 @@ export async function provisionHostShopApplication(
     const { error } = await db.from('host_shop_partnerships').insert(partnershipPayload);
     if (error) throw error;
   }
-
-  await db
-    .from('host_shop_applications')
-    .update({
-      intake: db.rpc ? undefined : undefined,
-    })
-    .eq('id', input.applicationId)
-    .then(undefined, () => undefined);
 
   const accessLink = identity.userId
     ? await createSecureAccessLink(db, email, identity.isNewUser, onboardingUrl)

--- a/lib/partners/provision-host-shop-application.ts
+++ b/lib/partners/provision-host-shop-application.ts
@@ -1,0 +1,372 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { logger } from '@/lib/logger';
+import { normalizeHostShopProgram } from '@/lib/partners/host-shop-onboarding';
+
+export type HostShopUploadedDocuments = {
+  shopLicense: string;
+  insurance: string;
+  workersComp: string;
+  supervisorLicense: string;
+  ein: string;
+  localBusiness?: string | null;
+};
+
+export type ProvisionHostShopApplicationInput = {
+  db: SupabaseClient;
+  applicationId: string;
+  businessName: string;
+  legalBusinessName: string;
+  ownerName: string;
+  contactName: string;
+  email: string;
+  phone: string;
+  address1: string;
+  address2?: string | null;
+  city: string;
+  state: string;
+  zip: string;
+  businessType: string;
+  licenseNumber: string;
+  supervisorName: string;
+  supervisorLicenseNumber: string;
+  supervisorYearsLicensed?: string | number | null;
+  workersCompStatus: string;
+  compensationModel: string;
+  numberOfEmployees?: string | number | null;
+  programs: string[];
+  documents: HostShopUploadedDocuments;
+};
+
+export type ProvisionHostShopApplicationResult = {
+  partnerId: string;
+  userId: string | null;
+  isNewUser: boolean;
+  accessLink: string | null;
+  portalUrl: string;
+  onboardingUrl: string;
+};
+
+function numericOrNull(value: string | number | null | undefined) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function fileName(path: string) {
+  return path.split('/').pop() || path;
+}
+
+function normalizedPrograms(programs: string[]) {
+  return [...new Set(programs.map((program) => normalizeHostShopProgram(program)).filter(Boolean))] as string[];
+}
+
+async function resolveOrCreateUser(
+  db: SupabaseClient,
+  email: string,
+  contactName: string,
+): Promise<{ userId: string | null; isNewUser: boolean }> {
+  const normalizedEmail = email.toLowerCase().trim();
+  const { data: profile } = await db
+    .from('profiles')
+    .select('id, role')
+    .eq('email', normalizedEmail)
+    .maybeSingle();
+
+  if (profile?.id) {
+    return { userId: profile.id as string, isNewUser: false };
+  }
+
+  try {
+    const { data: users } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+    const existing = users?.users?.find(
+      (user) => user.email?.toLowerCase() === normalizedEmail,
+    );
+    if (existing?.id) return { userId: existing.id, isNewUser: false };
+  } catch (error) {
+    logger.warn('[host-shop/provision] auth user lookup failed', {
+      email: normalizedEmail,
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+
+  const tempPassword = `${crypto.randomUUID().replace(/-/g, '')}Aa1!`;
+  const { data, error } = await db.auth.admin.createUser({
+    email: normalizedEmail,
+    password: tempPassword,
+    email_confirm: true,
+    user_metadata: {
+      full_name: contactName,
+      role: 'partner',
+      portal: 'host_shop',
+    },
+  });
+
+  if (error || !data.user?.id) {
+    logger.error('[host-shop/provision] auth user creation failed', undefined, {
+      email: normalizedEmail,
+      error: error?.message,
+    });
+    return { userId: null, isNewUser: false };
+  }
+
+  return { userId: data.user.id, isNewUser: true };
+}
+
+async function createSecureAccessLink(
+  db: SupabaseClient,
+  email: string,
+  isNewUser: boolean,
+  onboardingUrl: string,
+): Promise<string | null> {
+  try {
+    const { data, error } = await db.auth.admin.generateLink({
+      type: isNewUser ? 'recovery' : 'magiclink',
+      email: email.toLowerCase().trim(),
+      options: { redirectTo: onboardingUrl },
+    });
+    if (error) {
+      logger.warn('[host-shop/provision] secure access link generation failed', {
+        email,
+        error: error.message,
+      });
+      return null;
+    }
+    return data?.properties?.action_link || null;
+  } catch (error) {
+    logger.warn('[host-shop/provision] secure access link generation threw', {
+      email,
+      error: error instanceof Error ? error.message : String(error),
+    });
+    return null;
+  }
+}
+
+/**
+ * Provision conditional Host Shop portal access once the public application has
+ * successfully saved all required compliance documents.
+ *
+ * This does NOT compliance-approve the shop. It creates the partner identity,
+ * portal linkage and document records so the applicant can complete onboarding
+ * while Elevate reviews the submitted evidence.
+ */
+export async function provisionHostShopApplication(
+  input: ProvisionHostShopApplicationInput,
+): Promise<ProvisionHostShopApplicationResult> {
+  const { db } = input;
+  const email = input.email.toLowerCase().trim();
+  const programs = normalizedPrograms(input.programs);
+  const primaryProgram = programs[0] || 'barber';
+  const now = new Date().toISOString();
+  const appUrl = (process.env.NEXT_PUBLIC_LMS_URL || 'https://app.elevateforhumanity.org').replace(/\/$/, '');
+  const portalUrl = `${appUrl}/host-shop/login`;
+  const onboardingUrl = `${appUrl}/auth/callback?redirect=${encodeURIComponent('/host-shop/onboarding')}`;
+
+  const { data: existingPartner, error: existingPartnerError } = await db
+    .from('partners')
+    .select('id, approval_status, status, account_status, programs')
+    .eq('contact_email', email)
+    .maybeSingle();
+  if (existingPartnerError) throw existingPartnerError;
+
+  const existingPrograms = Array.isArray(existingPartner?.programs)
+    ? existingPartner.programs.map(String)
+    : [];
+  const mergedPrograms = [...new Set([...existingPrograms, ...programs])];
+
+  const partnerPayload = {
+    name: input.businessName,
+    legal_name: input.legalBusinessName,
+    shop_name: input.businessName,
+    owner_name: input.ownerName,
+    contact_name: input.contactName,
+    contact_email: email,
+    phone: input.phone,
+    contact_phone: input.phone,
+    address_line1: input.address1,
+    address_line2: input.address2 || null,
+    city: input.city,
+    state: input.state || 'Indiana',
+    zip: input.zip,
+    license_number: input.licenseNumber,
+    supervisor_name: input.supervisorName,
+    supervisor_license_number: input.supervisorLicenseNumber,
+    supervisor_years_licensed: numericOrNull(input.supervisorYearsLicensed),
+    compensation_model: input.compensationModel,
+    number_of_employees: numericOrNull(input.numberOfEmployees),
+    workers_comp_status: input.workersCompStatus,
+    has_general_liability: true,
+    can_supervise_and_verify: true,
+    partner_type: input.businessType || 'host_shop',
+    program_type: primaryProgram,
+    programs: mergedPrograms,
+    status: existingPartner?.status === 'active' ? 'active' : 'active',
+    approval_status: existingPartner?.approval_status === 'approved' ? 'approved' : 'pending',
+    account_status:
+      existingPartner?.approval_status === 'approved' || existingPartner?.account_status === 'active'
+        ? 'active'
+        : 'conditional_access',
+    documents_verified: existingPartner?.approval_status === 'approved' ? true : false,
+    onboarding_completed: false,
+    mou_acknowledged: true,
+    updated_at: now,
+  };
+
+  let partnerId = existingPartner?.id as string | undefined;
+  if (partnerId) {
+    const { error } = await db.from('partners').update(partnerPayload).eq('id', partnerId);
+    if (error) throw error;
+  } else {
+    const { data, error } = await db
+      .from('partners')
+      .insert({ ...partnerPayload, applied_at: now })
+      .select('id')
+      .single();
+    if (error || !data?.id) throw error || new Error('Host Shop partner insert returned no id.');
+    partnerId = data.id;
+  }
+
+  const identity = await resolveOrCreateUser(db, email, input.contactName);
+  if (identity.userId) {
+    const nameParts = input.contactName.trim().split(/\s+/);
+    const firstName = nameParts.shift() || input.contactName;
+    const lastName = nameParts.join(' ') || null;
+    const { data: existingProfile } = await db
+      .from('profiles')
+      .select('id, role')
+      .eq('id', identity.userId)
+      .maybeSingle();
+
+    if (!existingProfile) {
+      await db.from('profiles').insert({
+        id: identity.userId,
+        email,
+        full_name: input.contactName,
+        first_name: firstName,
+        last_name: lastName,
+        phone: input.phone,
+        role: 'partner',
+      });
+    } else if (!['admin', 'super_admin', 'org_admin', 'staff'].includes(String(existingProfile.role || ''))) {
+      await db.from('profiles').update({ role: 'partner' }).eq('id', identity.userId);
+    }
+
+    const { error: userLinkError } = await db.from('partner_users').upsert(
+      {
+        user_id: identity.userId,
+        partner_id: partnerId,
+        role: 'partner_admin',
+        status: 'active',
+      },
+      { onConflict: 'user_id,partner_id' },
+    );
+    if (userLinkError) throw userLinkError;
+  }
+
+  for (const programId of programs) {
+    const { error } = await db.from('partner_program_access').upsert(
+      { partner_id: partnerId, program_id: programId, revoked_at: null },
+      { onConflict: 'partner_id,program_id' },
+    );
+    if (error) throw error;
+  }
+
+  const programSpecificLicense = primaryProgram === 'barber' ? 'barbershop_license' : 'salon_license';
+  const docs = [
+    [programSpecificLicense, input.documents.shopLicense],
+    ['liability_insurance', input.documents.insurance],
+    ['workers_comp', input.documents.workersComp],
+    ['supervisor_license', input.documents.supervisorLicense],
+    ['ein_letter', input.documents.ein],
+    ...(input.documents.localBusiness ? [['business_license', input.documents.localBusiness]] : []),
+  ] as Array<[string, string]>;
+
+  for (const [documentType, path] of docs) {
+    await db
+      .from('partner_documents')
+      .delete()
+      .eq('partner_id', partnerId)
+      .eq('document_type', documentType)
+      .eq('program_id', primaryProgram);
+    const { error } = await db.from('partner_documents').insert({
+      partner_id: partnerId,
+      document_type: documentType,
+      program_id: primaryProgram,
+      state: input.state || 'Indiana',
+      display_name: fileName(path),
+      file_name: fileName(path),
+      file_url: path,
+      status: 'pending',
+      storage_bucket: 'documents',
+    });
+    if (error) throw error;
+  }
+
+  const partnershipPayload = {
+    application_id: input.applicationId,
+    partner_id: partnerId,
+    business_name: input.businessName,
+    business_type: input.businessType || 'other',
+    license_number: input.licenseNumber,
+    address: [input.address1, input.address2, input.city, input.state, input.zip].filter(Boolean).join(', '),
+    contact_name: input.contactName,
+    contact_email: email,
+    contact_phone: input.phone,
+    status: existingPartner?.approval_status === 'approved' ? 'active' : 'pending',
+    partner_tier: 'free',
+    portal_access_enabled: true,
+    portal_access_at: now,
+    onboarding_completed: false,
+    metadata: {
+      programs,
+      source: 'host_shop_application',
+      application_id: input.applicationId,
+      conditional_access: existingPartner?.approval_status !== 'approved',
+    },
+    updated_at: now,
+  };
+
+  const { data: existingPartnership } = await db
+    .from('host_shop_partnerships')
+    .select('id')
+    .or(`application_id.eq.${input.applicationId},partner_id.eq.${partnerId}`)
+    .limit(1)
+    .maybeSingle();
+
+  if (existingPartnership?.id) {
+    const { error } = await db
+      .from('host_shop_partnerships')
+      .update(partnershipPayload)
+      .eq('id', existingPartnership.id);
+    if (error) throw error;
+  } else {
+    const { error } = await db.from('host_shop_partnerships').insert(partnershipPayload);
+    if (error) throw error;
+  }
+
+  await db
+    .from('host_shop_applications')
+    .update({
+      intake: db.rpc ? undefined : undefined,
+    })
+    .eq('id', input.applicationId)
+    .then(undefined, () => undefined);
+
+  const accessLink = identity.userId
+    ? await createSecureAccessLink(db, email, identity.isNewUser, onboardingUrl)
+    : null;
+
+  logger.info('[host-shop/provision] conditional Host Shop access provisioned', {
+    applicationId: input.applicationId,
+    partnerId,
+    userId: identity.userId,
+    programs,
+  });
+
+  return {
+    partnerId,
+    userId: identity.userId,
+    isNewUser: identity.isNewUser,
+    accessLink,
+    portalUrl,
+    onboardingUrl,
+  };
+}

--- a/supabase/migrations/20260811212000_partner_program_access_controls.sql
+++ b/supabase/migrations/20260811212000_partner_program_access_controls.sql
@@ -1,0 +1,13 @@
+-- Align partner_program_access with the Host Shop portal and legacy partner provisioning.
+-- The portal already filters revoked_at, and older provisioning code writes the
+-- three capability flags. Production previously had only partner_id/program_id.
+
+alter table public.partner_program_access
+  add column if not exists can_view_apprentices boolean not null default true,
+  add column if not exists can_enter_progress boolean not null default true,
+  add column if not exists can_view_reports boolean not null default true,
+  add column if not exists revoked_at timestamptz;
+
+create index if not exists partner_program_access_active_idx
+  on public.partner_program_access (partner_id, program_id)
+  where revoked_at is null;

--- a/supabase/migrations/20260811213000_fix_host_shop_partnership_audit.sql
+++ b/supabase/migrations/20260811213000_fix_host_shop_partnership_audit.sql
@@ -1,0 +1,42 @@
+-- Repair the Host Shop partnership audit trigger against the current audit_logs schema.
+-- The legacy trigger wrote table_name/record_id/changed_by columns that no longer exist,
+-- which caused every host_shop_partnerships INSERT/UPDATE/DELETE to fail.
+
+create or replace function public.log_host_shop_partnership_changes()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_record_id text;
+begin
+  v_record_id := coalesce(new.id, old.id)::text;
+
+  insert into public.audit_logs (
+    action,
+    actor_id,
+    target_type,
+    target_id,
+    entity,
+    entity_type,
+    entity_id,
+    before_state,
+    after_state,
+    metadata
+  ) values (
+    lower(tg_op),
+    auth.uid(),
+    'host_shop_partnership',
+    v_record_id,
+    'host_shop_partnerships',
+    'host_shop_partnership',
+    v_record_id,
+    case when tg_op in ('UPDATE', 'DELETE') then to_jsonb(old) end,
+    case when tg_op in ('INSERT', 'UPDATE') then to_jsonb(new) end,
+    jsonb_build_object('table', 'host_shop_partnerships', 'trigger_op', tg_op)
+  );
+
+  return coalesce(new, old);
+end;
+$$;


### PR DESCRIPTION
## What Changed

Repairs the public application notification/onboarding contract across the live Marketing application surfaces. Every corrected submission route now saves the record, creates an internal Elevate notification, sends an applicant acknowledgment, sends the staff-side alert, and records future delivery attempts in `email_logs`. Host Shop submissions additionally provision conditional portal access after required documents save, without bypassing staff compliance approval.

## Key Repairs

- Added shared `notifyApplicationSubmission` contract with applicant/staff email result inspection, `email_logs` auditing, and `staff_notifications` fallback.
- Universal Host Site application now provisions/links a partner identity, `partner_users`, requested apprenticeship program access, `host_shop_partnerships`, and mirrored compliance documents.
- Host Shop email uses the applicant email as username and a secure recovery/magic-link; no plaintext passwords are emailed.
- Host Shop next steps explain portal onboarding/MOU, compliance verification, apprentice matching, OJL supervision, hours/competency verification, and that conditional access is not final approval.
- Fixed WIOA route that previously self-fetched a missing `/api/send-email` endpoint and swallowed failures.
- Added acknowledgment + Elevate alerts for Employer, Program Holder, Staff, and program request-info flows.
- Added dedicated `/api/staff/apply`; the Staff form no longer incorrectly posts a staff application into the student `/api/applications` contract.
- Partner selector now routes Employer -> `/apply/employer`, Training Provider -> `/apply/program-holder`, Host Shop -> `/partners/host-shop/apply`.
- Canonicalized legacy Barber/Cosmetology Host Site shortcuts to the universal Host Site application.
- Updated the apply-surface audit registry to current canonical routes.
- Normalized legacy Host Shop compliance document aliases so the portal does not ask for documents already uploaded under a second name.
- Added/used the missing `partner_program_access` capability/revocation columns required by the Host Shop board.
- Repaired the `host_shop_partnerships` audit trigger, which referenced columns no longer present in `audit_logs` and could block partnership writes.

## Production Evidence / Remediation

Production Supabase migrations were applied idempotently for:
1. `partner_program_access` capability/revocation columns.
2. Host Shop partnership audit trigger compatibility.

Existing Host Shop application `67f5333c-885d-4701-912c-8b0783013dd0` was backfilled as **conditional access only**, not compliance-approved. Verified production state:
- partner record exists
- approval status remains `pending`
- account status `conditional_access`
- 1 active `partner_users` link
- Barber + Cosmetology access (2 program access rows)
- 6 mirrored compliance documents
- Host Shop partnership with portal access enabled

## Historical Email Audit

Last-30-day production records reviewed:
- 6 `applications`
- 3 `host_shop_applications`
- no recent records in the sampled employer/program-holder/provider/staff/funding/apprenticeship application tables

For the seven most recent applicant/Host Shop emails checked, there were no corresponding durable `email_logs`, `email_events`, or notification-event records under the old code. The connected Elevate Gmail search also returned no matching recent staff-side application notifications for the checked references/names.

Known missed acknowledgment cases:
- Mark McCain — CDL program request-info (`55086e3f-603a-483a-8c59-040b34b4c56e`): old route sent staff only, not applicant acknowledgment.
- Ashton Morrow — Diesel Mechanic request-info (`22c1cfe7-a58b-4027-819b-c668dc3fe0fa`): old route sent staff only, not applicant acknowledgment.
- Host Shop application above: applicant reported no acknowledgment; old route did not inspect `{success:false}` email results.

The four recent full Student applications did provision auth users/profiles and the canonical route attempts/checks both student and staff email sends. Because the old route did not persist provider outcomes, historical delivery cannot be proven retroactively from the database.

## Security / Business Rule

Portal provisioning is not compliance approval. Host Shops can enter conditional onboarding after submitting the required evidence, but Elevate staff still controls the final `approved` state. No temporary/plaintext password is sent by email.

## Deployment

Database compatibility changes are already applied. Code deployment should include **Marketing + LMS**: Marketing owns the application endpoints; LMS consumes the corrected Host Shop onboarding requirements/portal access contract. Admin code is not changed.