### PR TITLE
Finish Supabase storage cleanup and replay production deploy

### DIFF
--- a/scripts/northflank/deploy-replay-20260812-supabase-cleanup.txt
+++ b/scripts/northflank/deploy-replay-20260812-supabase-cleanup.txt
@@ -1,0 +1,5 @@
+Production deployment replay marker — 2026-08-12
+
+Purpose: deploy the merged Supabase migration reconciliation, auth/profile provisioning hardening, storage canonicalization, and SAM storage policy synchronization from main to Marketing, LMS, and Admin.
+
+This file is intentionally under scripts/northflank/ so the existing path-filtered deploy workflows each trigger once on merge.

--- a/supabase/migrations/20260812170407_canonicalize_sam_storage_bucket_access.sql
+++ b/supabase/migrations/20260812170407_canonicalize_sam_storage_bucket_access.sql
@@ -1,0 +1,40 @@
+-- Canonical SAM.gov storage bucket access.
+-- The application table remains public.sam_documents; this migration configures Storage only.
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES (
+  'sam-documents',
+  'sam-documents',
+  false,
+  52428800,
+  ARRAY['application/pdf','image/jpeg','image/png','image/webp']
+)
+ON CONFLICT (id) DO UPDATE SET public = false;
+
+DROP POLICY IF EXISTS "sam_documents_owner_select" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_insert" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_update" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_delete" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_admin_all" ON storage.objects;
+
+CREATE POLICY "sam_documents_owner_select"
+ON storage.objects FOR SELECT TO authenticated
+USING (bucket_id = 'sam-documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_insert"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'sam-documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_update"
+ON storage.objects FOR UPDATE TO authenticated
+USING (bucket_id = 'sam-documents' AND (storage.foldername(name))[1] = auth.uid()::text)
+WITH CHECK (bucket_id = 'sam-documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_delete"
+ON storage.objects FOR DELETE TO authenticated
+USING (bucket_id = 'sam-documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_admin_all"
+ON storage.objects FOR ALL TO authenticated
+USING (bucket_id = 'sam-documents' AND public.is_admin())
+WITH CHECK (bucket_id = 'sam-documents' AND public.is_admin());

--- a/supabase/migrations/20260812170618_correct_sam_storage_bucket_to_runtime_name.sql
+++ b/supabase/migrations/20260812170618_correct_sam_storage_bucket_to_runtime_name.sql
@@ -1,0 +1,34 @@
+-- Runtime and bootstrap canonical SAM bucket is sam_documents.
+-- Remove policies from the unused hyphenated duplicate and secure the runtime bucket.
+
+DROP POLICY IF EXISTS "sam_documents_owner_select" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_insert" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_update" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_owner_delete" ON storage.objects;
+DROP POLICY IF EXISTS "sam_documents_admin_all" ON storage.objects;
+
+INSERT INTO storage.buckets (id, name, public, file_size_limit, allowed_mime_types)
+VALUES ('sam_documents','sam_documents',false,52428800,ARRAY['application/pdf','image/jpeg','image/png','image/webp'])
+ON CONFLICT (id) DO UPDATE SET public = false;
+
+CREATE POLICY "sam_documents_owner_select"
+ON storage.objects FOR SELECT TO authenticated
+USING (bucket_id = 'sam_documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_insert"
+ON storage.objects FOR INSERT TO authenticated
+WITH CHECK (bucket_id = 'sam_documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_update"
+ON storage.objects FOR UPDATE TO authenticated
+USING (bucket_id = 'sam_documents' AND (storage.foldername(name))[1] = auth.uid()::text)
+WITH CHECK (bucket_id = 'sam_documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_owner_delete"
+ON storage.objects FOR DELETE TO authenticated
+USING (bucket_id = 'sam_documents' AND (storage.foldername(name))[1] = auth.uid()::text);
+
+CREATE POLICY "sam_documents_admin_all"
+ON storage.objects FOR ALL TO authenticated
+USING (bucket_id = 'sam_documents' AND public.is_admin())
+WITH CHECK (bucket_id = 'sam_documents' AND public.is_admin());


### PR DESCRIPTION
Finalizes the remaining Supabase cleanup work and triggers one coordinated production replay for Marketing, LMS, and Admin.

Changes:
- syncs the live SAM storage policy migrations into GitHub
- keeps `sam_documents` as the runtime/bootstrap SAM bucket name
- secures SAM uploads with owner-folder and admin policies
- adds one Northflank deployment replay marker under `scripts/northflank/**` so each existing service workflow runs once on merge

The database changes are already live; this PR synchronizes repository migration history and replays the three production services from the resulting main commit.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Add `sam_documents` storage bucket with per-user RLS policies for SAM storage
> - Creates the `sam_documents` bucket (underscore name) as non-public with a 50 MiB file size limit and MIME types restricted to PDF and common image formats.
> - Adds RLS policies on `storage.objects` scoped to `sam_documents`: authenticated users can only access objects within their `auth.uid()` top-level folder; users passing `public.is_admin()` get full access.
> - An intermediate migration using `sam-documents` (hyphen) is included and immediately superseded by the corrected underscore-named bucket in the follow-up migration.
> - Adds a [deploy replay marker](https://github.com/elevate-for-humanity/Elevate-lms/pull/630/files#diff-cf170300ad2f6604f9c3206c3864f52805a82e6869978c9c7a4dda02d5e3c7f3) to trigger path-filtered deploy workflows for these migrations.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a9fe72f.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->