### PR TITLE
fix(program-holder): secure approval and complete onboarding

### DIFF
--- a/apps/admin/app/api/program-holder/applications/[id]/approve/route.ts
+++ b/apps/admin/app/api/program-holder/applications/[id]/approve/route.ts
@@ -8,12 +8,23 @@ import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 const ADMIN_ROLES = new Set(['admin', 'super_admin', 'staff', 'org_admin']);
 const PORTAL_BASE = 'https://www.elevateforhumanity.org';
 
+type AuthUserSummary = { id: string; email?: string | null };
+
 function splitName(fullName: string) {
   const parts = fullName.trim().split(/\s+/).filter(Boolean);
   return {
     firstName: parts.shift() || fullName,
     lastName: parts.join(' ') || null,
   };
+}
+
+function escapeHtml(value: unknown) {
+  return String(value ?? '')
+    .replaceAll('&', '&amp;')
+    .replaceAll('<', '&lt;')
+    .replaceAll('>', '&gt;')
+    .replaceAll('"', '&quot;')
+    .replaceAll("'", '&#039;');
 }
 
 async function requireAdminActor() {
@@ -30,7 +41,7 @@ async function requireAdminActor() {
   if (!profile || !ADMIN_ROLES.has(String(profile.role || ''))) {
     return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) } as const;
   }
-  return { db, user, profile } as const;
+  return { db, user } as const;
 }
 
 async function findOrCreateUser(
@@ -45,12 +56,17 @@ async function findOrCreateUser(
     .eq('email', normalizedEmail)
     .maybeSingle();
   if (existingProfile?.id) {
-    return { userId: String(existingProfile.id), isNewUser: false, existingRole: String(existingProfile.role || '') };
+    return {
+      userId: String(existingProfile.id),
+      isNewUser: false,
+      existingRole: String(existingProfile.role || ''),
+    };
   }
 
   const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
-  const existingAuthUser = (listed?.users ?? []).find(
-    (candidate: { id: string; email?: string | null }) => candidate.email?.toLowerCase() === normalizedEmail,
+  const users = (listed?.users ?? []) as AuthUserSummary[];
+  const existingAuthUser = users.find(
+    (candidate) => candidate.email?.toLowerCase() === normalizedEmail,
   );
   if (existingAuthUser?.id) {
     return { userId: existingAuthUser.id, isNewUser: false, existingRole: '' };
@@ -63,7 +79,9 @@ async function findOrCreateUser(
     email_confirm: true,
     user_metadata: { full_name: fullName, role: 'program_holder' },
   });
-  if (error || !data.user?.id) throw new Error(error?.message || 'Unable to create Program Holder account.');
+  if (error || !data.user?.id) {
+    throw new Error(error?.message || 'Unable to create Program Holder account.');
+  }
   return { userId: data.user.id, isNewUser: true, existingRole: '' };
 }
 
@@ -125,8 +143,8 @@ export async function POST(
 
     if (applicationError) throw applicationError;
     if (!application) return NextResponse.json({ error: 'Application not found.' }, { status: 404 });
-    if (application.status === 'denied') {
-      return NextResponse.json({ error: 'Denied applications must be reopened before approval.' }, { status: 409 });
+    if (application.status === 'rejected') {
+      return NextResponse.json({ error: 'Rejected applications must be reopened before approval.' }, { status: 409 });
     }
 
     const email = String(application.email || '').toLowerCase().trim();
@@ -134,42 +152,52 @@ export async function POST(
     if (!email) return NextResponse.json({ error: 'Application has no email address.' }, { status: 400 });
 
     const identity = await findOrCreateUser(db, email, contactName);
+    const { data: priorMou } = await db
+      .from('license_agreement_acceptances')
+      .select('accepted_at')
+      .eq('user_id', identity.userId)
+      .eq('agreement_type', 'program_holder_mou')
+      .order('accepted_at', { ascending: true })
+      .limit(1)
+      .maybeSingle();
 
     const { data: existingHolder } = await db
       .from('program_holders')
-      .select('id, user_id, status, approved_at, mou_signed')
+      .select('id, user_id, status, approved_at, mou_signed, mou_signed_at')
       .or(`user_id.eq.${identity.userId},contact_email.eq.${email}`)
       .limit(1)
       .maybeSingle();
 
     const now = new Date().toISOString();
-    let holderId = existingHolder?.id as string | undefined;
+    const alreadySigned = Boolean(existingHolder?.mou_signed || priorMou?.accepted_at);
     const holderPayload = {
-      tenant_id: application.tenant_id || null,
       user_id: identity.userId,
       organization_name: application.organization_name,
+      name: application.organization_name,
       contact_name: contactName,
       contact_email: email,
       contact_phone: application.phone || null,
       status: 'approved',
-      onboarding_completed: false,
-      approved_at: now,
+      approved_at: existingHolder?.approved_at || now,
       approved_by: adminUser.id,
-      source: 'program_holder_application',
-      updated_at: now,
+      mou_signed: alreadySigned,
+      mou_signed_at: existingHolder?.mou_signed_at || priorMou?.accepted_at || null,
+      mou_status: alreadySigned ? 'signed' : 'pending_signature',
     };
 
-    if (holderId) {
+    let holderId: string;
+    if (existingHolder?.id) {
+      holderId = String(existingHolder.id);
       const { error } = await db.from('program_holders').update(holderPayload).eq('id', holderId);
       if (error) throw error;
     } else {
       const { data, error } = await db
         .from('program_holders')
-        .insert({ ...holderPayload, created_at: now })
+        .insert(holderPayload)
         .select('id')
         .single();
       if (error || !data?.id) throw error || new Error('Program Holder record was not created.');
-      holderId = data.id;
+      holderId = String(data.id);
     }
 
     const { firstName, lastName } = splitName(contactName);
@@ -220,11 +248,12 @@ export async function POST(
 
     const accessLink = await secureAccessLink(db, email, identity.isNewUser);
     const portalUrl = `${PORTAL_BASE}/program-holder/dashboard`;
+    const nextUrl = alreadySigned ? portalUrl : `${PORTAL_BASE}/program-holder/sign-mou`;
     const subject = 'Program Holder Application Approved — Complete Your Onboarding | Elevate for Humanity';
     const result = await sendEmail({
       to: email,
       subject,
-      html: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto;color:#0f172a"><h2>Your Program Holder application is approved</h2><p>Hello ${contactName},</p><p><strong>${application.organization_name}</strong> has been approved to continue Program Holder onboarding with Elevate for Humanity.</p><p><strong>Username:</strong> ${email}</p><p>For security, Elevate does not email a plaintext password.</p><p><a href="${accessLink || portalUrl}" style="display:inline-block;background:#1d4ed8;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:bold">${identity.isNewUser ? 'Set Password & Continue Onboarding' : 'Secure Sign In & Continue Onboarding'}</a></p><h3>Next steps</h3><ol><li>Sign the required Program Holder MOU.</li><li>Complete your organization profile and required verification documents.</li><li>Elevate links only the programs you are authorized to manage.</li><li>Use the Program Holder portal for approved programs, students, documents, training-hour actions, and reporting.</li></ol><p>Portal: <a href="${portalUrl}">${portalUrl}</a></p><p>Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      html: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto;color:#0f172a"><h2>Your Program Holder application is approved</h2><p>Hello ${escapeHtml(contactName)},</p><p><strong>${escapeHtml(application.organization_name)}</strong> has been approved to continue Program Holder onboarding with Elevate for Humanity.</p><p><strong>Username:</strong> ${escapeHtml(email)}</p><p>For security, Elevate does not email a plaintext password.</p><p><a href="${accessLink || nextUrl}" style="display:inline-block;background:#1d4ed8;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:bold">${identity.isNewUser ? 'Set Password & Continue Onboarding' : 'Secure Sign In & Continue Onboarding'}</a></p><h3>Next steps</h3><ol>${alreadySigned ? '' : '<li>Sign the required Program Holder MOU.</li>'}<li>Complete your organization verification requirements.</li><li>Elevate links only the programs you are authorized to manage.</li><li>Use the Program Holder portal for approved programs, students, documents, training-hour actions, and reporting.</li></ol><p>Portal: <a href="${portalUrl}">${portalUrl}</a></p><p>Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
     });
     await auditEmail(db, {
       recipient: email,
@@ -234,7 +263,9 @@ export async function POST(
       error: result.success ? undefined : result.error,
     });
 
-    if (!result.success) {
+    if (result.success) {
+      await db.from('program_holders').update({ welcome_email_sent: true }).eq('id', holderId);
+    } else {
       await db.from('staff_notifications').insert({
         type: 'program_holder_approval_email_failed',
         title: `Program Holder approved but onboarding email failed: ${application.organization_name}`,
@@ -249,6 +280,7 @@ export async function POST(
       applicationId: id,
       programHolderId: holderId,
       userId: identity.userId,
+      mouSigned: alreadySigned,
       emailStatus: result.success ? 'sent' : 'failed',
     });
   } catch (error) {

--- a/apps/admin/app/api/program-holder/applications/[id]/approve/route.ts
+++ b/apps/admin/app/api/program-holder/applications/[id]/approve/route.ts
@@ -1,0 +1,261 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { sendEmail } from '@/lib/email/sendgrid';
+import { logger } from '@/lib/logger';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+const ADMIN_ROLES = new Set(['admin', 'super_admin', 'staff', 'org_admin']);
+const PORTAL_BASE = 'https://www.elevateforhumanity.org';
+
+function splitName(fullName: string) {
+  const parts = fullName.trim().split(/\s+/).filter(Boolean);
+  return {
+    firstName: parts.shift() || fullName,
+    lastName: parts.join(' ') || null,
+  };
+}
+
+async function requireAdminActor() {
+  const auth = await createClient();
+  const db = await requireAdminClient();
+  const { data: { user } } = await auth.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) } as const;
+
+  const { data: profile } = await db
+    .from('profiles')
+    .select('id, role')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (!profile || !ADMIN_ROLES.has(String(profile.role || ''))) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) } as const;
+  }
+  return { db, user, profile } as const;
+}
+
+async function findOrCreateUser(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  email: string,
+  fullName: string,
+) {
+  const normalizedEmail = email.toLowerCase().trim();
+  const { data: existingProfile } = await db
+    .from('profiles')
+    .select('id, role, program_holder_id')
+    .eq('email', normalizedEmail)
+    .maybeSingle();
+  if (existingProfile?.id) {
+    return { userId: String(existingProfile.id), isNewUser: false, existingRole: String(existingProfile.role || '') };
+  }
+
+  const { data: listed } = await db.auth.admin.listUsers({ page: 1, perPage: 1000 });
+  const existingAuthUser = (listed?.users ?? []).find(
+    (candidate: { id: string; email?: string | null }) => candidate.email?.toLowerCase() === normalizedEmail,
+  );
+  if (existingAuthUser?.id) {
+    return { userId: existingAuthUser.id, isNewUser: false, existingRole: '' };
+  }
+
+  const tempPassword = `${crypto.randomUUID().replace(/-/g, '')}Aa1!`;
+  const { data, error } = await db.auth.admin.createUser({
+    email: normalizedEmail,
+    password: tempPassword,
+    email_confirm: true,
+    user_metadata: { full_name: fullName, role: 'program_holder' },
+  });
+  if (error || !data.user?.id) throw new Error(error?.message || 'Unable to create Program Holder account.');
+  return { userId: data.user.id, isNewUser: true, existingRole: '' };
+}
+
+async function secureAccessLink(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  email: string,
+  isNewUser: boolean,
+) {
+  const redirectTo = `${PORTAL_BASE}/auth/callback?redirect=${encodeURIComponent('/program-holder/sign-mou')}`;
+  const { data, error } = await db.auth.admin.generateLink({
+    type: isNewUser ? 'recovery' : 'magiclink',
+    email: email.toLowerCase().trim(),
+    options: { redirectTo },
+  });
+  if (error) {
+    logger.warn('[program-holder/approve] secure access link failed', { email, error: error.message });
+    return null;
+  }
+  return data?.properties?.action_link || null;
+}
+
+async function auditEmail(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  params: { recipient: string; subject: string; applicationId: string; success: boolean; error?: string },
+) {
+  await db.from('email_logs').insert({
+    action: 'program_holder_approval_notification',
+    recipient_email: params.recipient,
+    recipient: params.recipient,
+    to: params.recipient,
+    subject: params.subject,
+    provider: 'sendgrid',
+    status: params.success ? 'sent' : 'failed',
+    error_message: params.error || null,
+    error: params.error || null,
+    sent_at: params.success ? new Date().toISOString() : null,
+    details: { application_id: params.applicationId, application_type: 'program_holder', event: 'approved' },
+    metadata: { application_id: params.applicationId, application_type: 'program_holder', event: 'approved' },
+  }).then(({ error }) => {
+    if (error) logger.warn('[program-holder/approve] email audit failed', { error: error.message });
+  });
+}
+
+export async function POST(
+  _request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireAdminActor();
+    if ('error' in actor) return actor.error;
+    const { db, user: adminUser } = actor;
+    const { id } = await params;
+
+    const { data: application, error: applicationError } = await db
+      .from('program_holder_applications')
+      .select('id, tenant_id, user_id, organization_name, contact_name, email, phone, status, data')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (applicationError) throw applicationError;
+    if (!application) return NextResponse.json({ error: 'Application not found.' }, { status: 404 });
+    if (application.status === 'denied') {
+      return NextResponse.json({ error: 'Denied applications must be reopened before approval.' }, { status: 409 });
+    }
+
+    const email = String(application.email || '').toLowerCase().trim();
+    const contactName = String(application.contact_name || application.organization_name || 'Program Holder').trim();
+    if (!email) return NextResponse.json({ error: 'Application has no email address.' }, { status: 400 });
+
+    const identity = await findOrCreateUser(db, email, contactName);
+
+    const { data: existingHolder } = await db
+      .from('program_holders')
+      .select('id, user_id, status, approved_at, mou_signed')
+      .or(`user_id.eq.${identity.userId},contact_email.eq.${email}`)
+      .limit(1)
+      .maybeSingle();
+
+    const now = new Date().toISOString();
+    let holderId = existingHolder?.id as string | undefined;
+    const holderPayload = {
+      tenant_id: application.tenant_id || null,
+      user_id: identity.userId,
+      organization_name: application.organization_name,
+      contact_name: contactName,
+      contact_email: email,
+      contact_phone: application.phone || null,
+      status: 'approved',
+      onboarding_completed: false,
+      approved_at: now,
+      approved_by: adminUser.id,
+      source: 'program_holder_application',
+      updated_at: now,
+    };
+
+    if (holderId) {
+      const { error } = await db.from('program_holders').update(holderPayload).eq('id', holderId);
+      if (error) throw error;
+    } else {
+      const { data, error } = await db
+        .from('program_holders')
+        .insert({ ...holderPayload, created_at: now })
+        .select('id')
+        .single();
+      if (error || !data?.id) throw error || new Error('Program Holder record was not created.');
+      holderId = data.id;
+    }
+
+    const { firstName, lastName } = splitName(contactName);
+    const privilegedRole = ['admin', 'super_admin', 'staff', 'org_admin'].includes(identity.existingRole);
+    const { data: profile } = await db.from('profiles').select('id').eq('id', identity.userId).maybeSingle();
+    if (profile?.id) {
+      const { error } = await db
+        .from('profiles')
+        .update({
+          program_holder_id: holderId,
+          ...(privilegedRole ? {} : { role: 'program_holder' }),
+        })
+        .eq('id', identity.userId);
+      if (error) throw error;
+    } else {
+      const { error } = await db.from('profiles').insert({
+        id: identity.userId,
+        email,
+        full_name: contactName,
+        first_name: firstName,
+        last_name: lastName,
+        phone: application.phone || null,
+        role: 'program_holder',
+        program_holder_id: holderId,
+        tenant_id: application.tenant_id || null,
+      });
+      if (error) throw error;
+    }
+
+    const existingData = application.data && typeof application.data === 'object' && !Array.isArray(application.data)
+      ? application.data
+      : {};
+    const { error: appUpdateError } = await db
+      .from('program_holder_applications')
+      .update({
+        status: 'approved',
+        user_id: identity.userId,
+        data: {
+          ...existingData,
+          approved_at: now,
+          approved_by: adminUser.id,
+          program_holder_id: holderId,
+        },
+        updated_at: now,
+      })
+      .eq('id', id);
+    if (appUpdateError) throw appUpdateError;
+
+    const accessLink = await secureAccessLink(db, email, identity.isNewUser);
+    const portalUrl = `${PORTAL_BASE}/program-holder/dashboard`;
+    const subject = 'Program Holder Application Approved — Complete Your Onboarding | Elevate for Humanity';
+    const result = await sendEmail({
+      to: email,
+      subject,
+      html: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto;color:#0f172a"><h2>Your Program Holder application is approved</h2><p>Hello ${contactName},</p><p><strong>${application.organization_name}</strong> has been approved to continue Program Holder onboarding with Elevate for Humanity.</p><p><strong>Username:</strong> ${email}</p><p>For security, Elevate does not email a plaintext password.</p><p><a href="${accessLink || portalUrl}" style="display:inline-block;background:#1d4ed8;color:#fff;padding:12px 20px;border-radius:8px;text-decoration:none;font-weight:bold">${identity.isNewUser ? 'Set Password & Continue Onboarding' : 'Secure Sign In & Continue Onboarding'}</a></p><h3>Next steps</h3><ol><li>Sign the required Program Holder MOU.</li><li>Complete your organization profile and required verification documents.</li><li>Elevate links only the programs you are authorized to manage.</li><li>Use the Program Holder portal for approved programs, students, documents, training-hour actions, and reporting.</li></ol><p>Portal: <a href="${portalUrl}">${portalUrl}</a></p><p>Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+    });
+    await auditEmail(db, {
+      recipient: email,
+      subject,
+      applicationId: id,
+      success: result.success === true,
+      error: result.success ? undefined : result.error,
+    });
+
+    if (!result.success) {
+      await db.from('staff_notifications').insert({
+        type: 'program_holder_approval_email_failed',
+        title: `Program Holder approved but onboarding email failed: ${application.organization_name}`,
+        message: `Application ${id} was approved and account provisioned, but the onboarding email to ${email} failed: ${result.error || 'unknown error'}`,
+        severity: 'error',
+        metadata: { application_id: id, program_holder_id: holderId, email, error: result.error || null },
+      });
+    }
+
+    return NextResponse.json({
+      success: true,
+      applicationId: id,
+      programHolderId: holderId,
+      userId: identity.userId,
+      emailStatus: result.success ? 'sent' : 'failed',
+    });
+  } catch (error) {
+    logger.error('[admin/program-holder/approve] failed', error instanceof Error ? error : undefined);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to approve Program Holder application.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/api/program-holder/applications/[id]/deny/route.ts
+++ b/apps/admin/app/api/program-holder/applications/[id]/deny/route.ts
@@ -1,0 +1,127 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { sendEmail } from '@/lib/email/sendgrid';
+import { logger } from '@/lib/logger';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
+
+const ADMIN_ROLES = new Set(['admin', 'super_admin', 'staff', 'org_admin']);
+
+async function requireAdminActor() {
+  const auth = await createClient();
+  const db = await requireAdminClient();
+  const { data: { user } } = await auth.auth.getUser();
+  if (!user) return { error: NextResponse.json({ error: 'Unauthorized' }, { status: 401 }) } as const;
+
+  const { data: profile } = await db
+    .from('profiles')
+    .select('id, role')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (!profile || !ADMIN_ROLES.has(String(profile.role || ''))) {
+    return { error: NextResponse.json({ error: 'Forbidden' }, { status: 403 }) } as const;
+  }
+  return { db, user } as const;
+}
+
+async function auditEmail(
+  db: Awaited<ReturnType<typeof requireAdminClient>>,
+  params: { recipient: string; subject: string; applicationId: string; success: boolean; error?: string },
+) {
+  await db.from('email_logs').insert({
+    action: 'program_holder_denial_notification',
+    recipient_email: params.recipient,
+    recipient: params.recipient,
+    to: params.recipient,
+    subject: params.subject,
+    provider: 'sendgrid',
+    status: params.success ? 'sent' : 'failed',
+    error_message: params.error || null,
+    error: params.error || null,
+    sent_at: params.success ? new Date().toISOString() : null,
+    details: { application_id: params.applicationId, application_type: 'program_holder', event: 'denied' },
+    metadata: { application_id: params.applicationId, application_type: 'program_holder', event: 'denied' },
+  }).then(({ error }) => {
+    if (error) logger.warn('[program-holder/deny] email audit failed', { error: error.message });
+  });
+}
+
+export async function POST(
+  request: NextRequest,
+  { params }: { params: Promise<{ id: string }> },
+) {
+  try {
+    const actor = await requireAdminActor();
+    if ('error' in actor) return actor.error;
+    const { db, user: adminUser } = actor;
+    const { id } = await params;
+    const body = await request.json().catch(() => ({}));
+    const reason = String(body?.reason || '').trim().slice(0, 2000);
+
+    const { data: application, error: applicationError } = await db
+      .from('program_holder_applications')
+      .select('id, organization_name, contact_name, email, status, data')
+      .eq('id', id)
+      .maybeSingle();
+    if (applicationError) throw applicationError;
+    if (!application) return NextResponse.json({ error: 'Application not found.' }, { status: 404 });
+    if (application.status === 'approved') {
+      return NextResponse.json({ error: 'Approved applications must be revoked through the Program Holder record, not denied.' }, { status: 409 });
+    }
+
+    const existingData = application.data && typeof application.data === 'object' && !Array.isArray(application.data)
+      ? application.data
+      : {};
+    const now = new Date().toISOString();
+    const { error: updateError } = await db
+      .from('program_holder_applications')
+      .update({
+        status: 'denied',
+        data: {
+          ...existingData,
+          denied_at: now,
+          denied_by: adminUser.id,
+          denial_reason: reason || null,
+        },
+        updated_at: now,
+      })
+      .eq('id', id);
+    if (updateError) throw updateError;
+
+    const email = String(application.email || '').trim().toLowerCase();
+    let emailStatus: 'sent' | 'failed' | 'skipped' = 'skipped';
+    if (email) {
+      const subject = 'Program Holder Application Update | Elevate for Humanity';
+      const result = await sendEmail({
+        to: email,
+        subject,
+        html: `<div style="font-family:Arial,sans-serif;max-width:640px;margin:auto;color:#0f172a"><h2>Program Holder application update</h2><p>Hello ${application.contact_name || 'Program Holder applicant'},</p><p>We completed the review of the Program Holder application for <strong>${application.organization_name}</strong>. We are unable to approve it at this time.</p>${reason ? `<p><strong>Review note:</strong> ${reason}</p>` : ''}<p>If you believe information is missing or has changed, reply to this email before submitting another application.</p><p>Questions? Call ${PLATFORM_DEFAULTS.supportPhone}.</p></div>`,
+      });
+      emailStatus = result.success ? 'sent' : 'failed';
+      await auditEmail(db, {
+        recipient: email,
+        subject,
+        applicationId: id,
+        success: result.success === true,
+        error: result.success ? undefined : result.error,
+      });
+      if (!result.success) {
+        await db.from('staff_notifications').insert({
+          type: 'program_holder_denial_email_failed',
+          title: `Program Holder denial email failed: ${application.organization_name}`,
+          message: `Application ${id} was denied, but the applicant email to ${email} failed: ${result.error || 'unknown error'}`,
+          severity: 'error',
+          metadata: { application_id: id, email, error: result.error || null },
+        });
+      }
+    }
+
+    return NextResponse.json({ success: true, applicationId: id, emailStatus });
+  } catch (error) {
+    logger.error('[admin/program-holder/deny] failed', error instanceof Error ? error : undefined);
+    return NextResponse.json(
+      { error: error instanceof Error ? error.message : 'Unable to deny Program Holder application.' },
+      { status: 500 },
+    );
+  }
+}

--- a/apps/admin/app/api/program-holder/applications/[id]/deny/route.ts
+++ b/apps/admin/app/api/program-holder/applications/[id]/deny/route.ts
@@ -39,8 +39,8 @@ async function auditEmail(
     error_message: params.error || null,
     error: params.error || null,
     sent_at: params.success ? new Date().toISOString() : null,
-    details: { application_id: params.applicationId, application_type: 'program_holder', event: 'denied' },
-    metadata: { application_id: params.applicationId, application_type: 'program_holder', event: 'denied' },
+    details: { application_id: params.applicationId, application_type: 'program_holder', event: 'rejected' },
+    metadata: { application_id: params.applicationId, application_type: 'program_holder', event: 'rejected' },
   }).then(({ error }) => {
     if (error) logger.warn('[program-holder/deny] email audit failed', { error: error.message });
   });
@@ -76,12 +76,12 @@ export async function POST(
     const { error: updateError } = await db
       .from('program_holder_applications')
       .update({
-        status: 'denied',
+        status: 'rejected',
         data: {
           ...existingData,
-          denied_at: now,
-          denied_by: adminUser.id,
-          denial_reason: reason || null,
+          rejected_at: now,
+          rejected_by: adminUser.id,
+          rejection_reason: reason || null,
         },
         updated_at: now,
       })
@@ -108,15 +108,15 @@ export async function POST(
       if (!result.success) {
         await db.from('staff_notifications').insert({
           type: 'program_holder_denial_email_failed',
-          title: `Program Holder denial email failed: ${application.organization_name}`,
-          message: `Application ${id} was denied, but the applicant email to ${email} failed: ${result.error || 'unknown error'}`,
+          title: `Program Holder rejection email failed: ${application.organization_name}`,
+          message: `Application ${id} was rejected, but the applicant email to ${email} failed: ${result.error || 'unknown error'}`,
           severity: 'error',
           metadata: { application_id: id, email, error: result.error || null },
         });
       }
     }
 
-    return NextResponse.json({ success: true, applicationId: id, emailStatus });
+    return NextResponse.json({ success: true, applicationId: id, status: 'rejected', emailStatus });
   } catch (error) {
     logger.error('[admin/program-holder/deny] failed', error instanceof Error ? error : undefined);
     return NextResponse.json(

--- a/apps/marketing/app/api/program-holder/applications/[id]/approve/route.ts
+++ b/apps/marketing/app/api/program-holder/applications/[id]/approve/route.ts
@@ -1,30 +1,16 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const supabase = await createClient();
-
-    const { data, error } = await supabase
-      .from('program_holder_applications')
-      .update({
-        status: 'approved',
-        approved_at: new Date().toISOString(),
-      })
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    return NextResponse.json({ success: true, data });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
-  }
+/**
+ * Program Holder review is an Admin-only mutation.
+ *
+ * This public Marketing endpoint previously changed application status without
+ * enforcing Admin authorization and also wrote columns that do not exist in
+ * the production application table. Keep the route closed so old bookmarks or
+ * clients cannot mutate review state through the public site.
+ */
+export async function POST() {
+  return NextResponse.json(
+    { error: 'Program Holder application review is available only in the Admin portal.' },
+    { status: 410 },
+  );
 }

--- a/apps/marketing/app/api/program-holder/applications/[id]/approve/route.ts
+++ b/apps/marketing/app/api/program-holder/applications/[id]/approve/route.ts
@@ -1,16 +1,6 @@
-import { NextResponse } from 'next/server';
+import { publicProgramHolderReviewDisabled } from '@/lib/program-holders/public-review-disabled';
 
-/**
- * Program Holder review is an Admin-only mutation.
- *
- * This public Marketing endpoint previously changed application status without
- * enforcing Admin authorization and also wrote columns that do not exist in
- * the production application table. Keep the route closed so old bookmarks or
- * clients cannot mutate review state through the public site.
- */
+/** Public Marketing review mutation is closed; authenticated Admin owns approval. */
 export async function POST() {
-  return NextResponse.json(
-    { error: 'Program Holder application review is available only in the Admin portal.' },
-    { status: 410 },
-  );
+  return publicProgramHolderReviewDisabled('approval');
 }

--- a/apps/marketing/app/api/program-holder/applications/[id]/deny/route.ts
+++ b/apps/marketing/app/api/program-holder/applications/[id]/deny/route.ts
@@ -1,15 +1,6 @@
-import { NextResponse } from 'next/server';
+import { publicProgramHolderReviewDisabled } from '@/lib/program-holders/public-review-disabled';
 
-/**
- * Program Holder denial is an Admin-only mutation.
- *
- * The public Marketing endpoint is intentionally closed. Review actions belong
- * to the authenticated Admin service, which also owns applicant notification
- * and audit logging.
- */
+/** Public Marketing review mutation is closed; authenticated Admin owns rejection. */
 export async function POST() {
-  return NextResponse.json(
-    { error: 'Program Holder application review is available only in the Admin portal.' },
-    { status: 410 },
-  );
+  return publicProgramHolderReviewDisabled('rejection');
 }

--- a/apps/marketing/app/api/program-holder/applications/[id]/deny/route.ts
+++ b/apps/marketing/app/api/program-holder/applications/[id]/deny/route.ts
@@ -1,33 +1,15 @@
-import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
+import { NextResponse } from 'next/server';
 
-export async function POST(
-  request: NextRequest,
-  { params }: { params: Promise<{ id: string }> }
-) {
-  try {
-    const { id } = await params;
-    const supabase = await createClient();
-    const body = await request.json();
-    const { reason } = body;
-
-    const { data, error } = await supabase
-      .from('program_holder_applications')
-      .update({
-        status: 'denied',
-        denied_at: new Date().toISOString(),
-        denial_reason: reason || null,
-      })
-      .eq('id', id)
-      .select()
-      .single();
-
-    if (error) {
-      return NextResponse.json({ error: error.message }, { status: 500 });
-    }
-
-    return NextResponse.json({ success: true, data });
-  } catch (err: any) {
-    return NextResponse.json({ error: err.message }, { status: 500 });
-  }
+/**
+ * Program Holder denial is an Admin-only mutation.
+ *
+ * The public Marketing endpoint is intentionally closed. Review actions belong
+ * to the authenticated Admin service, which also owns applicant notification
+ * and audit logging.
+ */
+export async function POST() {
+  return NextResponse.json(
+    { error: 'Program Holder application review is available only in the Admin portal.' },
+    { status: 410 },
+  );
 }

--- a/apps/marketing/app/program-holder/onboarding/page.tsx
+++ b/apps/marketing/app/program-holder/onboarding/page.tsx
@@ -1,7 +1,41 @@
-export const metadata = { robots: { index: false } };
-
 import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
 
-export default function ProgramHolderOnboardingPage() {
-  redirect('/program-holder');
+export const dynamic = 'force-dynamic';
+export const metadata = { robots: { index: false, follow: false } };
+
+export default async function ProgramHolderOnboardingPage() {
+  const auth = await createClient();
+  const db = await requireAdminClient();
+  const { data: { user } } = await auth.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect=/program-holder/onboarding');
+  }
+
+  const { data: profile } = await db
+    .from('profiles')
+    .select('program_holder_id')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (!profile?.program_holder_id) {
+    redirect('/apply/program-holder?status=pending');
+  }
+
+  const { data: holder } = await db
+    .from('program_holders')
+    .select('status, approved_at, mou_signed')
+    .eq('id', profile.program_holder_id)
+    .maybeSingle();
+
+  if (!holder || !holder.approved_at || !['approved', 'active'].includes(String(holder.status || ''))) {
+    redirect('/apply/program-holder?status=pending');
+  }
+
+  if (!holder.mou_signed) {
+    redirect('/program-holder/sign-mou');
+  }
+
+  redirect('/program-holder/dashboard');
 }

--- a/apps/marketing/app/program-holder/sign-mou/page.tsx
+++ b/apps/marketing/app/program-holder/sign-mou/page.tsx
@@ -1,7 +1,87 @@
-export const metadata = { robots: { index: false } };
-
+import Link from 'next/link';
 import { redirect } from 'next/navigation';
+import { createClient } from '@/lib/supabase/server';
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { DocumentSignatureBlock } from '@/components/documents';
+import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
-export default function SignMouPage() {
-  redirect('/legal/program-host-agreement');
+export const dynamic = 'force-dynamic';
+export const metadata = {
+  title: 'Program Holder MOU | Elevate for Humanity',
+  robots: { index: false, follow: false },
+};
+
+export default async function SignMouPage() {
+  const auth = await createClient();
+  const db = await requireAdminClient();
+  const { data: { user } } = await auth.auth.getUser();
+
+  if (!user) {
+    redirect('/login?redirect=/program-holder/sign-mou');
+  }
+
+  const { data: profile } = await db
+    .from('profiles')
+    .select('id, full_name, program_holder_id')
+    .eq('id', user.id)
+    .maybeSingle();
+  if (!profile?.program_holder_id) {
+    redirect('/program-holder?error=pending-approval');
+  }
+
+  const { data: holder } = await db
+    .from('program_holders')
+    .select('id, organization_name, status, approved_at, mou_signed')
+    .eq('id', profile.program_holder_id)
+    .maybeSingle();
+  if (!holder || !holder.approved_at || !['approved', 'active'].includes(String(holder.status || ''))) {
+    redirect('/program-holder?error=pending-approval');
+  }
+  if (holder.mou_signed) {
+    redirect('/program-holder/dashboard');
+  }
+
+  return (
+    <main className="min-h-screen bg-slate-50 px-4 py-10 text-slate-950">
+      <div className="mx-auto max-w-3xl rounded-2xl border border-slate-200 bg-white p-6 shadow-sm sm:p-9">
+        <p className="text-sm font-black uppercase tracking-[0.16em] text-blue-800">Program Holder onboarding</p>
+        <h1 className="mt-3 text-3xl font-black sm:text-4xl">Sign the Program Holder MOU</h1>
+        <p className="mt-4 text-base leading-7 text-slate-700">
+          Your application for <strong>{holder.organization_name}</strong> is approved. The MOU must be
+          signed before the Program Holder dashboard is unlocked.
+        </p>
+
+        <section className="mt-7 rounded-xl border border-blue-200 bg-blue-50 p-5 text-sm leading-6 text-blue-950">
+          <h2 className="font-black">Agreement incorporated by reference</h2>
+          <p className="mt-2">
+            By signing below, you acknowledge that you reviewed and accept the current Master Program
+            Host Agreement, including Elevate&apos;s control of curriculum, enrollment, credentials,
+            compliance, reporting, student records, and authorized program scope.
+          </p>
+          <Link
+            href="/legal/program-host-agreement"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="mt-3 inline-flex font-bold text-blue-800 underline"
+          >
+            Open the full Master Program Host Agreement
+          </Link>
+        </section>
+
+        <section className="mt-6 rounded-xl border border-amber-200 bg-amber-50 p-5 text-sm leading-6 text-amber-950">
+          <strong>After signature:</strong> your acceptance is recorded with timestamp and audit data,
+          your Program Holder record is marked MOU signed, and you are sent to the Program Holder
+          dashboard. Only programs explicitly authorized by {PLATFORM_DEFAULTS.orgName} will appear in
+          your account.
+        </section>
+
+        <DocumentSignatureBlock
+          agreementType="program_holder_mou"
+          agreementVersion="1.0"
+          buttonLabel="Sign Program Holder MOU & Continue"
+          nextUrl="/program-holder/dashboard"
+        />
+      </div>
+    </main>
+  );
 }

--- a/apps/marketing/app/program-holder/sign-mou/page.tsx
+++ b/apps/marketing/app/program-holder/sign-mou/page.tsx
@@ -26,7 +26,7 @@ export default async function SignMouPage() {
     .eq('id', user.id)
     .maybeSingle();
   if (!profile?.program_holder_id) {
-    redirect('/program-holder?error=pending-approval');
+    redirect('/apply/program-holder?status=pending');
   }
 
   const { data: holder } = await db
@@ -35,7 +35,7 @@ export default async function SignMouPage() {
     .eq('id', profile.program_holder_id)
     .maybeSingle();
   if (!holder || !holder.approved_at || !['approved', 'active'].includes(String(holder.status || ''))) {
-    redirect('/program-holder?error=pending-approval');
+    redirect('/apply/program-holder?status=pending');
   }
   if (holder.mou_signed) {
     redirect('/program-holder/dashboard');

--- a/lib/email/sendgrid.ts
+++ b/lib/email/sendgrid.ts
@@ -22,21 +22,79 @@ export interface EmailOptions {
   attachments?: EmailAttachment[];
 }
 
+type EmailSendResult = {
+  success: boolean;
+  error?: string;
+  data?: { provider: string };
+  from?: string;
+};
+
+async function auditTransportDelivery(
+  options: EmailOptions,
+  result: EmailSendResult,
+  resolvedFrom: string,
+  provider: 'sendgrid' | 'unconfigured' = 'sendgrid',
+): Promise<void> {
+  try {
+    // Dynamic import avoids making the email transport part of the Supabase
+    // bootstrap dependency graph. If the service-role client is unavailable
+    // (build-time/local tooling), email sending still behaves exactly as before.
+    const { getAdminClient } = await import('@/lib/supabase/admin');
+    const db = await getAdminClient();
+    if (!db) return;
+
+    const recipients = Array.isArray(options.to) ? options.to : [options.to];
+    const now = new Date().toISOString();
+    const rows = recipients
+      .map((recipient) => String(recipient || '').trim())
+      .filter(Boolean)
+      .map((recipient) => ({
+        action: 'email_transport_send',
+        recipient_email: recipient,
+        recipient,
+        to: recipient,
+        subject: options.subject,
+        provider,
+        status: result.success ? 'sent' : 'failed',
+        error_message: result.error ?? null,
+        error: result.error ?? null,
+        sent_at: result.success ? now : null,
+        details: {
+          transport: provider,
+          from: resolvedFrom,
+          has_attachments: Boolean(options.attachments?.length),
+          bcc_count: options.bcc ? (Array.isArray(options.bcc) ? options.bcc.length : 1) : 0,
+        },
+        metadata: {
+          transport: provider,
+          from: resolvedFrom,
+        },
+      }));
+
+    if (!rows.length) return;
+    const { error } = await db.from('email_logs').insert(rows);
+    if (error) {
+      logger.warn('[Email] delivery audit insert failed', { error: error.message });
+    }
+  } catch (error) {
+    logger.warn('[Email] delivery audit unavailable', {
+      error: error instanceof Error ? error.message : String(error),
+    });
+  }
+}
+
 /**
  * Send email via SendGrid HTTP API (no SDK — direct fetch).
  * All email in the app routes through this single function.
  * Hydrates secrets from Supabase app_secrets on first call.
+ *
+ * Every runtime send attempt is also written to email_logs when the service-role
+ * database client is available. That makes student/application emails auditable
+ * even when the calling feature does not maintain its own delivery log.
  */
-export async function sendEmail(options: EmailOptions) {
+export async function sendEmail(options: EmailOptions): Promise<EmailSendResult> {
   // Ensure runtime secrets (SENDGRID_API_KEY, EMAIL_FROM, etc.) are in process.env
   await hydrateProcessEnv();
-
-  const sendgridKey = process.env.SENDGRID_API_KEY;
-
-  if (!sendgridKey) {
-    logger.warn('[Email] SENDGRID_API_KEY not configured — email not sent');
-    return { success: false, error: 'Email service not configured. Set SENDGRID_API_KEY.' };
-  }
 
   const FROM_EMAIL =
     process.env.EMAIL_FROM ||
@@ -53,7 +111,26 @@ export async function sendEmail(options: EmailOptions) {
       : [options.bcc]
     : undefined;
 
-  return sendViaSendGrid(sendgridKey, { ...options, from, replyTo, to: toArr, bcc: bccArr });
+  const sendgridKey = process.env.SENDGRID_API_KEY;
+  if (!sendgridKey) {
+    logger.warn('[Email] SENDGRID_API_KEY not configured — email not sent');
+    const result: EmailSendResult = {
+      success: false,
+      error: 'Email service not configured. Set SENDGRID_API_KEY.',
+    };
+    await auditTransportDelivery(options, result, from, 'unconfigured');
+    return result;
+  }
+
+  const result = await sendViaSendGrid(sendgridKey, {
+    ...options,
+    from,
+    replyTo,
+    to: toArr,
+    bcc: bccArr,
+  });
+  await auditTransportDelivery(options, result, from, 'sendgrid');
+  return result;
 }
 
 async function sendViaSendGrid(
@@ -68,7 +145,7 @@ async function sendViaSendGrid(
     bcc?: string[];
     attachments?: EmailAttachment[];
   },
-) {
+): Promise<EmailSendResult> {
   try {
     const personalization: Record<string, unknown> = {
       to: opts.to.map((email) => ({ email })),

--- a/lib/program-holders/public-review-disabled.ts
+++ b/lib/program-holders/public-review-disabled.ts
@@ -1,0 +1,10 @@
+import { NextResponse } from 'next/server';
+
+export function publicProgramHolderReviewDisabled(action: 'approval' | 'rejection') {
+  return NextResponse.json(
+    {
+      error: `Program Holder ${action} is available only in the authenticated Admin portal.`,
+    },
+    { status: 410 },
+  );
+}

--- a/supabase/migrations/20260811220300_align_agreement_acceptance_schema.sql
+++ b/supabase/migrations/20260811220300_align_agreement_acceptance_schema.sql
@@ -1,6 +1,10 @@
 -- Align the live legal acceptance ledger with the canonical recorder in
 -- lib/legal/recordAgreementAcceptance.ts. Production previously lacked several
 -- audit/context columns and enum values used by signed website agreements.
+--
+-- Historical acceptance rows are intentionally NOT backfilled because the
+-- ledger has an immutability trigger. These additive fields apply to future
+-- signatures without rewriting prior legal evidence.
 
 alter type public.agreement_type add value if not exists 'ferpa';
 alter type public.agreement_type add value if not exists 'participation';
@@ -19,11 +23,3 @@ alter table public.license_agreement_acceptances
   add column if not exists tenant_id uuid,
   add column if not exists program_id uuid,
   add column if not exists is_immutable boolean not null default true;
-
-update public.license_agreement_acceptances
-set auth_email = coalesce(auth_email, signer_email),
-    acceptance_context = coalesce(acceptance_context, 'legacy'),
-    is_immutable = true
-where auth_email is null
-   or acceptance_context is null
-   or is_immutable is distinct from true;

--- a/supabase/migrations/20260811220300_align_agreement_acceptance_schema.sql
+++ b/supabase/migrations/20260811220300_align_agreement_acceptance_schema.sql
@@ -1,0 +1,29 @@
+-- Align the live legal acceptance ledger with the canonical recorder in
+-- lib/legal/recordAgreementAcceptance.ts. Production previously lacked several
+-- audit/context columns and enum values used by signed website agreements.
+
+alter type public.agreement_type add value if not exists 'ferpa';
+alter type public.agreement_type add value if not exists 'participation';
+alter type public.agreement_type add value if not exists 'media_release';
+alter type public.agreement_type add value if not exists 'eula';
+alter type public.agreement_type add value if not exists 'tos';
+alter type public.agreement_type add value if not exists 'aup';
+alter type public.agreement_type add value if not exists 'disclosures';
+alter type public.agreement_type add value if not exists 'nda';
+alter type public.agreement_type add value if not exists 'mou';
+
+alter table public.license_agreement_acceptances
+  add column if not exists auth_email text,
+  add column if not exists signature_typed text,
+  add column if not exists acceptance_context text,
+  add column if not exists tenant_id uuid,
+  add column if not exists program_id uuid,
+  add column if not exists is_immutable boolean not null default true;
+
+update public.license_agreement_acceptances
+set auth_email = coalesce(auth_email, signer_email),
+    acceptance_context = coalesce(acceptance_context, 'legacy'),
+    is_immutable = true
+where auth_email is null
+   or acceptance_context is null
+   or is_immutable is distinct from true;

--- a/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
+++ b/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
@@ -16,7 +16,7 @@ begin
 
   update public.program_holders
   set mou_signed = true,
-      mou_signed_at = coalesce(mou_signed_at, new.created_at, now()),
+      mou_signed_at = coalesce(mou_signed_at, new.accepted_at, now()),
       updated_at = now()
   where user_id = new.user_id;
 
@@ -46,7 +46,7 @@ set mou_signed = true,
     mou_signed_at = coalesce(ph.mou_signed_at, accepted.accepted_at),
     updated_at = now()
 from (
-  select user_id, min(created_at) as accepted_at
+  select user_id, min(accepted_at) as accepted_at
   from public.license_agreement_acceptances
   where agreement_type = 'program_holder_mou'
   group by user_id

--- a/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
+++ b/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
@@ -1,0 +1,58 @@
+-- Project the canonical legal acceptance into the Program Holder authorization
+-- record. The dashboard requires program_holders.mou_signed=true; previously the
+-- generic signature recorder wrote only license_agreement_acceptances, leaving
+-- approved Program Holders permanently blocked from the dashboard.
+
+create or replace function public.sync_program_holder_mou_acceptance_v1()
+returns trigger
+language plpgsql
+security definer
+set search_path = public, pg_temp
+as $$
+begin
+  if new.agreement_type <> 'program_holder_mou' then
+    return new;
+  end if;
+
+  update public.program_holders
+  set mou_signed = true,
+      mou_signed_at = coalesce(mou_signed_at, new.created_at, now()),
+      updated_at = now()
+  where user_id = new.user_id;
+
+  if not found then
+    raise exception 'No Program Holder record is linked to user %', new.user_id
+      using errcode = '23503';
+  end if;
+
+  return new;
+end;
+$$;
+
+revoke all on function public.sync_program_holder_mou_acceptance_v1() from public;
+
+drop trigger if exists trg_sync_program_holder_mou_acceptance_v1
+  on public.license_agreement_acceptances;
+
+create trigger trg_sync_program_holder_mou_acceptance_v1
+after insert on public.license_agreement_acceptances
+for each row
+when (new.agreement_type = 'program_holder_mou')
+execute function public.sync_program_holder_mou_acceptance_v1();
+
+-- Backfill any already-recorded Program Holder MOU acceptances.
+update public.program_holders ph
+set mou_signed = true,
+    mou_signed_at = coalesce(ph.mou_signed_at, accepted.accepted_at),
+    updated_at = now()
+from (
+  select user_id, min(created_at) as accepted_at
+  from public.license_agreement_acceptances
+  where agreement_type = 'program_holder_mou'
+  group by user_id
+) accepted
+where ph.user_id = accepted.user_id
+  and (ph.mou_signed is distinct from true or ph.mou_signed_at is null);
+
+comment on function public.sync_program_holder_mou_acceptance_v1()
+is 'Marks the linked Program Holder MOU signed when a canonical program_holder_mou agreement acceptance is recorded.';

--- a/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
+++ b/supabase/migrations/20260811220500_sync_program_holder_mou_acceptance.sql
@@ -17,7 +17,7 @@ begin
   update public.program_holders
   set mou_signed = true,
       mou_signed_at = coalesce(mou_signed_at, new.accepted_at, now()),
-      updated_at = now()
+      mou_status = 'signed'
   where user_id = new.user_id;
 
   if not found then
@@ -40,11 +40,12 @@ for each row
 when (new.agreement_type = 'program_holder_mou')
 execute function public.sync_program_holder_mou_acceptance_v1();
 
--- Backfill any already-recorded Program Holder MOU acceptances.
+-- Backfill any already-recorded Program Holder MOU acceptances without touching
+-- the immutable legal acceptance rows themselves.
 update public.program_holders ph
 set mou_signed = true,
     mou_signed_at = coalesce(ph.mou_signed_at, accepted.accepted_at),
-    updated_at = now()
+    mou_status = 'signed'
 from (
   select user_id, min(accepted_at) as accepted_at
   from public.license_agreement_acceptances


### PR DESCRIPTION
Completes the approval/onboarding side of the website application audit and closes the last delivery-audit gap.

Production defects fixed:
- Admin Program Holder application actions called relative approve/deny APIs that did not exist on the Admin service.
- The old public Marketing approve/deny routes were unauthenticated state-changing endpoints.
- The old Marketing approve route wrote a nonexistent column into `program_holder_applications`.
- Approval only changed status; it did not create/link the Program Holder auth account, profile, Program Holder record, secure sign-in, onboarding email, or delivery audit.
- `/program-holder/onboarding` redirected to nonexistent `/program-holder`.
- `/program-holder/sign-mou` redirected to a generic agreement whose acceptance did not set `program_holders.mou_signed`, causing a dashboard redirect loop.
- The canonical agreement recorder used legal-ledger columns/enum values missing from production.
- Standard Student applications checked email success in runtime but did not persist a durable transport result.

Changes:
- Adds authenticated Admin approve/reject endpoints at the paths already called by the Admin UI.
- Approval resolves/creates auth identity, creates/updates `program_holders`, links `profiles.program_holder_id`, preserves privileged roles, updates the application, generates a secure recovery/magic link, sends onboarding next steps, and audits delivery. No plaintext password is sent.
- Rejection uses the live valid application status `rejected`, stores reason/audit details in JSON, sends applicant update, and audits delivery.
- Public Marketing approve/deny mutations now return 410 and cannot change review state.
- Program Holder onboarding routes by authenticated approval/MOU state.
- Dedicated Program Holder MOU uses `program_holder_mou` and proceeds to the dashboard.
- Additive legal-ledger migration aligns missing enum/context columns without rewriting immutable historical records.
- MOU trigger projects the signed agreement to `program_holders.mou_signed`, `mou_signed_at`, and `mou_status`.
- Shared SendGrid transport now writes a best-effort `email_transport_send` row to `email_logs` for every future transactional send, including Student application emails. Feature-specific application logs remain available in addition to this transport-level audit.

Production DB remediation already applied:
- additive legal acceptance enum/columns
- Program Holder MOU projection trigger/backfill

Rollback-only production proof passed: a temporary approved Program Holder signed `program_holder_mou`; the live trigger set `mou_signed=true`, `mou_status='signed'`, and `mou_signed_at`. The transaction was rolled back and a follow-up query confirmed zero test rows remained.

This PR affects Admin + Marketing. It does not change LMS code.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Secure Program Holder approval and denial endpoints and complete onboarding flow
> - Moves Program Holder approval and denial mutations from the public Marketing API to Admin-only endpoints in [`apps/admin`](https://github.com/elevate-for-humanity/Elevate-lms/pull/603/files#diff-3171e11cf751e92f05542ff1727c66c0df8bbf5f4c0176f3d0b577ea7e13c747), returning HTTP 410 from the old public routes.
> - The new Admin endpoints authenticate the caller, update application status, send onboarding/rejection emails, audit every send attempt to `email_logs`, and alert staff via `staff_notifications` on email failure.
> - The [`sendEmail`](https://github.com/elevate-for-humanity/Elevate-lms/pull/603/files#diff-1fa43716d155f468c4a9ec58628fe5ff921c780230e0910b54259f247a42cdbd) function now always returns a typed `EmailSendResult` and writes an audit row to `email_logs` for every attempt, including unconfigured/failed cases.
> - The Program Holder onboarding page and MOU signing page are rewritten as server components that gate access by auth state, approval status, and MOU signature, routing users to the correct step.
> - A database migration adds a trigger on `license_agreement_acceptances` to automatically mark a `program_holders` row as MOU-signed when a `program_holder_mou` acceptance is recorded.
> - Risk: `sendEmail` callers that previously received no return value must now handle `EmailSendResult`; the public approval/denial routes are permanently disabled (410 Gone).
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 78b14af.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->