### PR TITLE
fix(host-shop): show onboarding next steps after application

### DIFF
--- a/apps/marketing/app/partners/host-shop/confirmation/page.tsx
+++ b/apps/marketing/app/partners/host-shop/confirmation/page.tsx
@@ -7,6 +7,8 @@ export const metadata = {
   robots: { index: false, follow: false },
 };
 
+const HOST_SHOP_LOGIN = 'https://app.elevateforhumanity.org/host-shop/login';
+
 export default async function HostSiteConfirmationPage({
   searchParams,
 }: {
@@ -21,12 +23,12 @@ export default async function HostSiteConfirmationPage({
         <p className="text-sm font-black uppercase tracking-[0.15em] text-brand-red-700">
           Host Site application received
         </p>
-        <h1 className="mt-3 text-3xl font-black sm:text-4xl">Your worksite review has started</h1>
+        <h1 className="mt-3 text-3xl font-black sm:text-4xl">Your application is saved and onboarding can begin</h1>
         <p className="mt-4 text-base leading-7 text-slate-700">
-          Elevate received your Host Site application and compliance documents. Submission does not
-          authorize the business to host apprentices yet. Authorized staff must verify licensing,
-          insurance, workers&apos; compensation/exemption records, supervising professional credentials,
-          worksite capacity, and program fit before approval.
+          Elevate received your Host Site application and compliance documents. Your Host Shop account
+          is provisioned for conditional onboarding while authorized staff verify licensing, insurance,
+          workers&apos; compensation/exemption records, supervising professional credentials, worksite
+          capacity, and program fit.
         </p>
 
         {reference ? (
@@ -37,12 +39,29 @@ export default async function HostSiteConfirmationPage({
         ) : null}
 
         <div className="mt-7 rounded-xl border border-blue-200 bg-blue-50 p-5 text-sm leading-6 text-blue-950">
-          <strong>What happens next:</strong> staff review the submitted records, contact the business
-          if clarification is required, complete the Host Site approval workflow, and only then link
-          eligible apprentices to the approved worksite.
+          <strong>Do this next:</strong>
+          <ol className="mt-3 list-decimal space-y-2 pl-5">
+            <li>Open the Host Shop portal using the same email address you entered on the application.</li>
+            <li>Use the secure setup/sign-in link in your acknowledgment email, or request a magic link from the Host Shop login page.</li>
+            <li>Complete the Host Site onboarding and MOU items shown in your portal.</li>
+            <li>Watch the portal/email for any document clarification requested by Elevate.</li>
+            <li>After final approval and apprentice matching, assigned apprentices will appear in the Host Shop board for OJL supervision, hours, and competency verification.</li>
+          </ol>
         </div>
 
-        <div className="mt-7 flex flex-col gap-3 sm:flex-row">
+        <div className="mt-5 rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm leading-6 text-amber-950">
+          <strong>Important:</strong> Portal access is conditional onboarding access. It does not by itself
+          approve the business to host an apprentice. Final Host Site approval remains an Elevate
+          compliance decision.
+        </div>
+
+        <div className="mt-7 flex flex-col gap-3 sm:flex-row sm:flex-wrap">
+          <a
+            href={HOST_SHOP_LOGIN}
+            className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand-red-700 px-5 py-3 font-bold text-white hover:bg-brand-red-800"
+          >
+            Open Host Shop Portal
+          </a>
           <Link
             href="/partners/host-shops"
             className="inline-flex min-h-11 items-center justify-center rounded-xl bg-slate-950 px-5 py-3 font-bold text-white hover:bg-slate-800"


### PR DESCRIPTION
Follow-up to PR #599. Updates only the public Host Site success page so it matches the newly merged conditional onboarding workflow.

After a successful Host Site application, the page now tells the applicant:
- the application and compliance documents are saved
- conditional Host Shop onboarding can begin immediately
- use the same application email as the portal username
- use the secure setup/magic-link flow rather than a plaintext password
- complete Host Site onboarding/MOU while Elevate reviews compliance
- final approval remains a separate Elevate decision
- approved/matched apprentices will appear in the Host Shop board for OJL hours and competency verification

No backend, database, LMS, or Admin behavior is changed in this follow-up.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Show onboarding next steps and Host Shop Portal link on application confirmation page
> Updates the [confirmation page](https://github.com/elevate-for-humanity/Elevate-lms/pull/600/files#diff-d6b4610369aafa524b1075c3eab082e4be84dd8854754ec014891ef9fb695ec6) shown after a Host Shop application is submitted. The headline and body copy now indicate the application is saved and onboarding can begin, with a numbered next-steps list and an "Important" notice clarifying conditional access versus final approval. A new "Open Host Shop Portal" button links to the Host Shop Portal login URL.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2c9896b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->