### PR TITLE
Fix stale Marketing images and hero poster blink

### DIFF
--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -50,7 +50,7 @@ export interface HeroVideoProps {
  * - audio-on playback is attempted first; browsers that block audible autoplay
  *   fall back to muted playback with a positive "Play audio" control;
  * - mobile switches to the page's assigned mobile source without a reload;
- * - the poster stays mounted behind video until a renderable frame is ready;
+ * - the poster stays visible only until a renderable video frame is ready;
  * - media errors fail to the page-specific poster instead of a broken/black frame;
  * - route changes stop all video/audio/timers immediately.
  */
@@ -298,7 +298,7 @@ export default function HeroVideo({
   }
 
   const showVideo = Boolean(videoSrc) && !videoFailed;
-  const showPoster = Boolean(posterImage);
+  const showPoster = Boolean(posterImage) && (!showVideo || !videoReady);
   const hasSoundControl = mediaActivated && Boolean(voiceoverSrc || showVideo);
   const activeSlide = demoActive ? demoSlides[demoSlideIndex] : null;
   const mediaClass = mediaFit === 'contain' ? 'object-contain' : 'object-cover';
@@ -337,7 +337,7 @@ export default function HeroVideo({
               setHasStarted(false);
               setMuted(false);
             }}
-            className={`absolute inset-0 z-10 h-full w-full ${mediaClass} object-center transition-opacity duration-300 ${videoReady ? 'opacity-100' : 'opacity-0'}`}
+            className={`absolute inset-0 z-10 h-full w-full ${mediaClass} object-center ${videoReady ? 'opacity-100' : 'opacity-0'}`}
             aria-label={analyticsName ? `${analyticsName} video` : 'Hero video'}
           />
         ) : null}

--- a/components/pwa/MarketingPwaRegistration.tsx
+++ b/components/pwa/MarketingPwaRegistration.tsx
@@ -17,9 +17,11 @@ export function MarketingPwaRegistration() {
 
     const register = async () => {
       try {
-        await navigator.serviceWorker.register('/sw-marketing.js', {
+        const registration = await navigator.serviceWorker.register('/sw-marketing.js', {
           scope: '/',
+          updateViaCache: 'none',
         });
+        await registration.update();
       } catch (error) {
         console.error('[pwa] Marketing service-worker registration failed', error);
       }
@@ -30,4 +32,3 @@ export function MarketingPwaRegistration() {
 
   return null;
 }
-

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -23,7 +23,7 @@ export interface HomeHeroVideoProps {
   banner: HeroBanner;
 }
 
-const HOME_MEDIA_REVISION = '20260812-home-hero';
+const HOME_MEDIA_REVISION = process.env.NEXT_PUBLIC_GIT_SHA?.slice(0, 12) || 'home-hero';
 
 function withMediaRevision(src?: string) {
   if (!src) return undefined;
@@ -35,14 +35,9 @@ function withMediaRevision(src?: string) {
  * Media playback, mobile source selection, error fallback, narration controls,
  * and route cleanup all live in components/marketing/HeroVideo.
  *
- * The page-specific poster is intentionally passed through to the canonical
- * renderer. HeroVideo keeps it mounted behind the video until a renderable
- * frame is ready, so slow mobile decoding, autoplay restrictions, and media
- * errors fall back to a real hero image instead of a blank/black frame.
- *
- * Homepage media URLs carry an explicit revision so a previously cached media
- * failure cannot pin the current deployment to the poster after a successful
- * release.
+ * Homepage media URLs are revisioned with the deployed commit SHA so browsers,
+ * service workers, and intermediary caches cannot pin a new deployment to an
+ * older poster/video/image response.
  */
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   const ctas = banner.secondaryCta

--- a/public/sw-marketing.js
+++ b/public/sw-marketing.js
@@ -57,16 +57,15 @@ self.addEventListener('activate', (event) => {
   );
 });
 
-async function staleWhileRevalidate(request) {
+async function networkFirst(request) {
   const cache = await caches.open(STATIC_CACHE);
-  const cached = await cache.match(request);
-  const network = fetch(request)
-    .then(async (response) => {
-      await safeCachePut(cache, request, response);
-      return response;
-    })
-    .catch(() => null);
-  return cached || network;
+  try {
+    const response = await fetch(request, { cache: 'no-store', redirect: 'follow' });
+    await safeCachePut(cache, request, response);
+    return response;
+  } catch {
+    return (await cache.match(request)) || null;
+  }
 }
 
 self.addEventListener('fetch', (event) => {
@@ -102,8 +101,11 @@ self.addEventListener('fetch', (event) => {
 
   if (!isStaticAsset) return;
 
+  // Always ask the network for Marketing imagery first. This prevents old
+  // cached images from appearing after a deploy when a path is reused for a
+  // different asset. Cached content is strictly an offline fallback.
   event.respondWith(
-    staleWhileRevalidate(request).then((response) => response || fetch(request)),
+    networkFirst(request).then((response) => response || fetch(request, { cache: 'no-store' })),
   );
 });
 


### PR DESCRIPTION
Focused Marketing visual bug fix. Changes only the Marketing image/service-worker and hero media behavior: (1) service worker switches image requests from stale-while-revalidate to network-first with cached offline fallback, (2) service-worker registration uses updateViaCache:'none' and forces registration.update(), (3) homepage hero media revision uses NEXT_PUBLIC_GIT_SHA so every deployment gets fresh media URLs, and (4) the canonical HeroVideo removes the 300ms poster/video crossfade and hides the poster immediately once a renderable video frame is ready. No Supabase, LMS, Admin, database, or unrelated feature changes.

<!-- Macroscope's pull request summary starts here -->
<!-- Macroscope will only edit the content between these invisible markers, and the markers themselves will not be visible in the GitHub rendered markdown. -->
<!-- If you delete either of the start / end markers from your PR's description, Macroscope will append its summary at the bottom of the description. -->
> [!NOTE]
> ### Fix stale marketing images and hero poster blink on the homepage
> - Replaces the `staleWhileRevalidate` strategy in [sw-marketing.js](https://github.com/elevate-for-humanity/Elevate-lms/pull/635/files#diff-93437ed516aeedf89a1eb5316986318b57f4aaa389dfb669094d05c9fc880619) with a network-first fetch that bypasses the browser cache (`no-store`) and only falls back to the cache on network failure, ensuring marketing images are always fresh.
> - Fixes a blink in [HeroVideo.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/635/files#diff-09bbffe6e45d3d6235aee606d0825338e90c31ab4910cb0742664fbdcdbb60cb) by hiding the poster image as soon as the video has a renderable frame, rather than keeping it visible until the video element is ready.
> - Forces service worker updates on mount in [MarketingPwaRegistration.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/635/files#diff-22768675b67caa630f75d91b3714629d478dd7c613d2541c998c9f381ac20887) by adding `updateViaCache: 'none'` and calling `registration.update()` after registration.
> - Homepage media URLs in [HomeHeroVideo.tsx](https://github.com/elevate-for-humanity/Elevate-lms/pull/635/files#diff-dbf377d6ffab2d32492c71ee711d7709b99700531992ade49e322c11003b98ff) now use the first 12 characters of `NEXT_PUBLIC_GIT_SHA` as a cache-busting query parameter, falling back to `'home-hero'`.
> - Behavioral Change: Static assets on marketing pages are now always fetched from the network first; cached assets are only served when the network is unavailable.
>
> <!-- Macroscope's review summary starts here -->
>
> <sup><a href="https://app.macroscope.com">Macroscope</a> summarized a88d261.</sup>
> <!-- Macroscope's review summary ends here -->
>
<!-- Macroscope's pull request summary ends here -->