### PR TITLE
Fix admin role destination after LMS consolidation

### DIFF
--- a/lib/auth/role-destinations.ts
+++ b/lib/auth/role-destinations.ts
@@ -24,10 +24,10 @@ export interface RoleRouteConfig {
 }
 
 export const ROLE_ROUTE_CONFIG: Readonly<Record<string, RoleRouteConfig>> = {
-  super_admin: { path: '/lms/dashboard', host: 'admin', portalKey: 'admin', label: 'Super Admin' },
-  admin: { path: '/lms/dashboard', host: 'admin', portalKey: 'admin', label: 'Admin' },
-  org_admin: { path: '/lms/dashboard', host: 'admin', portalKey: 'admin', label: 'Org Admin' },
-  advisor: { path: '/lms/dashboard', host: 'admin', portalKey: 'admin', label: 'Advisor' },
+  super_admin: { path: '/dashboard', host: 'admin', portalKey: 'admin', label: 'Super Admin' },
+  admin: { path: '/dashboard', host: 'admin', portalKey: 'admin', label: 'Admin' },
+  org_admin: { path: '/dashboard', host: 'admin', portalKey: 'admin', label: 'Org Admin' },
+  advisor: { path: '/dashboard', host: 'admin', portalKey: 'admin', label: 'Advisor' },
   staff: { path: '/staff-portal/dashboard', host: 'admin', portalKey: 'staff', label: 'Staff' },
   instructor: { path: '/instructor/dashboard', host: 'admin', portalKey: 'instructor', label: 'Instructor' },
   test_admin: { path: '/testing-center', host: 'admin', portalKey: 'testing', label: 'Test Admin' },


### PR DESCRIPTION
Follow-up to merged PR #642.

The LMS route consolidation correctly moved learner traffic to `/lms/dashboard`, but the broad route normalization also changed Admin-owned roles (`super_admin`, `admin`, `org_admin`, `advisor`) from Admin `/dashboard` to Admin `/lms/dashboard`, which does not exist.

This PR restores those four Admin role destinations to `/dashboard` while leaving learner/student roles on `/lms/dashboard`.

This is the blocker reported by the Auth/Role Routing integrity check after #642 merged.