### PR TITLE
fix(store): make PARIS Store experience live

### DIFF
--- a/apps/marketing/app/store/page.tsx
+++ b/apps/marketing/app/store/page.tsx
@@ -1,4 +1,6 @@
-export const dynamic = 'force-static';
+export const dynamic = 'force-dynamic';
+export const revalidate = 0;
+export const fetchCache = 'force-no-store';
 
 import type { Metadata } from 'next';
 import Link from 'next/link';


### PR DESCRIPTION
Removes forced static delivery from `/store` so the deployed PARIS interview and command-driven Website Builder demo are served from the current Marketing runtime instead of stale pre-rendered markup.

Changes:
- `dynamic = 'force-dynamic'`
- `revalidate = 0`
- `fetchCache = 'force-no-store'`

This is intentionally scoped to the Store page only and is based on current main `c77f44abc21667855b9053403d8d589b9db6c906`.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Make PARIS Store page dynamically rendered with no caching
> Changes [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/618/files#diff-b6d6b27753ec1eae9ee747476b0b5dc867fdab9b413ff0a68d97c27a19847d0b) from `force-static` to `force-dynamic` rendering and sets `revalidate = 0` and `fetchCache = 'force-no-store'` so the Store page is rendered fresh on every request with no ISR or fetch caching.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized e48764b.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->