### PR TITLE
Fix incorrect prepaid-card image after media dedupe merge

### DIFF
--- a/apps/marketing/app/banking/prepaid-card/page.tsx
+++ b/apps/marketing/app/banking/prepaid-card/page.tsx
@@ -45,7 +45,7 @@ export default function PrepaidCardPage() {
           <Image
             placeholder="blur"
             blurDataURL="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAoAAAAKCAYAAACNMs+9AAAAFUlEQVR42mP8z8BQDwADhQGAWjR9awAAAABJRU5ErkJggg=="
-          src="/images/pages/card-hvac.webp"
+          src="/images/pages/banking-page-3.jpg"
           alt="Prepaid Card"
           fill
           className="object-cover"


### PR DESCRIPTION
Follow-up to PR #629. Restores the banking-specific prepaid-card hero image that was incorrectly replaced by an HVAC image during the automated media dedupe pass. Keeps the duplicate-media audit framework and all other merged changes intact.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix incorrect hero image on prepaid card page
> Corrects the hero image src in [page.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/633/files#diff-76d58a80df1834077f586b242b852ba60cf1cd3756755dd9bc586d24e6dac6f2) from `/images/pages/card-hvac.webp` to `/images/pages/banking-page-3.jpg`, which was broken by a media deduplication merge.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized 2bb8a97.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->