### PR TITLE
Fix Admin login middleware and role-safe portal redirects

### DIFF
--- a/.github/workflows/integrity-gate.yml
+++ b/.github/workflows/integrity-gate.yml
@@ -86,6 +86,9 @@ jobs:
       - name: API admin guard check
         run: bash scripts/audit-api-auth-guards.sh
 
+      - name: Authentication and role routing check
+        run: pnpm exec tsx scripts/audit-auth-role-routing.ts
+
       - name: Canonical hero system check
         run: pnpm run audit:hero-banners
 
@@ -150,6 +153,8 @@ jobs:
             reports/store_integrity_report.json
             reports/pre_auth_registry_report.json
             reports/grants_audit_context_report.json
+            docs/audits/AUTH_ROLE_ROUTING_AUDIT.json
+            docs/audits/AUTH_ROLE_ROUTING_AUDIT.md
             docs/audits/image-assets-audit.json
             docs/audits/IMAGE_ASSETS_AUDIT.md
             docs/audits/VISUAL_LAYOUT_AUDIT.json

--- a/apps/admin/app/api/auth/admin-login/route.ts
+++ b/apps/admin/app/api/auth/admin-login/route.ts
@@ -4,6 +4,7 @@ import { createClient } from '@/lib/supabase/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { getServerSupabaseEnvMisconfigurationReason } from '@/lib/supabase/server-env';
 import { applyNormalizedSupabaseUrlToEnv } from '@/lib/supabase/normalize-url';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { ADMIN_ROLES } from '@/lib/rbac/role-matrix';
 
 const ADMIN_PORTAL_LOGIN_ROLES = [
@@ -37,6 +38,9 @@ function jsonError(error: unknown): NextResponse {
 
 export async function POST(req: NextRequest) {
   try {
+    const rateLimited = await applyRateLimit(req, 'auth');
+    if (rateLimited) return rateLimited as NextResponse;
+
     const body = (await req.json().catch(() => null)) as
       | { email?: unknown; password?: unknown }
       | null;

--- a/apps/admin/app/api/auth/admin-login/route.ts
+++ b/apps/admin/app/api/auth/admin-login/route.ts
@@ -13,92 +13,132 @@ const ADMIN_PORTAL_LOGIN_ROLES = [
   'proctor',
 ] as string[];
 
-export async function POST(req: NextRequest) {
-  const { email, password } = await req.json();
-
-  if (!email || !password) {
-    return NextResponse.json({ error: 'Email and password required.' }, { status: 400 });
-  }
-
-  try {
-    const { hydrateProcessEnv } = await import('@/lib/secrets');
-    await hydrateProcessEnv();
-  } catch {
-    // platform_secrets hydration unavailable — continue with injected env
-  }
-  applyNormalizedSupabaseUrlToEnv();
-
-  const misconfigured = getServerSupabaseEnvMisconfigurationReason();
-  if (misconfigured) {
-    return NextResponse.json(
-      {
-        error:
-          'Admin authentication is misconfigured on this server. Contact engineering to update Supabase keys in Northflank.',
-        detail: misconfigured,
-      },
-      { status: 503 },
+function jsonError(error: unknown): NextResponse {
+  const message = error instanceof Error ? error.message : String(error ?? '');
+  const configurationFailure =
+    /SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_URL|MISSING_ENV|createAdminClient|requireAdminClient/i.test(
+      message,
     );
-  }
 
-  const supabase = await createClient();
-  const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
-    email: email.trim(),
-    password,
+  console.error('[admin-login] unexpected authentication failure', {
+    configurationFailure,
+    message,
   });
 
-  if (authError || !authData?.user) {
-    const raw = authError?.message || 'Invalid email or password.';
-    const invalidApiKey = /invalid api key/i.test(raw);
-    return NextResponse.json(
-      {
-        error: invalidApiKey
-          ? 'Admin authentication is misconfigured (invalid Supabase anon key on this deployment). Contact engineering.'
-          : raw,
-      },
-      { status: invalidApiKey ? 503 : 401 },
-    );
+  return NextResponse.json(
+    {
+      error: configurationFailure
+        ? 'Admin authentication is temporarily unavailable because the server authentication configuration is incomplete.'
+        : 'Admin authentication failed unexpectedly. Please retry.',
+    },
+    { status: configurationFailure ? 503 : 500 },
+  );
+}
+
+export async function POST(req: NextRequest) {
+  try {
+    const body = (await req.json().catch(() => null)) as
+      | { email?: unknown; password?: unknown }
+      | null;
+    const email = typeof body?.email === 'string' ? body.email.trim() : '';
+    const password = typeof body?.password === 'string' ? body.password : '';
+
+    if (!email || !password) {
+      return NextResponse.json({ error: 'Email and password required.' }, { status: 400 });
+    }
+
+    try {
+      const { hydrateProcessEnv } = await import('@/lib/secrets');
+      await hydrateProcessEnv();
+    } catch {
+      // platform_secrets hydration unavailable — continue with injected env
+    }
+    applyNormalizedSupabaseUrlToEnv();
+
+    const misconfigured = getServerSupabaseEnvMisconfigurationReason();
+    if (misconfigured) {
+      return NextResponse.json(
+        {
+          error:
+            'Admin authentication is misconfigured on this server. Contact engineering to update Supabase keys in Northflank.',
+        },
+        { status: 503 },
+      );
+    }
+
+    const supabase = await createClient();
+    const { data: authData, error: authError } = await supabase.auth.signInWithPassword({
+      email,
+      password,
+    });
+
+    if (authError || !authData?.user) {
+      const raw = authError?.message || 'Invalid email or password.';
+      const invalidApiKey = /invalid api key/i.test(raw);
+      return NextResponse.json(
+        {
+          error: invalidApiKey
+            ? 'Admin authentication is misconfigured (invalid Supabase anon key on this deployment). Contact engineering.'
+            : raw,
+        },
+        { status: invalidApiKey ? 503 : 401 },
+      );
+    }
+
+    // requireAdminClient can throw on a cold start or missing service-role secret.
+    // Keep it inside this route-level try/catch so the client always receives JSON,
+    // never Next.js' HTML error document.
+    const db = await requireAdminClient();
+    const { data: profile, error: profileError } = await db
+      .from('profiles')
+      .select('role')
+      .eq('id', authData.user.id)
+      .maybeSingle();
+
+    if (profileError) {
+      await supabase.auth.signOut();
+      return NextResponse.json(
+        { error: `Profile load failed: ${profileError.message}. Contact support.` },
+        { status: 500 },
+      );
+    }
+
+    if (!profile) {
+      await supabase.auth.signOut();
+      return NextResponse.json(
+        { error: 'No profile found for your account. Contact support.' },
+        { status: 403 },
+      );
+    }
+
+    const { data: roleRows, error: rolesError } = await db
+      .from('user_roles')
+      .select('roles(name)')
+      .eq('user_id', authData.user.id);
+
+    if (rolesError) {
+      await supabase.auth.signOut();
+      return NextResponse.json(
+        { error: 'Unable to verify your admin roles. Please retry.' },
+        { status: 500 },
+      );
+    }
+
+    const secondaryRoles = (roleRows ?? [])
+      .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
+      .filter((role): role is string => typeof role === 'string');
+    const effectiveRoles = Array.from(new Set([profile.role, ...secondaryRoles].filter(Boolean))) as string[];
+
+    if (!effectiveRoles.some((role) => ADMIN_PORTAL_LOGIN_ROLES.includes(role))) {
+      await supabase.auth.signOut();
+      return NextResponse.json(
+        { error: 'You do not have permission to access the admin portal.' },
+        { status: 403 },
+      );
+    }
+
+    return NextResponse.json({ ok: true, role: profile.role, effectiveRoles });
+  } catch (error) {
+    return jsonError(error);
   }
-
-  const db = await requireAdminClient();
-  const { data: profile, error: profileError } = await db
-    .from('profiles')
-    .select('role')
-    .eq('id', authData.user.id)
-    .maybeSingle();
-
-  if (profileError) {
-    await supabase.auth.signOut();
-    return NextResponse.json(
-      { error: `Profile load failed: ${profileError.message}. Contact support.` },
-      { status: 500 },
-    );
-  }
-
-  if (!profile) {
-    await supabase.auth.signOut();
-    return NextResponse.json(
-      { error: 'No profile found for your account. Contact support.' },
-      { status: 403 },
-    );
-  }
-
-  const { data: roleRows } = await db
-    .from('user_roles')
-    .select('roles(name)')
-    .eq('user_id', authData.user.id);
-
-  const secondaryRoles = (roleRows ?? [])
-    .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
-    .filter((role): role is string => typeof role === 'string');
-  const effectiveRoles = Array.from(new Set([profile.role, ...secondaryRoles]));
-
-  if (!effectiveRoles.some((role) => ADMIN_PORTAL_LOGIN_ROLES.includes(role))) {
-    await supabase.auth.signOut();
-    return NextResponse.json(
-      { error: 'You do not have permission to access the admin portal.' },
-      { status: 403 },
-    );
-  }
-
-  return NextResponse.json({ ok: true, role: profile.role, effectiveRoles });
 }

--- a/apps/admin/app/login/LoginForm.tsx
+++ b/apps/admin/app/login/LoginForm.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect } from 'react';
+import { useState } from 'react';
 import { createClient } from '@/lib/supabase/client';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { validateRedirect } from '@/lib/auth/validate-redirect';
@@ -23,9 +23,9 @@ async function readAdminLoginResponse(res: Response): Promise<AdminLoginResponse
     return (await res.json()) as AdminLoginResponse;
   }
 
-  // A Next.js 404/500 document starts with <!DOCTYPE html>. Do not call
-  // response.json() on it — that is the source of the raw "Unexpected token <"
-  // error previously shown to administrators.
+  // A middleware redirect or Next.js 404/500 document starts with HTML. Do not
+  // call response.json() on it — that is the source of the raw
+  // "Unexpected token < / <!DOCTYPE ... is not valid JSON" error.
   const raw = await res.text();
   console.error('[admin-login] endpoint returned a non-JSON response', {
     status: res.status,
@@ -54,18 +54,10 @@ export default function AdminLoginForm({ redirectTo, initialError }: { redirectT
 
   const next = getSafeRedirect(redirectTo ?? null);
 
-  // Check if already logged in on mount
-  useEffect(() => {
-    async function checkSession() {
-      const supabase = createClient();
-      const { data: { user } } = await supabase.auth.getUser();
-      if (user) {
-        // Already logged in - redirect to admin dashboard
-        window.location.href = next;
-      }
-    }
-    checkSession();
-  }, [next]);
+  // Do not auto-redirect merely because a shared Supabase cookie exists.
+  // Sessions are deliberately scoped to .elevateforhumanity.org so a student,
+  // employer, or partner can arrive on the Admin subdomain with a valid session.
+  // Admin access must be proven by the credential endpoint + role check below.
 
   const handleLogin = async (e: React.FormEvent) => {
     e.preventDefault();

--- a/apps/admin/app/login/LoginForm.tsx
+++ b/apps/admin/app/login/LoginForm.tsx
@@ -1,13 +1,44 @@
 'use client';
 
 import { useState, useEffect } from 'react';
-import Image from 'next/image';
 import { createClient } from '@/lib/supabase/client';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { validateRedirect } from '@/lib/auth/validate-redirect';
 
 function getSafeRedirect(raw: string | null | undefined): string {
   return validateRedirect(raw, '/dashboard');
+}
+
+type AdminLoginResponse = {
+  ok?: boolean;
+  error?: string;
+  role?: string;
+  effectiveRoles?: string[];
+};
+
+async function readAdminLoginResponse(res: Response): Promise<AdminLoginResponse> {
+  const contentType = res.headers.get('content-type')?.toLowerCase() ?? '';
+
+  if (contentType.includes('application/json')) {
+    return (await res.json()) as AdminLoginResponse;
+  }
+
+  // A Next.js 404/500 document starts with <!DOCTYPE html>. Do not call
+  // response.json() on it — that is the source of the raw "Unexpected token <"
+  // error previously shown to administrators.
+  const raw = await res.text();
+  console.error('[admin-login] endpoint returned a non-JSON response', {
+    status: res.status,
+    contentType,
+    preview: raw.slice(0, 120),
+  });
+
+  return {
+    error:
+      res.status === 404
+        ? 'The admin authentication endpoint is not available on this deployment. Please retry after the Admin service finishes deploying.'
+        : `The admin authentication service returned an invalid response (HTTP ${res.status || 500}). Please retry.`,
+  };
 }
 
 export default function AdminLoginForm({ redirectTo, initialError }: { redirectTo?: string; initialError?: string }) {
@@ -46,21 +77,24 @@ export default function AdminLoginForm({ redirectTo, initialError }: { redirectT
       // Avoids RLS blocking the profile read when using the anon client.
       const res = await fetch('/api/auth/admin-login', {
         method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
+        headers: {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+        },
+        cache: 'no-store',
         body: JSON.stringify({ email: email.trim(), password }), // never trim passwords
       });
 
-      const body = await res.json();
+      const body = await readAdminLoginResponse(res);
 
-      if (!res.ok) {
+      if (!res.ok || body.ok !== true) {
         setError(body.error || 'Invalid email or password.');
-        setLoading(false);
         return;
       }
 
       window.location.href = next;
-    } catch (err: any) {
-      setError(err?.message || 'Invalid email or password');
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Admin authentication request failed. Please retry.');
     } finally {
       setLoading(false);
     }
@@ -82,8 +116,8 @@ export default function AdminLoginForm({ redirectTo, initialError }: { redirectT
 
       if (resetError) throw resetError;
       setForgotSent(true);
-    } catch (err: any) {
-      setForgotError(err?.message || 'Failed to send reset email. Try again.');
+    } catch (err: unknown) {
+      setForgotError(err instanceof Error ? err.message : 'Failed to send reset email. Try again.');
     } finally {
       setForgotLoading(false);
     }

--- a/apps/admin/middleware.ts
+++ b/apps/admin/middleware.ts
@@ -14,6 +14,10 @@ import {
 const PUBLIC_PATHS = [
   '/login',
   '/unauthorized',
+  // The credential endpoint must be reachable before a Supabase session exists.
+  // If middleware redirects this POST to /login, Next.js returns HTML and the
+  // login form sees "Unexpected token '<' / <!DOCTYPE ... is not valid JSON".
+  '/api/auth/admin-login',
   '/api/health',
   '/api/ping',
   '/api/version',

--- a/apps/lms/app/api/auth/signin/route.ts
+++ b/apps/lms/app/api/auth/signin/route.ts
@@ -1,9 +1,11 @@
 // PUBLIC ROUTE: sign-in endpoint — no auth possible
-import { safeInternalError } from '@/lib/api/safe-error';
 /**
  * Auth API - Sign In
- * Authenticates user with email and password
- * Protected with rate limiting and input validation
+ * Authenticates user with email and password.
+ * Protected with rate limiting and input validation.
+ *
+ * Session tokens are persisted only through Supabase's HttpOnly/shared-domain
+ * cookie response. They are intentionally not echoed into JSON.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
@@ -19,29 +21,27 @@ const _POST = withErrorHandling(async (request: NextRequest) => {
 
   const supabase = await createClient();
 
-  // Parse and validate request body
   let body;
   try {
     body = await request.json();
   } catch {
     return NextResponse.json(
       { error: 'Invalid JSON in request body', code: 'BAD_REQUEST' },
-      { status: 400 }
+      { status: 400 },
     );
   }
-  
+
   let validatedData;
   try {
     validatedData = signInSchema.parse(body);
   } catch (err) {
     return NextResponse.json(
       { error: 'Invalid request data', code: 'VALIDATION_ERROR', details: (err as Error).message },
-      { status: 400 }
+      { status: 400 },
     );
   }
   const { email, password } = validatedData;
 
-  // Sign in
   const { data, error } = await supabase.auth.signInWithPassword({
     email,
     password,
@@ -61,19 +61,22 @@ const _POST = withErrorHandling(async (request: NextRequest) => {
     throw APIErrors.internal('Authentication failed');
   }
 
-  return NextResponse.json({
-    success: true,
-    user: {
-      id: data.user.id,
-      email: data.user.email,
-      firstName: data.user.user_metadata?.first_name,
-      lastName: data.user.user_metadata?.last_name,
+  return NextResponse.json(
+    {
+      success: true,
+      user: {
+        id: data.user.id,
+        email: data.user.email,
+        firstName: data.user.user_metadata?.first_name,
+        lastName: data.user.user_metadata?.last_name,
+      },
     },
-    session: {
-      accessToken: data.session.access_token,
-      expiresAt: data.session.expires_at,
+    {
+      headers: {
+        'Cache-Control': 'no-store, private, max-age=0',
+      },
     },
-  });
+  );
 });
 
 export const runtime = 'nodejs';

--- a/apps/lms/app/dashboard/page.tsx
+++ b/apps/lms/app/dashboard/page.tsx
@@ -13,7 +13,11 @@ export default async function DashboardPage() {
   const supabase = await createClient();
   const { data: { user } } = await supabase.auth.getUser();
 
-  if (!user) redirect('/login?redirect=/dashboard');
+  // `/dashboard` is owned by the Admin deployment. The previous redirect
+  // preserved that ambiguous path and caused a student who signed in on the LMS
+  // host to be sent to admin.elevateforhumanity.org. Keep the login return path
+  // explicitly inside the LMS application instead.
+  if (!user) redirect('/login?redirect=/lms/dashboard');
 
   const { data: profile } = await supabase
     .from('profiles')

--- a/apps/lms/app/login/apprentice/ApprenticeLoginForm.tsx
+++ b/apps/lms/app/login/apprentice/ApprenticeLoginForm.tsx
@@ -6,6 +6,12 @@ import { Loader2 } from 'lucide-react';
 import { createClient } from '@/lib/supabase/client';
 import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
 
+const APPRENTICE_ROLES = new Set([
+  'apprentice',
+  'barber_apprentice',
+  'cosmetology_apprentice',
+]);
+
 export default function ApprenticeLoginForm() {
   const [email, setEmail] = useState('');
   const [password, setPassword] = useState('');
@@ -35,16 +41,43 @@ export default function ApprenticeLoginForm() {
         return;
       }
 
-      const { data: profile } = await supabase
+      const { data: profile, error: profileError } = await supabase
         .from('profiles')
-        .select('portal_type')
+        .select('role, portal_type')
         .eq('id', data.user.id)
         .maybeSingle();
+
+      if (profileError || !profile) {
+        await supabase.auth.signOut();
+        throw new Error('Your learner profile could not be verified. Please use the main login or contact support.');
+      }
+
+      const { data: roleRows, error: rolesError } = await supabase
+        .from('user_roles')
+        .select('roles(name)')
+        .eq('user_id', data.user.id);
+
+      if (rolesError) {
+        await supabase.auth.signOut();
+        throw new Error('Your apprenticeship access could not be verified. Please retry.');
+      }
+
+      const secondaryRoles = (roleRows ?? [])
+        .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
+        .filter((role): role is string => typeof role === 'string');
+      const effectiveRoles = new Set(
+        [profile.role, ...secondaryRoles].filter((role): role is string => typeof role === 'string'),
+      );
+
+      if (![...effectiveRoles].some((role) => APPRENTICE_ROLES.has(role))) {
+        await supabase.auth.signOut();
+        throw new Error('This account is not assigned to an apprenticeship portal. Please use the main student and partner login.');
+      }
 
       const dest = await resolveStudentHomePath(
         supabase,
         data.user.id,
-        profile?.portal_type,
+        profile.portal_type,
       );
 
       window.location.href = dest;

--- a/apps/lms/app/login/page.tsx
+++ b/apps/lms/app/login/page.tsx
@@ -16,6 +16,43 @@ const APPRENTICE_ROLES = new Set([
   'cosmetology_apprentice',
 ]);
 
+type SignInApiResponse = {
+  success?: boolean;
+  error?: string;
+  message?: string;
+  user?: { id?: string; email?: string };
+};
+
+async function serverSignIn(email: string, password: string): Promise<string> {
+  const response = await fetch('/api/auth/signin', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Accept: 'application/json',
+    },
+    cache: 'no-store',
+    body: JSON.stringify({ email: email.trim(), password }),
+  });
+
+  const contentType = response.headers.get('content-type')?.toLowerCase() ?? '';
+  if (!contentType.includes('application/json')) {
+    const raw = await response.text();
+    console.error('[login] sign-in endpoint returned non-JSON', {
+      status: response.status,
+      contentType,
+      preview: raw.slice(0, 120),
+    });
+    throw new Error(`Authentication service returned an invalid response (HTTP ${response.status || 500}).`);
+  }
+
+  const body = (await response.json()) as SignInApiResponse;
+  if (!response.ok || body.success !== true || !body.user?.id) {
+    throw new Error(body.error || body.message || 'Invalid email or password.');
+  }
+
+  return body.user.id;
+}
+
 export default function LoginPage() {
   const searchParams = useSafeSearchParams();
   const requestedRedirect = searchParams.get('next') || searchParams.get('redirect') || '';
@@ -40,14 +77,13 @@ export default function LoginPage() {
     setError('');
 
     try {
+      // Sign in through the server route instead of directly from the browser.
+      // lib/supabase/server.ts scopes Supabase auth cookies to
+      // .elevateforhumanity.org, so a valid session survives role-based moves
+      // between app, admin, and www subdomains. The API also applies the auth
+      // rate limiter and request validation.
+      const userId = await serverSignIn(email, password);
       const supabase = createClient();
-      const { data, error: signInError } = await supabase.auth.signInWithPassword({
-        email: email.trim(),
-        password,
-      });
-
-      if (signInError) throw signInError;
-      if (!data.user) throw new Error('Authentication completed without a user session.');
 
       // Resolve the user's authoritative role before evaluating any requested
       // redirect. Previously `/login?redirect=/dashboard` was honored first;
@@ -56,7 +92,7 @@ export default function LoginPage() {
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('role, portal_type, onboarding_completed')
-        .eq('id', data.user.id)
+        .eq('id', userId)
         .maybeSingle();
 
       if (profileError) {
@@ -71,7 +107,7 @@ export default function LoginPage() {
       const { data: roleRows, error: rolesError } = await supabase
         .from('user_roles')
         .select('roles(name)')
-        .eq('user_id', data.user.id);
+        .eq('user_id', userId);
 
       if (rolesError) {
         throw new Error('Unable to verify your portal access. Please try again.');
@@ -95,7 +131,7 @@ export default function LoginPage() {
         // canonical /apprentice runtime. Do not let a stale redirect override it.
         destination = await resolveStudentHomePath(
           supabase,
-          data.user.id,
+          userId,
           typeof profile.portal_type === 'string' ? profile.portal_type : undefined,
         );
         allowRequestedRedirect = false;

--- a/apps/lms/app/login/page.tsx
+++ b/apps/lms/app/login/page.tsx
@@ -4,11 +4,17 @@ import { FormEvent, useEffect, useState } from 'react';
 import Link from 'next/link';
 import { createClient } from '@/lib/supabase/client';
 import { validateRedirect } from '@/lib/auth/validate-redirect';
+import { resolveRoleCompatiblePostLoginUrl } from '@/lib/auth/post-login-redirect';
 import { useSafeSearchParams } from '@/hooks/useSafeSearchParams';
 import { siteUrls } from '@/lib/utils/site-urls';
-import { absoluteRoleDestination } from '@/lib/auth/absolute-role-destination';
 import { resolveStudentHomePath } from '@/lib/portal/resolve-student-home';
 import { resolveDashboardUrl } from '@/lib/routing/dashboard-resolver';
+
+const APPRENTICE_ROLES = new Set([
+  'apprentice',
+  'barber_apprentice',
+  'cosmetology_apprentice',
+]);
 
 export default function LoginPage() {
   const searchParams = useSafeSearchParams();
@@ -20,8 +26,8 @@ export default function LoginPage() {
   const [error, setError] = useState('');
   const [loading, setLoading] = useState(false);
 
-  // Restore the May behavior: an idle-timeout redirect must actually clear the
-  // Supabase browser session before the user signs in again.
+  // An idle-timeout redirect must actually clear the Supabase browser session
+  // before the user signs in again.
   useEffect(() => {
     if (reason !== 'idle') return;
     const supabase = createClient();
@@ -43,11 +49,10 @@ export default function LoginPage() {
       if (signInError) throw signInError;
       if (!data.user) throw new Error('Authentication completed without a user session.');
 
-      if (safeRedirect) {
-        window.location.assign(absoluteRoleDestination(safeRedirect));
-        return;
-      }
-
+      // Resolve the user's authoritative role before evaluating any requested
+      // redirect. Previously `/login?redirect=/dashboard` was honored first;
+      // `/dashboard` belongs to the Admin host, so students could be sent to
+      // admin.elevateforhumanity.org immediately after a successful login.
       const { data: profile, error: profileError } = await supabase
         .from('profiles')
         .select('role, portal_type, onboarding_completed')
@@ -63,35 +68,49 @@ export default function LoginPage() {
         return;
       }
 
-      const { data: roleRows } = await supabase
+      const { data: roleRows, error: rolesError } = await supabase
         .from('user_roles')
         .select('roles(name)')
         .eq('user_id', data.user.id);
 
+      if (rolesError) {
+        throw new Error('Unable to verify your portal access. Please try again.');
+      }
+
       const secondaryRoles = (roleRows ?? [])
         .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
         .filter((role): role is string => typeof role === 'string');
-      const effectiveRoles = Array.from(new Set([profile.role, ...secondaryRoles].filter(Boolean))) as string[];
+      const effectiveRoles = Array.from(
+        new Set([profile.role, ...secondaryRoles].filter(Boolean)),
+      ) as string[];
 
       let destination: string;
+      let allowRequestedRedirect = true;
 
       if (profile.role === 'employer' && profile.onboarding_completed !== true) {
         destination = `${siteUrls.app}/onboarding/employer`;
-      } else if (effectiveRoles.some((role) => ['apprentice', 'barber_apprentice', 'cosmetology_apprentice'].includes(role))) {
-        // Resolve the apprentice's actual occupation/program portal. Never hard-code barber.
+        allowRequestedRedirect = false;
+      } else if (effectiveRoles.some((role) => APPRENTICE_ROLES.has(role))) {
+        // Resolve program context while keeping every apprenticeship on the
+        // canonical /apprentice runtime. Do not let a stale redirect override it.
         destination = await resolveStudentHomePath(
           supabase,
           data.user.id,
           typeof profile.portal_type === 'string' ? profile.portal_type : undefined,
         );
-      } else if (
-        profile.role === 'student' &&
-        typeof profile.portal_type === 'string' &&
-        profile.portal_type.trim() !== ''
-      ) {
-        destination = `${siteUrls.app}/portal/${profile.portal_type.trim()}`;
+        allowRequestedRedirect = false;
       } else {
+        // portal_type is retained as enrollment metadata, not as permission to
+        // invent /portal/* routes. Role ownership determines the actual portal.
         destination = resolveDashboardUrl(profile.role, effectiveRoles);
+      }
+
+      if (safeRedirect && allowRequestedRedirect) {
+        destination = resolveRoleCompatiblePostLoginUrl(
+          safeRedirect,
+          profile.role,
+          effectiveRoles,
+        );
       }
 
       window.location.assign(destination);

--- a/lib/auth/post-login-redirect.ts
+++ b/lib/auth/post-login-redirect.ts
@@ -1,0 +1,61 @@
+import { absoluteRoleDestination } from '@/lib/auth/absolute-role-destination';
+import {
+  ROLE_ROUTE_CONFIG,
+  getRoleDestinationUrl,
+  resolveRoleRoute,
+} from '@/lib/auth/role-destinations';
+
+function firstPathSegment(path: string): string {
+  const pathname = path.split(/[?#]/, 1)[0] || '/';
+  const segment = pathname.split('/').filter(Boolean)[0];
+  return segment ? `/${segment}` : '/';
+}
+
+const ROLE_OWNED_PREFIXES = new Set(
+  Object.values(ROLE_ROUTE_CONFIG).map((config) => firstPathSegment(config.path)),
+);
+
+/**
+ * Returns a post-login URL that cannot move a user into another role's portal.
+ *
+ * `validateRedirect()` protects against open redirects. This adds the missing
+ * authorization layer: a local redirect must remain on the same deployed host
+ * as the user's canonical role destination, and role-owned top-level prefixes
+ * must match the user's own portal prefix.
+ */
+export function resolveRoleCompatiblePostLoginUrl(
+  requestedPath: string | null | undefined,
+  role: string | null | undefined,
+  effectiveRoles?: string[],
+): string {
+  const canonicalUrl = getRoleDestinationUrl(role, effectiveRoles);
+  if (!requestedPath) return canonicalUrl;
+
+  // Legacy field-based learner portals are not active application routes.
+  // Never route a successful login into a known dead /portal/* destination.
+  if (requestedPath === '/portal' || requestedPath.startsWith('/portal/')) {
+    return canonicalUrl;
+  }
+
+  try {
+    const requestedUrl = new URL(absoluteRoleDestination(requestedPath));
+    const canonical = new URL(canonicalUrl);
+
+    if (requestedUrl.origin !== canonical.origin) return canonicalUrl;
+
+    const requestedPrefix = firstPathSegment(requestedUrl.pathname);
+    const canonicalConfig = resolveRoleRoute(role, effectiveRoles);
+    const canonicalPrefix = firstPathSegment(canonicalConfig.path);
+
+    if (
+      ROLE_OWNED_PREFIXES.has(requestedPrefix) &&
+      requestedPrefix !== canonicalPrefix
+    ) {
+      return canonicalUrl;
+    }
+
+    return requestedUrl.toString();
+  } catch {
+    return canonicalUrl;
+  }
+}

--- a/lib/portal/router.ts
+++ b/lib/portal/router.ts
@@ -16,16 +16,22 @@ export type PortalKey =
   | 'hospitality'
   | 'jri';
 
+/**
+ * Only /apprentice currently has a dedicated learner runtime. The former
+ * /portal/* field pages are not present in apps/lms/app, so sending a valid
+ * student session there produces a 404. Keep the field value as metadata while
+ * routing standard learners through the canonical LMS dashboard.
+ */
 export const PORTAL_PATHS: Record<PortalKey, string> = {
   apprentice: '/apprentice',
-  healthcare: '/portal/healthcare',
-  technology: '/portal/technology',
-  business: '/portal/business',
-  beauty: '/portal/beauty',
-  trades: '/portal/trades',
-  'social-services': '/portal/social-services',
-  hospitality: '/portal/hospitality',
-  jri: '/portal/jri',
+  healthcare: '/lms/dashboard',
+  technology: '/lms/dashboard',
+  business: '/lms/dashboard',
+  beauty: '/lms/dashboard',
+  trades: '/lms/dashboard',
+  'social-services': '/lms/dashboard',
+  hospitality: '/lms/dashboard',
+  jri: '/lms/dashboard',
 };
 
 /** Legacy occupation-specific profile values all resolve to the canonical apprentice portal. */

--- a/scripts/audit-auth-role-routing.ts
+++ b/scripts/audit-auth-role-routing.ts
@@ -3,6 +3,12 @@ import fs from 'node:fs';
 import path from 'node:path';
 import { ROLE_ROUTE_CONFIG } from '../lib/auth/role-destinations';
 import { PORTAL_PATHS } from '../lib/portal/router';
+import {
+  ADMIN_ROLES,
+  INSTRUCTOR_ROLES,
+  STAFF_ROLES,
+  TESTING_CENTER_ROLES,
+} from '../lib/rbac/role-matrix';
 
 const ROOT = process.cwd();
 const APP_ROOTS = {
@@ -44,6 +50,15 @@ function read(file: string): string {
   return fs.readFileSync(path.join(ROOT, file), 'utf8');
 }
 
+function adminRolesForPath(route: string): readonly string[] {
+  if (route.startsWith('/staff-portal')) return STAFF_ROLES;
+  if (route.startsWith('/instructor')) return INSTRUCTOR_ROLES;
+  if (route === '/testing-center' || route.startsWith('/testing-center/')) {
+    return TESTING_CENTER_ROLES;
+  }
+  return ADMIN_ROLES;
+}
+
 const filesByHost = Object.fromEntries(
   Object.entries(APP_ROOTS).map(([host, appRoot]) => [host, walk(appRoot)]),
 ) as Record<Host, string[]>;
@@ -67,6 +82,14 @@ for (const [role, config] of Object.entries(ROLE_ROUTE_CONFIG)) {
       severity: 'blocker',
       code: 'ROLE_DESTINATION_MISSING',
       detail: `${role} -> ${host}:${config.path} has no active page.tsx route`,
+    });
+  }
+
+  if (host === 'admin' && !adminRolesForPath(config.path).includes(role as never)) {
+    findings.push({
+      severity: 'warning',
+      code: 'ROLE_DESTINATION_AUTH_MISMATCH',
+      detail: `${role} routes to Admin ${config.path} but is not included in that middleware role set`,
     });
   }
 }
@@ -118,6 +141,61 @@ for (const file of filesByHost.lms) {
   }
 }
 
+const lmsMainLogin = 'apps/lms/app/login/page.tsx';
+if (fs.existsSync(path.join(ROOT, lmsMainLogin))) {
+  const source = read(lmsMainLogin);
+  if (source.includes('signInWithPassword')) {
+    findings.push({
+      severity: 'blocker',
+      code: 'LMS_MAIN_LOGIN_BROWSER_ONLY_AUTH',
+      file: lmsMainLogin,
+      detail: 'Main LMS login bypasses the server sign-in route and shared-domain session cookie policy',
+    });
+  }
+  if (!source.includes("fetch('/api/auth/signin'")) {
+    findings.push({
+      severity: 'blocker',
+      code: 'LMS_MAIN_LOGIN_SERVER_AUTH_MISSING',
+      file: lmsMainLogin,
+      detail: 'Main LMS login is not using the rate-limited server sign-in endpoint',
+    });
+  }
+}
+
+const lmsSignInRoute = 'apps/lms/app/api/auth/signin/route.ts';
+if (fs.existsSync(path.join(ROOT, lmsSignInRoute))) {
+  const source = read(lmsSignInRoute);
+  if (!source.includes("applyRateLimit(request, 'auth')")) {
+    findings.push({
+      severity: 'blocker',
+      code: 'LMS_SIGNIN_NOT_RATE_LIMITED',
+      file: lmsSignInRoute,
+      detail: 'Public LMS credential endpoint is missing the auth rate limiter',
+    });
+  }
+  if (/accessToken\s*:|access_token/.test(source.split('return NextResponse.json')[1] ?? '')) {
+    findings.push({
+      severity: 'blocker',
+      code: 'LMS_SIGNIN_TOKEN_IN_JSON',
+      file: lmsSignInRoute,
+      detail: 'LMS sign-in response exposes session/access token material in JSON',
+    });
+  }
+}
+
+const sharedServerClient = 'lib/supabase/server.ts';
+if (fs.existsSync(path.join(ROOT, sharedServerClient))) {
+  const source = read(sharedServerClient);
+  if (!source.includes("domain: '.elevateforhumanity.org'")) {
+    findings.push({
+      severity: 'blocker',
+      code: 'SHARED_AUTH_COOKIE_DOMAIN_MISSING',
+      file: sharedServerClient,
+      detail: 'Server Supabase auth cookies are not scoped to the Elevate root domain for cross-portal sessions',
+    });
+  }
+}
+
 const adminLoginForm = 'apps/admin/app/login/LoginForm.tsx';
 if (fs.existsSync(path.join(ROOT, adminLoginForm))) {
   const source = read(adminLoginForm);
@@ -132,6 +210,14 @@ if (fs.existsSync(path.join(ROOT, adminLoginForm))) {
       detail: 'Admin login must validate response content-type before parsing JSON',
     });
   }
+  if (source.includes('supabase.auth.getUser()') && source.includes('window.location.href = next')) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ADMIN_LOGIN_SHARED_SESSION_AUTO_REDIRECT',
+      file: adminLoginForm,
+      detail: 'Admin login auto-redirects any shared-domain session without proving an Admin role',
+    });
+  }
 }
 
 const adminLoginRoute = 'apps/admin/app/api/auth/admin-login/route.ts';
@@ -143,6 +229,14 @@ if (fs.existsSync(path.join(ROOT, adminLoginRoute))) {
       code: 'ADMIN_LOGIN_UNCAUGHT_SERVER_ERROR',
       file: adminLoginRoute,
       detail: 'Admin login can throw before returning a JSON response',
+    });
+  }
+  if (!source.includes("applyRateLimit(req, 'auth')")) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ADMIN_LOGIN_NOT_RATE_LIMITED',
+      file: adminLoginRoute,
+      detail: 'Public Admin credential endpoint is missing the auth rate limiter',
     });
   }
 } else {

--- a/scripts/audit-auth-role-routing.ts
+++ b/scripts/audit-auth-role-routing.ts
@@ -154,6 +154,29 @@ if (fs.existsSync(path.join(ROOT, adminLoginRoute))) {
   });
 }
 
+// Credential endpoints must be reachable before a session exists. Protecting
+// the Admin POST with auth middleware redirects it to /login and returns HTML,
+// which produced the production "<!DOCTYPE ... is not valid JSON" failure.
+const adminMiddleware = 'apps/admin/middleware.ts';
+if (fs.existsSync(path.join(ROOT, adminMiddleware))) {
+  const source = read(adminMiddleware);
+  if (!source.includes("'/api/auth/admin-login'")) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ADMIN_LOGIN_API_NOT_PUBLIC',
+      file: adminMiddleware,
+      detail: '/api/auth/admin-login is not in the Admin middleware public-path allowlist',
+    });
+  }
+} else {
+  findings.push({
+    severity: 'blocker',
+    code: 'ADMIN_MIDDLEWARE_MISSING',
+    file: adminMiddleware,
+    detail: 'Active Admin middleware is missing',
+  });
+}
+
 // Non-route login-like files are a maintenance risk. They are warnings rather
 // than blockers because role-specific login pages can legitimately coexist.
 for (const file of loginFiles) {

--- a/scripts/audit-auth-role-routing.ts
+++ b/scripts/audit-auth-role-routing.ts
@@ -1,0 +1,227 @@
+#!/usr/bin/env tsx
+import fs from 'node:fs';
+import path from 'node:path';
+import { ROLE_ROUTE_CONFIG } from '../lib/auth/role-destinations';
+import { PORTAL_PATHS } from '../lib/portal/router';
+
+const ROOT = process.cwd();
+const APP_ROOTS = {
+  admin: 'apps/admin/app',
+  lms: 'apps/lms/app',
+  marketing: 'apps/marketing/app',
+} as const;
+
+type Host = keyof typeof APP_ROOTS;
+type Finding = { severity: 'blocker' | 'warning'; code: string; file?: string; detail: string };
+
+function walk(relativeDir: string, out: string[] = []): string[] {
+  const absoluteDir = path.join(ROOT, relativeDir);
+  if (!fs.existsSync(absoluteDir)) return out;
+  for (const entry of fs.readdirSync(absoluteDir, { withFileTypes: true })) {
+    if (entry.name.startsWith('.') || ['node_modules', '.next'].includes(entry.name)) continue;
+    const rel = path.posix.join(relativeDir.replaceAll('\\', '/'), entry.name);
+    if (entry.isDirectory()) walk(rel, out);
+    else out.push(rel);
+  }
+  return out;
+}
+
+function routeFromPage(appRoot: string, file: string): string | null {
+  if (!/\/page\.(?:tsx?|jsx?)$/.test(file)) return null;
+  const relative = path.posix.relative(appRoot, path.posix.dirname(file));
+  const segments = relative === '.' ? [] : relative.split('/');
+  const visible = segments.filter(
+    (segment) =>
+      segment &&
+      !/^\(.*\)$/.test(segment) &&
+      !segment.startsWith('@') &&
+      !segment.startsWith('(..'),
+  );
+  return visible.length ? `/${visible.join('/')}` : '/';
+}
+
+function read(file: string): string {
+  return fs.readFileSync(path.join(ROOT, file), 'utf8');
+}
+
+const filesByHost = Object.fromEntries(
+  Object.entries(APP_ROOTS).map(([host, appRoot]) => [host, walk(appRoot)]),
+) as Record<Host, string[]>;
+
+const routesByHost = Object.fromEntries(
+  Object.entries(APP_ROOTS).map(([host, appRoot]) => [
+    host,
+    new Set(filesByHost[host as Host].map((file) => routeFromPage(appRoot, file)).filter(Boolean)),
+  ]),
+) as Record<Host, Set<string>>;
+
+const findings: Finding[] = [];
+
+// Every canonical role destination must resolve to a page in the deployment
+// that owns that role. This catches role records that authenticate correctly
+// but are then sent to a 404 or the wrong application.
+for (const [role, config] of Object.entries(ROLE_ROUTE_CONFIG)) {
+  const host = config.host as Host;
+  if (!routesByHost[host]?.has(config.path)) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ROLE_DESTINATION_MISSING',
+      detail: `${role} -> ${host}:${config.path} has no active page.tsx route`,
+    });
+  }
+}
+
+// Field/category portal metadata must not invent routes that do not exist.
+for (const [portal, route] of Object.entries(PORTAL_PATHS)) {
+  if (!routesByHost.lms.has(route)) {
+    findings.push({
+      severity: 'blocker',
+      code: 'LEARNER_PORTAL_MISSING',
+      detail: `${portal} -> lms:${route} has no active page.tsx route`,
+    });
+  }
+}
+
+const activeFiles = Object.values(filesByHost).flat();
+const loginFiles = activeFiles.filter((file) => {
+  if (!/\.(?:tsx?|jsx?)$/.test(file)) return false;
+  const source = read(file);
+  return /(?:\/login\/|\/login\/page\.|LoginForm)/.test(file) || source.includes('signInWithPassword');
+});
+
+for (const file of filesByHost.lms) {
+  if (!/\.(?:tsx?|jsx?)$/.test(file)) continue;
+  const source = read(file);
+  if (/\/login\?redirect=\/dashboard(?:["'`&]|$)/.test(source)) {
+    findings.push({
+      severity: 'blocker',
+      code: 'AMBIGUOUS_LMS_DASHBOARD_REDIRECT',
+      file,
+      detail: 'LMS login return path uses /dashboard, which belongs to the Admin deployment',
+    });
+  }
+  if (/absoluteRoleDestination\(safeRedirect\)/.test(source)) {
+    findings.push({
+      severity: 'blocker',
+      code: 'REDIRECT_BEFORE_ROLE_CHECK',
+      file,
+      detail: 'Login redirect can be converted to a deployment URL without role compatibility enforcement',
+    });
+  }
+  if (/\/portal\/\$\{\s*profile\.portal_type/.test(source)) {
+    findings.push({
+      severity: 'blocker',
+      code: 'DYNAMIC_PORTAL_TYPE_ROUTE',
+      file,
+      detail: 'profile.portal_type is being used to invent an LMS /portal/* route',
+    });
+  }
+}
+
+const adminLoginForm = 'apps/admin/app/login/LoginForm.tsx';
+if (fs.existsSync(path.join(ROOT, adminLoginForm))) {
+  const source = read(adminLoginForm);
+  if (
+    source.includes("fetch('/api/auth/admin-login'") &&
+    !source.includes("headers.get('content-type')")
+  ) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ADMIN_LOGIN_BLIND_JSON_PARSE',
+      file: adminLoginForm,
+      detail: 'Admin login must validate response content-type before parsing JSON',
+    });
+  }
+}
+
+const adminLoginRoute = 'apps/admin/app/api/auth/admin-login/route.ts';
+if (fs.existsSync(path.join(ROOT, adminLoginRoute))) {
+  const source = read(adminLoginRoute);
+  if (source.includes('requireAdminClient()') && !source.includes('return jsonError(error)')) {
+    findings.push({
+      severity: 'blocker',
+      code: 'ADMIN_LOGIN_UNCAUGHT_SERVER_ERROR',
+      file: adminLoginRoute,
+      detail: 'Admin login can throw before returning a JSON response',
+    });
+  }
+} else {
+  findings.push({
+    severity: 'blocker',
+    code: 'ADMIN_LOGIN_API_MISSING',
+    file: adminLoginRoute,
+    detail: 'Admin login API route is missing from the active Admin app',
+  });
+}
+
+// Non-route login-like files are a maintenance risk. They are warnings rather
+// than blockers because role-specific login pages can legitimately coexist.
+for (const file of loginFiles) {
+  if (/page-new\.(?:tsx?|jsx?)$/.test(file) || /LoginForm\.old\./.test(file)) {
+    findings.push({
+      severity: 'warning',
+      code: 'STALE_LOGIN_IMPLEMENTATION',
+      file,
+      detail: 'Login implementation is not a canonical Next.js route and should be removed or archived',
+    });
+  }
+}
+
+const blockers = findings.filter((finding) => finding.severity === 'blocker');
+const warnings = findings.filter((finding) => finding.severity === 'warning');
+const report = {
+  generatedAt: new Date().toISOString(),
+  routeCounts: Object.fromEntries(
+    Object.entries(routesByHost).map(([host, routes]) => [host, routes.size]),
+  ),
+  canonicalRoleMappings: Object.keys(ROLE_ROUTE_CONFIG).length,
+  activeLoginFiles: loginFiles.sort(),
+  blockers,
+  warnings,
+};
+
+const outDir = path.join(ROOT, 'docs', 'audits');
+fs.mkdirSync(outDir, { recursive: true });
+fs.writeFileSync(
+  path.join(outDir, 'AUTH_ROLE_ROUTING_AUDIT.json'),
+  JSON.stringify(report, null, 2),
+);
+
+const lines = [
+  '# Authentication + Role Routing Audit',
+  '',
+  `Generated: ${report.generatedAt}`,
+  '',
+  `- Admin routes: ${report.routeCounts.admin}`,
+  `- LMS routes: ${report.routeCounts.lms}`,
+  `- Marketing routes: ${report.routeCounts.marketing}`,
+  `- Canonical role mappings checked: ${report.canonicalRoleMappings}`,
+  `- Active login/auth implementations inventoried: ${report.activeLoginFiles.length}`,
+  `- Blocking findings: ${blockers.length}`,
+  `- Warnings: ${warnings.length}`,
+  '',
+  '## Blocking findings',
+  '',
+  ...(blockers.length
+    ? blockers.map((finding) => `- **${finding.code}** ${finding.file ? `\`${finding.file}\` — ` : ''}${finding.detail}`)
+    : ['None']),
+  '',
+  '## Warnings',
+  '',
+  ...(warnings.length
+    ? warnings.map((finding) => `- **${finding.code}** ${finding.file ? `\`${finding.file}\` — ` : ''}${finding.detail}`)
+    : ['None']),
+  '',
+  '## Active login/auth inventory',
+  '',
+  ...report.activeLoginFiles.map((file) => `- \`${file}\``),
+  '',
+];
+fs.writeFileSync(path.join(outDir, 'AUTH_ROLE_ROUTING_AUDIT.md'), lines.join('\n'));
+
+console.log(`Auth/role audit: ${blockers.length} blocker(s), ${warnings.length} warning(s)`);
+for (const finding of findings) {
+  console.log(`${finding.severity.toUpperCase()} ${finding.code}: ${finding.detail}${finding.file ? ` (${finding.file})` : ''}`);
+}
+
+if (blockers.length) process.exitCode = 1;


### PR DESCRIPTION
## What this fixes
- Fixes the direct cause of the production Admin error shown in the screenshot: Admin middleware was protecting `/api/auth/admin-login`, so an anonymous credential POST could be redirected to `/login` and return HTML (`<!DOCTYPE ...`) instead of JSON.
- Adds `/api/auth/admin-login` to the Admin public-path allowlist and applies the existing auth rate limiter to the now-public credential endpoint.
- Keeps the Admin login API inside a full JSON error boundary so Supabase/admin-client failures cannot fall through to a Next.js HTML 500 document.
- Makes the Admin login form validate response content type before parsing, eliminating raw `Unexpected token '<' / <!DOCTYPE ... is not valid JSON` errors.
- Removes the Admin login page's automatic redirect for any existing shared-domain Supabase session; a student/employer/partner session can no longer be treated as Admin merely because a valid root-domain auth cookie exists.
- Moves the main LMS login through the rate-limited server sign-in endpoint so Supabase auth cookies are established for `.elevateforhumanity.org` before role-based movement across `app`, `admin`, or `www`.
- Keeps access/refresh tokens out of the LMS sign-in JSON response; session state is carried by Supabase cookies.
- Resolves primary/effective roles before honoring LMS `redirect=` parameters and enforces role-compatible destinations.
- Changes the ambiguous LMS `/dashboard` unauthenticated return path to `/lms/dashboard`.
- Stops `portal_type` metadata from inventing nonexistent `/portal/*` learner routes; standard learner categories resolve to the working LMS dashboard while apprenticeship stays on `/apprentice`.
- Enforces an actual apprenticeship role on the dedicated apprentice login.
- Adds an active-app authentication/role-routing integrity gate covering route existence, credential middleware exposure, rate limiting, shared-domain sessions, token leakage, and redirect regressions.

## Live Supabase role audit
- The account in the screenshot (`curvaturebodysculpting@gmail.com`) has a valid `admin` primary role. The failure is routing/middleware, not a role denial.
- No profiles have noncanonical primary roles.
- No orphan `user_roles` assignments exist.
- Two student profiles carry specialized `portal_type` values (`cosmetology`, `trades`); they are now kept on the canonical LMS dashboard instead of missing `/portal/*` routes.
- One account has a legitimate-looking multi-role combination (`partner` primary + `program_holder` secondary); it is not mutated automatically.
- 73 auth users lack profile rows; none signed in within the last 30 days, so roles are not guessed or bulk-created for dormant/legacy identities.
- `advisor` is declared in routing as an Admin-host role but is not in the Admin middleware role set. There are currently zero advisor assignments; the audit reports this governance mismatch without broadening Admin privileges automatically.

## Deployment safety
Production deployment workflows remain restricted to `main`. This PR will be merged only after the current auth/role, type, and build validation completes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix admin login middleware bypass and enforce role-safe post-login redirects
> - Adds `/api/auth/admin-login` to [middleware.ts](https://github.com/elevate-for-humanity/Elevate-lms/pull/616/files#diff-8c77ff212195bfeb17b57db46023e4b8b4bbe1c813474969ceec48e54da86ebb) public paths so credential POSTs receive JSON instead of being redirected to `/login`
> - Hardens the [admin-login route](https://github.com/elevate-for-humanity/Elevate-lms/pull/616/files#diff-4bc83f9cb872b277aef9ff5637658285496ae2262747bcbff29e50ceadc9a05f) with rate limiting, stricter input validation, and consistent JSON error responses (503 for misconfiguration, 500 for unexpected errors)
> - Reworks [LMS login](https://github.com/elevate-for-humanity/Elevate-lms/pull/616/files#diff-296cd460eda52582924b7896e5ee00d9e4b33d62a21af14d7951f8f5e29953db) to sign in via the server endpoint, then resolve destinations from authoritative role checks, filtering redirects through a new `resolveRoleCompatiblePostLoginUrl` utility that blocks cross-portal and legacy `/portal/*` paths
> - Updates [PORTAL_PATHS](https://github.com/elevate-for-humanity/Elevate-lms/pull/616/files#diff-8d48ec10633e361f41e70f10621e17d9d7e2e61e2141a146270b6d9388825bb7) to route non-apprentice portals to `/lms/dashboard` instead of non-existent `/portal/*` pages
> - Adds a CI audit step in [integrity-gate.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/616/files#diff-6c16bbe0d3f42bfc7867e15c62d51be3df4e468dd380f717ca28406363f82eba) that validates role route config and public path inclusion, failing the build on blocking findings
> - Behavioral Change: the LMS signin API no longer returns session tokens in its JSON response and sets `Cache-Control: no-store, private`
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 28a24fd.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->