### PR TITLE
Trigger Marketing deploy for PWA changes

### DIFF
--- a/.github/workflows/deploy-marketing.yml
+++ b/.github/workflows/deploy-marketing.yml
@@ -12,6 +12,7 @@ on:
       - 'components/home/**'
       - 'components/ui/**'
       - 'components/voice/**'
+      - 'components/pwa/**'
       - 'lib/ai/**'
       - 'lib/navigation/**'
       - 'lib/programs/**'


### PR DESCRIPTION
Adds components/pwa/** to the Marketing production deployment path filter so canonical service-worker changes trigger a fresh Marketing build and deployment.