### PR TITLE
Fix student hero image preload warning

### DIFF
--- a/apps/marketing/app/apply/student/page.tsx
+++ b/apps/marketing/app/apply/student/page.tsx
@@ -140,7 +140,8 @@ export default async function StudentApplicationPage({
           fill
           sizes="100vw"
           className="object-cover"
-          priority
+          loading="eager"
+          fetchPriority="high"
         />
       </div>
 


### PR DESCRIPTION
## What changed

- Replaced the student application hero image’s deprecated `priority` preload behavior with `loading="eager"` and `fetchPriority="high"`.

## Why

Edge reported that `/images/pages/apply-page-4.jpg` was preloaded but not consumed shortly after page load. The image should still load immediately because it is above the fold, but it does not need a separate preload link.

## Impact

The hero remains eager and high-priority while eliminating the unused preload warning and avoiding wasted preload bandwidth.

## Validation

- Compared the branch to `main`.
- Confirmed only `apps/marketing/app/apply/student/page.tsx` changed: two additions and one deletion.