### PR TITLE
Fix Marketing visual runtime gates and queue Northflank deploys

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -50,12 +50,12 @@ permissions:
   contents: read
   actions: read
 
-# Marketing deployments own only the Marketing service. A newer Marketing run
-# cancels an older Marketing run, but unrelated Admin/LMS commits must not abort
-# a valid Marketing deployment in this monorepo.
+# Marketing deployments own only the Marketing service. New Marketing runs queue
+# behind an active Marketing release instead of canceling it. The Northflank
+# trigger also waits for any in-flight service build before acquiring a new slot.
 concurrency:
   group: northflank-marketing-deploy
-  cancel-in-progress: true
+  cancel-in-progress: false
 
 env:
   EXPECTED_SHA: ${{ github.sha }}
@@ -168,7 +168,7 @@ jobs:
             echo "Existing upstream returned HTTP $status; continuing in recovery mode."
           fi
 
-      - name: Trigger fresh Marketing build
+      - name: Acquire queued Marketing build
         id: trigger_build
         run: pnpm tsx scripts/northflank/trigger-build.ts "$NORTHFLANK_MARKETING_SERVICE_ID"
 
@@ -178,6 +178,7 @@ jobs:
           BUILD_ID="${{ steps.trigger_build.outputs.build_id }}"
           test -n "$BUILD_ID" || { echo "Northflank trigger returned no build_id"; exit 1; }
           echo "Northflank build id: $BUILD_ID"
+          echo "Reused existing build: ${{ steps.trigger_build.outputs.reused_build }}"
 
       - name: Wait for Marketing build
         run: pnpm tsx scripts/northflank/wait-service.ts "$NORTHFLANK_MARKETING_SERVICE_ID" --build-id "${{ steps.trigger_build.outputs.build_id }}" --timeout-ms 3600000
@@ -210,20 +211,31 @@ jobs:
           for i in $(seq 1 30); do
             health_status=$(curl -sk --max-time 10 -o /tmp/www-health.json -w "%{http_code}" "https://www.elevateforhumanity.org/api/health?deploy=${EXPECTED_SHA}" || true)
             version_status=$(curl -sk --max-time 10 -o /tmp/www-version.json -w "%{http_code}" "https://www.elevateforhumanity.org/api/version?deploy=${EXPECTED_SHA}" || true)
-            page_status=$(curl -sk --max-time 10 -o /tmp/www-page.html -w "%{http_code}" "https://www.elevateforhumanity.org/programs/barber-apprenticeship?deploy=${EXPECTED_SHA}" || true)
+            home_status=$(curl -sk --max-time 15 -o /tmp/www-home.html -w "%{http_code}" "https://www.elevateforhumanity.org/?deploy=${EXPECTED_SHA}" || true)
+            page_status=$(curl -sk --max-time 15 -o /tmp/www-page.html -w "%{http_code}" "https://www.elevateforhumanity.org/programs/barber-apprenticeship?deploy=${EXPECTED_SHA}" || true)
+            razors_status=$(curl -sk --max-time 15 -o /tmp/razors-image.webp -w "%{http_code}" "https://www.elevateforhumanity.org/images/partners/razors-image-storefront.webp?deploy=${EXPECTED_SHA}" || true)
+            hero_status=$(curl -sk --max-time 15 -o /tmp/home-hero.webp -w "%{http_code}" "https://www.elevateforhumanity.org/images/heroes/hero-homepage.webp?deploy=${EXPECTED_SHA}" || true)
             LIVE_SHA="$(node -e "try{const d=require('/tmp/www-version.json');process.stdout.write(d.commitSha||d.commit||'')}catch(e){}")"
-            echo "Attempt $i/30: health=$health_status version=$version_status page=$page_status live_sha=${LIVE_SHA:-missing}"
+            razors_bytes=$(wc -c < /tmp/razors-image.webp 2>/dev/null || echo 0)
+            hero_bytes=$(wc -c < /tmp/home-hero.webp 2>/dev/null || echo 0)
+            echo "Attempt $i/30: health=$health_status version=$version_status home=$home_status barber=$page_status razors=$razors_status/$razors_bytes hero=$hero_status/$hero_bytes live_sha=${LIVE_SHA:-missing}"
             if [ "$health_status" = "200" ] \
               && [ "$version_status" = "200" ] \
+              && [ "$home_status" = "200" ] \
               && [ "$page_status" = "200" ] \
+              && [ "$razors_status" = "200" ] \
+              && [ "$hero_status" = "200" ] \
+              && [ "$razors_bytes" -gt 1000 ] \
+              && [ "$hero_bytes" -gt 1000 ] \
               && [ "$LIVE_SHA" = "$EXPECTED_SHA" ] \
+              && grep -q "AI-Powered 360° Humanitarian Workforce Hub" /tmp/www-home.html \
               && grep -q "Barber Apprenticeship" /tmp/www-page.html; then
-              echo "MARKETING DEPLOYMENT VERIFIED: $EXPECTED_SHA is live"
+              echo "MARKETING DEPLOYMENT VERIFIED: $EXPECTED_SHA is live with required visual assets"
               exit 0
             fi
             sleep 20
           done
-          echo "DEPLOYMENT FAILED: production did not converge to $EXPECTED_SHA"
+          echo "DEPLOYMENT FAILED: production did not converge to $EXPECTED_SHA with required visual assets"
           cat /tmp/www-health.json 2>/dev/null || true
           cat /tmp/www-version.json 2>/dev/null || true
           exit 1

--- a/.github/workflows/integrity-gate.yml
+++ b/.github/workflows/integrity-gate.yml
@@ -89,25 +89,34 @@ jobs:
       - name: Authentication and role routing check
         run: pnpm exec tsx scripts/audit-auth-role-routing.ts
 
+      # Visual checks are intentionally independent of preceding auth/repository
+      # failures. They must still execute so hero, asset, contrast, and duplicate
+      # media regressions cannot be hidden by an unrelated earlier gate failure.
       - name: Canonical hero system check
+        if: ${{ always() }}
         run: pnpm run audit:hero-banners
 
       - name: Runtime image assets and packaging check
+        if: ${{ always() }}
         run: pnpm run audit:image-assets
 
       - name: Active platform visual layout report
+        if: ${{ always() }}
         run: pnpm run audit:visual-layout
 
       - name: Link integrity check
         run: pnpm run integrity:links
 
       - name: Media integrity check
+        if: ${{ always() }}
         run: pnpm run integrity:media
 
       - name: Public UX and media acceptance check
+        if: ${{ always() }}
         run: pnpm run audit:public-media-nav
 
       - name: Homepage section media uniqueness check
+        if: ${{ always() }}
         run: node scripts/audit-homepage-section-media.mjs
 
       - name: LMS course integrity check

--- a/Dockerfile.marketing
+++ b/Dockerfile.marketing
@@ -102,6 +102,12 @@ RUN test -f /app/public/version.json && \
     test -f /app/public/manifest-marketing.json && \
     test -f /app/apps/marketing/public/manifest-marketing.json && \
     test -f /app/apps/marketing/server.js && \
+    test -s /app/public/images/partners/razors-image-storefront.webp && \
+    test -s /app/apps/marketing/public/images/partners/razors-image-storefront.webp && \
+    test -s /app/public/images/heroes/hero-homepage.webp && \
+    test -s /app/apps/marketing/public/images/heroes/hero-homepage.webp && \
+    test -s /app/public/images/pages/barber-apprenticeship-hero.jpg && \
+    test -s /app/public/images/pages/workforce-training.webp && \
     (test -f /app/public/sw.js || test -f /app/public/sw-marketing.js) && \
     echo "Marketing runtime assets verified"
 

--- a/components/home/HomeBeautyPriority.tsx
+++ b/components/home/HomeBeautyPriority.tsx
@@ -7,7 +7,7 @@ const TRACKS = [
     title: 'Barbering Apprenticeship',
     hours: '2,000 OJL hours + 144 hours of Related Technical Instruction',
     focus: 'Fades, clipper work, shaving, sanitation, shop operations',
-    image: '/images/pages/barber-hero-main.webp',
+    image: '/images/pages/barber-apprenticeship-hero.jpg',
     href: '/barber-apprenticeship',
     icon: Scissors,
   },

--- a/components/home/HomeFinalCTA.tsx
+++ b/components/home/HomeFinalCTA.tsx
@@ -20,8 +20,8 @@ export function HomeFinalCTA() {
       <div className="relative mx-auto grid max-w-5xl overflow-hidden rounded-2xl border border-white/20 bg-brand-red-800 shadow-xl lg:grid-cols-[0.9fr_1.1fr]">
         <div className="relative min-h-[220px] lg:min-h-[320px]">
           <Image
-            src="/images/pages/about-supportive-services.webp"
-            alt="Elevate for Humanity learner support and career training"
+            src="/images/pages/workforce-training.webp"
+            alt="Elevate for Humanity workforce training and career advancement"
             fill
             sizes="(max-width: 1024px) 100vw, 45vw"
             className="object-cover"

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -28,10 +28,10 @@ export interface HomeHeroVideoProps {
  * Media playback, mobile source selection, error fallback, narration controls,
  * and route cleanup all live in components/marketing/HeroVideo.
  *
- * The homepage intentionally does not pass a poster layer into HeroVideo.
- * Its dedicated R2 video is the primary hero media; keeping a separate poster
- * underneath the opacity-faded video caused a visible poster/frame flash on
- * some browsers during first-frame decoding.
+ * The page-specific poster is intentionally passed through to the canonical
+ * renderer. HeroVideo keeps it mounted behind the video until a renderable
+ * frame is ready, so slow mobile decoding, autoplay restrictions, and media
+ * errors fall back to a real hero image instead of a blank/black frame.
  */
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   const ctas = banner.secondaryCta
@@ -42,6 +42,7 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
     <HeroVideo
       videoSrcDesktop={banner.videoSrcDesktop}
       videoSrcMobile={banner.videoSrcMobile}
+      posterImage={banner.posterImage}
       voiceoverSrc={banner.voiceoverSrc}
       microLabel={banner.microLabel}
       belowHeroHeadline={banner.belowHeroHeadline}

--- a/scripts/audit-homepage-section-media.mjs
+++ b/scripts/audit-homepage-section-media.mjs
@@ -4,68 +4,149 @@ import path from 'node:path';
 
 const ROOT = process.cwd();
 const HOME_PAGE = path.join(ROOT, 'apps/marketing/app/page.tsx');
+const COMPONENT_ROOT = path.join(ROOT, 'components');
 const REUSABLE_MEDIA = /(?:logo|favicon|icon|badge|seal|partner|sponsor|credential|certification|qr|avatar|placeholder)/i;
 const ASSET_RE = /['"](\/(?:images|uploads|media)\/[^'"\s)]+)['"]/g;
+const IMPORT_RE = /from\s+['"]([^'"]+)['"]/g;
 
 if (!fs.existsSync(HOME_PAGE)) {
   console.error('FAIL: Marketing homepage source is missing.');
   process.exit(1);
 }
 
-const homeSource = fs.readFileSync(HOME_PAGE, 'utf8');
-const sectionFiles = new Set();
-for (const match of homeSource.matchAll(/from\s+['"]@\/components\/home\/([^'"]+)['"]/g)) {
-  const base = path.join(ROOT, 'components/home', match[1]);
+function resolveModule(fromFile, specifier) {
+  let base;
+  if (specifier.startsWith('@/components/')) {
+    base = path.join(ROOT, specifier.slice(2));
+  } else if (specifier.startsWith('.')) {
+    base = path.resolve(path.dirname(fromFile), specifier);
+  } else {
+    return null;
+  }
+
   const candidates = path.extname(base)
     ? [base]
-    : [`${base}.tsx`, `${base}.ts`, `${base}.jsx`, `${base}.js`, path.join(base, 'index.tsx')];
+    : [
+        `${base}.tsx`,
+        `${base}.ts`,
+        `${base}.jsx`,
+        `${base}.js`,
+        path.join(base, 'index.tsx'),
+        path.join(base, 'index.ts'),
+        path.join(base, 'index.jsx'),
+        path.join(base, 'index.js'),
+      ];
+
   const resolved = candidates.find((candidate) => fs.existsSync(candidate));
-  if (resolved) sectionFiles.add(resolved);
+  if (!resolved) return null;
+
+  const normalized = path.resolve(resolved);
+  if (!normalized.startsWith(`${COMPONENT_ROOT}${path.sep}`)) return null;
+  return normalized;
+}
+
+function collectComponentTree(rootFile) {
+  const visited = new Set();
+  const stack = [rootFile];
+
+  while (stack.length) {
+    const file = stack.pop();
+    if (!file || visited.has(file)) continue;
+    visited.add(file);
+
+    const source = fs.readFileSync(file, 'utf8');
+    IMPORT_RE.lastIndex = 0;
+    for (const match of source.matchAll(IMPORT_RE)) {
+      const resolved = resolveModule(file, match[1]);
+      if (resolved && !visited.has(resolved)) stack.push(resolved);
+    }
+  }
+
+  return visited;
+}
+
+function rootLabel(file) {
+  return path.relative(ROOT, file).replaceAll('\\', '/');
+}
+
+const homeSource = fs.readFileSync(HOME_PAGE, 'utf8');
+const sectionRoots = new Set();
+for (const match of homeSource.matchAll(IMPORT_RE)) {
+  const specifier = match[1];
+  const isSection =
+    specifier.startsWith('@/components/home/') ||
+    specifier === '@/components/ui/HomeHeroVideo' ||
+    specifier === '@/components/MarqueeBanner';
+  if (!isSection) continue;
+
+  const resolved = resolveModule(HOME_PAGE, specifier);
+  if (resolved) sectionRoots.add(resolved);
 }
 
 const uses = new Map();
-const withinComponent = [];
-for (const file of sectionFiles) {
-  const source = fs.readFileSync(file, 'utf8');
+const withinSection = [];
+const scannedFiles = new Set();
+
+for (const rootFile of sectionRoots) {
+  const root = rootLabel(rootFile);
+  const tree = collectComponentTree(rootFile);
   const localCounts = new Map();
-  for (const match of source.matchAll(ASSET_RE)) {
-    const asset = match[1].split(/[?#]/)[0];
-    if (REUSABLE_MEDIA.test(asset)) continue;
-    localCounts.set(asset, (localCounts.get(asset) ?? 0) + 1);
-    const files = uses.get(asset) ?? new Set();
-    files.add(path.relative(ROOT, file).replaceAll('\\', '/'));
-    uses.set(asset, files);
+  const localFiles = new Map();
+
+  for (const file of tree) {
+    scannedFiles.add(file);
+    const source = fs.readFileSync(file, 'utf8');
+    ASSET_RE.lastIndex = 0;
+
+    for (const match of source.matchAll(ASSET_RE)) {
+      const asset = match[1].split(/[?#]/)[0];
+      if (REUSABLE_MEDIA.test(asset)) continue;
+
+      localCounts.set(asset, (localCounts.get(asset) ?? 0) + 1);
+      const assetFiles = localFiles.get(asset) ?? new Set();
+      assetFiles.add(rootLabel(file));
+      localFiles.set(asset, assetFiles);
+
+      const roots = uses.get(asset) ?? new Set();
+      roots.add(root);
+      uses.set(asset, roots);
+    }
   }
+
   for (const [asset, count] of localCounts) {
     if (count > 1) {
-      withinComponent.push({
+      withinSection.push({
         asset,
         count,
-        file: path.relative(ROOT, file).replaceAll('\\', '/'),
+        root,
+        files: [...(localFiles.get(asset) ?? [])],
       });
     }
   }
 }
 
 const crossSection = [...uses.entries()]
-  .filter(([, files]) => files.size > 1)
-  .map(([asset, files]) => ({ asset, files: [...files] }));
+  .filter(([, roots]) => roots.size > 1)
+  .map(([asset, roots]) => ({ asset, roots: [...roots] }));
 
 console.log('Homepage section media audit');
-console.log(`- live homepage section components checked: ${sectionFiles.size}`);
-console.log(`- duplicate non-brand assets inside a section: ${withinComponent.length}`);
-console.log(`- duplicate non-brand assets across sections: ${crossSection.length}`);
+console.log(`- visible homepage section roots checked: ${sectionRoots.size}`);
+console.log(`- transitive component files checked: ${scannedFiles.size}`);
+console.log(`- duplicate non-brand assets inside a section tree: ${withinSection.length}`);
+console.log(`- duplicate non-brand assets across visible sections: ${crossSection.length}`);
 
-for (const item of withinComponent) {
-  console.error(`- ${item.asset} appears ${item.count} times in ${item.file}`);
+for (const item of withinSection) {
+  console.error(
+    `- ${item.asset} appears ${item.count} times under ${item.root}: ${item.files.join(', ')}`,
+  );
 }
 for (const item of crossSection) {
-  console.error(`- ${item.asset} is reused across: ${item.files.join(', ')}`);
+  console.error(`- ${item.asset} is reused across: ${item.roots.join(', ')}`);
 }
 
-if (withinComponent.length || crossSection.length) {
-  console.error('FAIL: the live homepage reuses non-brand imagery across visible sections.');
+if (withinSection.length || crossSection.length) {
+  console.error('FAIL: the live homepage reuses non-brand imagery across visible section trees.');
   process.exit(1);
 }
 
-console.log('PASS: live homepage section imagery is unique.');
+console.log('PASS: live homepage section imagery is unique, including nested components.');

--- a/scripts/audit-image-assets.mjs
+++ b/scripts/audit-image-assets.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import fs from 'node:fs';
 import path from 'node:path';
+import { LEGACY_IMAGE_ALIASES } from '../lib/media/legacy-image-aliases.mjs';
 
 const ROOT = process.cwd();
 
@@ -76,6 +77,41 @@ function candidateRuntimePaths(service, ref) {
   );
 }
 
+function resolveRuntimeAsset(service, ref) {
+  const directCandidates = candidateRuntimePaths(service, ref);
+  const directExisting = directCandidates.filter((candidate) => fs.existsSync(candidate));
+  if (directExisting.length > 0) {
+    return {
+      exists: true,
+      resolution: 'direct',
+      resolvedRef: ref,
+      existingPaths: directExisting,
+      checkedPaths: directCandidates,
+    };
+  }
+
+  const aliasTarget = LEGACY_IMAGE_ALIASES[ref];
+  if (!aliasTarget || aliasTarget === ref) {
+    return {
+      exists: false,
+      resolution: aliasTarget === ref ? 'invalid-self-alias' : 'missing',
+      resolvedRef: aliasTarget || ref,
+      existingPaths: [],
+      checkedPaths: directCandidates,
+    };
+  }
+
+  const aliasCandidates = candidateRuntimePaths(service, aliasTarget);
+  const aliasExisting = aliasCandidates.filter((candidate) => fs.existsSync(candidate));
+  return {
+    exists: aliasExisting.length > 0,
+    resolution: aliasExisting.length > 0 ? 'verified-rewrite' : 'missing-rewrite-target',
+    resolvedRef: aliasTarget,
+    existingPaths: aliasExisting,
+    checkedPaths: [...directCandidates, ...aliasCandidates],
+  };
+}
+
 function auditPackagingContracts() {
   const failures = [];
 
@@ -115,15 +151,16 @@ for (const file of files) {
     const ref = m[1];
     if (!ref.startsWith('/images/')) continue;
 
-    const candidates = candidateRuntimePaths(service, ref);
-    const existingPaths = candidates.filter((candidate) => fs.existsSync(candidate));
+    const resolved = resolveRuntimeAsset(service, ref);
     refs.push({
       file: relFile,
       service,
       ref,
-      exists: existingPaths.length > 0,
-      existingPaths: existingPaths.map((candidate) => path.relative(ROOT, candidate)),
-      checkedPaths: candidates.map((candidate) => path.relative(ROOT, candidate)),
+      exists: resolved.exists,
+      resolution: resolved.resolution,
+      resolvedRef: resolved.resolvedRef,
+      existingPaths: resolved.existingPaths.map((candidate) => path.relative(ROOT, candidate)),
+      checkedPaths: resolved.checkedPaths.map((candidate) => path.relative(ROOT, candidate)),
       pexels: PEXELS_RE.test(ref),
     });
   }
@@ -133,6 +170,7 @@ const unique = new Map();
 for (const r of refs) unique.set(`${r.file}::${r.ref}`, r);
 const rows = [...unique.values()];
 const missing = rows.filter((r) => !r.exists);
+const rewritten = rows.filter((r) => r.resolution === 'verified-rewrite');
 const pexels = rows.filter((r) => r.pexels);
 const packagingFailures = auditPackagingContracts();
 
@@ -144,6 +182,7 @@ const byService = Object.fromEntries(
       {
         imageRefs: serviceRows.length,
         missingRefs: serviceRows.filter((row) => !row.exists).length,
+        verifiedRewrites: serviceRows.filter((row) => row.resolution === 'verified-rewrite').length,
       },
     ];
   }),
@@ -154,10 +193,12 @@ const report = {
   scannedFiles: files.length,
   imageRefs: rows.length,
   missingRefs: missing.length,
+  verifiedRewrites: rewritten.length,
   pexelsRefs: pexels.length,
   packagingFailures: packagingFailures.length,
   byService,
   missing,
+  rewritten,
   pexels,
   packaging: packagingFailures,
 };
@@ -171,12 +212,15 @@ const mdPath = path.join(outDir, 'IMAGE_ASSETS_AUDIT.md');
 const serviceSummary = Object.entries(byService)
   .map(
     ([service, counts]) =>
-      `- ${service}: ${counts.imageRefs} refs, ${counts.missingRefs} missing`,
+      `- ${service}: ${counts.imageRefs} refs, ${counts.missingRefs} missing, ${counts.verifiedRewrites} verified rewrites`,
   )
   .join('\n');
-const md = `# Image Assets Audit — active platform\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing runtime refs: ${report.missingRefs}\n- Legacy pexels refs: ${report.pexelsRefs}\n- Runtime packaging failures: ${report.packagingFailures}\n\n## Service coverage\n${serviceSummary}\n\n## Missing runtime refs\n${missing
+const md = `# Image Assets Audit — active platform\n\n- Scanned files: ${report.scannedFiles}\n- Image refs (/images/*): ${report.imageRefs}\n- Missing runtime refs: ${report.missingRefs}\n- Verified legacy rewrites: ${report.verifiedRewrites}\n- Legacy pexels refs: ${report.pexelsRefs}\n- Runtime packaging failures: ${report.packagingFailures}\n\n## Service coverage\n${serviceSummary}\n\n## Missing runtime refs\n${missing
   .slice(0, 300)
-  .map((r) => `- ${r.ref} in \`${r.file}\` (${r.service}); checked: ${r.checkedPaths.join(', ')}`)
+  .map((r) => `- ${r.ref} in \`${r.file}\` (${r.service}); resolution=${r.resolution}; checked: ${r.checkedPaths.join(', ')}`)
+  .join('\n') || 'None'}\n\n## Verified legacy rewrites\n${rewritten
+  .slice(0, 300)
+  .map((r) => `- ${r.ref} -> ${r.resolvedRef} in \`${r.file}\` (${r.service})`)
   .join('\n') || 'None'}\n\n## Runtime packaging failures\n${packagingFailures
   .map((r) => `- ${r.service}: ${r.reason} in \`${r.dockerfile}\``)
   .join('\n') || 'None'}\n\n## Legacy pexels refs\n${pexels
@@ -189,6 +233,7 @@ console.log(`Wrote ${jsonPath}`);
 console.log(`Wrote ${mdPath}`);
 console.log(`Scanned files: ${files.length}`);
 console.log(`Missing runtime refs: ${missing.length}`);
+console.log(`Verified legacy rewrites: ${rewritten.length}`);
 console.log(`Runtime packaging failures: ${packagingFailures.length}`);
 console.log(`Pexels refs: ${pexels.length}`);
 

--- a/scripts/audit-visual-layout.mjs
+++ b/scripts/audit-visual-layout.mjs
@@ -74,6 +74,9 @@ const IMAGE_PERF_PATTERNS = [
   },
 ];
 
+const LIGHT_SURFACE = '(?:bg-white|bg-(?:slate|gray|zinc|neutral)-(?:50|100))';
+const LOW_CONTRAST_NEUTRAL = 'text-(?:slate|gray|zinc|neutral)-(?:200|300|400)';
+
 const LAYOUT_TEXT_PATTERNS = [
   {
     id: 'hero-gradient-overlay',
@@ -92,6 +95,24 @@ const LAYOUT_TEXT_PATTERNS = [
     re: /bg-white[^"']*["'][^"']*text-white/g,
     severity: 'high',
     message: 'Possible white text on white background',
+  },
+  {
+    id: 'low-contrast-neutral-on-light',
+    re: new RegExp(
+      `className=["'\x60][^"'\x60]*${LIGHT_SURFACE}[^"'\x60]*${LOW_CONTRAST_NEUTRAL}[^"'\x60]*["'\x60]`,
+      'g',
+    ),
+    severity: 'high',
+    message: 'Low-contrast neutral text on a light surface',
+  },
+  {
+    id: 'low-contrast-neutral-on-light-reversed',
+    re: new RegExp(
+      `className=["'\x60][^"'\x60]*${LOW_CONTRAST_NEUTRAL}[^"'\x60]*${LIGHT_SURFACE}[^"'\x60]*["'\x60]`,
+      'g',
+    ),
+    severity: 'high',
+    message: 'Low-contrast neutral text on a light surface',
   },
   {
     id: 'empty-next-image-alt',
@@ -268,7 +289,7 @@ const serviceRows = Object.entries(report.filesByService)
   .map(([service, count]) => `| ${service} | ${count} |`)
   .join('\n');
 
-const md = `# Visual layout audit — active platform\n\nGenerated: ${report.generatedAt}\n\nThis report scans the deployed monorepo app trees, not the legacy root \`app/\` tree.\n\n## Coverage\n\n| Service | TSX/JSX files scanned |\n|---|---:|\n${serviceRows}\n\n| Category | Critical | High | Medium | Low | Total |\n|----------|----------|------|--------|-----|-------|\n| Oversized heroes | ${report.summary.oversizedHero.critical} | ${report.summary.oversizedHero.high} | ${report.summary.oversizedHero.medium} | ${report.summary.oversizedHero.low} | ${report.summary.oversizedHeroTotal} |\n| Image load cost | ${report.summary.imagePerf.critical} | ${report.summary.imagePerf.high} | ${report.summary.imagePerf.medium} | ${report.summary.imagePerf.low} | ${report.summary.imagePerfTotal} |\n| Layout / text | ${report.summary.layoutText.critical} | ${report.summary.layoutText.high} | ${report.summary.layoutText.medium} | ${report.summary.layoutText.low} | ${report.summary.layoutTextTotal} |\n\n**Canonical Marketing hero:** \`${CANONICAL_HERO_CLASS}\` or a canonical hero renderer.\n\n**Active Marketing pages with hero intent but no canonical hero marker:** ${report.summary.marketingPagesWithHeroButNotCanonical}\n\n## Marketing pages requiring canonicalization\n\n${marketingPagesNoCanonical.map((file) => `- \`${file}\``).join('\n') || '_None_'}\n\n### Critical findings\n\n${report.criticalHits.length ? report.criticalHits.map((hit) => `- \`${hit.file}:${hit.line}\` ${hit.message}`).join('\n') : '_None_'}\n\n${mdSection('Oversized hero / banner patterns', report.topOversizedHeroFiles)}\n${mdSection('Image performance', report.topImagePerfFiles)}\n${mdSection('Layout & text standard violations', report.topLayoutTextFiles)}\n\n## Re-run\n\n- \`node scripts/audit-visual-layout.mjs\`\n- \`node scripts/audit-image-assets.mjs\`\n- \`pnpm audit:public-media-nav\`\n- \`pnpm audit:hero-banners\`\n`;
+const md = `# Visual layout audit — active platform\n\nGenerated: ${report.generatedAt}\n\nThis report scans the deployed monorepo app trees, not the legacy root \`app/\` tree.\n\n## Coverage\n\n| Service | TSX/JSX files scanned |\n|---|---:|\n${serviceRows}\n\n| Category | Critical | High | Medium | Low | Total |\n|----------|----------|------|--------|-----|-------|\n| Oversized heroes | ${report.summary.oversizedHero.critical} | ${report.summary.oversizedHero.high} | ${report.summary.oversizedHero.medium} | ${report.summary.oversizedHero.low} | ${report.summary.oversizedHeroTotal} |\n| Image load cost | ${report.summary.imagePerf.critical} | ${report.summary.imagePerf.high} | ${report.summary.imagePerf.medium} | ${report.summary.imagePerf.low} | ${report.summary.imagePerfTotal} |\n| Layout / text | ${report.summary.layoutText.critical} | ${report.summary.layoutText.high} | ${report.summary.layoutText.medium} | ${report.summary.layoutText.low} | ${report.summary.layoutTextTotal} |\n\n**Canonical Marketing hero:** \`${CANONICAL_HERO_CLASS}\` or a canonical hero renderer.\n\n**Active Marketing pages with hero intent but no canonical hero marker:** ${report.summary.marketingPagesWithHeroButNotCanonical}\n\n## Marketing pages requiring canonicalization\n\n${marketingPagesNoCanonical.map((file) => `- \`${file}\``).join('\n') || '_None_'}\n\n### Critical findings\n\n${report.criticalHits.length ? report.criticalHits.map((hit) => `- \`${hit.file}:${hit.line}\` ${hit.message}`).join('\n') : '_None_'}\n\n${mdSection('Oversized hero / banner patterns', report.topOversizedHeroFiles)}\n${mdSection('Image performance', report.topImagePerfFiles)}\n${mdSection('Layout, text & contrast standard violations', report.topLayoutTextFiles)}\n\n## Re-run\n\n- \`node scripts/audit-visual-layout.mjs\`\n- \`node scripts/audit-image-assets.mjs\`\n- \`pnpm audit:public-media-nav\`\n- \`pnpm audit:hero-banners\`\n`;
 
 const mdPath = path.join(outDir, 'VISUAL_LAYOUT_AUDIT.md');
 fs.writeFileSync(mdPath, md);

--- a/scripts/northflank/trigger-build.ts
+++ b/scripts/northflank/trigger-build.ts
@@ -1,6 +1,10 @@
 #!/usr/bin/env tsx
 /**
- * Trigger exactly one Northflank build for a combined service.
+ * Acquire a safe Northflank build slot and return exactly one build id.
+ *
+ * - Reuses an active or successful build for the same Git SHA.
+ * - Waits for a different in-flight build instead of overlapping/canceling it.
+ * - Triggers one fresh build only when the service has no competing build.
  *
  * Service configuration and build arguments are applied separately by
  * configure-services.ts. This script intentionally does not PATCH the combined
@@ -15,10 +19,64 @@ import { nfFetch, projectApiPath, resolveProjectId } from './lib';
 
 interface NorthflankBuildResponse {
   id: string;
-  status: string;
+  status?: string;
   sha?: string;
   concluded?: boolean;
+  success?: boolean;
   createdAt?: string;
+}
+
+interface NorthflankBuildList {
+  builds?: NorthflankBuildResponse[];
+}
+
+const TERMINAL_STATUSES = new Set([
+  'ABORTED',
+  'CANCELLED',
+  'CANCELED',
+  'COMPLETED',
+  'CRASHED',
+  'ERROR',
+  'FAILED',
+  'FAILURE',
+  'SKIPPED',
+  'SUBMISSION_FAILURE',
+  'SUCCESS',
+]);
+const SUCCESS_STATUSES = new Set(['COMPLETED', 'SKIPPED', 'SUCCESS']);
+const POLL_MS = 15_000;
+const SLOT_TIMEOUT_MS = Number(process.env.NORTHFLANK_BUILD_SLOT_TIMEOUT_MS || 3_600_000);
+
+function normalizedStatus(build: NorthflankBuildResponse): string {
+  return String(build.status || '').trim().toUpperCase();
+}
+
+function isActive(build: NorthflankBuildResponse): boolean {
+  if (build.concluded === true) return false;
+  const status = normalizedStatus(build);
+  if (TERMINAL_STATUSES.has(status)) return false;
+  return Boolean(status) || build.concluded === false;
+}
+
+function isSuccessfulForSha(build: NorthflankBuildResponse, sha: string): boolean {
+  if ((build.sha || '').toLowerCase() !== sha.toLowerCase()) return false;
+  if (build.success === true) return true;
+  return SUCCESS_STATUSES.has(normalizedStatus(build));
+}
+
+function emitBuildId(buildId: string, reused: boolean) {
+  console.log(`${reused ? 'Reusing' : 'Triggered'} Northflank build: ${buildId}`);
+  if (process.env.GITHUB_OUTPUT) {
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `build_id=${buildId}\n`, 'utf8');
+    fs.appendFileSync(process.env.GITHUB_OUTPUT, `reused_build=${reused ? 'true' : 'false'}\n`, 'utf8');
+  }
+}
+
+async function listBuilds(projectId: string, serviceId: string) {
+  const result = await nfFetch<NorthflankBuildList>(
+    projectApiPath(projectId, `/services/${serviceId}/build?per_page=20`),
+  );
+  return Array.isArray(result.builds) ? result.builds : [];
 }
 
 async function main() {
@@ -43,26 +101,61 @@ async function main() {
   }
 
   const buildPath = projectApiPath(projectId, `/services/${serviceId}/build`);
-  console.log('=== SINGLE BUILD TRIGGER ===');
+  const started = Date.now();
+
+  console.log('=== NORTHFLANK BUILD SLOT ===');
   console.log(`Service: ${serviceId}`);
   console.log(`SHA:     ${currentSha}`);
 
-  const build = await nfFetch<NorthflankBuildResponse>(buildPath, {
-    method: 'POST',
-    body: JSON.stringify({
-      sha: currentSha,
-      no_cache: process.env.FORCE_FRESH_BUILD === 'true',
-    }),
-  });
+  while (Date.now() - started < SLOT_TIMEOUT_MS) {
+    const builds = await listBuilds(projectId, serviceId);
 
-  if (!build.id) {
-    throw new Error(`Northflank build response did not include an id: ${JSON.stringify(build)}`);
+    const sameShaActive = builds.find(
+      (build) => isActive(build) && (build.sha || '').toLowerCase() === currentSha.toLowerCase(),
+    );
+    if (sameShaActive?.id) {
+      console.log(
+        `Same SHA already has an in-flight build (${normalizedStatus(sameShaActive) || 'PENDING'}); using it instead of triggering a duplicate.`,
+      );
+      emitBuildId(sameShaActive.id, true);
+      return;
+    }
+
+    const competing = builds.find((build) => isActive(build));
+    if (competing) {
+      console.log(
+        `Northflank build ${competing.id} (${normalizedStatus(competing) || 'PENDING'}) is still active for ${competing.sha || 'unknown SHA'}; keeping this release queued.`,
+      );
+      await new Promise((resolve) => setTimeout(resolve, POLL_MS));
+      continue;
+    }
+
+    const reusable = builds.find((build) => isSuccessfulForSha(build, currentSha));
+    if (reusable?.id) {
+      console.log('A successful build already exists for this exact SHA; reusing it.');
+      emitBuildId(reusable.id, true);
+      return;
+    }
+
+    const build = await nfFetch<NorthflankBuildResponse>(buildPath, {
+      method: 'POST',
+      body: JSON.stringify({
+        sha: currentSha,
+        no_cache: process.env.FORCE_FRESH_BUILD === 'true',
+      }),
+    });
+
+    if (!build.id) {
+      throw new Error(`Northflank build response did not include an id: ${JSON.stringify(build)}`);
+    }
+
+    emitBuildId(build.id, false);
+    return;
   }
 
-  console.log(`Build triggered once: ${build.id}`);
-  if (process.env.GITHUB_OUTPUT) {
-    fs.appendFileSync(process.env.GITHUB_OUTPUT, `build_id=${build.id}\n`, 'utf8');
-  }
+  throw new Error(
+    `Timed out after ${SLOT_TIMEOUT_MS}ms waiting for a safe Northflank build slot for ${serviceId}. Existing builds were left untouched.`,
+  );
 }
 
 main().catch((error) => {

--- a/scripts/northflank/trigger-build.ts
+++ b/scripts/northflank/trigger-build.ts
@@ -2,7 +2,7 @@
 /**
  * Acquire a safe Northflank build slot and return exactly one build id.
  *
- * - Reuses an active or successful build for the same Git SHA.
+ * - Reuses an active or positively successful build for the same Git SHA.
  * - Waits for a different in-flight build instead of overlapping/canceling it.
  * - Triggers one fresh build only when the service has no competing build.
  *
@@ -43,7 +43,6 @@ const TERMINAL_STATUSES = new Set([
   'SUBMISSION_FAILURE',
   'SUCCESS',
 ]);
-const SUCCESS_STATUSES = new Set(['COMPLETED', 'SKIPPED', 'SUCCESS']);
 const POLL_MS = 15_000;
 const SLOT_TIMEOUT_MS = Number(process.env.NORTHFLANK_BUILD_SLOT_TIMEOUT_MS || 3_600_000);
 
@@ -61,7 +60,10 @@ function isActive(build: NorthflankBuildResponse): boolean {
 function isSuccessfulForSha(build: NorthflankBuildResponse, sha: string): boolean {
   if ((build.sha || '').toLowerCase() !== sha.toLowerCase()) return false;
   if (build.success === true) return true;
-  return SUCCESS_STATUSES.has(normalizedStatus(build));
+  // SUCCESS is unambiguous even when the API omits the boolean. COMPLETED and
+  // SKIPPED are not reused unless success=true because they can represent a
+  // concluded build that did not produce a deployable artifact.
+  return normalizedStatus(build) === 'SUCCESS';
 }
 
 function emitBuildId(buildId: string, reused: boolean) {


### PR DESCRIPTION
Production visual/runtime hardening for Marketing.

Fixes:
- keep homepage hero poster mounted until video is renderable, preventing blank/black mobile first frames
- remove duplicate visible homepage photography
- recursively audit nested homepage section media for duplicate assets
- add static light-surface contrast guardrails
- make visual integrity checks execute even if an earlier unrelated gate fails
- verify Razor's Image, homepage hero, and replacement homepage assets are packaged in the final Marketing container
- verify Razor's Image and homepage hero assets over HTTPS after deployment
- queue GitHub Marketing deployments instead of canceling in-progress runs
- deduplicate/wait for in-flight Northflank builds so overlapping releases do not compete or cancel each other

No Northflank deployment is triggered by this PR; deployment remains main-only.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Marketing visual runtime gates and queue Northflank deploys
> - Reworks [`trigger-build.ts`](https://github.com/elevate-for-humanity/Elevate-lms/pull/623/files#diff-5f9321e97d4e6d33aba8e8a34bc116208669c212399d7c090c63573e9aaa198e) to poll for a safe build slot, reuse in-flight or successful builds for the same SHA, and queue behind competing builds instead of triggering a duplicate; emits a `reused_build` output flag.
> - Updates the [deploy-marketing.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/623/files#diff-7ed4e9c6c7fd619fac2e29bf6d09777971cacb52529cde4889d592e845752e8f) workflow to queue runs instead of canceling in-progress ones, and adds production smoke checks for hero/partner images (byte-size thresholds) and homepage headline text.
> - Adds `test -s` size checks to [Dockerfile.marketing](https://github.com/elevate-for-humanity/Elevate-lms/pull/623/files#diff-d1c7872239f27c34dfcb01665a6921752815856680aa34584ffb264a861b790b) so the build fails if key visual assets are missing or empty.
> - Visual and media audit steps in [integrity-gate.yml](https://github.com/elevate-for-humanity/Elevate-lms/pull/623/files#diff-6c16bbe0d3f42bfc7867e15c62d51be3df4e468dd380f717ca28406363f82eba) now run unconditionally (`if: always()`) so reports are produced even when earlier gates fail.
> - Updates homepage components to use new image paths (`barber-apprenticeship-hero.jpg`, `workforce-training.webp`) and passes a `posterImage` prop to the hero video renderer.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 801bdd3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->