### PR TITLE
Trigger Marketing deploys for shared voice changes

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -13,6 +13,8 @@ on:
       - 'components/programs/**'
       - 'components/home/**'
       - 'components/ui/**'
+      - 'components/voice/**'
+      - 'lib/ai/**'
       - 'lib/navigation/**'
       - 'lib/programs/**'
       - 'lib/apprenticeship-programs/**'


### PR DESCRIPTION
Adds the shared natural-voice code paths to the Marketing deployment workflow so the just-merged voice repair is actually released to www and future voice changes cannot silently miss Marketing.

Only two path filters change:
- `components/voice/**`
- `lib/ai/**`

Marketing already queues deployments with `cancel-in-progress: false`; this PR does not alter LMS or Admin workflow filters.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Trigger Marketing deploys on changes to shared voice and AI components
> Adds `components/voice/**` and `lib/ai/**` as path filters in the [deploy-marketing.yml](.github/workflows/deploy-marketing.yml) push trigger so that changes to shared voice or AI code automatically redeploy the marketing site.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 111c558.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->