### PR TITLE
Fix live Marketing missing image and contrast regression

### DIFF
--- a/apps/marketing/app/call-now/page.tsx
+++ b/apps/marketing/app/call-now/page.tsx
@@ -32,7 +32,7 @@ const START_OPTIONS = [
       'Not sure which program is right for you? Submit an inquiry and get a personalized response within 24 hours.',
     href: '/inquiry',
     action: 'Get Info',
-    image: '/images/pages/about-supportive-services.webp',
+    image: '/images/pages/career-counseling.jpg',
     imageAlt: 'Student receiving advising and support',
   },
   {
@@ -113,11 +113,11 @@ export default function GetStartedPage() {
                   />
                 </div>
                 <div className="p-8">
-                  <h3 className="mb-2 text-xl font-bold text-slate-900 transition-colors group-hover:text-brand-blue-600">
+                  <h3 className="mb-2 text-xl font-bold text-slate-950 transition-colors group-hover:text-brand-blue-700">
                     {option.title}
                   </h3>
-                  <p className="mb-4 text-slate-700">{option.description}</p>
-                  <span className="flex items-center gap-2 font-semibold text-brand-blue-600">
+                  <p className="mb-4 text-slate-800">{option.description}</p>
+                  <span className="flex items-center gap-2 font-semibold text-brand-blue-700">
                     {option.action} <ArrowRight className="h-4 w-4" aria-hidden="true" />
                   </span>
                 </div>
@@ -129,7 +129,7 @@ export default function GetStartedPage() {
 
       <section className="py-16">
         <div className="mx-auto max-w-4xl px-4 text-center">
-          <h2 className="mb-8 text-2xl font-bold">Everything Is Self-Service</h2>
+          <h2 className="mb-8 text-2xl font-bold text-slate-950">Everything Is Self-Service</h2>
           <div className="grid gap-6 md:grid-cols-3">
             {[
               'Apply online in minutes',
@@ -140,10 +140,10 @@ export default function GetStartedPage() {
               'Enroll and start training',
             ].map((item) => (
               <div key={item} className="flex items-center justify-center gap-2">
-                <span className="flex-shrink-0 text-slate-400" aria-hidden="true">
+                <span className="flex-shrink-0 text-slate-600" aria-hidden="true">
                   •
                 </span>
-                <span className="text-slate-900">{item}</span>
+                <span className="text-slate-950">{item}</span>
               </div>
             ))}
           </div>


### PR DESCRIPTION
Targeted production repair based on the live-site audit.

- replaces the confirmed missing `/images/pages/about-supportive-services.webp` reference on Get Started with an existing advising image
- strengthens card/body/action contrast on the same surface
- leaves PR #629 unmerged because several heuristic dedupe substitutions are semantically incorrect and unsafe for production

This is intentionally narrow so Marketing can deploy the confirmed live defect without importing the unsafe image-swap set.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix missing image and contrast issues on the call-now marketing page
> - Fixes the 'Ask a Question' card image in [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/632/files#diff-7b167fca0432fe429a36a8f9d4913092343ee5258135df9356d9b1ce6ce991fe) by pointing to `/images/pages/career-counseling.jpg` instead of a broken supportive-services path.
> - Darkens several text colors across the page: card titles move from `slate-900` to `slate-950`, descriptions from `slate-700` to `slate-800`, and bullet dots from `slate-400` to `slate-600` to restore contrast.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 900ec99.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->