### PR TITLE
Fix Store initial loading shell

### DIFF
--- a/apps/marketing/app/store/page.tsx
+++ b/apps/marketing/app/store/page.tsx
@@ -1,6 +1,5 @@
-export const dynamic = 'force-dynamic';
-export const revalidate = 0;
-export const fetchCache = 'force-no-store';
+export const dynamic = 'force-static';
+export const revalidate = 300;
 
 import type { Metadata } from 'next';
 import Link from 'next/link';


### PR DESCRIPTION
Render /store as static server content with a short revalidation window instead of forcing request-time no-store rendering. This preserves the existing Store UI and routes while preventing the bare Loading shell from preceding the storefront in the initial HTML response.