### PR TITLE
fix: consolidate best code from 43-branch audit

### DIFF
--- a/apps/admin/app/staff-portal/page.tsx
+++ b/apps/admin/app/staff-portal/page.tsx
@@ -11,7 +11,6 @@ import {
   ClipboardList,
   BarChart2,
   Calendar,
-  FileText,
   DollarSign,
   BookOpen,
   Star,
@@ -19,24 +18,28 @@ import {
   ChevronRight,
   CheckCircle,
   AlertCircle,
-  Video,
+  BriefcaseBusiness,
+  GraduationCap,
 } from 'lucide-react';
 export const dynamic = 'force-dynamic';
 
 export const metadata: Metadata = {
   title: 'Staff Portal',
   description: 'Manage students, track enrollments, and access administrative tools.',
+  robots: { index: false, follow: false },
+  alternates: { canonical: 'https://admin.elevateforhumanity.org/staff-portal' },
 };
+
+const MARKETING_URL = process.env.NEXT_PUBLIC_SITE_URL ?? PLATFORM_DEFAULTS.siteUrl;
 
 export default async function StaffPortalLanding() {
   const { user } = await requireStaffPortalAccess();
   const supabase = await createClient();
 
-  // Fetch completion state if logged in
   let payrollDone = false;
   let handbookDone = false;
   let skillsCount = 0;
-  let profile: any = null;
+  let profile: { full_name?: string | null; role?: string | null } | null = null;
 
   if (user) {
     const [{ data: pp }, { data: ha }, { data: us }, { data: pr }] = await Promise.all([
@@ -52,83 +55,72 @@ export default async function StaffPortalLanding() {
   }
 
   const quickLinks = [
-    { label: 'Students', href: '/students', icon: Users, desc: 'Manage enrollments' },
-    {
-      label: 'Attendance',
-      href: '/admin/attendance',
-      icon: ClipboardList,
-      desc: 'Record & export',
-    },
-    { label: 'Reports', href: '/admin/reports', icon: BarChart2, desc: 'Progress & outcomes' },
-    { label: 'Scheduling', href: '/admin/scheduling', icon: Calendar, desc: 'Classes & sessions' },
-    { label: 'Documents', href: '/employee/documents', icon: FileText, desc: 'Forms & uploads' },
-    { label: 'My Payroll', href: '/employee/payroll', icon: DollarSign, desc: 'Pay stubs & W-2' },
-    {
-      label: 'Handbook',
-      href: '/employee/handbook',
-      icon: BookOpen,
-      desc: 'Policies & procedures',
-    },
-    { label: 'My Skills', href: '/admin/staff-portal/skills', icon: Star, desc: 'Track competencies' },
-    { label: 'Interviews', href: '/careers', icon: Video, desc: 'Hiring pipeline' },
-    { label: 'Settings', href: '/admin/staff-portal/settings', icon: Settings, desc: 'Preferences' },
+    { label: 'Students', href: '/staff-portal/students', icon: Users, desc: 'Manage enrollments' },
+    { label: 'Attendance', href: '/staff-portal/attendance', icon: ClipboardList, desc: 'Record & export' },
+    { label: 'Reports', href: '/staff-portal/reports', icon: BarChart2, desc: 'Progress & outcomes' },
+    { label: 'Scheduling', href: '/crm/appointments', icon: Calendar, desc: 'Appointments & sessions' },
+    { label: 'My Payroll', href: '/hr/payroll', icon: DollarSign, desc: 'Payroll administration' },
+    { label: 'Handbook', href: `${MARKETING_URL}/handbook`, icon: BookOpen, desc: 'Policies & procedures' },
+    { label: 'My Skills', href: '/staff-portal/skills', icon: Star, desc: 'Track competencies' },
+    { label: 'Cases', href: '/staff-portal/cases', icon: BriefcaseBusiness, desc: 'Assigned cases' },
+    { label: 'Training', href: '/staff-portal/training', icon: GraduationCap, desc: 'Staff development' },
+    { label: 'Settings', href: '/staff-portal/settings', icon: Settings, desc: 'Preferences' },
   ];
 
   const onboardingItems = [
-    { label: 'Orientation Video', href: '/onboarding/staff/orientation', done: !!user },
-    { label: 'Employee Handbook', href: '/employee/handbook', done: handbookDone },
-    { label: 'Payroll & W-9 Setup', href: '/onboarding/payroll-setup', done: payrollDone },
-    { label: 'Skills Assessment', href: '/admin/staff-portal/skills', done: skillsCount >= 5 },
+    { label: 'Staff Orientation', href: `${MARKETING_URL}/onboarding/staff`, done: !!user },
+    { label: 'Employee Handbook', href: `${MARKETING_URL}/handbook`, done: handbookDone },
+    { label: 'Payroll & W-9 Setup', href: `${MARKETING_URL}/onboarding/payroll-setup`, done: payrollDone },
+    { label: 'Skills Assessment', href: '/staff-portal/skills', done: skillsCount >= 5 },
   ];
-  const onboardingComplete = onboardingItems.filter((i) => i.done).length;
+  const onboardingComplete = onboardingItems.filter((item) => item.done).length;
 
   return (
     <div className="min-h-screen bg-white">
-      <div className="bg-white border-b">
-        <div className="max-w-6xl mx-auto px-4 py-3">
+      <div className="border-b bg-white">
+        <div className="mx-auto max-w-6xl px-4 py-3">
           <Breadcrumbs items={[{ label: 'Staff Portal' }]} />
         </div>
       </div>
 
-      {/* Hero */}
       <section className="relative h-[220px] sm:h-[260px]">
-          <Image
-            placeholder="blur"
-            blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
-          src="/images/pages/staff-portal-page-1.webp"
+        <Image
+          placeholder="blur"
+          blurDataURL={blurDataURL}
+          src="/images/pages/admin/staff-portal-page-1.webp"
           alt="Staff Portal"
           fill
           sizes="100vw"
           className="object-cover"
           priority
         />
-        <div className="absolute inset-0 flex flex-col justify-end pb-8 px-6 max-w-6xl mx-auto w-full">
-          <h1 className="text-3xl font-bold text-slate-900 mb-1">
+        <div className="absolute inset-0 mx-auto flex w-full max-w-6xl flex-col justify-end px-6 pb-8">
+          <h1 className="mb-1 text-3xl font-bold text-slate-900">
             {user && profile?.full_name
               ? `Welcome, ${profile.full_name.split(' ')[0]}`
               : 'Staff Portal'}
           </h1>
-          <p className="text-slate-600 text-sm">
-            ${PLATFORM_DEFAULTS.orgName} · Staff &amp; Instructor Tools
+          <p className="text-sm text-slate-600">
+            {PLATFORM_DEFAULTS.orgName} · Staff &amp; Instructor Tools
           </p>
         </div>
       </section>
 
-      <div className="max-w-6xl mx-auto px-4 py-8">
-        {/* Onboarding progress (only if logged in and not complete) */}
+      <div className="mx-auto max-w-6xl px-4 py-8">
         {user && onboardingComplete < onboardingItems.length && (
-          <div className="bg-white rounded-xl border mb-8 overflow-hidden">
-            <div className="px-6 py-4 border-b flex items-center justify-between">
+          <div className="mb-8 overflow-hidden rounded-xl border bg-white">
+            <div className="flex items-center justify-between border-b px-6 py-4">
               <div>
                 <h2 className="font-bold text-slate-900">Complete Your Onboarding</h2>
                 <p className="text-xs text-slate-500">
                   {onboardingComplete}/{onboardingItems.length} steps done
                 </p>
               </div>
-              <Link href="/staff-portal"
-                className="text-sm text-brand-blue-600 hover:underline font-medium flex items-center gap-1"
+              <Link
+                href={`${MARKETING_URL}/onboarding/staff`}
+                className="flex items-center gap-1 text-sm font-medium text-brand-blue-600 hover:underline"
               >
-                View All <ChevronRight className="w-3.5 h-3.5" />
+                View onboarding <ChevronRight className="h-3.5 w-3.5" />
               </Link>
             </div>
             <div className="divide-y">
@@ -136,64 +128,58 @@ export default async function StaffPortalLanding() {
                 <Link
                   key={item.label}
                   href={item.href}
-                  className="flex items-center gap-4 px-6 py-3.5 hover:bg-white transition"
+                  className="flex items-center gap-4 px-6 py-3.5 transition hover:bg-slate-50"
                 >
                   {item.done ? (
-                    <CheckCircle className="w-5 h-5 text-brand-green-500 flex-shrink-0" />
+                    <CheckCircle className="h-5 w-5 flex-shrink-0 text-brand-green-500" />
                   ) : (
-                    <AlertCircle className="w-5 h-5 text-amber-400 flex-shrink-0" />
+                    <AlertCircle className="h-5 w-5 flex-shrink-0 text-amber-500" />
                   )}
                   <span
-                    className={`text-sm font-medium flex-1 ${item.done ? 'text-slate-400 line-through' : 'text-slate-800'}`}
+                    className={`flex-1 text-sm font-medium ${item.done ? 'text-slate-500 line-through' : 'text-slate-800'}`}
                   >
                     {item.label}
                   </span>
-                  {!item.done && <ChevronRight className="w-4 h-4 text-slate-300" />}
+                  {!item.done && <ChevronRight className="h-4 w-4 text-slate-400" />}
                 </Link>
               ))}
             </div>
           </div>
         )}
 
-        {/* Quick links grid */}
-        <h2 className="text-xs font-bold uppercase tracking-widest text-slate-400 mb-3">
-          Quick Access
-        </h2>
-        <div className="grid grid-cols-2 sm:grid-cols-3 md:grid-cols-5 gap-3 mb-8">
+        <h2 className="mb-3 text-xs font-bold uppercase tracking-widest text-slate-500">Quick Access</h2>
+        <div className="mb-8 grid grid-cols-2 gap-3 sm:grid-cols-3 md:grid-cols-5">
           {quickLinks.map(({ label, href, icon: Icon, desc }) => (
             <Link
               key={href}
               href={href}
-              className="bg-white rounded-xl border p-4 flex flex-col items-center text-center hover:border-brand-blue-300 hover:bg-brand-blue-50 transition group"
+              className="group flex flex-col items-center rounded-xl border bg-white p-4 text-center transition hover:border-brand-blue-300 hover:bg-brand-blue-50"
             >
-              <div className="w-10 h-10 bg-white group-hover:bg-brand-blue-100 rounded-xl flex items-center justify-center mb-2 transition">
-                <Icon className="w-5 h-5 text-slate-500 group-hover:text-brand-blue-600" />
+              <div className="mb-2 flex h-10 w-10 items-center justify-center rounded-xl bg-slate-50 transition group-hover:bg-brand-blue-100">
+                <Icon className="h-5 w-5 text-slate-600 group-hover:text-brand-blue-600" />
               </div>
-              <p className="text-sm font-semibold text-slate-800 group-hover:text-brand-blue-700">
-                {label}
-              </p>
-              <p className="text-xs text-slate-500 mt-0.5">{desc}</p>
+              <p className="text-sm font-semibold text-slate-800 group-hover:text-brand-blue-700">{label}</p>
+              <p className="mt-0.5 text-xs text-slate-600">{desc}</p>
             </Link>
           ))}
         </div>
 
-        {/* Not logged in CTA */}
         {!user && (
-          <div className="bg-white rounded-xl border p-8 text-center">
-            <h2 className="text-xl font-bold text-slate-900 mb-2">Sign In to Access Staff Tools</h2>
-            <p className="text-slate-500 mb-6">
-              Your dashboard, payroll, handbook, and student management tools are available after
-              signing in.
+          <div className="rounded-xl border bg-white p-8 text-center">
+            <h2 className="mb-2 text-xl font-bold text-slate-900">Sign In to Access Staff Tools</h2>
+            <p className="mb-6 text-slate-600">
+              Your dashboard, payroll, handbook, and student management tools are available after signing in.
             </p>
             <div className="flex flex-wrap justify-center gap-3">
               <Link
-                href="/login?redirect=/admin/staff-portal"
-                className="px-6 py-3 bg-brand-blue-600 text-white font-bold rounded-xl hover:bg-brand-blue-700"
+                href="/login?redirect=/staff-portal"
+                className="rounded-xl bg-brand-blue-600 px-6 py-3 font-bold text-white hover:bg-brand-blue-700"
               >
                 Sign In
               </Link>
-              <Link href="/staff-portal"
-                className="px-6 py-3 bg-white text-slate-900 font-bold rounded-xl hover:bg-slate-200"
+              <Link
+                href={`${MARKETING_URL}/onboarding/staff`}
+                className="rounded-xl bg-slate-100 px-6 py-3 font-bold text-slate-900 hover:bg-slate-200"
               >
                 New Staff Onboarding
               </Link>

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -16,6 +16,7 @@ const PUBLIC_PATHS = [
   '/unauthorized',
   '/api/health',
   '/api/ping',
+  '/api/version',
   '/auth/confirm',
   '/auth/reset-password',
   '/install',

--- a/apps/lms/app/employer/error.tsx
+++ b/apps/lms/app/employer/error.tsx
@@ -14,8 +14,8 @@ export default function EmployerError({
       error={error}
       reset={reset}
       title="Employer Portal Error"
-      backHref="/employer"
-      backLabel="Back to Employer Portal"
+      backHref="/employer/dashboard"
+      backLabel="Back to Employer Dashboard"
     />
   );
 }

--- a/scripts/audit-public-site-media-nav.mjs
+++ b/scripts/audit-public-site-media-nav.mjs
@@ -8,6 +8,7 @@ const MARKETING_APP = fs.existsSync(path.join(ROOT, 'apps/marketing/app'))
   ? 'apps/marketing/app'
   : 'app';
 const PAGE_NAMES = new Set(['page.tsx', 'page.ts', 'page.jsx', 'page.js']);
+const LAYOUT_NAMES = ['layout.tsx', 'layout.ts', 'layout.jsx', 'layout.js'];
 const SOURCE_EXTS = ['.tsx', '.ts', '.jsx', '.js', '.json'];
 const MEDIA_EXT = '(?:png|jpe?g|webp|avif|gif|svg|ico|mp4|webm|mov|m4v|mp3|m4a|wav|ogg|aac)';
 const ASSET_RE = new RegExp(
@@ -28,22 +29,23 @@ const HERO_OPTIONAL = [
 ];
 
 const abs = (rel) => path.join(ROOT, rel);
-const isFile = (rel) => {
+const read = (rel) => fs.readFileSync(abs(rel), 'utf8');
+const lineNumber = (source, index) => source.slice(0, index).split('\n').length;
+const isRedirectSource = (source) => /\b(?:redirect|permanentRedirect)\s*\(/.test(source);
+
+function isFile(rel) {
   try {
     return fs.statSync(abs(rel)).isFile();
   } catch {
     return false;
   }
-};
-const read = (rel) => fs.readFileSync(abs(rel), 'utf8');
-const lineNumber = (source, index) => source.slice(0, index).split('\n').length;
-const isRedirectSource = (source) => /\b(?:redirect|permanentRedirect)\s*\(/.test(source);
+}
 
 function walk(relDir) {
-  const absDir = abs(relDir);
-  if (!fs.existsSync(absDir)) return [];
+  const dir = abs(relDir);
+  if (!fs.existsSync(dir)) return [];
   const out = [];
-  for (const entry of fs.readdirSync(absDir, { withFileTypes: true })) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     if (['node_modules', '.next', 'dist', 'build', '.turbo', 'coverage', '.git'].includes(entry.name)) continue;
     const rel = path.join(relDir, entry.name).replaceAll('\\', '/');
     if (entry.isDirectory()) out.push(...walk(rel));
@@ -55,6 +57,11 @@ function walk(relDir) {
 const ALL_MARKETING_FILES = walk(MARKETING_APP);
 const ALL_PAGE_FILES = ALL_MARKETING_FILES.filter((file) => PAGE_NAMES.has(path.basename(file)));
 
+function pathSegments(href) {
+  const clean = href.split(/[?#]/)[0].replace(/^\/+|\/+$/g, '');
+  return clean ? clean.split('/') : [];
+}
+
 function routeSegmentsForPage(file) {
   const rel = file.slice(MARKETING_APP.length).replace(/^\//, '');
   return rel
@@ -62,11 +69,6 @@ function routeSegmentsForPage(file) {
     .slice(0, -1)
     .filter(Boolean)
     .filter((segment) => !/^\(.*\)$/.test(segment) && !segment.startsWith('@'));
-}
-
-function pathSegments(href) {
-  const clean = href.split(/[?#]/)[0].replace(/^\/+|\/+$/g, '');
-  return clean ? clean.split('/') : [];
 }
 
 function directStaticPage(href) {
@@ -102,7 +104,6 @@ function routePageFile(href) {
   if (!href.startsWith('/')) return null;
   const direct = directStaticPage(href);
   if (direct) return direct;
-
   const target = pathSegments(href);
   const matches = ALL_PAGE_FILES.filter((file) => routePatternMatches(routeSegmentsForPage(file), target));
   if (!matches.length) return null;
@@ -134,7 +135,6 @@ function resolveSourceImport(fromFile, specifier) {
   const base = specifier.startsWith('@/')
     ? specifier.slice(2)
     : path.posix.normalize(path.posix.join(path.posix.dirname(fromFile), specifier));
-
   const candidates = [];
   if (path.extname(base)) candidates.push(base);
   else {
@@ -172,6 +172,31 @@ function dependencyClosure(seeds) {
     for (const dep of directDependencies(file)) if (!seen.has(dep)) queue.push(dep);
   }
   return seen;
+}
+
+function routeLayoutFiles(pageFile) {
+  if (!pageFile) return [];
+  const pageDir = path.posix.dirname(pageFile);
+  const appRoot = MARKETING_APP.replaceAll('\\', '/');
+  const relDir = pageDir.slice(appRoot.length).replace(/^\//, '');
+  const segments = relDir ? relDir.split('/') : [];
+  const directories = [appRoot];
+  let current = appRoot;
+  for (const segment of segments) {
+    current = `${current}/${segment}`;
+    directories.push(current);
+  }
+  const layouts = [];
+  for (const dir of directories) {
+    for (const name of LAYOUT_NAMES) {
+      const candidate = `${dir}/${name}`;
+      if (isFile(candidate)) {
+        layouts.push(candidate);
+        break;
+      }
+    }
+  }
+  return layouts;
 }
 
 function parseRouteConstants() {
@@ -230,16 +255,18 @@ function collectSitemapHrefs(routeConstants) {
 function pageSourceBundle(href) {
   const page = routePageFile(href);
   if (!page) return { page: null, files: new Set(), source: '' };
-  const files = dependencyClosure([page]);
+  const files = dependencyClosure([page, ...routeLayoutFiles(page)]);
   const source = [...files].map((file) => read(file)).join('\n');
   return { page, files, source };
 }
 
 function collectCanonicalFiles(sitemapHrefs, publicNavItems) {
   const seeds = [];
-  for (const href of sitemapHrefs) seeds.push(routePageFile(href));
-  for (const item of publicNavItems) seeds.push(routePageFile(item.href));
-  for (const layout of [`${MARKETING_APP}/layout.tsx`, `${MARKETING_APP}/layout.ts`]) if (isFile(layout)) seeds.push(layout);
+  for (const href of new Set([...sitemapHrefs, ...publicNavItems.map((item) => item.href)])) {
+    const page = routePageFile(href);
+    if (!page) continue;
+    seeds.push(page, ...routeLayoutFiles(page));
+  }
   return dependencyClosure(seeds);
 }
 
@@ -331,7 +358,7 @@ function collectDuplicateMediaFindings(sitemapHrefs) {
 }
 
 function isStaticAssetHref(href) {
-  return /\.(?:pdf|png|jpe?g|webp|avif|svg|gif|zip|docx?|xlsx?|csv)(?:[?#].*)?$/i.test(href);
+  return /\.(?:pdf|png|jpe?g|webp|svg|gif|zip|docx?|xlsx?|csv)(?:[?#].*)?$/i.test(href);
 }
 
 function collectActionFindings(files, routeConstants) {
@@ -372,7 +399,7 @@ function collectContrastRisks(files) {
   const findings = [];
   const classPattern = /className=["'`]([^"'`]+)["'`]/g;
   const lightBg = /\bbg-(?:white|slate-50|slate-100|gray-50|gray-100)\b/;
-  const weakOnLight = /\btext-(?:slate|gray|zinc|neutral|stone)-(?:300|400)\b|\btext-white\b/;
+  const weakOnLight = /\btext-(?:slate|gray|zinc|neutral|stone)-(?:300|400)\b/;
   const darkBg = /\bbg-(?:black|slate-800|slate-900|slate-950|gray-900|gray-950|brand-blue-700|brand-blue-800|brand-blue-900)\b/;
   const weakOnDark = /\btext-(?:black|slate|gray|zinc|neutral|stone)-(?:600|700|800|900|950)\b/;
   for (const file of files) {


### PR DESCRIPTION
## Scope
This PR is the safe carry-forward from the full 43-branch reconciliation against current `main` and live production.

### Included
- adopt the newer Admin Staff Portal landing from the semantic-consolidation work because its service-local `/staff-portal/*` links match the current Admin route tree, it fixes the literal organization-name rendering bug, adds correct canonical/noindex metadata, uses the Admin-owned hero asset, and explicitly sends onboarding/handbook links to Marketing
- preserve the later Employer portal error-route correction so an LMS employer error returns to canonical `/employer/dashboard` instead of the older `/employer` route
- adopt the post-#604 public visual-acceptance scanner correction so nested route layouts are included in hero/media evaluation and redirect-only pages are not treated as public visual pages
- expose Admin `/api/version` through middleware because the deploy verifier follows redirects and was receiving the login page instead of runtime build identity; the previous Admin build/deploy/health succeeded but the final release-identity check failed for this reason

### Explicitly not carried forward
- no wholesale merge of old semantic-consolidation branches
- no removal of Creator portal ownership
- no deletion of current Marketing staff compatibility surfaces
- no restoration of superseded #576/#578/#579 release code
- no stale SEO, hero, Website Builder, Host Shop, or release branch overwrites

This is intentionally a four-file reconciliation PR on top of current main.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Consolidate navigation targets and source analysis in staff portal and audit script
> - Updates quick links in [staff-portal/page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/607/files#diff-cdf17ee3f50b052de8baa4f5d41ad27c700d2f7a462f338c2e12567b35d8fc5c) to route under `/staff-portal/*`, adds Cases and Training links, removes Documents and Interviews, and replaces hardcoded handbook/onboarding URLs with a `MARKETING_URL` constant derived from `NEXT_PUBLIC_SITE_URL`.
> - Adds `noindex`/`nofollow` metadata and a canonical URL to the staff portal page.
> - Fixes the employer error boundary back button in [error.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/607/files#diff-525ab2875c7ff85e09b125dc4ab04702b9460ee4ebb4b76b82ee0e55c54fb5cc) to navigate to `/employer/dashboard` instead of `/employer`.
> - Adds `/api/version` to `PUBLIC_PATHS` in [middleware.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/607/files#diff-8c77ff212195bfeb17b57db46023e4b8b4bbe1c813474969ceec48e54da86ebb) so version checks bypass auth.
> - Expands [audit-public-site-media-nav.mjs](https://github.com/elevate-for-humanity/Elevate-lms/pull/607/files#diff-b9a76cdb9488cbfaa42feda16473768df11f1afd482891d2024b7528ca4dac15) to include route layout files in source analysis, deduplicates canonical hrefs, and stops flagging `text-white` and `.avif` hrefs as risks.
> - Risk: the staff portal page references a `blurDataURL` variable for the hero image placeholder that may not be defined, causing a build or runtime error.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d138116.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->