### PR TITLE
Fix live Admin login contract

### DIFF
--- a/.github/workflows/deploy-admin.yml
+++ b/.github/workflows/deploy-admin.yml
@@ -157,6 +157,31 @@ jobs:
           cat /tmp/admin-health.json 2>/dev/null || true
           exit 1
 
+      - name: Smoke Admin login API contract
+        run: |
+          set -euo pipefail
+          headers=/tmp/admin-login-headers.txt
+          body=/tmp/admin-login-body.json
+          status=$(curl -sk --max-time 15 \
+            -D "$headers" \
+            -o "$body" \
+            -w "%{http_code}" \
+            -X POST \
+            -H 'Content-Type: application/json' \
+            -H 'Accept: application/json' \
+            --data '{}' \
+            https://admin.elevateforhumanity.org/api/auth/admin-login || true)
+          content_type=$(awk 'BEGIN{IGNORECASE=1} /^content-type:/ {print $2}' "$headers" | tr -d '\r' | tail -1)
+          echo "Admin login contract: status=${status} content-type=${content_type}"
+          cat "$body" || true
+          test "$status" = "400"
+          echo "$content_type" | grep -qi '^application/json'
+          grep -q '"error":"Email and password required."' "$body"
+          if grep -qi '<!DOCTYPE\|<html' "$body"; then
+            echo 'Admin login endpoint returned HTML instead of JSON.'
+            exit 1
+          fi
+
       - name: Verify deployed SHA matches main
         env:
           EXPECTED_SHA: ${{ github.sha }}

--- a/apps/admin/app/api/auth/admin-login/route.ts
+++ b/apps/admin/app/api/auth/admin-login/route.ts
@@ -1,11 +1,10 @@
-// RLS-safe admin login — uses service role key to read profiles and effective roles.
+// PUBLIC ROUTE: authenticate first, then authorize from the authenticated session.
 import { NextRequest, NextResponse } from 'next/server';
 import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
 import { getServerSupabaseEnvMisconfigurationReason } from '@/lib/supabase/server-env';
 import { applyNormalizedSupabaseUrlToEnv } from '@/lib/supabase/normalize-url';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
-import { ADMIN_ROLES } from '@/lib/rbac/role-matrix';
+import { ADMIN_ROLES, normalizeRoles } from '@/lib/rbac/role-matrix';
 
 const ADMIN_PORTAL_LOGIN_ROLES = [
   ...ADMIN_ROLES,
@@ -17,7 +16,7 @@ const ADMIN_PORTAL_LOGIN_ROLES = [
 function jsonError(error: unknown): NextResponse {
   const message = error instanceof Error ? error.message : String(error ?? '');
   const configurationFailure =
-    /SUPABASE_SERVICE_ROLE_KEY|NEXT_PUBLIC_SUPABASE_URL|MISSING_ENV|createAdminClient|requireAdminClient/i.test(
+    /NEXT_PUBLIC_SUPABASE_URL|NEXT_PUBLIC_SUPABASE_ANON_KEY|SUPABASE_URL|SUPABASE_ANON_KEY|MISSING_ENV/i.test(
       message,
     );
 
@@ -32,8 +31,18 @@ function jsonError(error: unknown): NextResponse {
         ? 'Admin authentication is temporarily unavailable because the server authentication configuration is incomplete.'
         : 'Admin authentication failed unexpectedly. Please retry.',
     },
-    { status: configurationFailure ? 503 : 500 },
+    {
+      status: configurationFailure ? 503 : 500,
+      headers: { 'Cache-Control': 'no-store, private' },
+    },
   );
+}
+
+function json(body: Record<string, unknown>, status = 200): NextResponse {
+  return NextResponse.json(body, {
+    status,
+    headers: { 'Cache-Control': 'no-store, private' },
+  });
 }
 
 export async function POST(req: NextRequest) {
@@ -47,26 +56,32 @@ export async function POST(req: NextRequest) {
     const email = typeof body?.email === 'string' ? body.email.trim() : '';
     const password = typeof body?.password === 'string' ? body.password : '';
 
+    // This also serves as the production route-contract probe: an anonymous
+    // POST with an empty body must reach this handler and return JSON 400,
+    // never a middleware redirect or Next.js HTML document.
     if (!email || !password) {
-      return NextResponse.json({ error: 'Email and password required.' }, { status: 400 });
+      return json({ error: 'Email and password required.' }, 400);
     }
 
     try {
       const { hydrateProcessEnv } = await import('@/lib/secrets');
       await hydrateProcessEnv();
     } catch {
-      // platform_secrets hydration unavailable — continue with injected env
+      // Secret hydration is optional for this route. Admin login only needs the
+      // public Supabase URL/anon key; authorization is evaluated through the
+      // newly authenticated user's own session and RLS policies.
     }
     applyNormalizedSupabaseUrlToEnv();
 
     const misconfigured = getServerSupabaseEnvMisconfigurationReason();
     if (misconfigured) {
-      return NextResponse.json(
+      console.error('[admin-login] Supabase public auth configuration invalid', { misconfigured });
+      return json(
         {
           error:
-            'Admin authentication is misconfigured on this server. Contact engineering to update Supabase keys in Northflank.',
+            'Admin authentication is misconfigured on this server. Contact engineering to update the Supabase public auth configuration in Northflank.',
         },
-        { status: 503 },
+        503,
       );
     }
 
@@ -79,21 +94,20 @@ export async function POST(req: NextRequest) {
     if (authError || !authData?.user) {
       const raw = authError?.message || 'Invalid email or password.';
       const invalidApiKey = /invalid api key/i.test(raw);
-      return NextResponse.json(
+      return json(
         {
           error: invalidApiKey
             ? 'Admin authentication is misconfigured (invalid Supabase anon key on this deployment). Contact engineering.'
             : raw,
         },
-        { status: invalidApiKey ? 503 : 401 },
+        invalidApiKey ? 503 : 401,
       );
     }
 
-    // requireAdminClient can throw on a cold start or missing service-role secret.
-    // Keep it inside this route-level try/catch so the client always receives JSON,
-    // never Next.js' HTML error document.
-    const db = await requireAdminClient();
-    const { data: profile, error: profileError } = await db
+    // Do not depend on SUPABASE_SERVICE_ROLE_KEY for interactive sign-in.
+    // The authenticated browser/server session must be able to read its own
+    // profile; the rest of the platform's route guards use the same RLS path.
+    const { data: profile, error: profileError } = await supabase
       .from('profiles')
       .select('role')
       .eq('id', authData.user.id)
@@ -101,47 +115,58 @@ export async function POST(req: NextRequest) {
 
     if (profileError) {
       await supabase.auth.signOut();
-      return NextResponse.json(
-        { error: `Profile load failed: ${profileError.message}. Contact support.` },
-        { status: 500 },
+      console.error('[admin-login] authenticated profile read failed', {
+        userId: authData.user.id,
+        code: profileError.code,
+        message: profileError.message,
+      });
+      return json(
+        { error: 'Your account authenticated, but its profile could not be verified. Please retry or contact support.' },
+        503,
       );
     }
 
-    if (!profile) {
+    if (!profile?.role) {
       await supabase.auth.signOut();
-      return NextResponse.json(
-        { error: 'No profile found for your account. Contact support.' },
-        { status: 403 },
-      );
+      return json({ error: 'No profile or role was found for your account. Contact support.' }, 403);
     }
 
-    const { data: roleRows, error: rolesError } = await db
+    const { data: roleRows, error: rolesError } = await supabase
       .from('user_roles')
       .select('roles(name)')
       .eq('user_id', authData.user.id);
 
-    if (rolesError) {
+    const secondaryRoles = rolesError
+      ? []
+      : (roleRows ?? [])
+          .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
+          .filter((role): role is string => typeof role === 'string');
+
+    const effectiveRoles = normalizeRoles([profile.role, ...secondaryRoles]);
+    const primaryRoleAllowed = ADMIN_PORTAL_LOGIN_ROLES.includes(profile.role);
+    const effectiveRoleAllowed = effectiveRoles.some((role) =>
+      ADMIN_PORTAL_LOGIN_ROLES.includes(role),
+    );
+
+    // If the primary profile role already grants Admin access, a secondary-role
+    // RLS failure must not block login. If access depends on a secondary role,
+    // however, fail closed because that role could not be verified.
+    if (rolesError && !primaryRoleAllowed) {
       await supabase.auth.signOut();
-      return NextResponse.json(
-        { error: 'Unable to verify your admin roles. Please retry.' },
-        { status: 500 },
-      );
+      console.error('[admin-login] secondary role verification failed', {
+        userId: authData.user.id,
+        code: rolesError.code,
+        message: rolesError.message,
+      });
+      return json({ error: 'Unable to verify your Admin portal role. Please retry.' }, 503);
     }
 
-    const secondaryRoles = (roleRows ?? [])
-      .map((row) => (row as { roles?: { name?: unknown } | null }).roles?.name)
-      .filter((role): role is string => typeof role === 'string');
-    const effectiveRoles = Array.from(new Set([profile.role, ...secondaryRoles].filter(Boolean))) as string[];
-
-    if (!effectiveRoles.some((role) => ADMIN_PORTAL_LOGIN_ROLES.includes(role))) {
+    if (!primaryRoleAllowed && !effectiveRoleAllowed) {
       await supabase.auth.signOut();
-      return NextResponse.json(
-        { error: 'You do not have permission to access the admin portal.' },
-        { status: 403 },
-      );
+      return json({ error: 'You do not have permission to access the admin portal.' }, 403);
     }
 
-    return NextResponse.json({ ok: true, role: profile.role, effectiveRoles });
+    return json({ ok: true, role: profile.role, effectiveRoles });
   } catch (error) {
     return jsonError(error);
   }

--- a/scripts/verify-admin-critical-routes.mjs
+++ b/scripts/verify-admin-critical-routes.mjs
@@ -8,6 +8,7 @@ const routesFile = path.join(nextDir, 'routes-manifest.json');
 const requiredAppPaths = [
   '/page',
   '/api/ping/route',
+  '/api/auth/admin-login/route',
   '/api/admin/workflows/run/route',
   '/studio/page',
   '/studio/workflows/page',
@@ -44,6 +45,9 @@ if (routes) {
   if (redirects.some((rule) => rule.source === '/studio/workflows/new')) {
     fail('/studio/workflows/new is still shadowed by a redirect');
   }
+  if (redirects.some((rule) => rule.source === '/api/auth/admin-login')) {
+    fail('/api/auth/admin-login is shadowed by a redirect');
+  }
 
   const rewriteGroups = routes.rewrites && !Array.isArray(routes.rewrites)
     ? Object.values(routes.rewrites)
@@ -51,6 +55,9 @@ if (routes) {
   const rewrites = rewriteGroups.flat().filter(Boolean);
   if (rewrites.some((rule) => rule.source === '/api/admin/workflows/run')) {
     fail('/api/admin/workflows/run is still shadowed by a rewrite');
+  }
+  if (rewrites.some((rule) => rule.source === '/api/auth/admin-login')) {
+    fail('/api/auth/admin-login is shadowed by a rewrite');
   }
 }
 


### PR DESCRIPTION
## Why this is needed
The Admin service can pass liveness/readiness and route smoke tests while `/api/auth/admin-login` is still broken. The user confirmed the current deployed container is not fixed.

## Changes
- Removes the interactive Admin login route's hard dependency on `SUPABASE_SERVICE_ROLE_KEY` / `requireAdminClient()`.
- Verifies the authenticated user's own `profiles.role` and secondary roles through the authenticated Supabase session, matching the platform's existing route-guard model.
- Fails closed when access depends on an unverifiable secondary role, but does not block a verified primary Admin role because a secondary-role query failed.
- Requires `/api/auth/admin-login/route` to be present in the packaged Admin `.next` build and ensures it is not shadowed by redirects/rewrites.
- Adds a live post-deploy contract smoke test: anonymous `POST {}` to `/api/auth/admin-login` must return HTTP 400 + `application/json` + `Email and password required`, and must never return HTML.

## Deployment behavior
Branch validation does not deploy. Once merged, the normal Admin deploy runs once and cannot report success unless the live login API contract passes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix Admin login API contract to use public Supabase auth instead of service-role key
> - Reworks [`POST /api/auth/admin-login`](https://github.com/elevate-for-humanity/Elevate-lms/pull/627/files#diff-4bc83f9cb872b277aef9ff5637658285496ae2262747bcbff29e50ceadc9a05f) to authenticate via the public Supabase client under RLS, removing the service-role key dependency entirely.
> - Returns consistent JSON with `Cache-Control: no-store, private` headers on all responses; returns 400 when email/password are missing, 503 on misconfiguration or invalid anon key, and 403 when the user lacks an allowed Admin role.
> - Adds a smoke test step in the [CI/CD deploy workflow](https://github.com/elevate-for-humanity/Elevate-lms/pull/627/files#diff-daf7602af3bf35582d4429f9815881f05a27a4b370b68700ab937b3b34834ee2) that asserts the login endpoint returns a 400 JSON response for an empty body, failing deployment if the contract is broken.
> - Extends the [critical routes verification script](https://github.com/elevate-for-humanity/Elevate-lms/pull/627/files#diff-dfa2bd13d3def974cb6b456bea4f91520f091ea945986c443e86e9f9ba2c1f79) to fail if the admin-login route is missing from the build or shadowed by a redirect or rewrite.
> - Risk: error messages and some HTTP status codes have changed, which may affect any clients that parse the previous error responses.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized c4221f3.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->