### PR TITLE
fix(marketing): refresh homepage hero and final CTA media

### DIFF
--- a/components/home/HomeFinalCTA.tsx
+++ b/components/home/HomeFinalCTA.tsx
@@ -11,6 +11,8 @@ import Link from 'next/link';
 import { ArrowRight, Phone } from 'lucide-react';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
+const FINAL_CTA_IMAGE = '/images/pages/workforce-training.webp?v=20260812-home-cta';
+
 export function HomeFinalCTA() {
   return (
     <section
@@ -20,9 +22,12 @@ export function HomeFinalCTA() {
       <div className="relative mx-auto grid max-w-5xl overflow-hidden rounded-2xl border border-white/20 bg-brand-red-800 shadow-xl lg:grid-cols-[0.9fr_1.1fr]">
         <div className="relative min-h-[220px] lg:min-h-[320px]">
           <Image
-            src="/images/pages/workforce-training.webp"
+            src={FINAL_CTA_IMAGE}
             alt="Elevate for Humanity workforce training and career advancement"
             fill
+            priority
+            fetchPriority="high"
+            unoptimized
             sizes="(max-width: 1024px) 100vw, 45vw"
             className="object-cover"
           />

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -23,6 +23,13 @@ export interface HomeHeroVideoProps {
   banner: HeroBanner;
 }
 
+const HOME_MEDIA_REVISION = '20260812-home-hero';
+
+function withMediaRevision(src?: string) {
+  if (!src) return undefined;
+  return `${src}${src.includes('?') ? '&' : '?'}v=${HOME_MEDIA_REVISION}`;
+}
+
 /**
  * Homepage compatibility wrapper.
  * Media playback, mobile source selection, error fallback, narration controls,
@@ -32,6 +39,10 @@ export interface HomeHeroVideoProps {
  * renderer. HeroVideo keeps it mounted behind the video until a renderable
  * frame is ready, so slow mobile decoding, autoplay restrictions, and media
  * errors fall back to a real hero image instead of a blank/black frame.
+ *
+ * Homepage media URLs carry an explicit revision so a previously cached media
+ * failure cannot pin the current deployment to the poster after a successful
+ * release.
  */
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   const ctas = banner.secondaryCta
@@ -40,10 +51,10 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
 
   return (
     <HeroVideo
-      videoSrcDesktop={banner.videoSrcDesktop}
-      videoSrcMobile={banner.videoSrcMobile}
-      posterImage={banner.posterImage}
-      voiceoverSrc={banner.voiceoverSrc}
+      videoSrcDesktop={withMediaRevision(banner.videoSrcDesktop)}
+      videoSrcMobile={withMediaRevision(banner.videoSrcMobile)}
+      posterImage={withMediaRevision(banner.posterImage)}
+      voiceoverSrc={withMediaRevision(banner.voiceoverSrc)}
       microLabel={banner.microLabel}
       belowHeroHeadline={banner.belowHeroHeadline}
       belowHeroSubheadline={banner.belowHeroSubheadline}


### PR DESCRIPTION
Targeted homepage visual repair based on live behavior.

- Adds an explicit homepage media revision to hero video/poster/voiceover URLs so a cached failed media response cannot keep the hero pinned to the poster after a successful deployment.
- Version-busts and priority-loads the final CTA workforce image so the intended Get Started/Ready to Start visual is requested fresh.
- Leaves navigation, homepage content, routing, and unrelated application code untouched.

The Marketing Dockerfile already verifies the CTA and poster assets exist in the runtime image; this PR addresses the browser/runtime delivery layer.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add cache-busting revision query strings to homepage hero and final CTA media
> - Adds a `withMediaRevision` helper in [`HomeHeroVideo.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/626/files#diff-dbf377d6ffab2d32492c71ee711d7709b99700531992ade49e322c11003b98ff) that appends a `v=` query parameter to media URLs for cache-busting; applied to desktop/mobile video, poster image, and voiceover sources.
> - Updates [`HomeFinalCTA.tsx`](https://github.com/elevate-for-humanity/Elevate-lms/pull/626/files#diff-24e0dc7dffc42028604bebe5f2bca361fd65405185737380412d8778e8a094b0) to use a versioned image URL constant and sets `priority`, `fetchPriority="high"`, and `unoptimized` on the CTA `Image` element.
> - Behavioral Change: the final CTA image now bypasses Next.js image optimization pipeline.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized d4fbb40.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->