### PR TITLE
fix(runtime): harden Redis rate limits, env audit, and build timestamps

### DIFF
--- a/Dockerfile.admin
+++ b/Dockerfile.admin
@@ -35,6 +35,9 @@ COPY --from=dependencies /app/node_modules ./node_modules
 COPY --from=dependencies /app/apps/admin/node_modules ./apps/admin/node_modules
 COPY . .
 
+# Capture a real build timestamp even when the platform does not inject one.
+RUN node -e "const fs=require('fs'); const raw=process.env.BUILD_TIMESTAMP; const ts=raw&&raw!=='unknown'?raw:new Date().toISOString(); fs.writeFileSync('lib/version/generated-build-timestamp.ts', 'export const GENERATED_BUILD_TIMESTAMP = '+JSON.stringify(ts)+';\n'); console.log('Admin build timestamp:', ts)"
+
 # Stamp the admin service worker with the current deployment SHA before build.
 RUN node scripts/stamp-sw.mjs
 RUN ! grep -q '__CACHE_VERSION__' /app/public/sw-admin.js || \

--- a/Dockerfile.lms
+++ b/Dockerfile.lms
@@ -35,6 +35,9 @@ COPY --from=dependencies /app/node_modules ./node_modules
 COPY --from=dependencies /app/apps/lms/node_modules ./apps/lms/node_modules
 COPY . .
 
+# Capture a real build timestamp even when the platform does not inject one.
+RUN node -e "const fs=require('fs'); const raw=process.env.BUILD_TIMESTAMP; const ts=raw&&raw!=='unknown'?raw:new Date().toISOString(); fs.writeFileSync('lib/version/generated-build-timestamp.ts', 'export const GENERATED_BUILD_TIMESTAMP = '+JSON.stringify(ts)+';\n'); console.log('LMS build timestamp:', ts)"
+
 RUN pnpm --filter @elevate/lms build
 RUN test -d /app/apps/lms/.next
 RUN test -f /app/apps/lms/.next/BUILD_ID

--- a/Dockerfile.marketing
+++ b/Dockerfile.marketing
@@ -37,19 +37,22 @@ ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 COPY --from=dependencies /workspace/node_modules ./node_modules
 COPY . .
 
+# Capture a real build timestamp even when Northflank does not inject one.
+RUN node -e "const fs=require('fs'); const raw=process.env.BUILD_TIMESTAMP; const ts=raw&&raw!=='unknown'?raw:new Date().toISOString(); fs.writeFileSync('lib/version/generated-build-timestamp.ts', 'export const GENERATED_BUILD_TIMESTAMP = '+JSON.stringify(ts)+';\n'); fs.writeFileSync('/tmp/elevate-build-timestamp', ts); console.log('Marketing build timestamp:', ts)"
+
 # Northflank injects NF_GIT_SHA for Git builds. Use it as the only immutable
 # build identity so deployment does not require a config PATCH per commit.
 RUN EFFECTIVE_SHA="${NF_GIT_SHA}" && \
+    EFFECTIVE_BUILT_AT="$(cat /tmp/elevate-build-timestamp)" && \
     test -n "${EFFECTIVE_SHA}" && \
     test "${EFFECTIVE_SHA}" != "unknown" && \
     echo "${EFFECTIVE_SHA}" | grep -qE '^[a-f0-9]{7,40}$' && \
     echo "Marketing build SHA validated: ${EFFECTIVE_SHA}" && \
     printf '{"service":"marketing","commit":"%s","builtAt":"%s"}\n' \
-      "${EFFECTIVE_SHA}" "${BUILD_TIMESTAMP}" > /workspace/public/version.json
+      "${EFFECTIVE_SHA}" "${EFFECTIVE_BUILT_AT}" > /workspace/public/version.json
 
 RUN node scripts/stamp-sw.mjs
 
-# Fail fast if any production worker still contains the unstamped placeholder.
 RUN echo "Verifying marketing service-worker cache versions..." && \
     ! grep -R -q '__CACHE_VERSION__' /workspace/public/sw.js /workspace/public/sw-marketing.js 2>/dev/null && \
     echo "Marketing service workers stamped correctly"
@@ -89,15 +92,11 @@ COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/.next/static \
     ./apps/marketing/.next/static/
 
-# Keep public assets in both locations supported by the standalone monorepo
-# runtime. This prevents stale/missing PWA and image assets when server.js is
-# executed from /app/apps/marketing/server.js but process.cwd() is /app.
 COPY --from=builder --chown=nextjs:nodejs /workspace/public ./public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/marketing/public ./public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/public ./apps/marketing/public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/marketing/public ./apps/marketing/public/
 
-# Refuse to publish an image that cannot prove its PWA assets and build identity.
 RUN test -f /app/public/version.json && \
     test -f /app/apps/marketing/public/version.json && \
     test -f /app/public/manifest-marketing.json && \
@@ -112,8 +111,6 @@ USER nextjs
 
 EXPOSE 3000
 
-# Container health is pure liveness. /api/version is reserved for deployment
-# identity verification and /api/health is reserved for Northflank readiness.
 HEALTHCHECK --interval=30s --timeout=10s --start-period=120s --retries=3 \
   CMD curl -fsS "http://127.0.0.1:${PORT:-3000}/api/ping" || exit 1
 

--- a/apps/admin/app/api/version/route.ts
+++ b/apps/admin/app/api/version/route.ts
@@ -1,12 +1,9 @@
 /**
  * GET /api/version
- *
- * Returns deterministic build identity: commit SHA, BUILD_ID, timestamp.
- * This endpoint is the source of truth for production parity checks.
- * NEVER cache this response — use Cache-Control: no-store.
+ * Returns deterministic build identity and never caches the response.
  */
-
 import { NextResponse } from 'next/server';
+import { getBuildTimestamp } from '@/lib/version/getAppVersion';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,9 +14,7 @@ function val(input: string | undefined, fallback = 'unknown'): string {
 
 export async function GET() {
   const commitSha = val(
-    process.env.GIT_SHA ??
-      process.env.GITHUB_SHA ??
-      process.env.NEXT_PUBLIC_GIT_SHA,
+    process.env.GIT_SHA ?? process.env.GITHUB_SHA ?? process.env.NEXT_PUBLIC_GIT_SHA,
   );
 
   const buildId = val(
@@ -32,7 +27,7 @@ export async function GET() {
       service: 'admin',
       commitSha,
       buildId,
-      builtAt: val(process.env.BUILD_TIMESTAMP),
+      builtAt: getBuildTimestamp(),
       nodeEnvironment: val(process.env.NODE_ENV),
       timestamp: new Date().toISOString(),
     },

--- a/apps/lms/app/api/version/route.ts
+++ b/apps/lms/app/api/version/route.ts
@@ -1,12 +1,9 @@
 /**
  * GET /api/version
- *
- * Returns deterministic build identity: commit SHA, BUILD_ID, timestamp.
- * This endpoint is the source of truth for production parity checks.
- * NEVER cache this response — use Cache-Control: no-store.
+ * Returns deterministic build identity and never caches the response.
  */
-
 import { NextResponse } from 'next/server';
+import { getBuildTimestamp } from '@/lib/version/getAppVersion';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,9 +14,7 @@ function val(input: string | undefined, fallback = 'unknown'): string {
 
 export async function GET() {
   const commitSha = val(
-    process.env.GIT_SHA ??
-      process.env.GITHUB_SHA ??
-      process.env.NEXT_PUBLIC_GIT_SHA,
+    process.env.GIT_SHA ?? process.env.GITHUB_SHA ?? process.env.NEXT_PUBLIC_GIT_SHA,
   );
 
   const buildId = val(
@@ -32,7 +27,7 @@ export async function GET() {
       service: 'lms',
       commitSha,
       buildId,
-      builtAt: val(process.env.BUILD_TIMESTAMP),
+      builtAt: getBuildTimestamp(),
       nodeEnvironment: val(process.env.NODE_ENV),
       timestamp: new Date().toISOString(),
     },

--- a/apps/marketing/app/api/version/route.ts
+++ b/apps/marketing/app/api/version/route.ts
@@ -1,12 +1,9 @@
 /**
  * GET /api/version
- *
- * Returns deterministic build identity: commit SHA, BUILD_ID, timestamp.
- * This endpoint is the source of truth for production parity checks.
- * NEVER cache this response — use Cache-Control: no-store.
+ * Returns deterministic build identity and never caches the response.
  */
-
 import { NextResponse } from 'next/server';
+import { getBuildTimestamp } from '@/lib/version/getAppVersion';
 
 export const runtime = 'nodejs';
 export const dynamic = 'force-dynamic';
@@ -17,9 +14,7 @@ function val(input: string | undefined, fallback = 'unknown'): string {
 
 export async function GET() {
   const commitSha = val(
-    process.env.GIT_SHA ??
-      process.env.GITHUB_SHA ??
-      process.env.NEXT_PUBLIC_GIT_SHA,
+    process.env.GIT_SHA ?? process.env.GITHUB_SHA ?? process.env.NEXT_PUBLIC_GIT_SHA,
   );
 
   const buildId = val(
@@ -32,7 +27,7 @@ export async function GET() {
       service: 'marketing',
       commitSha,
       buildId,
-      builtAt: val(process.env.BUILD_TIMESTAMP),
+      builtAt: getBuildTimestamp(),
       nodeEnvironment: val(process.env.NODE_ENV),
       timestamp: new Date().toISOString(),
     },

--- a/lib/api/with-rate-limit.ts
+++ b/lib/api/with-rate-limit.ts
@@ -1,107 +1,115 @@
-import { logger } from '@/lib/logger';
-
 import { NextRequest, NextResponse } from 'next/server';
 import { Ratelimit } from '@upstash/ratelimit';
-import { getIdentifier, createRateLimitHeaders } from '@/lib/rate-limit';
+import { logger } from '@/lib/logger';
+import {
+  authRateLimit,
+  paymentRateLimit,
+  contactRateLimit,
+  apiRateLimit,
+  strictRateLimit,
+  publicRateLimit,
+  pageLoadRateLimit,
+  getIdentifier,
+  createRateLimitHeaders,
+  getRetryAfterSeconds,
+} from '@/lib/rate-limit';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
 
 type RateLimiterGetter = { get: () => Ratelimit | null };
+type CanonicalTier = 'strict' | 'contact' | 'api' | 'auth' | 'payment' | 'public' | 'pageLoad';
+
+function canonicalTierFor(limiter: Ratelimit | null | RateLimiterGetter): CanonicalTier | null {
+  if (limiter === strictRateLimit) return 'strict';
+  if (limiter === contactRateLimit) return 'contact';
+  if (limiter === apiRateLimit) return 'api';
+  if (limiter === authRateLimit) return 'auth';
+  if (limiter === paymentRateLimit) return 'payment';
+  if (limiter === publicRateLimit) return 'public';
+  if (limiter === pageLoadRateLimit) return 'pageLoad';
+  return null;
+}
 
 /**
- * Rate limit middleware for API routes
- *
- * Usage:
- * export const POST = withRateLimit(handler, { limiter: authRateLimit });
+ * Compatibility wrapper for older routes.
+ * Shared Elevate limiters are delegated to the canonical applyRateLimit()
+ * implementation so Redis failures, IP resolution, reset timestamps, and local
+ * fallback behavior are identical across both historical import paths.
  */
 export function withRateLimit<T = any>(
   handler: (request: NextRequest, context?: any) => Promise<NextResponse>,
   options: {
     limiter: Ratelimit | null | RateLimiterGetter;
-    skipOnMissing?: boolean; // Skip rate limiting if Redis not configured
+    skipOnMissing?: boolean;
   },
 ) {
   return async (request: NextRequest, context?: any): Promise<NextResponse> => {
-    const { skipOnMissing = true } = options;
+    const canonicalTier = canonicalTierFor(options.limiter);
 
-    // Get limiter (support both direct and getter patterns)
+    if (canonicalTier) {
+      const rateLimited = await applyRateLimit(request, canonicalTier);
+      if (rateLimited) return rateLimited;
+      return handler(request, context);
+    }
+
+    const { skipOnMissing = true } = options;
     const limiter =
       typeof (options.limiter as any)?.get === 'function'
         ? (options.limiter as RateLimiterGetter).get()
         : (options.limiter as Ratelimit | null);
 
-    // Skip if rate limiter not configured
     if (!limiter) {
       if (skipOnMissing) {
-        logger.warn('⚠️ Rate limiting skipped - Redis not configured');
+        logger.warn('[rate-limit] Custom limiter not configured; request allowed');
         return handler(request, context);
-      } else {
-        return NextResponse.json({ error: 'Rate limiting not configured' }, { status: 503 });
       }
+      return NextResponse.json({ error: 'Rate limiting not configured' }, { status: 503 });
     }
 
-    // Get identifier (IP address)
     const identifier = getIdentifier(request);
 
     try {
-      // Check rate limit
       const result = await limiter.limit(identifier);
-
-      // Add rate limit headers
       const headers = createRateLimitHeaders(result);
 
-      // If rate limit exceeded
       if (!result.success) {
+        const retryAfter = getRetryAfterSeconds(result.reset);
         return NextResponse.json(
           {
             error: 'Too many requests',
             message: 'You have exceeded the rate limit. Please try again later.',
-            retryAfter: Math.ceil((result.reset - Date.now()) / 1000),
+            retryAfter,
           },
           {
             status: 429,
             headers: {
               ...headers,
-              'Retry-After': Math.ceil((result.reset - Date.now()) / 1000).toString(),
+              'Retry-After': retryAfter.toString(),
             },
           },
         );
       }
 
-      // Execute handler
       const response = await handler(request, context);
-
-      // Add rate limit headers to successful response
-      Object.entries(headers).forEach(([key, value]) => {
-        response.headers.set(key, value);
-      });
-
+      Object.entries(headers).forEach(([key, value]) => response.headers.set(key, value));
       return response;
     } catch (error) {
-      logger.error('Rate limit error:', error);
-
-      // On error, allow request but log
-      if (skipOnMissing) {
-        return handler(request, context);
-      } else {
-        return NextResponse.json({ error: 'Rate limiting error' }, { status: 500 });
-      }
+      logger.error('Custom rate limit error:', error);
+      if (skipOnMissing) return handler(request, context);
+      return NextResponse.json({ error: 'Rate limiting error' }, { status: 500 });
     }
   };
 }
 
-/**
- * Combined rate limit and auth middleware
- */
 export function withRateLimitAndAuth<T = any>(
   handler: (request: NextRequest, context: any, user: any) => Promise<NextResponse>,
   options: {
-    limiter: Ratelimit | null;
+    limiter: Ratelimit | null | RateLimiterGetter;
     roles?: string[];
     skipOnMissing?: boolean;
   },
 ) {
   return withRateLimit(
     async (request: NextRequest, context: any) => {
-      // Import auth check
       const { createClient } = await import('@/lib/supabase/server');
       const supabase = await createClient();
 
@@ -114,7 +122,6 @@ export function withRateLimitAndAuth<T = any>(
         return NextResponse.json({ error: 'Unauthorized' }, { status: 401 });
       }
 
-      // Check roles if specified
       if (options.roles && options.roles.length > 0) {
         const { data: profile } = await supabase
           .from('profiles')

--- a/lib/api/withRateLimit.ts
+++ b/lib/api/withRateLimit.ts
@@ -9,41 +9,79 @@ import {
   publicRateLimit,
   pageLoadRateLimit,
   createRateLimitHeaders,
+  checkInMemoryRateLimit,
+  getIdentifier,
+  getRetryAfterSeconds,
+  type RateLimitTier,
 } from '@/lib/rate-limit';
 
-type Tier = 'strict' | 'contact' | 'api' | 'auth' | 'payment' | 'public' | 'pageLoad';
+type Tier = Extract<
+  RateLimitTier,
+  'strict' | 'contact' | 'api' | 'auth' | 'payment' | 'public' | 'pageLoad'
+>;
 
 const limiters: Record<Tier, { get: () => any }> = {
-  strict: strictRateLimit, // 3 req / 5 min
-  contact: contactRateLimit, // 3 req / 1 min
-  api: apiRateLimit, // 60 req / 1 min
-  auth: authRateLimit, // 5 req / 1 min
-  payment: paymentRateLimit, // 10 req / 1 min
-  public: publicRateLimit, // 5 req / 1 min (public AI tutor)
-  pageLoad: pageLoadRateLimit, // 30 req / 1 min (public content endpoints)
+  strict: strictRateLimit,
+  contact: contactRateLimit,
+  api: apiRateLimit,
+  auth: authRateLimit,
+  payment: paymentRateLimit,
+  public: publicRateLimit,
+  pageLoad: pageLoadRateLimit,
 };
 
-function getIP(request: Request): string {
-  const h = request.headers;
-  return (
-    h.get('x-forwarded-for')?.split(',')[0]?.trim() ||
-    h.get('x-real-ip') ||
-    h.get('cf-connecting-ip') ||
-    'unknown'
+const INTERNAL_IP_PREFIXES = [
+  '127.',
+  '::1',
+  '10.',
+  '172.16.',
+  '172.17.',
+  '172.18.',
+  '172.19.',
+  '172.20.',
+  '172.21.',
+  '172.22.',
+  '172.23.',
+  '172.24.',
+  '172.25.',
+  '172.26.',
+  '172.27.',
+  '172.28.',
+  '172.29.',
+  '172.30.',
+  '172.31.',
+  '192.168.',
+];
+
+function isInternalIP(identifier: string): boolean {
+  return INTERNAL_IP_PREFIXES.some((prefix) => identifier.startsWith(prefix));
+}
+
+function tooManyRequests(result: {
+  success: boolean;
+  limit: number;
+  remaining: number;
+  reset: number;
+}): NextResponse {
+  return NextResponse.json(
+    { error: 'Too many requests. Please try again later.' },
+    {
+      status: 429,
+      headers: {
+        ...createRateLimitHeaders(result),
+        'Retry-After': String(getRetryAfterSeconds(result.reset)),
+      },
+    },
   );
 }
 
-// IPs that should never consume Upstash quota.
-// ECS health checks originate from localhost (task-internal) or the VPC CIDR.
-const INTERNAL_IP_PREFIXES = ['127.', '::1', '10.', '172.16.', '172.17.', '172.18.', '172.19.', '172.20.', '172.21.', '172.22.', '172.23.', '172.24.', '172.25.', '172.26.', '172.27.', '172.28.', '172.29.', '172.30.', '172.31.'];
-
-function isInternalIP(ip: string): boolean {
-  return INTERNAL_IP_PREFIXES.some((prefix) => ip.startsWith(prefix));
-}
-
 /**
- * Check rate limit and return 429 response if exceeded.
- * Returns null if the request is allowed.
+ * Check rate limit and return a 429 response if exceeded.
+ *
+ * Upstash is the distributed limiter. If it is missing, exhausted, or
+ * temporarily unavailable, a bounded in-process limiter takes over so Redis
+ * cannot become a production outage. The fallback remains fail-safe: requests
+ * are still limited, but counters are per running instance until Redis recovers.
  */
 export async function applyRateLimit(
   request: Request,
@@ -57,10 +95,6 @@ export async function applyRateLimit(
     }
   })();
 
-  // Public inquiry and authenticated identity upload must not become service
-  // outages merely because Redis/Upstash is temporarily unavailable. Identity
-  // is still protected by auth + the auth request-rate tier; only the Redis
-  // failure mode changes from fail-closed to fail-open.
   const effectiveTier: Tier =
     pathname === '/api/inquiry' && tier === 'strict'
       ? 'contact'
@@ -68,70 +102,47 @@ export async function applyRateLimit(
         ? 'auth'
         : tier;
 
+  const identifier = getIdentifier(request);
+  if (isInternalIP(identifier)) return null;
+
   const limiter = limiters[effectiveTier]?.get();
-  const failClosed = effectiveTier === 'strict';
-  const isProduction = process.env.NODE_ENV === 'production';
 
   if (!limiter) {
-    if (failClosed && isProduction) {
-      logger.error('[rate-limit] Redis unavailable — failing closed', undefined, { tier: effectiveTier });
-      return NextResponse.json({ error: 'Rate limiting temporarily unavailable' }, { status: 503 });
-    }
-
-    logger.warn('[rate-limit] Redis unavailable — failing open', { tier: effectiveTier });
-    return null;
+    const fallback = checkInMemoryRateLimit(effectiveTier, identifier);
+    logger.warn('[rate-limit] Upstash not configured; using local fallback', {
+      tier: effectiveTier,
+    });
+    return fallback.success ? null : tooManyRequests(fallback);
   }
 
-  const id = getIP(request);
-
-  if (isInternalIP(id)) return null;
-
   try {
-    const result = await limiter.limit(id);
-
-    if (!result.success) {
-      return NextResponse.json(
-        { error: 'Too many requests. Please try again later.' },
-        {
-          status: 429,
-          headers: {
-            ...createRateLimitHeaders(result),
-            'Retry-After': String(Math.ceil((result.reset - Date.now()) / 1000)),
-          },
-        },
-      );
-    }
+    const result = await limiter.limit(identifier);
+    if (!result.success) return tooManyRequests(result);
+    return null;
   } catch (err) {
     const msg = err instanceof Error ? err.message : String(err);
     const isQuotaExhausted = msg.includes('max requests limit exceeded');
-    const isCredential = msg.includes('401') || msg.includes('403') || msg.includes('Unauthorized');
+    const isCredential =
+      msg.includes('401') || msg.includes('403') || msg.includes('Unauthorized');
 
-    if (failClosed) {
-      logger.error('[rate-limit] Redis error — failing closed', undefined, {
-        tier: effectiveTier,
-        error: msg,
-      });
-      return NextResponse.json({ error: 'Rate limiting temporarily unavailable' }, { status: 503 });
-    }
+    const fallback = checkInMemoryRateLimit(effectiveTier, identifier);
 
     if (isQuotaExhausted) {
-      logger.warn('[rate-limit] Upstash monthly quota exhausted — failing open until reset', {
+      logger.warn('[rate-limit] Upstash quota exhausted; using local fallback', {
         tier: effectiveTier,
       });
     } else if (isCredential) {
-      logger.error('[rate-limit] Redis credential error — failing open', undefined, {
+      logger.error('[rate-limit] Upstash credential error; using local fallback', undefined, {
         tier: effectiveTier,
-        action: 'Check UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in SSM /elevate/',
+        action: 'Check UPSTASH_REDIS_REST_URL and UPSTASH_REDIS_REST_TOKEN in runtime secrets',
       });
     } else {
-      logger.warn('[rate-limit] Redis unavailable — failing open', {
+      logger.warn('[rate-limit] Upstash unavailable; using local fallback', {
         tier: effectiveTier,
         error: msg,
       });
     }
 
-    return null;
+    return fallback.success ? null : tooManyRequests(fallback);
   }
-
-  return null;
 }

--- a/lib/rate-limit.ts
+++ b/lib/rate-limit.ts
@@ -2,7 +2,7 @@ import { logger } from '@/lib/logger';
 import { Ratelimit } from '@upstash/ratelimit';
 import { Redis } from '@upstash/redis';
 
-// Lazy initialize Redis client to avoid build-time errors
+// Lazy initialize Redis client to avoid build-time errors.
 let redis: Redis | null = null;
 
 function getRedis(): Redis | null {
@@ -23,20 +23,20 @@ export function getRedisClient(): Redis | null {
   return getRedis();
 }
 
-// Rate limit configurations
-const RATE_LIMITS = {
-  auth: { requests: 5, window: '1 m' }, // 5 requests per minute
-  payment: { requests: 10, window: '1 m' }, // 10 requests per minute
-  contact: { requests: 3, window: '1 m' }, // 3 requests per minute
-  api: { requests: 60, window: '1 m' }, // 60 requests per minute (tightened from 100)
-  strict: { requests: 3, window: '5 m' }, // 3 requests per 5 minutes
-  public: { requests: 5, window: '1 m' }, // 5 requests per minute (tightened from 10)
-  pageLoad: { requests: 30, window: '1 m' }, // 30 requests per minute for public content
-  license: { requests: 5, window: '5 m' }, // 5 license operations per 5 minutes
-  licenseValidate: { requests: 20, window: '1 m' }, // 20 validations per minute
+export const RATE_LIMITS = {
+  auth: { requests: 5, window: '1 m' },
+  payment: { requests: 10, window: '1 m' },
+  contact: { requests: 3, window: '1 m' },
+  api: { requests: 180, window: '1 m' },
+  strict: { requests: 3, window: '5 m' },
+  public: { requests: 20, window: '1 m' },
+  pageLoad: { requests: 180, window: '1 m' },
+  license: { requests: 5, window: '5 m' },
+  licenseValidate: { requests: 20, window: '1 m' },
 } as const;
 
-// Create rate limiters lazily
+export type RateLimitTier = keyof typeof RATE_LIMITS;
+
 function createRateLimiter(
   config: { requests: number; window: string },
   prefix: string,
@@ -51,7 +51,6 @@ function createRateLimiter(
   });
 }
 
-// Lazy getters for rate limiters
 let _authRateLimit: Ratelimit | null | undefined;
 let _paymentRateLimit: Ratelimit | null | undefined;
 let _contactRateLimit: Ratelimit | null | undefined;
@@ -108,31 +107,114 @@ export const licenseValidateRateLimit = {
     )),
 };
 
-// Helper function to get identifier from request
-export function getIdentifier(request: Request): string {
-  // Try to get IP from headers
-  const forwarded = request.headers.get('x-forwarded-for');
-  const realIp = request.headers.get('x-real-ip');
-  const ip = forwarded?.split(',')[0] || realIp || 'unknown';
-
-  return ip;
+function simpleHash(input: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    hash ^= input.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(36);
 }
 
-// Helper function to create rate limit headers
+export function getIdentifier(request: Request): string {
+  const forwarded = request.headers.get('x-forwarded-for')?.split(',')[0]?.trim();
+  const realIp = request.headers.get('x-real-ip')?.trim();
+  const cloudflareIp = request.headers.get('cf-connecting-ip')?.trim();
+  const ip = cloudflareIp || forwarded || realIp;
+
+  if (ip) return ip;
+
+  // Avoid putting every request with a missing proxy header into one shared
+  // "unknown" bucket. This fingerprint is only a last-resort fallback.
+  const fingerprintSeed = [
+    request.headers.get('user-agent') || '',
+    request.headers.get('accept-language') || '',
+    request.headers.get('sec-ch-ua') || '',
+  ].join('|');
+
+  return `anonymous:${simpleHash(fingerprintSeed || 'no-client-headers')}`;
+}
+
+function parseWindowMs(window: string): number {
+  const match = window.trim().match(/^(\d+)\s*([smhd])$/i);
+  if (!match) return 60_000;
+
+  const value = Number(match[1]);
+  const unit = match[2].toLowerCase();
+  const multipliers: Record<string, number> = {
+    s: 1_000,
+    m: 60_000,
+    h: 3_600_000,
+    d: 86_400_000,
+  };
+  return value * multipliers[unit];
+}
+
+type LocalBucket = { count: number; reset: number };
+const localBuckets = new Map<string, LocalBucket>();
+
+export function checkInMemoryRateLimit(
+  tier: RateLimitTier,
+  identifier: string,
+  now = Date.now(),
+): { success: boolean; limit: number; remaining: number; reset: number } {
+  const config = RATE_LIMITS[tier];
+  const key = `${tier}:${identifier}`;
+  const windowMs = parseWindowMs(config.window);
+  const existing = localBuckets.get(key);
+
+  let bucket: LocalBucket;
+  if (!existing || existing.reset <= now) {
+    bucket = { count: 1, reset: now + windowMs };
+  } else {
+    bucket = { count: existing.count + 1, reset: existing.reset };
+  }
+
+  localBuckets.set(key, bucket);
+
+  // Keep the fallback bounded during a long-lived process.
+  if (localBuckets.size > 10_000) {
+    for (const [bucketKey, candidate] of localBuckets) {
+      if (candidate.reset <= now) localBuckets.delete(bucketKey);
+      if (localBuckets.size <= 8_000) break;
+    }
+  }
+
+  return {
+    success: bucket.count <= config.requests,
+    limit: config.requests,
+    remaining: Math.max(config.requests - bucket.count, 0),
+    reset: bucket.reset,
+  };
+}
+
+export function normalizeRateLimitReset(reset: number, now = Date.now()): number {
+  if (!Number.isFinite(reset) || reset <= 0) return now + 1_000;
+
+  // Some Redis/rate-limit implementations expose epoch seconds; Upstash uses
+  // epoch milliseconds. Normalize either form before headers are produced.
+  const normalized = reset < 1_000_000_000_000 ? reset * 1_000 : reset;
+  return Math.max(normalized, now + 1_000);
+}
+
+export function getRetryAfterSeconds(reset: number, now = Date.now()): number {
+  return Math.max(1, Math.ceil((normalizeRateLimitReset(reset, now) - now) / 1_000));
+}
+
 export function createRateLimitHeaders(result: {
   success: boolean;
   limit: number;
   remaining: number;
   reset: number;
 }): Record<string, string> {
+  const reset = normalizeRateLimitReset(result.reset);
   return {
     'X-RateLimit-Limit': result.limit.toString(),
     'X-RateLimit-Remaining': result.remaining.toString(),
-    'X-RateLimit-Reset': new Date(result.reset).toISOString(),
+    'X-RateLimit-Reset': new Date(reset).toISOString(),
   };
 }
 
-// Legacy interface for backwards compatibility
 interface RateLimitConfig {
   key: string;
   limit: number;
@@ -142,7 +224,7 @@ interface RateLimitConfig {
 export async function checkRateLimit(config: RateLimitConfig) {
   const r = getRedis();
   if (!r) {
-    logger.warn('⚠️ Rate limiting disabled - Redis not configured');
+    logger.warn('Rate limiting Redis not configured; legacy check is allowing request');
     return { ok: true, remaining: config.limit, current: 0 };
   }
 

--- a/lib/version/generated-build-timestamp.ts
+++ b/lib/version/generated-build-timestamp.ts
@@ -1,0 +1,3 @@
+// This file is overwritten during Docker builds with the actual UTC build time.
+// Keep a safe repository default for local development and non-Docker tooling.
+export const GENERATED_BUILD_TIMESTAMP = 'unknown';

--- a/lib/version/getAppVersion.ts
+++ b/lib/version/getAppVersion.ts
@@ -1,70 +1,56 @@
 /**
  * UNIFIED VERSION UTILITY
- * 
+ *
  * SINGLE SOURCE OF TRUTH for all version/SHA information.
- * Consolidates 5 SHA variables into one canonical resolution.
- * 
- * Priority: GITHUB_SHA → GIT_SHA → NF_GIT_SHA → NEXT_PUBLIC_GIT_SHA → NEXT_PUBLIC_BUILD_VERSION → 'unknown'
  */
+
+import { GENERATED_BUILD_TIMESTAMP } from './generated-build-timestamp';
 
 let cachedVersion: string | null = null;
 let cachedBuildTimestamp: string | null = null;
 
-/**
- * Get canonical Git SHA with unified resolution chain.
- * Only runs once per process (cached).
- */
-export function getAppVersion(): string {
-  if (cachedVersion) {
-    return cachedVersion;
+function usable(value: string | undefined): string | null {
+  const normalized = value?.trim();
+  if (!normalized || normalized === 'unknown' || normalized === 'undefined' || normalized === 'null') {
+    return null;
   }
+  return normalized;
+}
 
-  // Unified resolution - GITHUB_SHA is primary (set by CI workflow)
-  // NF_GIT_SHA - Northflank injected SHA
-  // GIT_SHA - Git integration fallback
-  // COMMIT_SHA - Legacy (may be stale from Northflank cache)
-  // NEXT_PUBLIC_* - Client accessible fallbacks
+export function getAppVersion(): string {
+  if (cachedVersion) return cachedVersion;
+
   cachedVersion =
-    process.env.GITHUB_SHA ||
-    process.env.GIT_SHA ||
-    process.env.NF_GIT_SHA ||
-    process.env.NEXT_PUBLIC_GIT_SHA ||
-    process.env.NEXT_PUBLIC_BUILD_VERSION ||
+    usable(process.env.GITHUB_SHA) ||
+    usable(process.env.GIT_SHA) ||
+    usable(process.env.NF_GIT_SHA) ||
+    usable(process.env.NEXT_PUBLIC_GIT_SHA) ||
+    usable(process.env.NEXT_PUBLIC_BUILD_VERSION) ||
     'unknown';
 
   return cachedVersion;
 }
 
-/**
- * Get build timestamp.
- * Only runs once per process (cached).
- */
 export function getBuildTimestamp(): string {
-  if (cachedBuildTimestamp !== null) {
-    return cachedBuildTimestamp;
-  }
+  if (cachedBuildTimestamp !== null) return cachedBuildTimestamp;
 
-  cachedBuildTimestamp = process.env.BUILD_TIMESTAMP ?? 'unknown';
+  cachedBuildTimestamp =
+    usable(process.env.BUILD_TIMESTAMP) ||
+    usable(process.env.NEXT_PUBLIC_BUILD_TIMESTAMP) ||
+    usable(GENERATED_BUILD_TIMESTAMP) ||
+    'unknown';
+
   return cachedBuildTimestamp;
 }
 
-/**
- * Get canonical SHA (alias for getAppVersion).
- */
 export function getCanonicalSha(): string {
   return getAppVersion();
 }
 
-/**
- * Get BUILD_ID environment variable.
- */
 export function getBuildId(): string {
-  return process.env.BUILD_ID || getCanonicalSha();
+  return usable(process.env.BUILD_ID) || usable(process.env.NEXT_PUBLIC_BUILD_ID) || getCanonicalSha();
 }
 
-/**
- * Create standardized version info object.
- */
 export function getVersionInfo(serviceName: string = 'unknown'): {
   service: string;
   gitSha: string;

--- a/scripts/audit-env-connections.mjs
+++ b/scripts/audit-env-connections.mjs
@@ -2,7 +2,8 @@
 
 /**
  * Environment Variables Audit Script
- * Tests all API connections and generates a status report
+ * Tests required platform connections and reports optional integrations as
+ * skipped when they are intentionally not configured.
  */
 
 import { createClient } from '@supabase/supabase-js';
@@ -18,15 +19,7 @@ const results = {
 };
 
 function logTest(service, status, message, details = null) {
-  const icon = status === 'success' ? '✅' : status === 'failed' ? '❌' : '⚠️';
-
-  results.services[service] = {
-    status,
-    message,
-    details,
-    tested_at: new Date().toISOString(),
-  };
-
+  results.services[service] = { status, message, details, tested_at: new Date().toISOString() };
   results.summary.total++;
   if (status === 'success') results.summary.working++;
   else if (status === 'failed') results.summary.failed++;
@@ -40,39 +33,25 @@ async function testSupabase() {
     const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
     if (!url || !anonKey) {
-      logTest('Supabase', 'failed', 'Missing URL or anon key');
+      logTest('Supabase', 'failed', 'Missing NEXT_PUBLIC_SUPABASE_URL or NEXT_PUBLIC_SUPABASE_ANON_KEY');
       return;
     }
 
-    // Test anon key
     const supabaseAnon = createClient(url, anonKey);
-    const { data: anonData, error: anonError } = await supabaseAnon
-      .from('programs')
-      .select('count')
-      .limit(1);
+    const { error: anonError } = await supabaseAnon.from('programs').select('count').limit(1);
 
-    if (anonError) {
-      logTest('Supabase (Anon)', 'failed', anonError.message);
-    } else {
-      logTest('Supabase (Anon)', 'success', 'Connected successfully');
+    if (anonError) logTest('Supabase (Anon)', 'failed', anonError.message);
+    else logTest('Supabase (Anon)', 'success', 'Connected successfully');
+
+    if (!serviceKey) {
+      logTest('Supabase (Service Role)', 'failed', 'SUPABASE_SERVICE_ROLE_KEY is required for server workflows');
+      return;
     }
 
-    // Test service role key
-    if (serviceKey) {
-      const supabaseService = createClient(url, serviceKey);
-      const { data: serviceData, error: serviceError } = await supabaseService
-        .from('programs')
-        .select('count')
-        .limit(1);
-
-      if (serviceError) {
-        logTest('Supabase (Service Role)', 'failed', serviceError.message);
-      } else {
-        logTest('Supabase (Service Role)', 'success', 'Connected successfully');
-      }
-    } else {
-      logTest('Supabase (Service Role)', 'skipped', 'Service role key not set');
-    }
+    const supabaseService = createClient(url, serviceKey);
+    const { error: serviceError } = await supabaseService.from('programs').select('count').limit(1);
+    if (serviceError) logTest('Supabase (Service Role)', 'failed', serviceError.message);
+    else logTest('Supabase (Service Role)', 'success', 'Connected successfully');
   } catch (error) {
     logTest('Supabase', 'failed', error.message);
   }
@@ -84,13 +63,11 @@ async function testStripe() {
     const publishableKey = process.env.NEXT_PUBLIC_STRIPE_PUBLISHABLE_KEY;
 
     if (!secretKey) {
-      logTest('Stripe', 'failed', 'Missing secret key');
+      logTest('Stripe', 'failed', 'Missing STRIPE_SECRET_KEY');
       return;
     }
 
     const stripe = new Stripe(secretKey, { apiVersion: '2024-12-18.acacia' });
-
-    // Test by retrieving account info
     const account = await stripe.accounts.retrieve();
 
     logTest(
@@ -101,7 +78,7 @@ async function testStripe() {
         account_id: account.id,
         charges_enabled: account.charges_enabled,
         payouts_enabled: account.payouts_enabled,
-        publishable_key_set: !!publishableKey,
+        publishable_key_set: Boolean(publishableKey),
       },
     );
   } catch (error) {
@@ -110,43 +87,32 @@ async function testStripe() {
 }
 
 async function testResend() {
+  const apiKey = process.env.RESEND_API_KEY;
+  if (!apiKey) {
+    logTest('Resend', 'skipped', 'Not configured; SendGrid/SMTP may be the active email provider');
+    return;
+  }
+
   try {
-    const apiKey = process.env.RESEND_API_KEY;
-
-    if (!apiKey) {
-      logTest('Resend', 'failed', 'Missing API key');
-      return;
-    }
-
     const resend = new Resend(apiKey);
-
-    // Test by listing domains (doesn't send email)
     const { data, error } = await resend.domains.list();
-
-    if (error) {
-      logTest('Resend', 'failed', error.message);
-    } else {
-      logTest('Resend', 'success', `Connected successfully. Domains: ${data?.data?.length || 0}`);
-    }
+    if (error) logTest('Resend', 'failed', error.message);
+    else logTest('Resend', 'success', `Connected successfully. Domains: ${data?.data?.length || 0}`);
   } catch (error) {
     logTest('Resend', 'failed', error.message);
   }
 }
 
 async function testOpenAI() {
+  const apiKey = process.env.OPENAI_API_KEY;
+  if (!apiKey) {
+    logTest('OpenAI', 'skipped', 'Not configured; other configured AI providers may be active');
+    return;
+  }
+
   try {
-    const apiKey = process.env.OPENAI_API_KEY;
-
-    if (!apiKey) {
-      logTest('OpenAI', 'failed', 'Missing API key');
-      return;
-    }
-
     const openai = new OpenAI({ apiKey });
-
-    // Test by listing models
     const models = await openai.models.list();
-
     logTest('OpenAI', 'success', `Connected successfully. Models available: ${models.data.length}`);
   } catch (error) {
     logTest('OpenAI', 'failed', error.message);
@@ -154,63 +120,60 @@ async function testOpenAI() {
 }
 
 async function testUpstash() {
+  const url = process.env.UPSTASH_REDIS_REST_URL;
+  const token = process.env.UPSTASH_REDIS_REST_TOKEN;
+
+  if (!url || !token) {
+    logTest(
+      'Upstash Redis',
+      'skipped',
+      'Distributed rate limiting not configured; bounded local fallback is active',
+    );
+    return;
+  }
+
   try {
-    const url = process.env.UPSTASH_REDIS_REST_URL;
-    const token = process.env.UPSTASH_REDIS_REST_TOKEN;
-
-    if (!url || !token) {
-      logTest('Upstash Redis', 'failed', 'Missing URL or token');
-      return;
-    }
-
     const redis = new Redis({ url, token });
-
-    // Test by pinging
     const testKey = `audit_test_${Date.now()}`;
     await redis.set(testKey, 'test', { ex: 10 });
     const value = await redis.get(testKey);
     await redis.del(testKey);
 
-    if (value === 'test') {
-      logTest('Upstash Redis', 'success', 'Connected and tested read/write');
-    } else {
-      logTest('Upstash Redis', 'failed', 'Connection succeeded but read/write failed');
-    }
+    if (value === 'test') logTest('Upstash Redis', 'success', 'Connected and tested read/write');
+    else logTest('Upstash Redis', 'failed', 'Connection succeeded but read/write failed');
   } catch (error) {
     logTest('Upstash Redis', 'failed', error.message);
   }
 }
 
 async function testDatabase() {
-  try {
-    const dbUrl = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+  const dbUrl = process.env.POSTGRES_URL || process.env.DATABASE_URL;
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
 
-    if (!dbUrl) {
-      logTest('PostgreSQL', 'failed', 'Missing database URL');
-      return;
-    }
-
-    // Use Supabase client to test database
-    const url = process.env.NEXT_PUBLIC_SUPABASE_URL;
-    const serviceKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
-
-    if (!url || !serviceKey) {
-      logTest('PostgreSQL', 'skipped', 'Using Supabase test instead');
-      return;
-    }
-
-    const supabase = createClient(url, serviceKey);
-
-    // Test by counting programs
-    const { count, error } = await supabase
-      .from('programs')
-      .select('*', { count: 'exact', head: true });
-
-    if (error) {
-      logTest('PostgreSQL', 'failed', error.message);
+  if (!dbUrl) {
+    if (url && serviceKey) {
+      logTest(
+        'PostgreSQL (Direct)',
+        'skipped',
+        'Direct DATABASE_URL/POSTGRES_URL is not configured; Supabase API is the active database connection',
+      );
     } else {
-      logTest('PostgreSQL', 'success', `Connected. Programs in database: ${count || 0}`);
+      logTest('PostgreSQL (Direct)', 'skipped', 'Direct database URL not configured');
     }
+    return;
+  }
+
+  if (!url || !serviceKey) {
+    logTest('PostgreSQL (Direct)', 'skipped', 'Direct URL exists; Supabase service connection is tested separately');
+    return;
+  }
+
+  try {
+    const supabase = createClient(url, serviceKey);
+    const { count, error } = await supabase.from('programs').select('*', { count: 'exact', head: true });
+    if (error) logTest('PostgreSQL', 'failed', error.message);
+    else logTest('PostgreSQL', 'success', `Connected. Programs in database: ${count || 0}`);
   } catch (error) {
     logTest('PostgreSQL', 'failed', error.message);
   }
@@ -232,6 +195,9 @@ async function testEnvironmentVariables() {
     'RESEND_API_KEY',
     'UPSTASH_REDIS_REST_URL',
     'UPSTASH_REDIS_REST_TOKEN',
+    'REDIS_URL',
+    'DATABASE_URL',
+    'POSTGRES_URL',
     'AFFIRM_PUBLIC_KEY',
     'AFFIRM_PRIVATE_KEY',
   ];
@@ -246,9 +212,7 @@ async function testEnvironmentVariables() {
       optional_missing: optionalMissing,
     });
   } else {
-    logTest('Environment Variables', 'failed', `Missing ${missing.length} required variables`, {
-      missing,
-    });
+    logTest('Environment Variables', 'failed', `Missing ${missing.length} required variables`, { missing });
   }
 }
 
@@ -261,20 +225,13 @@ async function runAudit() {
   await testOpenAI();
   await testUpstash();
 
-  // Save results to file
   const fs = await import('fs');
-  const reportPath = './audit-report.json';
-  fs.writeFileSync(reportPath, JSON.stringify(results, null, 2));
+  fs.writeFileSync('./audit-report.json', JSON.stringify(results, null, 2));
 
-  // Exit with error code if any tests failed
-  if (results.summary.failed > 0) {
-    process.exit(1);
-  } else {
-    process.exit(0);
-  }
+  process.exit(results.summary.failed > 0 ? 1 : 0);
 }
 
 runAudit().catch((error) => {
-  console.error('\n❌ Audit failed:', error);
+  console.error('\nAudit failed:', error);
   process.exit(1);
 });

--- a/tests/unit/rate-limit-local-strict.test.ts
+++ b/tests/unit/rate-limit-local-strict.test.ts
@@ -1,33 +1,61 @@
 import { afterEach, describe, expect, it } from 'vitest';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { getRetryAfterSeconds, normalizeRateLimitReset } from '@/lib/rate-limit';
 
 const originalNodeEnv = process.env.NODE_ENV;
+const originalRedisUrl = process.env.UPSTASH_REDIS_REST_URL;
+const originalRedisToken = process.env.UPSTASH_REDIS_REST_TOKEN;
 
-describe('applyRateLimit strict local behavior', () => {
+describe('applyRateLimit resilient fallback behavior', () => {
   afterEach(() => {
     process.env.NODE_ENV = originalNodeEnv;
+
+    if (originalRedisUrl === undefined) delete process.env.UPSTASH_REDIS_REST_URL;
+    else process.env.UPSTASH_REDIS_REST_URL = originalRedisUrl;
+
+    if (originalRedisToken === undefined) delete process.env.UPSTASH_REDIS_REST_TOKEN;
+    else process.env.UPSTASH_REDIS_REST_TOKEN = originalRedisToken;
   });
 
-  it('fails open for strict routes in test/local environments when Redis is not configured', async () => {
+  it('allows local/test strict requests when Redis is not configured', async () => {
     process.env.NODE_ENV = 'test';
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
 
-    const result = await applyRateLimit(new Request('http://localhost/api/devstudio/chat'), 'strict');
+    const result = await applyRateLimit(
+      new Request('http://localhost/api/devstudio/chat', {
+        headers: { 'x-forwarded-for': '198.51.100.11' },
+      }),
+      'strict',
+    );
 
     expect(result).toBeNull();
   });
 
-  it('still fails closed for strict routes in production when Redis is not configured', async () => {
+  it('uses a local strict limiter in production instead of returning 503 when Redis is absent', async () => {
     process.env.NODE_ENV = 'production';
     delete process.env.UPSTASH_REDIS_REST_URL;
     delete process.env.UPSTASH_REDIS_REST_TOKEN;
 
-    // Use absolute URL for production test
-    const result = await applyRateLimit(new Request('https://www.elevateforhumanity.org/api/devstudio/chat'), 'strict');
+    const request = () =>
+      new Request('https://www.elevateforhumanity.org/api/devstudio/chat', {
+        headers: { 'x-forwarded-for': '198.51.100.22' },
+      });
 
-    expect(result?.status).toBe(503);
-    await expect(result?.json()).resolves.toEqual({ error: 'Rate limiting temporarily unavailable' });
+    expect(await applyRateLimit(request(), 'strict')).toBeNull();
+    expect(await applyRateLimit(request(), 'strict')).toBeNull();
+    expect(await applyRateLimit(request(), 'strict')).toBeNull();
+
+    const fourth = await applyRateLimit(request(), 'strict');
+    expect(fourth?.status).toBe(429);
+    expect(Number(fourth?.headers.get('Retry-After'))).toBeGreaterThanOrEqual(1);
+  });
+
+  it('normalizes epoch seconds and never emits a negative retry delay', () => {
+    const now = Date.now();
+    const resetSeconds = Math.floor((now + 30_000) / 1_000);
+
+    expect(normalizeRateLimitReset(resetSeconds, now)).toBeGreaterThan(now);
+    expect(getRetryAfterSeconds(now - 60_000, now)).toBe(1);
   });
 });
-


### PR DESCRIPTION
## Production repair

- Uses Upstash as the distributed limiter but falls back to a bounded in-process limiter when Redis is missing, quota-exhausted, credential-invalid, malformed, or temporarily unavailable.
- Standardizes proxy IP resolution across Cloudflare/Northflank and removes the shared `unknown` bucket failure mode.
- Normalizes rate-limit reset timestamps and clamps `Retry-After` to a safe positive value.
- Raises general API/page-load limits to reduce false 429s while preserving strict/auth/contact/payment limits.
- Routes the legacy rate-limit wrapper through the canonical guard for shared Elevate limiters.
- Stops the environment audit from treating optional Resend/OpenAI/Upstash/direct-DB integrations as production failures when they are intentionally absent.
- Stamps a real UTC build timestamp into Marketing, LMS, and Admin images when Northflank does not inject `BUILD_TIMESTAMP`.
- Updates all three `/api/version` routes to use the canonical build timestamp.
- Adds regression tests for production Redis fallback and timestamp-safe retry behavior.

This PR does not change Supabase data, Stripe configuration, DNS, or application business flows.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Harden Redis rate limits with in-memory fallback and improve build timestamp resolution
> - Adds a bounded in-memory fallback in [`applyRateLimit`](https://github.com/elevate-for-humanity/Elevate-lms/pull/608/files#diff-a365e29c75b1ec3411f323dd72772e4f98107ecef36bbf4ad739d2382647f989) so that when Upstash/Redis is unavailable, requests are rate-limited in-process instead of returning 503
> - Raises rate limits for `api`, `public`, and `pageLoad` tiers (e.g. `api` from unknown to 180/min) in [`lib/rate-limit.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/608/files#diff-3aaa328e8b72e6cfcf44fe4c80c07b601eae494bdf2ad23ee2731931beca08c5)
> - Improves client fingerprinting in `getIdentifier` to use header-derived anonymous fingerprints when no proxy IP header is present, reducing accidental bucket sharing
> - Normalizes `Retry-After` and `X-RateLimit-Reset` headers across all rate-limit paths via new `normalizeRateLimitReset` and `getRetryAfterSeconds` helpers
> - Resolves `builtAt` in `/api/version` routes from a generated build-time artifact ([`generated-build-timestamp.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/608/files#diff-a3dc36123f51b8a75e47f846f8c5a3a37ff56232d30cce693fc5b2b9af8356bc)) written during Docker builds, falling back through `BUILD_TIMESTAMP` env vars
> - Updates [`audit-env-connections.mjs`](https://github.com/elevate-for-humanity/Elevate-lms/pull/608/files#diff-79e79c4c75a9b939186bb552aaf0e0c94f48a342e01d824818adda65571f6168) to skip rather than fail when optional services (Resend, OpenAI, Upstash) are unconfigured, and to require `SUPABASE_SERVICE_ROLE_KEY`
> - Behavioral Change: strict-tier routes no longer return 503 when Redis is absent; they now enforce limits via the in-memory fallback
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c46c475.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->