### PR TITLE
fix(applications): promote public intake into canonical review tables

### DIFF
--- a/apps/marketing/app/api/employer/apply/route.ts
+++ b/apps/marketing/app/api/employer/apply/route.ts
@@ -60,38 +60,83 @@ export async function POST(request: Request) {
       company_name: companyName,
       contact_name: contactName,
       email,
-      phone,
-      industry,
-      employee_count: employeeCount,
-      hiring_needs: hiringNeeds,
-      notes,
+      phone: phone || null,
+      industry: industry || null,
+      employee_count: employeeCount || null,
+      hiring_needs: hiringNeeds || null,
+      notes: notes || null,
     };
 
-    const { data, error } = await admin
+    // Preserve the universal intake/audit record, but do not depend on an Edge
+    // Function to move it into the canonical Admin review table. Production does
+    // not currently have process-intake deployed.
+    const { data: intake, error: intakeError } = await admin
       .from('application_intake')
       .insert({
         application_type: 'employer',
         payload,
         source: 'public_form',
       })
-      .select('id, created_at')
-      .maybeSingle();
+      .select('id')
+      .single();
 
-    if (error || !data?.id) {
-      logger.error('[employer/apply] intake insert failed', error ?? undefined, { email, companyName });
+    if (intakeError || !intake?.id) {
+      logger.error('[employer/apply] intake insert failed', intakeError ?? undefined, { email, companyName });
       return NextResponse.json(
         { ok: false, error: 'We could not save the employer application. Please try again.' },
         { status: 500 },
       );
     }
 
+    const { data: application, error: applicationError } = await admin
+      .from('employer_applications')
+      .insert({
+        company_name: companyName,
+        contact_name: contactName,
+        email,
+        phone: phone || null,
+        status: 'pending',
+        state: 'submitted',
+        data: payload,
+        intake: payload,
+      })
+      .select('id')
+      .single();
+
+    if (applicationError || !application?.id) {
+      await admin
+        .from('application_intake')
+        .update({ status: 'rejected', error: applicationError?.message || 'Canonical employer application insert failed.' })
+        .eq('id', intake.id);
+      logger.error('[employer/apply] canonical insert failed', applicationError ?? undefined, {
+        intakeId: intake.id,
+        email,
+        companyName,
+      });
+      return NextResponse.json(
+        { ok: false, error: 'We could not place the employer application into review. Please try again.' },
+        { status: 500 },
+      );
+    }
+
+    await admin
+      .from('application_intake')
+      .update({
+        status: 'processed',
+        processed_at: new Date().toISOString(),
+        destination_table: 'employer_applications',
+        destination_id: application.id,
+        error: null,
+      })
+      .eq('id', intake.id);
+
     const safeCompany = escapeHtml(companyName);
     const safeName = escapeHtml(contactName);
     const safeEmail = escapeHtml(email);
-    const safeRef = escapeHtml(data.id);
+    const safeRef = escapeHtml(application.id);
     const notifications = await notifyApplicationSubmission({
       db: admin,
-      applicationId: data.id,
+      applicationId: application.id,
       applicationType: 'employer',
       applicantName: contactName,
       applicantEmail: email,
@@ -99,14 +144,15 @@ export async function POST(request: Request) {
       applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>Employer Partnership Application Received</h2><p>Hello ${safeName},</p><p>We received the employer partnership application for <strong>${safeCompany}</strong>.</p><p><strong>Reference:</strong> ${safeRef}</p><h3>What happens next</h3><ol><li>Our workforce team reviews your hiring, OJT, WEX, apprenticeship, and training needs.</li><li>If additional employer verification or agreements are needed, we will send the exact next step.</li><li>Once the partnership is approved, your employer/partner portal access and onboarding instructions will be issued to <strong>${safeEmail}</strong>.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
       staffSubject: `[EMPLOYER APPLICATION] ${companyName}`,
       staffHtml: `<h2>New Employer Partnership Application</h2><p><strong>${safeCompany}</strong><br>${safeName}<br>${safeEmail}<br>${escapeHtml(phone || 'No phone')}</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Industry:</strong> ${escapeHtml(industry || 'Not provided')}</p><p><strong>Hiring/workforce needs:</strong> ${escapeHtml(hiringNeeds || 'Not provided')}</p><p>Review the application and initiate employer onboarding when approved.</p>`,
-      metadata: { company_name: companyName, industry },
+      metadata: { company_name: companyName, industry, intake_id: intake.id },
     });
 
     return NextResponse.json(
       {
         ok: true,
-        applicationId: data.id,
-        referenceNumber: data.id,
+        applicationId: application.id,
+        referenceNumber: application.id,
+        intakeId: intake.id,
         applicationType: 'employer',
         notificationStatus: notifications,
       },

--- a/apps/marketing/app/api/employer/apply/route.ts
+++ b/apps/marketing/app/api/employer/apply/route.ts
@@ -60,83 +60,38 @@ export async function POST(request: Request) {
       company_name: companyName,
       contact_name: contactName,
       email,
-      phone: phone || null,
-      industry: industry || null,
-      employee_count: employeeCount || null,
-      hiring_needs: hiringNeeds || null,
-      notes: notes || null,
+      phone,
+      industry,
+      employee_count: employeeCount,
+      hiring_needs: hiringNeeds,
+      notes,
     };
 
-    // Preserve the universal intake/audit record, but do not depend on an Edge
-    // Function to move it into the canonical Admin review table. Production does
-    // not currently have process-intake deployed.
-    const { data: intake, error: intakeError } = await admin
+    const { data, error } = await admin
       .from('application_intake')
       .insert({
         application_type: 'employer',
         payload,
         source: 'public_form',
       })
-      .select('id')
-      .single();
+      .select('id, created_at')
+      .maybeSingle();
 
-    if (intakeError || !intake?.id) {
-      logger.error('[employer/apply] intake insert failed', intakeError ?? undefined, { email, companyName });
+    if (error || !data?.id) {
+      logger.error('[employer/apply] intake insert failed', error ?? undefined, { email, companyName });
       return NextResponse.json(
         { ok: false, error: 'We could not save the employer application. Please try again.' },
         { status: 500 },
       );
     }
 
-    const { data: application, error: applicationError } = await admin
-      .from('employer_applications')
-      .insert({
-        company_name: companyName,
-        contact_name: contactName,
-        email,
-        phone: phone || null,
-        status: 'pending',
-        state: 'submitted',
-        data: payload,
-        intake: payload,
-      })
-      .select('id')
-      .single();
-
-    if (applicationError || !application?.id) {
-      await admin
-        .from('application_intake')
-        .update({ status: 'rejected', error: applicationError?.message || 'Canonical employer application insert failed.' })
-        .eq('id', intake.id);
-      logger.error('[employer/apply] canonical insert failed', applicationError ?? undefined, {
-        intakeId: intake.id,
-        email,
-        companyName,
-      });
-      return NextResponse.json(
-        { ok: false, error: 'We could not place the employer application into review. Please try again.' },
-        { status: 500 },
-      );
-    }
-
-    await admin
-      .from('application_intake')
-      .update({
-        status: 'processed',
-        processed_at: new Date().toISOString(),
-        destination_table: 'employer_applications',
-        destination_id: application.id,
-        error: null,
-      })
-      .eq('id', intake.id);
-
     const safeCompany = escapeHtml(companyName);
     const safeName = escapeHtml(contactName);
     const safeEmail = escapeHtml(email);
-    const safeRef = escapeHtml(application.id);
+    const safeRef = escapeHtml(data.id);
     const notifications = await notifyApplicationSubmission({
       db: admin,
-      applicationId: application.id,
+      applicationId: data.id,
       applicationType: 'employer',
       applicantName: contactName,
       applicantEmail: email,
@@ -144,15 +99,14 @@ export async function POST(request: Request) {
       applicantHtml: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto"><h2>Employer Partnership Application Received</h2><p>Hello ${safeName},</p><p>We received the employer partnership application for <strong>${safeCompany}</strong>.</p><p><strong>Reference:</strong> ${safeRef}</p><h3>What happens next</h3><ol><li>Our workforce team reviews your hiring, OJT, WEX, apprenticeship, and training needs.</li><li>If additional employer verification or agreements are needed, we will send the exact next step.</li><li>Once the partnership is approved, your employer/partner portal access and onboarding instructions will be issued to <strong>${safeEmail}</strong>.</li></ol><p>You do not need to submit another application. Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
       staffSubject: `[EMPLOYER APPLICATION] ${companyName}`,
       staffHtml: `<h2>New Employer Partnership Application</h2><p><strong>${safeCompany}</strong><br>${safeName}<br>${safeEmail}<br>${escapeHtml(phone || 'No phone')}</p><p><strong>Reference:</strong> ${safeRef}</p><p><strong>Industry:</strong> ${escapeHtml(industry || 'Not provided')}</p><p><strong>Hiring/workforce needs:</strong> ${escapeHtml(hiringNeeds || 'Not provided')}</p><p>Review the application and initiate employer onboarding when approved.</p>`,
-      metadata: { company_name: companyName, industry, intake_id: intake.id },
+      metadata: { company_name: companyName, industry },
     });
 
     return NextResponse.json(
       {
         ok: true,
-        applicationId: application.id,
-        referenceNumber: application.id,
-        intakeId: intake.id,
+        applicationId: data.id,
+        referenceNumber: data.id,
         applicationType: 'employer',
         notificationStatus: notifications,
       },

--- a/supabase/migrations/20260811214500_promote_public_application_intake.sql
+++ b/supabase/migrations/20260811214500_promote_public_application_intake.sql
@@ -1,0 +1,128 @@
+-- Promote public application_intake rows into canonical review tables in the
+-- same transaction. This removes the production dependency on the optional
+-- process-intake Edge Function and prevents acknowledged submissions from being
+-- stranded in application_intake.
+
+create or replace function public.promote_public_application_intake_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+declare
+  v_destination_id uuid;
+begin
+  if new.status <> 'received' then
+    return new;
+  end if;
+
+  if new.application_type = 'employer' then
+    insert into public.employer_applications (
+      tenant_id,
+      company_name,
+      contact_name,
+      email,
+      phone,
+      status,
+      data,
+      intake,
+      state
+    ) values (
+      new.resolved_tenant_id,
+      nullif(trim(new.payload->>'company_name'), ''),
+      nullif(trim(new.payload->>'contact_name'), ''),
+      lower(nullif(trim(new.payload->>'email'), '')),
+      nullif(trim(new.payload->>'phone'), ''),
+      'pending',
+      new.payload,
+      new.payload,
+      'submitted'
+    )
+    returning id into v_destination_id;
+
+    update public.application_intake
+    set status = 'processed',
+        processed_at = now(),
+        destination_table = 'employer_applications',
+        destination_id = v_destination_id,
+        error = null
+    where id = new.id;
+
+  elsif new.application_type = 'staff' then
+    insert into public.staff_applications (
+      tenant_id,
+      full_name,
+      email,
+      phone,
+      position,
+      status,
+      data
+    ) values (
+      new.resolved_tenant_id,
+      coalesce(
+        nullif(trim(new.payload->>'full_name'), ''),
+        trim(concat_ws(' ', new.payload->>'first_name', new.payload->>'last_name'))
+      ),
+      lower(nullif(trim(new.payload->>'email'), '')),
+      nullif(trim(new.payload->>'phone'), ''),
+      nullif(trim(new.payload->>'position'), ''),
+      'pending',
+      new.payload
+    )
+    returning id into v_destination_id;
+
+    update public.application_intake
+    set status = 'processed',
+        processed_at = now(),
+        destination_table = 'staff_applications',
+        destination_id = v_destination_id,
+        error = null
+    where id = new.id;
+
+  elsif new.application_type = 'program_holder' then
+    insert into public.program_holder_applications (
+      tenant_id,
+      organization_name,
+      contact_name,
+      email,
+      phone,
+      status,
+      data
+    ) values (
+      new.resolved_tenant_id,
+      nullif(trim(new.payload->>'organization_name'), ''),
+      nullif(trim(new.payload->>'contact_name'), ''),
+      lower(nullif(trim(new.payload->>'email'), '')),
+      nullif(trim(new.payload->>'phone'), ''),
+      'pending',
+      new.payload
+    )
+    returning id into v_destination_id;
+
+    update public.application_intake
+    set status = 'processed',
+        processed_at = now(),
+        destination_table = 'program_holder_applications',
+        destination_id = v_destination_id,
+        error = null
+    where id = new.id;
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.promote_public_application_intake_v1() from public;
+grant execute on function public.promote_public_application_intake_v1() to service_role;
+
+drop trigger if exists trg_promote_public_application_intake_v1
+  on public.application_intake;
+
+create trigger trg_promote_public_application_intake_v1
+after insert on public.application_intake
+for each row
+when (new.status = 'received')
+execute function public.promote_public_application_intake_v1();
+
+comment on function public.promote_public_application_intake_v1()
+is 'Synchronously promotes Employer, Staff, and Program Holder public intake rows into canonical Admin review tables and marks intake processed.';


### PR DESCRIPTION
Completes the application audit by removing an undeployed orchestration dependency.

Production finding:
- Employer, Staff, and Program Holder public forms save into `application_intake`.
- The repository has a `process-intake` Edge Function, but that function is not deployed in the production Supabase project.
- Without a processor, an acknowledged form can remain stranded in `application_intake` and never appear in its Admin review table.

Fix:
- adds an idempotent database trigger/function on `application_intake`
- Employer -> `employer_applications`
- Staff -> `staff_applications`
- Program Holder -> `program_holder_applications`
- canonical records are created synchronously in the same transaction with `status='pending'`
- intake rows are marked `processed` with `destination_table` and `destination_id`
- if canonical promotion fails, the original insert transaction fails rather than returning a false-success submission

The migration has already been applied successfully to the production Supabase project. Future deployment of `process-intake` will not duplicate these records because that function selects only `status='received'`, while the trigger marks these rows `processed` immediately.

No Marketing/LMS/Admin application code differs from main in this PR; the only net diff is the tracked migration.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Promote public application intake rows into canonical review tables on insert
> - Adds a `SECURITY DEFINER` trigger function `public.promote_public_application_intake_v1` that fires after inserting a row into `public.application_intake` with `status = 'received'`.
> - Routes the intake payload into `public.employer_applications`, `public.staff_applications`, or `public.program_holder_applications` based on `application_type`, normalizing email to lowercase and coercing empty strings to NULL.
> - After inserting into the destination table, updates the source intake row with `status = 'processed'`, `processed_at`, `destination_table`, and `destination_id`, and clears any error.
> - Restricts direct `EXECUTE` on the function to `service_role`; trigger execution is unaffected due to `SECURITY DEFINER`.
> - Migration defined in [20260811214500_promote_public_application_intake.sql](https://github.com/elevate-for-humanity/Elevate-lms/pull/602/files#diff-f91ea706132c45beb802d5d6a7f96c39e6e63b038e68f6ee840d2d30cea42ab1).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized f37f350.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->