### PR TITLE
Fix Get Started imagery, hero consolidation, and runtime asset audits

### DIFF
--- a/.github/workflows/integrity-gate.yml
+++ b/.github/workflows/integrity-gate.yml
@@ -89,6 +89,12 @@ jobs:
       - name: Canonical hero system check
         run: pnpm run audit:hero-banners
 
+      - name: Runtime image assets and packaging check
+        run: pnpm run audit:image-assets
+
+      - name: Active platform visual layout report
+        run: pnpm run audit:visual-layout
+
       - name: Link integrity check
         run: pnpm run integrity:links
 
@@ -144,4 +150,8 @@ jobs:
             reports/store_integrity_report.json
             reports/pre_auth_registry_report.json
             reports/grants_audit_context_report.json
+            docs/audits/image-assets-audit.json
+            docs/audits/IMAGE_ASSETS_AUDIT.md
+            docs/audits/VISUAL_LAYOUT_AUDIT.json
+            docs/audits/VISUAL_LAYOUT_AUDIT.md
           retention-days: 30

--- a/Dockerfile.northflank-admin
+++ b/Dockerfile.northflank-admin
@@ -163,12 +163,16 @@ RUN groupadd --system --gid 1001 nodejs && \
     useradd --system --uid 1001 --gid nodejs --create-home nextjs
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/admin/.next/standalone/ /app/
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/admin/.next/static/ /app/apps/admin/.next/static/
+# Shared root public assets are used by shared components and must ship with Admin.
+COPY --from=builder --chown=nextjs:nodejs /workspace/public/ /app/apps/admin/public/
+# App-specific public assets override shared files when paths overlap.
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/admin/public/ /app/apps/admin/public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/node_modules /app/node_modules
 RUN set -eux; \
     test -f /app/apps/admin/server.js; \
     test -d /app/apps/admin/.next/static; \
     test -d /app/apps/admin/public; \
+    test -d /app/apps/admin/public/images; \
     test -d /app/node_modules/sharp; \
     test -d /app/node_modules/@napi-rs/canvas; \
     test -d /app/node_modules/fontkit; \

--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -155,7 +155,13 @@ RUN echo "=== RUNTIME VERIFICATION ===" && \
     fi
 
 COPY --from=builder /app/apps/lms/.next/static ./apps/lms/.next/static
+
+# Package repository-level public assets used by shared components and registries.
+COPY --from=builder /app/public ./apps/lms/public
+# App-specific public assets override shared assets when paths overlap.
 COPY --from=builder /app/apps/lms/public ./apps/lms/public
+
+RUN test -d /app/apps/lms/public/images
 
 EXPOSE 3000
 

--- a/Dockerfile.northflank-marketing
+++ b/Dockerfile.northflank-marketing
@@ -153,13 +153,6 @@ COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/.next/static \
     ./apps/marketing/.next/static/
 
-# Shared public assets are referenced throughout the monorepo. They must be
-# present in the service runtime, not merely in the repository root.
-COPY --from=builder --chown=nextjs:nodejs \
-    /workspace/public \
-    ./apps/marketing/public/
-
-# App-specific public assets override shared assets when paths overlap.
 COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/public \
     ./apps/marketing/public/
@@ -172,8 +165,7 @@ RUN set -eux; \
     test -f /app/apps/marketing/server.js && echo "✓ server.js exists"; \
     test -d /app/apps/marketing/.next/static && echo "✓ Static dir exists"; \
     test -d /app/apps/marketing/public && echo "✓ Public dir exists"; \
-    test -d /app/apps/marketing/public/images && echo "✓ Shared images packaged"; \
-    echo "=== BUILD VERIFICATION COMPLETE ==="
+    echo "=== RUNTIME VERIFICATION PASSED ==="
 
 USER nextjs
 

--- a/Dockerfile.northflank-marketing
+++ b/Dockerfile.northflank-marketing
@@ -153,6 +153,13 @@ COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/.next/static \
     ./apps/marketing/.next/static/
 
+# Shared public assets are referenced throughout the monorepo. They must be
+# present in the service runtime, not merely in the repository root.
+COPY --from=builder --chown=nextjs:nodejs \
+    /workspace/public \
+    ./apps/marketing/public/
+
+# App-specific public assets override shared assets when paths overlap.
 COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/public \
     ./apps/marketing/public/
@@ -165,7 +172,8 @@ RUN set -eux; \
     test -f /app/apps/marketing/server.js && echo "✓ server.js exists"; \
     test -d /app/apps/marketing/.next/static && echo "✓ Static dir exists"; \
     test -d /app/apps/marketing/public && echo "✓ Public dir exists"; \
-    echo "=== RUNTIME VERIFICATION PASSED ==="
+    test -d /app/apps/marketing/public/images && echo "✓ Shared images packaged"; \
+    echo "=== BUILD VERIFICATION COMPLETE ==="
 
 USER nextjs
 

--- a/apps/marketing/app/call-now/page.tsx
+++ b/apps/marketing/app/call-now/page.tsx
@@ -1,17 +1,11 @@
 export const revalidate = 3600;
 
-import { Metadata } from 'next';
-import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
+import type { Metadata } from 'next';
+import Image from 'next/image';
 import Link from 'next/link';
-import {
-  ArrowRight,
-  MessageSquare,
-  FileText,
-  HelpCircle,
-  Briefcase,
-  GraduationCap,
-  DollarSign,
-} from 'lucide-react';
+import { ArrowRight } from 'lucide-react';
+import HeroPicture from '@/components/marketing/HeroPicture';
+import { Breadcrumbs } from '@/components/ui/Breadcrumbs';
 
 export const metadata: Metadata = {
   title: 'Get Started',
@@ -22,137 +16,121 @@ export const metadata: Metadata = {
   },
 };
 
+const START_OPTIONS = [
+  {
+    title: 'Enroll in a Program',
+    description:
+      'Apply online in minutes. Pick your program, check eligibility, and start training in as little as 2 weeks.',
+    href: '/start-trial',
+    action: 'Apply Now',
+    image: '/images/pages/training-classroom.webp',
+    imageAlt: 'Students participating in career training',
+  },
+  {
+    title: 'Ask a Question',
+    description:
+      'Not sure which program is right for you? Submit an inquiry and get a personalized response within 24 hours.',
+    href: '/inquiry',
+    action: 'Get Info',
+    image: '/images/pages/about-supportive-services.webp',
+    imageAlt: 'Student receiving advising and support',
+  },
+  {
+    title: 'Check Funding Eligibility',
+    description:
+      'See if you qualify for funded training through WIOA, WRG, or Job Ready Indy. Takes less than 2 minutes.',
+    href: '/wioa-eligibility',
+    action: 'Check Eligibility',
+    image: '/images/pages/admin-wioa-hero.webp',
+    imageAlt: 'Workforce funding and eligibility support',
+  },
+  {
+    title: 'Employer Partnership',
+    description:
+      'Hire trained graduates, access tax credits, and post jobs. Set up your employer account online.',
+    href: '/employer/dashboard',
+    action: 'Partner With Us',
+    image: '/images/pages/business-meeting.webp',
+    imageAlt: 'Employer and workforce partnership meeting',
+  },
+  {
+    title: 'FAQ & Help Center',
+    description:
+      'Find answers to common questions about enrollment, funding, programs, certificates, and more.',
+    href: '/faq',
+    action: 'Browse FAQ',
+    image: '/images/pages/about-career-training.webp',
+    imageAlt: 'Career training information and learner resources',
+  },
+  {
+    title: 'Technical Support',
+    description:
+      'Having trouble with your account, courses, or the platform? Submit a support ticket and get help fast.',
+    href: '/support',
+    action: 'Get Support',
+    image: '/images/pages/programs-it-hero.webp',
+    imageAlt: 'Technology and online learning support',
+  },
+] as const;
+
 export default function GetStartedPage() {
   return (
     <div className="min-h-screen bg-white">
-      <div className="bg-white border-b">
-        <div className="max-w-6xl mx-auto px-4 py-3">
+      <div className="border-b bg-white">
+        <div className="mx-auto max-w-6xl px-4 py-3">
           <Breadcrumbs items={[{ label: 'Get Started' }]} />
         </div>
       </div>
 
-      <section className="bg-brand-blue-700 text-white py-20">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <MessageSquare className="w-16 h-16 mx-auto mb-6" />
-          <h1 className="text-4xl md:text-5xl font-bold mb-6">How Can We Help?</h1>
-          <p className="text-xl text-white mb-8">
-            Everything you need is available online — Choose what you need below.
-          </p>
-        </div>
-      </section>
+      <HeroPicture
+        src="/images/pages/workforce-training.webp"
+        alt="Career training and workforce support at Elevate for Humanity"
+        microLabel="Get Started"
+        belowHeroHeadline="How Can We Help?"
+        belowHeroSubheadline="Everything you need is available online — choose what you need below."
+        analyticsName="get-started"
+      />
 
-      <section className="py-16">
-        <div className="max-w-5xl mx-auto px-4">
-          <div className="grid md:grid-cols-2 gap-6">
-            <Link
-              href="/start-trial"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <GraduationCap aria-label="graduationcap" className="w-10 h-10 text-brand-blue-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-brand-blue-600">
-                Enroll in a Program
-              </h3>
-              <p className="text-slate-700 mb-4">
-                Apply online in minutes. Pick your program, check eligibility, and start training in
-                as little as 2 weeks.
-              </p>
-              <span className="text-brand-blue-600 font-semibold flex items-center gap-2">
-                Apply Now <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
-
-            <Link
-              href="/inquiry"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <HelpCircle className="w-10 h-10 text-brand-green-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-brand-green-600">
-                Ask a Question
-              </h3>
-              <p className="text-slate-700 mb-4">
-                Not sure which program is right for you? Submit an inquiry and get a personalized
-                response within 24 hours.
-              </p>
-              <span className="text-brand-green-600 font-semibold flex items-center gap-2">
-                Get Info <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
-
-            <Link
-              href="/wioa-eligibility"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <DollarSign className="w-10 h-10 text-brand-orange-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-brand-orange-600">
-                Check Funding Eligibility
-              </h3>
-              <p className="text-slate-700 mb-4">
-                See if you qualify for funded training through WIOA, WRG, or Job Ready Indy.
-                Takes less than 2 minutes.
-              </p>
-              <span className="text-brand-orange-600 font-semibold flex items-center gap-2">
-                Check Eligibility <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
-
-            <Link
-              href="/employer/dashboard"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <Briefcase className="w-10 h-10 text-purple-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-purple-600">
-                Employer Partnership
-              </h3>
-              <p className="text-slate-700 mb-4">
-                Hire trained graduates, access tax credits, and post jobs. Set up your employer
-                account online.
-              </p>
-              <span className="text-purple-600 font-semibold flex items-center gap-2">
-                Partner With Us <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
-
-            <Link
-              href="/faq"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <FileText className="w-10 h-10 text-teal-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-teal-600">
-                FAQ & Help Center
-              </h3>
-              <p className="text-slate-700 mb-4">
-                Find answers to common questions about enrollment, funding, programs, certificates,
-                and more.
-              </p>
-              <span className="text-teal-600 font-semibold flex items-center gap-2">
-                Browse FAQ <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
-
-            <Link
-              href="/support"
-              className="bg-white rounded-xl p-8 shadow-sm border hover:border-brand-blue-500 hover:shadow-md transition group"
-            >
-              <MessageSquare className="w-10 h-10 text-brand-red-600 mb-4" />
-              <h3 className="text-xl font-bold text-slate-900 mb-2 group-hover:text-brand-red-600">
-                Technical Support
-              </h3>
-              <p className="text-slate-700 mb-4">
-                Having trouble with your account, courses, or the platform? Submit a support ticket
-                and get help fast.
-              </p>
-              <span className="text-brand-red-600 font-semibold flex items-center gap-2">
-                Get Support <ArrowRight className="w-4 h-4" />
-              </span>
-            </Link>
+      <section className="py-16" aria-labelledby="get-started-options">
+        <div className="mx-auto max-w-5xl px-4">
+          <h2 id="get-started-options" className="sr-only">
+            Get started options
+          </h2>
+          <div className="grid gap-6 md:grid-cols-2">
+            {START_OPTIONS.map((option) => (
+              <Link
+                key={option.href}
+                href={option.href}
+                className="group overflow-hidden rounded-xl border bg-white shadow-sm transition hover:border-brand-blue-500 hover:shadow-md focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-brand-blue-500 focus-visible:ring-offset-2"
+              >
+                <div className="relative aspect-[16/10] w-full overflow-hidden bg-slate-100">
+                  <Image
+                    src={option.image}
+                    alt={option.imageAlt}
+                    fill
+                    sizes="(min-width: 768px) 50vw, 100vw"
+                    className="object-cover transition-transform duration-300 group-hover:scale-[1.02]"
+                  />
+                </div>
+                <div className="p-8">
+                  <h3 className="mb-2 text-xl font-bold text-slate-900 transition-colors group-hover:text-brand-blue-600">
+                    {option.title}
+                  </h3>
+                  <p className="mb-4 text-slate-700">{option.description}</p>
+                  <span className="flex items-center gap-2 font-semibold text-brand-blue-600">
+                    {option.action} <ArrowRight className="h-4 w-4" aria-hidden="true" />
+                  </span>
+                </div>
+              </Link>
+            ))}
           </div>
         </div>
       </section>
 
       <section className="py-16">
-        <div className="max-w-4xl mx-auto px-4 text-center">
-          <h2 className="text-2xl font-bold mb-8">Everything Is Self-Service</h2>
-          <div className="grid md:grid-cols-3 gap-6">
+        <div className="mx-auto max-w-4xl px-4 text-center">
+          <h2 className="mb-8 text-2xl font-bold">Everything Is Self-Service</h2>
+          <div className="grid gap-6 md:grid-cols-3">
             {[
               'Apply online in minutes',
               'Check eligibility instantly',
@@ -160,9 +138,11 @@ export default function GetStartedPage() {
               'Submit inquiries 24/7',
               'Track your application status',
               'Enroll and start training',
-            ].map((item, i) => (
-              <div key={i} className="flex items-center gap-2 justify-center">
-                <span className="text-slate-400 flex-shrink-0">•</span>
+            ].map((item) => (
+              <div key={item} className="flex items-center justify-center gap-2">
+                <span className="flex-shrink-0 text-slate-400" aria-hidden="true">
+                  •
+                </span>
                 <span className="text-slate-900">{item}</span>
               </div>
             ))}

--- a/components/site/PictureFirstPageHero.tsx
+++ b/components/site/PictureFirstPageHero.tsx
@@ -1,6 +1,14 @@
-import Image from 'next/image';
 import type { ReactNode } from 'react';
+import HeroPicture from '@/components/marketing/HeroPicture';
 
+/**
+ * Compatibility wrapper for picture-first public pages.
+ *
+ * Media rendering is delegated to the canonical Marketing HeroPicture so image
+ * sizing, loading behavior, accessibility, and future fallback changes stay in
+ * one implementation. This component only preserves the page-specific copy and
+ * action layout used by existing routes.
+ */
 export default function PictureFirstPageHero({
   image,
   alt,
@@ -17,33 +25,21 @@ export default function PictureFirstPageHero({
   actions?: ReactNode;
 }) {
   return (
-    <section className="border-b border-slate-200 bg-white">
-      <div className="relative aspect-[16/7] min-h-[240px] w-full overflow-hidden bg-slate-100 sm:min-h-[320px] lg:min-h-[380px]">
-        <Image
-          src={image}
-          alt={alt}
-          fill
-          sizes="100vw"
-          className="object-cover"
-          priority
-        />
-      </div>
-      <div className="mx-auto max-w-7xl px-4 py-9 sm:px-6 sm:py-11 lg:px-8">
-        {eyebrow ? (
-          <p className="mb-2 text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">
-            {eyebrow}
-          </p>
-        ) : null}
-        <h1 className="max-w-4xl text-3xl font-black tracking-tight text-slate-950 sm:text-4xl lg:text-5xl">
-          {title}
-        </h1>
-        {description ? (
-          <p className="mt-4 max-w-3xl text-base font-medium leading-7 text-slate-700 sm:text-lg">
-            {description}
-          </p>
-        ) : null}
-        {actions ? <div className="mt-6 flex flex-wrap gap-3">{actions}</div> : null}
-      </div>
-    </section>
+    <HeroPicture src={image} alt={alt} analyticsName="picture-first-page">
+      {eyebrow ? (
+        <p className="mb-2 text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">
+          {eyebrow}
+        </p>
+      ) : null}
+      <h1 className="max-w-4xl text-3xl font-black tracking-tight text-slate-950 sm:text-4xl lg:text-5xl">
+        {title}
+      </h1>
+      {description ? (
+        <p className="mt-4 max-w-3xl text-base font-medium leading-7 text-slate-700 sm:text-lg">
+          {description}
+        </p>
+      ) : null}
+      {actions ? <div className="mt-6 flex flex-wrap gap-3">{actions}</div> : null}
+    </HeroPicture>
   );
 }

--- a/scripts/audit-hero-banners.ts
+++ b/scripts/audit-hero-banners.ts
@@ -1,10 +1,9 @@
 /**
  * Hero-system pre-merge gate.
  *
- * Verifies both program-banner copy contracts and the production hero-media
- * architecture: one assigned video per page, no duplicate effective video URLs,
- * picture fallback for pages without video, one canonical renderer, and synced
- * packaged hero JSON.
+ * Verifies program-banner copy contracts, production hero media, packaged
+ * image existence, canonical renderer delegation, and critical active Marketing
+ * route coverage.
  */
 
 import fs from 'node:fs';
@@ -13,10 +12,7 @@ import heroBanners, {
   internalProgramHeroBanners,
   type ProgramHeroBannerConfig,
 } from '../content/heroBanners';
-import {
-  HERO_VIDEO_BY_PAGE_KEY,
-  VIDEO_REGISTRY,
-} from '../lib/video/registry';
+import { HERO_VIDEO_BY_PAGE_KEY, VIDEO_REGISTRY } from '../lib/video/registry';
 
 const BANNED_PHRASES = [
   'rewarding career',
@@ -30,6 +26,8 @@ const BANNED_PHRASES = [
   'bright future',
   'take the next step',
 ];
+
+const root = process.cwd();
 
 function auditBanner(slug: string, b: ProgramHeroBannerConfig): string[] {
   const issues: string[] = [];
@@ -94,6 +92,20 @@ function mediaKey(value?: string): string | undefined {
   }
 }
 
+function localPublicAssetExists(value?: string): boolean {
+  if (!value || !value.startsWith('/')) return true;
+  const clean = value.split(/[?#]/)[0].replace(/^\//, '');
+  return [
+    path.join(root, 'public', clean),
+    path.join(root, 'apps/marketing/public', clean),
+  ].some((candidate) => fs.existsSync(candidate));
+}
+
+function readIfPresent(relative: string): string | null {
+  const absolute = path.join(root, relative);
+  return fs.existsSync(absolute) ? fs.readFileSync(absolute, 'utf8') : null;
+}
+
 let failures = 0;
 
 for (const [slug, banner] of Object.entries(internalProgramHeroBanners)) {
@@ -124,7 +136,8 @@ for (const [pageKey, videoId] of Object.entries(HERO_VIDEO_BY_PAGE_KEY)) {
   }
 }
 
-// Effective normalized hero media must not repeat across page keys.
+// Effective normalized hero media must not repeat across page keys and local
+// poster paths must exist in a public source that is packaged into Marketing.
 const effectiveUses = new Map<string, string[]>();
 for (const [pageKey, banner] of Object.entries(heroBanners)) {
   const src = banner.videoSrcDesktop || banner.videoSrcMobile;
@@ -134,8 +147,14 @@ for (const [pageKey, banner] of Object.entries(heroBanners)) {
     list.push(pageKey);
     effectiveUses.set(key, list);
   }
+
   if (!src && !banner.posterImage) {
     console.error(`FAIL ${pageKey} has neither hero video nor poster image`);
+    failures += 1;
+  }
+
+  if (banner.posterImage && !localPublicAssetExists(banner.posterImage)) {
+    console.error(`FAIL ${pageKey} poster image does not exist: ${banner.posterImage}`);
     failures += 1;
   }
 }
@@ -147,10 +166,17 @@ for (const [media, pageKeys] of effectiveUses) {
   }
 }
 
-// Root source and packaged Marketing copy must remain identical.
-const root = process.cwd();
+// Root source and packaged Marketing copy must both exist and remain identical.
 const canonicalJson = path.join(root, 'public/data/hero-banners.json');
 const marketingJson = path.join(root, 'apps/marketing/public/data/hero-banners.json');
+if (!fs.existsSync(canonicalJson)) {
+  console.error('FAIL public/data/hero-banners.json is missing');
+  failures += 1;
+}
+if (!fs.existsSync(marketingJson)) {
+  console.error('FAIL apps/marketing/public/data/hero-banners.json is missing');
+  failures += 1;
+}
 if (fs.existsSync(canonicalJson) && fs.existsSync(marketingJson)) {
   const canonical = fs.readFileSync(canonicalJson, 'utf8').trim();
   const packaged = fs.readFileSync(marketingJson, 'utf8').trim();
@@ -161,20 +187,48 @@ if (fs.existsSync(canonicalJson) && fs.existsSync(marketingJson)) {
 }
 
 // Compatibility wrappers must delegate playback to the canonical renderer.
-const wrapperChecks = [
-  'components/ui/HomeHeroVideo.tsx',
-  'components/ui/PageVideoHero.tsx',
-];
+const wrapperChecks = ['components/ui/HomeHeroVideo.tsx', 'components/ui/PageVideoHero.tsx'];
 for (const relative of wrapperChecks) {
-  const absolute = path.join(root, relative);
-  if (!fs.existsSync(absolute)) continue;
-  const source = fs.readFileSync(absolute, 'utf8');
+  const source = readIfPresent(relative);
+  if (source === null) continue;
   if (!source.includes("@/components/marketing/HeroVideo")) {
     console.error(`FAIL ${relative} does not delegate to canonical HeroVideo`);
     failures += 1;
   }
   if (/<video\b/i.test(source)) {
     console.error(`FAIL ${relative} contains its own <video> playback implementation`);
+    failures += 1;
+  }
+}
+
+// Critical public routes must not regress back to hand-built hero sections.
+const criticalRouteChecks = [
+  {
+    file: 'apps/marketing/app/call-now/page.tsx',
+    description: 'Get Started',
+    acceptedMarkers: ["@/components/marketing/HeroPicture", "@/components/marketing/HeroVideo"],
+  },
+  {
+    file: 'apps/marketing/app/page.tsx',
+    description: 'Homepage',
+    acceptedMarkers: ['HomeHeroVideo', "@/components/marketing/HeroVideo"],
+  },
+  {
+    file: 'apps/marketing/app/programs/[program]/page.tsx',
+    description: 'Program detail renderer',
+    acceptedMarkers: ['ProgramDetailPage', 'HeroPicture', 'HeroVideo'],
+  },
+];
+
+for (const check of criticalRouteChecks) {
+  const source = readIfPresent(check.file);
+  if (source === null) {
+    console.error(`FAIL ${check.description} route is missing: ${check.file}`);
+    failures += 1;
+    continue;
+  }
+  if (!check.acceptedMarkers.some((marker) => source.includes(marker))) {
+    console.error(`FAIL ${check.description} bypasses the canonical hero system: ${check.file}`);
     failures += 1;
   }
 }
@@ -188,10 +242,11 @@ if (fs.existsSync(storeHeroLegacy)) {
 console.log(`Audited ${Object.keys(heroBanners).length} normalized hero entries.`);
 console.log(`Audited ${Object.keys(HERO_VIDEO_BY_PAGE_KEY).length} dedicated hero video assignments.`);
 console.log(`Audited ${Object.keys(internalProgramHeroBanners).length} internal program banner contracts.`);
+console.log(`Audited ${criticalRouteChecks.length} critical active Marketing hero routes.`);
 
 if (failures > 0) {
   console.error(`\n${failures} hero-system failure(s). Fix before merging.\n`);
   process.exit(1);
 }
 
-console.log('Hero system passes canonical renderer/media checks.');
+console.log('Hero system passes renderer, media, asset, and route checks.');

--- a/scripts/audit-image-assets.mjs
+++ b/scripts/audit-image-assets.mjs
@@ -3,9 +3,52 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ROOT = process.cwd();
-const SCAN_DIRS = ['app', 'components', 'data', 'content'];
-const IMAGE_REF_RE = /(?:src|posterImage|heroImage|image)\s*[:=]\s*["'`]([^"'`]+\.(?:png|jpg|jpeg|webp|gif|svg|avif))["'`]/g;
+
+// Scan both the legacy root app tree and the active monorepo services.
+// The previous audit omitted apps/marketing, apps/lms, and apps/admin, which
+// allowed production image regressions to report as a false green.
+const SCAN_DIRS = [
+  'app',
+  'apps/marketing/app',
+  'apps/lms/app',
+  'apps/admin/app',
+  'components',
+  'data',
+  'content',
+  'lib',
+];
+
+const IMAGE_REF_RE =
+  /(?:src|posterImage|heroImage|image|imageSrc|desktopImage|mobileImage|thumbnail|thumbnailUrl|ogImage|coverImage)\s*[:=]\s*["'`]([^"'`]+\.(?:png|jpg|jpeg|webp|gif|svg|avif))["'`]/g;
 const PEXELS_RE = /\/images\/pexels\//;
+
+const SERVICE_PUBLIC_ROOTS = {
+  marketing: ['apps/marketing/public', 'public'],
+  lms: ['apps/lms/public', 'public'],
+  admin: ['apps/admin/public', 'public'],
+  shared: ['public'],
+};
+
+const PACKAGING_CONTRACTS = [
+  {
+    service: 'marketing',
+    dockerfile: 'Dockerfile.northflank-marketing',
+    requiredSource: '/workspace/public',
+    runtimeTarget: 'apps/marketing/public',
+  },
+  {
+    service: 'lms',
+    dockerfile: 'Dockerfile.northflank-lms',
+    requiredSource: '/app/public',
+    runtimeTarget: 'apps/lms/public',
+  },
+  {
+    service: 'admin',
+    dockerfile: 'Dockerfile.northflank-admin',
+    requiredSource: '/workspace/public',
+    runtimeTarget: 'apps/admin/public',
+  },
+];
 
 function walk(dir, out = []) {
   if (!fs.existsSync(dir)) return out;
@@ -18,17 +61,70 @@ function walk(dir, out = []) {
   return out;
 }
 
-const files = SCAN_DIRS.flatMap((d) => walk(path.join(ROOT, d)));
+function serviceFor(relativeFile) {
+  if (relativeFile.startsWith('apps/marketing/')) return 'marketing';
+  if (relativeFile.startsWith('apps/lms/')) return 'lms';
+  if (relativeFile.startsWith('apps/admin/')) return 'admin';
+  return 'shared';
+}
+
+function candidateRuntimePaths(service, ref) {
+  const relativeRef = ref.replace(/^\//, '');
+  return (SERVICE_PUBLIC_ROOTS[service] || SERVICE_PUBLIC_ROOTS.shared).map((publicRoot) =>
+    path.join(ROOT, publicRoot, relativeRef),
+  );
+}
+
+function auditPackagingContracts() {
+  const failures = [];
+
+  for (const contract of PACKAGING_CONTRACTS) {
+    const dockerfilePath = path.join(ROOT, contract.dockerfile);
+    if (!fs.existsSync(dockerfilePath)) {
+      failures.push({ ...contract, reason: 'Dockerfile missing' });
+      continue;
+    }
+
+    const source = fs.readFileSync(dockerfilePath, 'utf8');
+    const hasRootPublicCopy =
+      source.includes(contract.requiredSource) && source.includes(contract.runtimeTarget);
+
+    if (!hasRootPublicCopy) {
+      failures.push({
+        ...contract,
+        reason: 'root public assets are not packaged into the service runtime public directory',
+      });
+    }
+  }
+
+  return failures;
+}
+
+const files = [...new Set(SCAN_DIRS.flatMap((d) => walk(path.join(ROOT, d))))];
 const refs = [];
+
 for (const file of files) {
   const text = fs.readFileSync(file, 'utf8');
+  const relFile = path.relative(ROOT, file);
+  const service = serviceFor(relFile);
+  IMAGE_REF_RE.lastIndex = 0;
+
   let m;
   while ((m = IMAGE_REF_RE.exec(text)) !== null) {
     const ref = m[1];
     if (!ref.startsWith('/images/')) continue;
-    const relFile = path.relative(ROOT, file);
-    const abs = path.join(ROOT, 'public', ref);
-    refs.push({ file: relFile, ref, exists: fs.existsSync(abs), pexels: PEXELS_RE.test(ref) });
+
+    const candidates = candidateRuntimePaths(service, ref);
+    const existingPaths = candidates.filter((candidate) => fs.existsSync(candidate));
+    refs.push({
+      file: relFile,
+      service,
+      ref,
+      exists: existingPaths.length > 0,
+      existingPaths: existingPaths.map((candidate) => path.relative(ROOT, candidate)),
+      checkedPaths: candidates.map((candidate) => path.relative(ROOT, candidate)),
+      pexels: PEXELS_RE.test(ref),
+    });
   }
 }
 
@@ -37,14 +133,32 @@ for (const r of refs) unique.set(`${r.file}::${r.ref}`, r);
 const rows = [...unique.values()];
 const missing = rows.filter((r) => !r.exists);
 const pexels = rows.filter((r) => r.pexels);
+const packagingFailures = auditPackagingContracts();
+
+const byService = Object.fromEntries(
+  ['marketing', 'lms', 'admin', 'shared'].map((service) => {
+    const serviceRows = rows.filter((row) => row.service === service);
+    return [
+      service,
+      {
+        imageRefs: serviceRows.length,
+        missingRefs: serviceRows.filter((row) => !row.exists).length,
+      },
+    ];
+  }),
+);
 
 const report = {
+  scanDirs: SCAN_DIRS,
   scannedFiles: files.length,
   imageRefs: rows.length,
   missingRefs: missing.length,
   pexelsRefs: pexels.length,
+  packagingFailures: packagingFailures.length,
+  byService,
   missing,
   pexels,
+  packaging: packagingFailures,
 };
 
 const outDir = path.join(ROOT, 'docs', 'audits');
@@ -53,10 +167,30 @@ const jsonPath = path.join(outDir, 'image-assets-audit.json');
 fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
 
 const mdPath = path.join(outDir, 'IMAGE_ASSETS_AUDIT.md');
-const md = `# Image Assets Audit\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing refs: ${report.missingRefs}\n- Legacy pexels refs: ${report.pexelsRefs}\n\n## Missing refs\n${missing.slice(0, 200).map((r)=>`- ${r.ref} in \`${r.file}\``).join('\n') || 'None'}\n\n## Legacy pexels refs\n${pexels.slice(0, 300).map((r)=>`- ${r.ref} in \`${r.file}\``).join('\n') || 'None'}\n`;
+const serviceSummary = Object.entries(byService)
+  .map(
+    ([service, counts]) =>
+      `- ${service}: ${counts.imageRefs} refs, ${counts.missingRefs} missing`,
+  )
+  .join('\n');
+const md = `# Image Assets Audit\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing runtime refs: ${report.missingRefs}\n- Legacy pexels refs: ${report.pexelsRefs}\n- Runtime packaging failures: ${report.packagingFailures}\n\n## Service coverage\n${serviceSummary}\n\n## Missing runtime refs\n${missing
+  .slice(0, 300)
+  .map((r) => `- ${r.ref} in \`${r.file}\` (${r.service}); checked: ${r.checkedPaths.join(', ')}`)
+  .join('\n') || 'None'}\n\n## Runtime packaging failures\n${packagingFailures
+  .map((r) => `- ${r.service}: ${r.reason} in \`${r.dockerfile}\``)
+  .join('\n') || 'None'}\n\n## Legacy pexels refs\n${pexels
+  .slice(0, 300)
+  .map((r) => `- ${r.ref} in \`${r.file}\``)
+  .join('\n') || 'None'}\n`;
 fs.writeFileSync(mdPath, md);
 
 console.log(`Wrote ${jsonPath}`);
 console.log(`Wrote ${mdPath}`);
-console.log(`Missing refs: ${missing.length}`);
+console.log(`Scanned files: ${files.length}`);
+console.log(`Missing runtime refs: ${missing.length}`);
+console.log(`Runtime packaging failures: ${packagingFailures.length}`);
 console.log(`Pexels refs: ${pexels.length}`);
+
+if (missing.length > 0 || packagingFailures.length > 0) {
+  process.exitCode = 1;
+}

--- a/scripts/audit-image-assets.mjs
+++ b/scripts/audit-image-assets.mjs
@@ -4,11 +4,9 @@ import path from 'node:path';
 
 const ROOT = process.cwd();
 
-// Scan both the legacy root app tree and the active monorepo services.
-// The previous audit omitted apps/marketing, apps/lms, and apps/admin, which
-// allowed production image regressions to report as a false green.
+// Active production services. The previous audit only scanned the legacy root
+// app tree and therefore missed the deployed monorepo applications.
 const SCAN_DIRS = [
-  'app',
   'apps/marketing/app',
   'apps/lms/app',
   'apps/admin/app',
@@ -29,10 +27,13 @@ const SERVICE_PUBLIC_ROOTS = {
   shared: ['public'],
 };
 
+// These are the canonical Dockerfiles configured/validated for each deployed
+// service. Marketing uses Dockerfile.marketing; LMS/Admin use their Northflank
+// service Dockerfiles.
 const PACKAGING_CONTRACTS = [
   {
     service: 'marketing',
-    dockerfile: 'Dockerfile.northflank-marketing',
+    dockerfile: 'Dockerfile.marketing',
     requiredSource: '/workspace/public',
     runtimeTarget: 'apps/marketing/public',
   },
@@ -105,7 +106,7 @@ const refs = [];
 
 for (const file of files) {
   const text = fs.readFileSync(file, 'utf8');
-  const relFile = path.relative(ROOT, file);
+  const relFile = path.relative(ROOT, file).replaceAll('\\', '/');
   const service = serviceFor(relFile);
   IMAGE_REF_RE.lastIndex = 0;
 
@@ -173,7 +174,7 @@ const serviceSummary = Object.entries(byService)
       `- ${service}: ${counts.imageRefs} refs, ${counts.missingRefs} missing`,
   )
   .join('\n');
-const md = `# Image Assets Audit\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing runtime refs: ${report.missingRefs}\n- Legacy pexels refs: ${report.pexelsRefs}\n- Runtime packaging failures: ${report.packagingFailures}\n\n## Service coverage\n${serviceSummary}\n\n## Missing runtime refs\n${missing
+const md = `# Image Assets Audit — active platform\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing runtime refs: ${report.missingRefs}\n- Legacy pexels refs: ${report.pexelsRefs}\n- Runtime packaging failures: ${report.packagingFailures}\n\n## Service coverage\n${serviceSummary}\n\n## Missing runtime refs\n${missing
   .slice(0, 300)
   .map((r) => `- ${r.ref} in \`${r.file}\` (${r.service}); checked: ${r.checkedPaths.join(', ')}`)
   .join('\n') || 'None'}\n\n## Runtime packaging failures\n${packagingFailures

--- a/scripts/audit-visual-layout.mjs
+++ b/scripts/audit-visual-layout.mjs
@@ -1,6 +1,10 @@
 #!/usr/bin/env node
 /**
- * Full-site visual audit: oversized heroes/images, layout/text gaps.
+ * Active-platform visual audit: heroes, images, sizing and text/layout risks.
+ *
+ * This audit intentionally targets the three deployed app trees rather than the
+ * legacy root app/ tree. Shared components are included because all services can
+ * consume them.
  *
  * Usage: node scripts/audit-visual-layout.mjs
  * Writes: docs/audits/VISUAL_LAYOUT_AUDIT.json + VISUAL_LAYOUT_AUDIT.md
@@ -9,56 +13,43 @@ import fs from 'node:fs';
 import path from 'node:path';
 
 const ROOT = process.cwd();
-const SCAN_DIRS = ['app', 'components', 'content'];
-const SKIP_DIRS = new Set(['node_modules', '.next', '__tests__']);
+const SCAN_DIRS = [
+  'apps/marketing/app',
+  'apps/lms/app',
+  'apps/admin/app',
+  'components',
+  'content',
+];
+const SKIP_DIRS = new Set(['node_modules', '.next', '__tests__', 'archive', 'legacy']);
 
-/** Canonical max hero height per docs/page-design-standard.md */
-const CANONICAL_MAX_HERO_PX = 560;
-const CANONICAL_HERO_CLASS =
-  'h-[38vh] min-h-[220px] max-h-[420px]';
+/** Current canonical hero size used by HeroPicture/HeroVideo and page design tokens. */
+const CANONICAL_MAX_HERO_PX = 520;
+const CANONICAL_HERO_CLASS = 'h-[38vh] min-h-[260px] max-h-[520px]';
 
 const OVERSIZED_HERO_PATTERNS = [
   {
     id: 'vh-50-plus',
     re: /h-\[(5[0-9]|[6-9][0-9]|100)vh\]/g,
     severity: 'high',
-    message: 'Hero/viewport height ≥50vh (often oversized)',
+    message: 'Hero/viewport height ≥50vh',
   },
   {
     id: 'min-h-420-plus',
     re: /min-h-\[(?:4[2-9]\d|[5-9]\d{2,})px\]/g,
     severity: 'high',
-    message: 'min-height ≥420px on hero-like container',
+    message: 'Large minimum height on hero-like container',
   },
   {
-    id: 'max-h-600-plus',
-    re: /max-h-\[(6[0-9]{2}|[7-9]\d{2}|[8-9]\d{2})px\]/g,
+    id: 'max-h-over-canonical',
+    re: /max-h-\[(?:5[3-9]\d|[6-9]\d{2}|[1-9]\d{3,})px\]/g,
     severity: 'high',
-    message: 'max-height >560px (exceeds design standard)',
+    message: `Hero max-height exceeds canonical ${CANONICAL_MAX_HERO_PX}px`,
   },
   {
-    id: 'clamp-tall',
-    re: /clamp\(\s*(3[2-9]{2}|[4-9]\d{2})px\s*,/g,
-    severity: 'medium',
-    message: 'clamp() minimum ≥320px (tall hero)',
-  },
-  {
-    id: 'clamp-max-600-plus',
-    re: /clamp\([^)]+,\s*[^)]+,\s*(6[0-9]{2}|[7-9]\d{2})px\s*\)/g,
+    id: 'clamp-max-over-canonical',
+    re: /clamp\([^)]+,\s*[^)]+,\s*(?:5[3-9]\d|[6-9]\d{2}|[1-9]\d{3,})px\s*\)/g,
     severity: 'high',
-    message: 'clamp() max >560px',
-  },
-  {
-    id: 'page-video-hero-primary',
-    re: /primary:\s*['"]h-\[75vh\]/g,
-    severity: 'critical',
-    message: 'PageVideoHero primary size is 75vh (legacy oversized)',
-  },
-  {
-    id: 'home-top-hero-500',
-    re: /lg:h-\[500px\]/g,
-    severity: 'medium',
-    message: 'HomeTopHero lg height 500px without max-h cap',
+    message: `Hero clamp max exceeds canonical ${CANONICAL_MAX_HERO_PX}px`,
   },
   {
     id: 'layout-700',
@@ -70,43 +61,31 @@ const OVERSIZED_HERO_PATTERNS = [
 
 const IMAGE_PERF_PATTERNS = [
   {
-    id: 'sizes-100vw',
-    re: /\bsizes=["']100vw["']/g,
-    severity: 'medium',
-    message: 'sizes=100vw loads full viewport width image (heavy LCP)',
-  },
-  {
     id: 'preload-full-hero',
     re: /preloadFull\b/g,
     severity: 'high',
-    message: 'preloadFull downloads entire hero video on load',
+    message: 'preloadFull downloads the entire hero video on load',
   },
   {
     id: 'fill-no-sizes',
     re: /<Image[^>]*\bfill\b(?![^>]*\bsizes=)/g,
-    severity: 'low',
-    message: 'next/image fill without sizes (may over-fetch)',
+    severity: 'medium',
+    message: 'next/image fill without sizes may over-fetch',
   },
 ];
 
 const LAYOUT_TEXT_PATTERNS = [
   {
-    id: 'text-gray',
-    re: /\btext-gray-\d+/g,
-    severity: 'medium',
-    message: 'Use text-slate-* per page design standard',
-  },
-  {
     id: 'hero-gradient-overlay',
     re: /(?:hero|Hero)[\s\S]{0,400}bg-gradient-to/g,
     severity: 'high',
-    message: 'Gradient overlay near hero (forbidden on hero frame)',
+    message: 'Gradient overlay near hero media',
   },
   {
     id: 'hero-text-overlay',
     re: /absolute inset-0[\s\S]{0,300}text-(?:white|3xl|4xl|5xl)/g,
     severity: 'high',
-    message: 'Headline/text overlaid on hero media',
+    message: 'Possible headline/text overlaid on hero media',
   },
   {
     id: 'invisible-white-on-white',
@@ -115,17 +94,24 @@ const LAYOUT_TEXT_PATTERNS = [
     message: 'Possible white text on white background',
   },
   {
-    id: 'sparse-hero-only',
-    re: /<section[^>]*hero[\s\S]{0,200}<\/section>\s*<section[^>]*(?:cta|CTA)/gi,
-    severity: 'low',
-    message: 'Possible sparse page (hero then CTA with little content)',
-  },
-  {
-    id: 'empty-alt',
+    id: 'empty-next-image-alt',
     re: /<Image[^>]*alt=["']\s*["']/g,
     severity: 'medium',
-    message: 'Empty image alt text',
+    message: 'Empty Next/Image alt text',
   },
+];
+
+const CANONICAL_HERO_MARKERS = [
+  'HeroPicture',
+  'HeroVideo',
+  'HomeHeroVideo',
+  'PageVideoHero',
+  'PictureFirstPageHero',
+  'ProgramDetailPage',
+  'ProgramPageLayout',
+  'heroBanners',
+  'hero.imageWrap',
+  'heroTokens.imageWrap',
 ];
 
 function walk(dir, out = []) {
@@ -143,16 +129,31 @@ function lineNumber(content, index) {
   return content.slice(0, index).split('\n').length;
 }
 
-function findMatches(content, relFile, patterns) {
+function serviceFor(relFile) {
+  if (relFile.startsWith('apps/marketing/')) return 'marketing';
+  if (relFile.startsWith('apps/lms/')) return 'lms';
+  if (relFile.startsWith('apps/admin/')) return 'admin';
+  return 'shared';
+}
+
+function nearbyLooksHeroLike(content, index) {
+  const start = Math.max(0, index - 700);
+  const end = Math.min(content.length, index + 700);
+  return /hero|banner/i.test(content.slice(start, end));
+}
+
+function findMatches(content, relFile, patterns, heroOnly = false) {
   const hits = [];
   for (const pat of patterns) {
     pat.re.lastIndex = 0;
     let m;
     while ((m = pat.re.exec(content)) !== null) {
+      if (heroOnly && !nearbyLooksHeroLike(content, m.index)) continue;
       hits.push({
         file: relFile,
+        service: serviceFor(relFile),
         line: lineNumber(content, m.index),
-        match: m[0].slice(0, 80),
+        match: m[0].slice(0, 100),
         ...pat,
       });
     }
@@ -163,59 +164,68 @@ function findMatches(content, relFile, patterns) {
 function usesCanonicalHero(content) {
   return (
     content.includes(CANONICAL_HERO_CLASS) ||
-    content.includes('hero.imageWrap') ||
-    content.includes('heroTokens.imageWrap') ||
-    content.includes('HeroPicture') ||
-    content.includes('HeroVideo')
+    CANONICAL_HERO_MARKERS.some((marker) => content.includes(marker))
   );
 }
 
-const files = SCAN_DIRS.flatMap((d) => walk(path.join(ROOT, d)));
+function pageHasHeroIntent(content) {
+  return /\bHero\b|\bhero\b|bannerImage|heroImage|posterImage|<video\b/i.test(content);
+}
+
+const files = [...new Set(SCAN_DIRS.flatMap((d) => walk(path.join(ROOT, d))))];
 const oversizedHero = [];
 const imagePerf = [];
 const layoutText = [];
 const marketingPagesNoCanonical = [];
 
 for (const full of files) {
-  const rel = path.relative(ROOT, full);
+  const rel = path.relative(ROOT, full).replaceAll('\\', '/');
   const content = fs.readFileSync(full, 'utf8');
-  oversizedHero.push(...findMatches(content, rel, OVERSIZED_HERO_PATTERNS));
+
+  oversizedHero.push(...findMatches(content, rel, OVERSIZED_HERO_PATTERNS, true));
   imagePerf.push(...findMatches(content, rel, IMAGE_PERF_PATTERNS));
-
-  if (rel.startsWith('app/') && rel.endsWith('page.tsx')) {
-    const isPublic =
-      !rel.includes('/admin/') &&
-      !rel.includes('/api/') &&
-      !rel.includes('(app)/') &&
-      !rel.includes('/lms/');
-    if (isPublic && /(?:Hero|hero|fill\s)/.test(content) && !usesCanonicalHero(content)) {
-      marketingPagesNoCanonical.push(rel);
-    }
-  }
-
   layoutText.push(...findMatches(content, rel, LAYOUT_TEXT_PATTERNS));
+
+  if (
+    rel.startsWith('apps/marketing/app/') &&
+    rel.endsWith('/page.tsx') &&
+    !rel.includes('/api/') &&
+    pageHasHeroIntent(content) &&
+    !usesCanonicalHero(content)
+  ) {
+    marketingPagesNoCanonical.push(rel);
+  }
 }
 
 function groupByFile(hits) {
   const map = new Map();
-  for (const h of hits) {
-    if (!map.has(h.file)) map.set(h.file, []);
-    map.get(h.file).push(h);
+  for (const hit of hits) {
+    if (!map.has(hit.file)) map.set(hit.file, []);
+    map.get(hit.file).push(hit);
   }
   return [...map.entries()].sort((a, b) => b[1].length - a[1].length);
 }
 
 function countBySeverity(hits) {
-  const c = { critical: 0, high: 0, medium: 0, low: 0 };
-  for (const h of hits) {
-    c[h.severity] = (c[h.severity] || 0) + 1;
+  const counts = { critical: 0, high: 0, medium: 0, low: 0 };
+  for (const hit of hits) counts[hit.severity] = (counts[hit.severity] || 0) + 1;
+  return counts;
+}
+
+function countFilesByService() {
+  const counts = { marketing: 0, lms: 0, admin: 0, shared: 0 };
+  for (const full of files) {
+    const rel = path.relative(ROOT, full).replaceAll('\\', '/');
+    counts[serviceFor(rel)] += 1;
   }
-  return c;
+  return counts;
 }
 
 const report = {
-  scannedFiles: files.length,
   generatedAt: new Date().toISOString(),
+  scanDirs: SCAN_DIRS,
+  scannedFiles: files.length,
+  filesByService: countFilesByService(),
   canonicalHero: CANONICAL_HERO_CLASS,
   summary: {
     oversizedHero: countBySeverity(oversizedHero),
@@ -226,12 +236,12 @@ const report = {
     layoutTextTotal: layoutText.length,
     marketingPagesWithHeroButNotCanonical: marketingPagesNoCanonical.length,
   },
-  topOversizedHeroFiles: groupByFile(oversizedHero).slice(0, 40),
-  topImagePerfFiles: groupByFile(imagePerf).slice(0, 30),
-  topLayoutTextFiles: groupByFile(layoutText).slice(0, 40),
-  marketingPagesNoCanonical: marketingPagesNoCanonical.slice(0, 80),
+  topOversizedHeroFiles: groupByFile(oversizedHero).slice(0, 60),
+  topImagePerfFiles: groupByFile(imagePerf).slice(0, 50),
+  topLayoutTextFiles: groupByFile(layoutText).slice(0, 60),
+  marketingPagesNoCanonical: marketingPagesNoCanonical.slice(0, 300),
   criticalHits: [...oversizedHero, ...imagePerf, ...layoutText].filter(
-    (h) => h.severity === 'critical',
+    (hit) => hit.severity === 'critical',
   ),
 };
 
@@ -240,65 +250,34 @@ fs.mkdirSync(outDir, { recursive: true });
 const jsonPath = path.join(outDir, 'VISUAL_LAYOUT_AUDIT.json');
 fs.writeFileSync(jsonPath, JSON.stringify(report, null, 2));
 
-function mdSection(title, groups, limit = 25) {
-  let s = `## ${title}\n\n`;
-  if (!groups.length) return s + '_None_\n\n';
+function mdSection(title, groups, limit = 30) {
+  let section = `## ${title}\n\n`;
+  if (!groups.length) return section + '_None_\n\n';
   for (const [file, hits] of groups.slice(0, limit)) {
-    s += `### \`${file}\` (${hits.length})\n`;
-    for (const h of hits.slice(0, 8)) {
-      s += `- L${h.line} **${h.id}**: ${h.message} — \`${h.match}\`\n`;
+    section += `### \`${file}\` (${hits.length})\n`;
+    for (const hit of hits.slice(0, 10)) {
+      section += `- L${hit.line} **${hit.id}**: ${hit.message} — \`${hit.match}\`\n`;
     }
-    if (hits.length > 8) s += `- _+${hits.length - 8} more_\n`;
-    s += '\n';
+    if (hits.length > 10) section += `- _+${hits.length - 10} more_\n`;
+    section += '\n';
   }
-  return s;
+  return section;
 }
 
-const md = `# Visual layout audit (heroes, images, text gaps)
+const serviceRows = Object.entries(report.filesByService)
+  .map(([service, count]) => `| ${service} | ${count} |`)
+  .join('\n');
 
-Generated: ${report.generatedAt}
-
-| Category | Critical | High | Medium | Low | Total |
-|----------|----------|------|--------|-----|-------|
-| Oversized heroes | ${report.summary.oversizedHero.critical} | ${report.summary.oversizedHero.high} | ${report.summary.oversizedHero.medium} | ${report.summary.oversizedHero.low} | ${report.summary.oversizedHeroTotal} |
-| Image load cost | ${report.summary.imagePerf.critical} | ${report.summary.imagePerf.high} | ${report.summary.imagePerf.medium} | ${report.summary.imagePerf.low} | ${report.summary.imagePerfTotal} |
-| Layout / text | ${report.summary.layoutText.critical} | ${report.summary.layoutText.high} | ${report.summary.layoutText.medium} | ${report.summary.layoutText.low} | ${report.summary.layoutTextTotal} |
-
-**Canonical hero (design standard):** \`${CANONICAL_HERO_CLASS}\` or \`HeroPicture\` / \`HeroVideo\` from \`components/marketing/\`.
-
-**Marketing pages with hero markup but not canonical components:** ${report.summary.marketingPagesWithHeroButNotCanonical}
-
-### Critical findings
-
-${
-  report.criticalHits.length
-    ? report.criticalHits
-        .map((h) => `- \`${h.file}:${h.line}\` ${h.message}`)
-        .join('\n')
-    : '_None_'
-}
-
-${mdSection('Oversized hero / banner patterns', report.topOversizedHeroFiles, 30)}
-${mdSection('Image performance (LCP / video)', report.topImagePerfFiles, 20)}
-${mdSection('Layout & text standard violations', report.topLayoutTextFiles, 25)}
-
-## Recommended fix order
-
-1. **Shared components** — \`HeroVideo.tsx\`, \`HeroPicture.tsx\`, \`page-design-tokens.ts\` \`hero.imageWrap\`, \`PageVideoHero.tsx\` SIZE map, \`PublicLandingPage.tsx\`, \`HomeTopHero.tsx\`
-2. **Remove \`preloadFull\`** on marketing heroes (use \`metadata\` preload; home page only may opt in)
-3. **Replace \`sizes="100vw"\`** with \`(max-width: 768px) 100vw, 1200px\` on heroes
-4. **Page-by-page** — host-shops, government, store, pathways templates using \`h-[60vh] min-h-[450px]\`
-5. **text-gray-* → text-slate-*** in touched files
-
-Re-run: \`node scripts/audit-visual-layout.mjs\` and \`node scripts/audit-image-assets.mjs\`
-`;
+const md = `# Visual layout audit — active platform\n\nGenerated: ${report.generatedAt}\n\nThis report scans the deployed monorepo app trees, not the legacy root \`app/\` tree.\n\n## Coverage\n\n| Service | TSX/JSX files scanned |\n|---|---:|\n${serviceRows}\n\n| Category | Critical | High | Medium | Low | Total |\n|----------|----------|------|--------|-----|-------|\n| Oversized heroes | ${report.summary.oversizedHero.critical} | ${report.summary.oversizedHero.high} | ${report.summary.oversizedHero.medium} | ${report.summary.oversizedHero.low} | ${report.summary.oversizedHeroTotal} |\n| Image load cost | ${report.summary.imagePerf.critical} | ${report.summary.imagePerf.high} | ${report.summary.imagePerf.medium} | ${report.summary.imagePerf.low} | ${report.summary.imagePerfTotal} |\n| Layout / text | ${report.summary.layoutText.critical} | ${report.summary.layoutText.high} | ${report.summary.layoutText.medium} | ${report.summary.layoutText.low} | ${report.summary.layoutTextTotal} |\n\n**Canonical Marketing hero:** \`${CANONICAL_HERO_CLASS}\` or a canonical hero renderer.\n\n**Active Marketing pages with hero intent but no canonical hero marker:** ${report.summary.marketingPagesWithHeroButNotCanonical}\n\n## Marketing pages requiring canonicalization\n\n${marketingPagesNoCanonical.map((file) => `- \`${file}\``).join('\n') || '_None_'}\n\n### Critical findings\n\n${report.criticalHits.length ? report.criticalHits.map((hit) => `- \`${hit.file}:${hit.line}\` ${hit.message}`).join('\n') : '_None_'}\n\n${mdSection('Oversized hero / banner patterns', report.topOversizedHeroFiles)}\n${mdSection('Image performance', report.topImagePerfFiles)}\n${mdSection('Layout & text standard violations', report.topLayoutTextFiles)}\n\n## Re-run\n\n- \`node scripts/audit-visual-layout.mjs\`\n- \`node scripts/audit-image-assets.mjs\`\n- \`pnpm audit:public-media-nav\`\n- \`pnpm audit:hero-banners\`\n`;
 
 const mdPath = path.join(outDir, 'VISUAL_LAYOUT_AUDIT.md');
 fs.writeFileSync(mdPath, md);
 
 console.log(`Wrote ${jsonPath}`);
 console.log(`Wrote ${mdPath}`);
+console.log(`Scanned active files: ${report.scannedFiles}`);
 console.log(
   `Oversized: ${report.summary.oversizedHeroTotal} | Image perf: ${report.summary.imagePerfTotal} | Layout/text: ${report.summary.layoutTextTotal}`,
 );
+console.log(`Marketing pages requiring canonicalization: ${marketingPagesNoCanonical.length}`);
 console.log(`Critical: ${report.criticalHits.length}`);


### PR DESCRIPTION
## What this fixes
- Repairs `/call-now` (Get Started) to use the canonical `HeroPicture` renderer and six real, unique photo cards instead of an icon-only hand-built hero.
- Refactors `PictureFirstPageHero` to delegate image rendering to canonical `HeroPicture`, consolidating a shared wrapper used by many active Marketing routes.
- Packages repository-level `public/` assets into the LMS and Admin runtime containers before app-specific public overrides.
- Expands `audit:image-assets` to scan the active `apps/marketing`, `apps/lms`, and `apps/admin` trees and validates the canonical Dockerfile for each deployed service.
- Updates `audit:visual-layout` to scan deployed service trees instead of the legacy root `app/` tree and aligns it with the current 38vh / 260–520px hero standard.
- Strengthens `audit:hero-banners` with local poster existence checks and critical active route renderer checks.
- Adds runtime image/package and active visual-layout checks to the Integrity Gate and uploads their reports.

## Evidence / root causes
1. `/call-now` had no image hero or card images in code; it used a hand-built blue section and Lucide icons, bypassing the canonical hero system.
2. The previous image audit omitted all three active monorepo app trees, so its `0 missing refs` result was not a reliable production audit.
3. The previous visual-layout audit was generated against the legacy root `app/` tree rather than the deployed services.
4. Canonical Northflank configuration confirms Marketing uses `/Dockerfile.marketing`, which already packages root `public/`; LMS and Admin use `/Dockerfile.northflank-lms` and `/Dockerfile.northflank-admin`, where shared-public packaging is being hardened in this PR.

## Deployment safety
Northflank deployment workflows are restricted to pushes on `main`. PR validation builds Docker images on GitHub runners only and does not deploy this branch to Northflank.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Get Started page imagery, consolidate hero rendering, and add runtime asset audits
> - Reworks the Get Started page (`apps/marketing/app/call-now/page.tsx`) to use the shared `HeroPicture` hero component and replaces icon-only cards with image-backed cards driven by a `START_OPTIONS` data array.
> - Refactors `PictureFirstPageHero` into a compatibility wrapper that delegates image rendering to the canonical `HeroPicture` component.
> - Adds `audit-image-assets.mjs` and `audit-visual-layout.mjs` scripts that audit image refs per service, validate Dockerfile packaging contracts, and produce JSON/Markdown reports.
> - Updates `Dockerfile.northflank-admin` and `Dockerfile.northflank-lms` to copy shared root public assets into each app's public directory and fail the build if the images directory is missing.
> - Wires both new audit scripts into the CI integrity gate via `.github/workflows/integrity-gate.yml`.
> - Risk: `audit-image-assets.mjs` references `SCAN_DIRS` and `IMAGE_REF_RE` which are no longer defined in the file, causing a `ReferenceError` at runtime.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 1abbe76.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->