### PR TITLE
Fix LMS Northflank ffmpeg install failure

### DIFF
--- a/Dockerfile.northflank-lms
+++ b/Dockerfile.northflank-lms
@@ -27,6 +27,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     build-essential \
     ca-certificates \
+    ffmpeg \
     libcairo2-dev \
     libpango1.0-dev \
     libjpeg-dev \
@@ -40,6 +41,7 @@ RUN corepack enable && corepack prepare pnpm@10.28.2 --activate
 
 ENV PNPM_HOME="/app/.pnpm-home"
 ENV PATH="$PNPM_HOME:$PATH"
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
 WORKDIR /app
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
@@ -57,6 +59,7 @@ ENV BUILD_SCOPE=LMS
 ENV CI=true
 ENV DISABLE_WEBPACK_FILESYSTEM_CACHE=1
 
+RUN test -x "$FFMPEG_BIN" && "$FFMPEG_BIN" -version >/dev/null
 RUN pnpm install --no-frozen-lockfile --strict-peer-dependencies=false
 
 ARG NEXT_PUBLIC_SITE_URL=https://www.elevateforhumanity.org
@@ -111,6 +114,7 @@ FROM node:22-bookworm-slim AS runner
 RUN apt-get update && apt-get install -y --no-install-recommends \
     ca-certificates \
     curl \
+    ffmpeg \
     fonts-liberation \
     libcairo2 \
     libpango-1.0-0 \
@@ -129,6 +133,7 @@ ENV NEXT_TELEMETRY_DISABLED=1
 ENV HOSTNAME=0.0.0.0
 ENV PORT=3000
 ENV NODE_OPTIONS="--max-old-space-size=8192"
+ENV FFMPEG_BIN=/usr/bin/ffmpeg
 ENV NF_GIT_SHA=$NF_GIT_SHA
 ENV GIT_SHA=$NF_GIT_SHA
 ENV GITHUB_SHA=$NF_GIT_SHA
@@ -162,6 +167,7 @@ COPY --from=builder /app/public ./apps/lms/public
 COPY --from=builder /app/apps/lms/public ./apps/lms/public
 
 RUN test -d /app/apps/lms/public/images
+RUN test -x "$FFMPEG_BIN" && "$FFMPEG_BIN" -version >/dev/null
 
 EXPOSE 3000
 


### PR DESCRIPTION
LMS Northflank builds failed twice because ffmpeg-static's install script lost its external GitHub binary download with ECONNRESET. Install Debian ffmpeg in the builder/runner and set FFMPEG_BIN=/usr/bin/ffmpeg so ffmpeg-static detects an existing executable and skips the fragile download. Includes explicit ffmpeg verification in both stages.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix ffmpeg install failure in LMS Northflank Dockerfile
> Adds `ffmpeg` to the `apt-get install` lists in both the builder and runner stages of [Dockerfile.northflank-lms](https://github.com/elevate-for-humanity/Elevate-lms/pull/631/files#diff-8c5ba886d0cc82d0a3c0cb8542ab1b50d080bce8d7ea7f5aa0e959d9339e517e), and sets `FFMPEG_BIN=/usr/bin/ffmpeg` in both stages. A `RUN` assertion checks that the binary exists and prints its version, causing the build to fail fast if `ffmpeg` is missing or not executable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized aef9150.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->