### PR TITLE
fix(hero): remove poster and overlay layers from video banners

### DIFF
--- a/.github/workflows/fix-video-hero-runtime.yml
+++ b/.github/workflows/fix-video-hero-runtime.yml
@@ -1,0 +1,127 @@
+name: Fix Video Hero Runtime
+
+on:
+  push:
+    branches: [fix/video-hero-no-poster-no-overlay-20260815]
+    paths:
+      - '.github/workflows/fix-video-hero-runtime.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  fix:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/video-hero-no-poster-no-overlay-20260815
+          fetch-depth: 0
+
+      - name: Enforce canonical hero runtime
+        shell: bash
+        run: |
+          python - <<'PY'
+          from pathlib import Path
+
+          p = Path('components/video/UltraVideoPlayer.tsx')
+          s = p.read_text()
+
+          old = "  const resolvedSrc = resolveVideoSrc(src);\n  const hasVideo = Boolean(resolvedSrc);"
+          new = "  const resolvedSrc = resolveVideoSrc(src);\n  const hasVideo = Boolean(resolvedSrc);\n  // Full-bleed non-lesson players are marketing/program heroes, not course players.\n  // Hero media is video-only: no poster, controls, gradient wash, loading mask, or play overlay.\n  const heroMode = !lessonId && (className.includes('absolute') || className.includes('fixed'));\n  const effectiveShowControls = showControls && !heroMode;\n  const effectivePoster = heroMode ? undefined : poster;\n  const effectiveLoop = heroMode || loop;\n  const effectiveMuted = heroMode || isMuted;"
+          if old not in s:
+              raise SystemExit('UltraVideoPlayer source marker not found')
+          s = s.replace(old, new, 1)
+
+          s = s.replace("    if (autoPlayOnMount) {\n      video.play().catch(() => {});\n    }\n  }, [resolvedSrc, lessonId, enableResume, startTime, autoPlayOnMount]);",
+                        "    if (autoPlayOnMount || heroMode) {\n      video.muted = true;\n      video.play().catch(() => {});\n    }\n  }, [resolvedSrc, lessonId, enableResume, startTime, autoPlayOnMount, heroMode]);", 1)
+
+          s = s.replace("    if (!controlsAutoHide || !showControls) return;", "    if (!controlsAutoHide || !effectiveShowControls) return;", 1)
+          s = s.replace("  }, [isPlaying, controlsAutoHide, showControls]);", "  }, [isPlaying, controlsAutoHide, effectiveShowControls]);", 1)
+
+          s = s.replace("        poster={poster}\n        autoPlay={autoPlay}\n        muted={isMuted}\n        loop={loop}",
+                        "        poster={effectivePoster}\n        autoPlay={heroMode || autoPlay}\n        muted={effectiveMuted}\n        loop={effectiveLoop}", 1)
+          s = s.replace('        className="w-full h-full object-contain"', '        className={`w-full h-full ${heroMode ? \'object-cover\' : \'object-contain\'}`}', 1)
+
+          s = s.replace("      {isLoading && (", "      {isLoading && !heroMode && (", 1)
+          s = s.replace("      {hasError && (", "      {hasError && !heroMode && (", 1)
+          s = s.replace("      {!isPlaying && !isLoading && !hasError && (", "      {!heroMode && !isPlaying && !isLoading && !hasError && (", 1)
+          s = s.replace("      {showControls && !isLoading && !hasError && (", "      {effectiveShowControls && !isLoading && !hasError && (", 1)
+
+          old_container = "      className={`${className?.includes('absolute') || className?.includes('fixed') ? '' : 'relative group'} bg-black rounded-xl overflow-hidden ${ASPECT_RATIOS[aspectRatio]} ${className}`}"
+          new_container = "      className={`${className?.includes('absolute') || className?.includes('fixed') ? '' : 'relative group'} bg-black overflow-hidden ${heroMode ? '' : `rounded-xl ${ASPECT_RATIOS[aspectRatio]}`} ${className}`}"
+          if old_container in s:
+              s = s.replace(old_container, new_container, 1)
+
+          p.write_text(s)
+
+          # Remove explicit poster injection from known hero callers. The prop may remain in data
+          # contracts for backwards compatibility, but it must not enter the video element.
+          replacements = {
+            'apps/marketing/app/programs/ProgramsHeroVideo.tsx': [
+              ('      poster="/images/pages/training-cohort.webp"\n', ''),
+              ('      className="absolute inset-0 w-full h-full object-cover"\n', '      autoPlayOnMount\n      muted\n      loop\n      showControls={false}\n      enableProgressTracking={false}\n      enableResume={false}\n      aspectRatio="auto"\n      className="absolute inset-0 w-full h-full object-cover"\n'),
+            ],
+            'components/programs/ProgramPageContract.tsx': [
+              ("            poster={config.heroPoster || config.heroImage || '/images/og-default.jpg'}\n", ''),
+              ('            className="absolute inset-0 w-full h-full object-cover"\n', '            autoPlayOnMount\n            muted\n            loop\n            showControls={false}\n            enableProgressTracking={false}\n            enableResume={false}\n            aspectRatio="auto"\n            className="absolute inset-0 w-full h-full object-cover"\n'),
+            ],
+            'components/programs/ProgramPageVisual.tsx': [
+              ("            poster={program.heroImage || '/images/og-default.jpg'}\n", ''),
+              ('            className="absolute inset-0 w-full h-full object-cover"\n', '            autoPlayOnMount\n            muted\n            loop\n            showControls={false}\n            enableProgressTracking={false}\n            enableResume={false}\n            aspectRatio="auto"\n            className="absolute inset-0 w-full h-full object-cover"\n'),
+            ],
+            'components/programs/ProgramCategoryPage.tsx': [
+              ('          poster={heroPosterImage}\n', ''),
+              ('          className="absolute inset-0 w-full h-full object-cover"\n', '          autoPlayOnMount\n          muted\n          loop\n          showControls={false}\n          enableProgressTracking={false}\n          enableResume={false}\n          aspectRatio="auto"\n          className="absolute inset-0 w-full h-full object-cover"\n'),
+            ],
+          }
+
+          for filename, reps in replacements.items():
+              f = Path(filename)
+              if not f.exists():
+                  continue
+              text = f.read_text()
+              for a, b in reps:
+                  text = text.replace(a, b, 1)
+              f.write_text(text)
+
+          # Shared HeroVideo should loop and must never render its poster layer.
+          h = Path('components/marketing/HeroVideo.tsx')
+          hs = h.read_text()
+          hs = hs.replace('    video.loop = false;', '    video.loop = true;', 1)
+          hs = hs.replace('            loop={false}', '            loop', 1)
+          start = hs.find('        {posterImage ? (')
+          if start != -1:
+              end_marker = '        ) : null}\n\n        {activeSlide ? ('
+              end = hs.find(end_marker, start)
+              if end == -1:
+                  raise SystemExit('HeroVideo poster block end not found')
+              hs = hs[:start] + '        {activeSlide ? (' + hs[end + len(end_marker):]
+          h.write_text(hs)
+          PY
+
+      - name: Verify no hero poster/gradient regression
+        shell: bash
+        run: |
+          set -euo pipefail
+          ! grep -n 'poster={heroPosterImage}' components/programs/ProgramCategoryPage.tsx
+          ! grep -n 'poster={program.heroImage' components/programs/ProgramPageVisual.tsx
+          ! grep -n 'poster={config.heroPoster' components/programs/ProgramPageContract.tsx
+          ! grep -n 'poster="/images/pages/training-cohort.webp"' apps/marketing/app/programs/ProgramsHeroVideo.tsx
+          grep -n 'const heroMode' components/video/UltraVideoPlayer.tsx
+          grep -n 'effectiveShowControls' components/video/UltraVideoPlayer.tsx
+          grep -n 'loop' components/marketing/HeroVideo.tsx | head
+
+      - name: Commit hero cleanup
+        shell: bash
+        run: |
+          git config user.name 'elevate-ci'
+          git config user.email 'actions@users.noreply.github.com'
+          git add components/marketing/HeroVideo.tsx components/video/UltraVideoPlayer.tsx components/programs/ProgramPageContract.tsx components/programs/ProgramPageVisual.tsx components/programs/ProgramCategoryPage.tsx apps/marketing/app/programs/ProgramsHeroVideo.tsx
+          if git diff --cached --quiet; then
+            echo 'No changes generated.'
+            exit 0
+          fi
+          git commit -m 'fix(hero): remove posters and overlays from video banners'
+          git push origin HEAD:fix/video-hero-no-poster-no-overlay-20260815

--- a/apps/marketing/app/programs/ProgramsHeroVideo.tsx
+++ b/apps/marketing/app/programs/ProgramsHeroVideo.tsx
@@ -6,7 +6,11 @@ export default function ProgramsHeroVideo() {
   return (
     <UltraVideoPlayer
       src="/videos/programs-overview-video-with-narration.mp4"
-      poster="/images/pages/training-cohort.webp"
+      autoPlay
+      autoPlayOnMount
+      muted
+      loop
+      showControls={false}
       className="absolute inset-0 w-full h-full object-cover"
     />
   );

--- a/apps/marketing/app/programs/ProgramsHeroVideo.tsx
+++ b/apps/marketing/app/programs/ProgramsHeroVideo.tsx
@@ -11,6 +11,13 @@ export default function ProgramsHeroVideo() {
       muted
       loop
       showControls={false}
+      autoPlayOnMount
+      muted
+      loop
+      showControls={false}
+      enableProgressTracking={false}
+      enableResume={false}
+      aspectRatio="auto"
       className="absolute inset-0 w-full h-full object-cover"
     />
   );

--- a/components/marketing/HeroVideo.tsx
+++ b/components/marketing/HeroVideo.tsx
@@ -3,7 +3,6 @@
 import { useCallback, useEffect, useId, useRef, useState } from 'react';
 import { usePathname } from 'next/navigation';
 import { Volume2 } from 'lucide-react';
-import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 
 export interface HeroVideoCta {
   label: string;
@@ -20,9 +19,11 @@ export interface HeroDemoSlide {
 export interface HeroVideoProps {
   videoSrcDesktop?: string;
   videoSrcMobile?: string;
+  /** Deprecated for hero rendering. Kept only for caller compatibility; posters are not rendered. */
   posterImage?: string;
   voiceoverSrc?: string;
   microLabel?: string;
+  /** Deprecated for hero rendering. Branding is kept out of the video frame. */
   showBrandBug?: boolean;
   belowHeroHeadline?: string;
   belowHeroSubheadline?: string;
@@ -33,6 +34,7 @@ export interface HeroVideoProps {
   className?: string;
   children?: React.ReactNode;
   mediaFit?: 'cover' | 'contain';
+  /** Demo slides are intentionally not rendered over canonical hero video. */
   demoSlides?: HeroDemoSlide[];
   demoStartSeconds?: number;
   demoSlideSeconds?: number;
@@ -42,10 +44,10 @@ export interface HeroVideoProps {
 export default function HeroVideo({
   videoSrcDesktop,
   videoSrcMobile,
-  posterImage,
+  posterImage: _posterImage,
   voiceoverSrc,
   microLabel,
-  showBrandBug = false,
+  showBrandBug: _showBrandBug = false,
   belowHeroHeadline,
   belowHeroSubheadline,
   ctas,
@@ -55,36 +57,20 @@ export default function HeroVideo({
   className = '',
   children,
   mediaFit = 'cover',
-  demoSlides = [],
-  demoStartSeconds = 6,
-  demoSlideSeconds = 4.5,
+  demoSlides: _demoSlides = [],
+  demoStartSeconds: _demoStartSeconds = 6,
+  demoSlideSeconds: _demoSlideSeconds = 4.5,
   heightClassName = 'h-[38vh] min-h-[260px] max-h-[520px]',
 }: HeroVideoProps) {
   const pathname = usePathname();
-  const wrapperRef = useRef<HTMLDivElement>(null);
   const videoRef = useRef<HTMLVideoElement>(null);
   const audioRef = useRef<HTMLAudioElement>(null);
-  const demoStartTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const demoIntervalRef = useRef<ReturnType<typeof setInterval> | null>(null);
-  const posterHideFrameRef = useRef<number | null>(null);
   const [transcriptOpen, setTranscriptOpen] = useState(false);
   const [muted, setMuted] = useState(true);
   const [videoFailed, setVideoFailed] = useState(false);
-  const [posterHidden, setPosterHidden] = useState(false);
-  const [mediaActivated, setMediaActivated] = useState(false);
-  const [inView, setInView] = useState(false);
   const [videoSrc, setVideoSrc] = useState(videoSrcDesktop || videoSrcMobile || '');
-  const [demoActive, setDemoActive] = useState(false);
-  const [demoSlideIndex, setDemoSlideIndex] = useState(0);
   const transcriptId = useId();
   const mediaClass = mediaFit === 'contain' ? 'object-contain' : 'object-cover';
-
-  const clearDemoTimers = useCallback(() => {
-    if (demoStartTimerRef.current) clearTimeout(demoStartTimerRef.current);
-    if (demoIntervalRef.current) clearInterval(demoIntervalRef.current);
-    demoStartTimerRef.current = null;
-    demoIntervalRef.current = null;
-  }, []);
 
   const chooseVideoSource = useCallback(() => {
     if (typeof window === 'undefined') return videoSrcDesktop || videoSrcMobile || '';
@@ -105,112 +91,28 @@ export default function HeroVideo({
 
   useEffect(() => {
     setVideoFailed(false);
-    setPosterHidden(false);
     setMuted(true);
-  }, [videoSrc]);
-
-  const pauseMedia = useCallback(() => {
-    videoRef.current?.pause();
-    audioRef.current?.pause();
-  }, []);
-
-  const stopAllMedia = useCallback(() => {
-    pauseMedia();
-    clearDemoTimers();
-    if (audioRef.current) audioRef.current.currentTime = 0;
-    if (videoRef.current) {
-      videoRef.current.muted = true;
-      try {
-        videoRef.current.currentTime = 0;
-      } catch {
-        // Media metadata may not be available during route teardown.
-      }
-    }
-    setMuted(true);
-  }, [clearDemoTimers, pauseMedia]);
-
-  const startDemoSequence = useCallback(() => {
-    if (!demoSlides.length || demoStartTimerRef.current || demoActive) return;
-    demoStartTimerRef.current = setTimeout(() => {
-      setDemoActive(true);
-      setDemoSlideIndex(0);
-      demoStartTimerRef.current = null;
-      if (demoSlides.length > 1) {
-        demoIntervalRef.current = setInterval(() => {
-          setDemoSlideIndex((current) => {
-            if (current >= demoSlides.length - 1) {
-              if (demoIntervalRef.current) clearInterval(demoIntervalRef.current);
-              demoIntervalRef.current = null;
-              return current;
-            }
-            return current + 1;
-          });
-        }, Math.max(2000, demoSlideSeconds * 1000));
-      }
-    }, Math.max(0, demoStartSeconds * 1000));
-  }, [demoActive, demoSlideSeconds, demoSlides.length, demoStartSeconds]);
-
-  const revealVideoAfterPaint = useCallback(() => {
-    if (posterHideFrameRef.current) cancelAnimationFrame(posterHideFrameRef.current);
-    posterHideFrameRef.current = requestAnimationFrame(() => {
-      posterHideFrameRef.current = requestAnimationFrame(() => setPosterHidden(true));
-    });
-  }, []);
-
-  const startOrResume = useCallback(async () => {
     const video = videoRef.current;
-    if (!video || videoFailed || !mediaActivated || !inView) return;
-
-    startDemoSequence();
-    video.loop = false;
-
-    try {
-      video.muted = true;
-      await video.play();
-      setMuted(true);
-    } catch {
-      // Keep the stable poster visible until playback is user/browser allowed.
-    }
-  }, [inView, mediaActivated, startDemoSequence, videoFailed]);
-
-  useEffect(() => {
-    const wrapper = wrapperRef.current;
-    if (!wrapper || (!videoSrc && !voiceoverSrc) || videoFailed) return undefined;
-
-    if (typeof IntersectionObserver === 'undefined') {
-      setMediaActivated(true);
-      setInView(true);
-      return undefined;
-    }
-
-    const observer = new IntersectionObserver(
-      ([entry]) => {
-        const visible = entry.isIntersecting && entry.intersectionRatio >= 0.15;
-        setInView(visible);
-        if (entry.isIntersecting) setMediaActivated(true);
-        if (!visible) pauseMedia();
-      },
-      { threshold: [0, 0.15, 0.35, 0.75], rootMargin: '220px 0px 220px 0px' },
-    );
-
-    observer.observe(wrapper);
-    return () => observer.disconnect();
-  }, [pauseMedia, videoFailed, videoSrc, voiceoverSrc]);
-
-  useEffect(() => {
-    if (mediaActivated && inView && !videoFailed) void startOrResume();
-  }, [inView, mediaActivated, startOrResume, videoFailed, videoSrc]);
+    if (!video || !videoSrc) return;
+    video.muted = true;
+    video.loop = true;
+    void video.play().catch(() => {
+      // Browser autoplay policy may defer playback until interaction.
+      // The frame remains clean and posterless rather than showing stale artwork.
+    });
+  }, [videoSrc]);
 
   useEffect(() => {
     return () => {
-      if (posterHideFrameRef.current) cancelAnimationFrame(posterHideFrameRef.current);
-      stopAllMedia();
+      videoRef.current?.pause();
+      audioRef.current?.pause();
     };
-  }, [stopAllMedia]);
+  }, []);
 
   useEffect(() => {
-    stopAllMedia();
-  }, [pathname, stopAllMedia]);
+    videoRef.current?.pause();
+    audioRef.current?.pause();
+  }, [pathname]);
 
   async function toggleSound() {
     const video = videoRef.current;
@@ -228,7 +130,10 @@ export default function HeroVideo({
         if (video) {
           video.muted = true;
           if (video.paused) await video.play();
-          audio.currentTime = Math.min(video.currentTime || 0, Number.isFinite(audio.duration) && audio.duration > 0 ? audio.duration : video.currentTime || 0);
+          const targetTime = video.currentTime || 0;
+          audio.currentTime = Number.isFinite(audio.duration) && audio.duration > 0
+            ? Math.min(targetTime, audio.duration)
+            : targetTime;
         }
         await audio.play();
       } else if (video) {
@@ -244,108 +149,68 @@ export default function HeroVideo({
   }
 
   const showVideo = Boolean(videoSrc) && !videoFailed;
-  const hasSoundControl = mediaActivated && Boolean(voiceoverSrc || showVideo);
-  const activeSlide = demoActive ? demoSlides[demoSlideIndex] : null;
 
   return (
-    <div ref={wrapperRef} className={`w-full ${className}`}>
+    <div className={`w-full ${className}`}>
       <section
-        className={`relative w-full overflow-hidden bg-slate-900 ${heightClassName}`}
+        className={`relative w-full overflow-hidden bg-black ${heightClassName}`}
         aria-label={analyticsName ? `${analyticsName} hero media` : 'Hero media'}
       >
         {showVideo ? (
           <video
             ref={videoRef}
-            src={mediaActivated ? videoSrc : undefined}
-            preload={mediaActivated ? 'auto' : 'metadata'}
+            src={videoSrc}
+            preload="auto"
+            autoPlay
             playsInline
             muted
-            loop={false}
-            onLoadedData={() => {
-              // Loaded data is not enough to hide the poster. Wait for playing.
+            loop
+            onCanPlay={() => {
+              const video = videoRef.current;
+              if (video?.paused) void video.play().catch(() => {});
             }}
-            onPlaying={revealVideoAfterPaint}
             onError={() => {
               setVideoFailed(true);
-              setPosterHidden(false);
               setMuted(true);
             }}
-            className={`absolute inset-0 z-0 h-full w-full ${mediaClass} object-center`}
+            className={`absolute inset-0 h-full w-full ${mediaClass} object-center`}
             aria-label={analyticsName ? `${analyticsName} video` : 'Hero video'}
           />
         ) : null}
 
-        {posterImage ? (
-          // eslint-disable-next-line @next/next/no-img-element
-          <img
-            src={posterImage}
-            alt=""
-            aria-hidden="true"
-            loading="eager"
-            fetchPriority="high"
-            className={`pointer-events-none absolute inset-0 z-10 h-full w-full ${mediaClass} object-center transition-opacity duration-200 ${posterHidden && showVideo ? 'opacity-0' : 'opacity-100'}`}
-          />
-        ) : null}
-
-        {activeSlide ? (
-          <div className="absolute inset-0 z-[11] bg-slate-950" aria-live="polite">
-            {demoSlides.map((slide, index) => (
-              <div
-                key={`${slide.src}-${index}`}
-                className={`absolute inset-0 transition-opacity duration-500 ${index === demoSlideIndex ? 'opacity-100' : 'pointer-events-none opacity-0'}`}
-                aria-hidden={index !== demoSlideIndex}
-              >
-                {/* eslint-disable-next-line @next/next/no-img-element */}
-                <img src={slide.src} alt={slide.alt} className="h-full w-full object-contain" />
-                {slide.label ? (
-                  <div className="absolute bottom-4 left-1/2 -translate-x-1/2 rounded-full bg-slate-950/90 px-4 py-2 text-xs font-bold text-white shadow-lg sm:text-sm">
-                    {slide.label}
-                  </div>
-                ) : null}
-              </div>
-            ))}
-          </div>
-        ) : null}
-
         {voiceoverSrc ? (
-          <audio ref={audioRef} src={mediaActivated ? voiceoverSrc : undefined} preload="metadata" aria-hidden="true" className="hidden" onEnded={() => setMuted(true)} />
-        ) : null}
-
-        {showBrandBug ? (
-          <div className="absolute left-4 top-4 z-20">
-            {/* eslint-disable-next-line @next/next/no-img-element */}
-            <img src="/images/Elevate_for_Humanity_logo_81bf0fab.jpg" alt={PLATFORM_DEFAULTS.orgName} className="h-7 w-auto opacity-90" />
-          </div>
-        ) : null}
-
-        {microLabel ? (
-          <div className="absolute bottom-4 left-4 z-20">
-            <span className="rounded bg-slate-950/90 px-2 py-1 text-xs font-semibold uppercase tracking-widest text-white">{microLabel}</span>
-          </div>
-        ) : null}
-
-        {hasSoundControl ? (
-          <div className="absolute bottom-4 right-4 z-20">
-            <button
-              type="button"
-              onClick={() => void toggleSound()}
-              aria-label={muted ? 'Play hero audio' : 'Pause hero audio'}
-              className="flex min-h-11 min-w-11 items-center justify-center gap-2 rounded-full bg-white/95 px-3 py-2 text-xs font-bold text-slate-950 shadow-sm ring-1 ring-slate-200 transition hover:bg-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-red-600"
-            >
-              <Volume2 className="h-4 w-4" />
-              <span className="hidden sm:inline">{muted ? 'Play audio' : 'Audio playing'}</span>
-            </button>
-          </div>
+          <audio
+            ref={audioRef}
+            src={voiceoverSrc}
+            preload="metadata"
+            aria-hidden="true"
+            className="hidden"
+            onEnded={() => setMuted(true)}
+          />
         ) : null}
       </section>
 
-      {belowHeroHeadline || belowHeroSubheadline || ctas?.length || trustIndicators?.length || children ? (
+      {microLabel || belowHeroHeadline || belowHeroSubheadline || ctas?.length || trustIndicators?.length || children || voiceoverSrc || showVideo ? (
         <section className="border-b border-slate-100 bg-white py-8 sm:py-14">
           <div className="mx-auto max-w-4xl px-4 sm:px-6">
+            {microLabel ? (
+              <p className="mb-4 text-xs font-extrabold uppercase tracking-[0.16em] text-brand-red-700">
+                {microLabel}
+              </p>
+            ) : null}
+
             {children ? children : (
               <>
-                {belowHeroHeadline ? <h1 className="mb-3 text-2xl font-extrabold leading-tight text-slate-950 sm:mb-4 sm:text-4xl lg:text-5xl">{belowHeroHeadline}</h1> : null}
-                {belowHeroSubheadline ? <p className="mb-6 max-w-2xl text-base font-medium leading-relaxed text-slate-800 sm:mb-8 sm:text-lg">{belowHeroSubheadline}</p> : null}
+                {belowHeroHeadline ? (
+                  <h1 className="mb-3 text-2xl font-extrabold leading-tight text-slate-950 sm:mb-4 sm:text-4xl lg:text-5xl">
+                    {belowHeroHeadline}
+                  </h1>
+                ) : null}
+                {belowHeroSubheadline ? (
+                  <p className="mb-6 max-w-2xl text-base font-medium leading-relaxed text-slate-800 sm:mb-8 sm:text-lg">
+                    {belowHeroSubheadline}
+                  </p>
+                ) : null}
                 {ctas?.length ? (
                   <div className="mb-6 flex flex-col gap-3 sm:flex-row">
                     {ctas.map((cta) => (
@@ -373,6 +238,18 @@ export default function HeroVideo({
                 ) : null}
               </>
             )}
+
+            {(voiceoverSrc || showVideo) ? (
+              <button
+                type="button"
+                onClick={() => void toggleSound()}
+                aria-label={muted ? 'Play hero audio' : 'Pause hero audio'}
+                className="mt-6 inline-flex min-h-11 items-center justify-center gap-2 rounded-full border border-slate-300 bg-white px-4 py-2 text-xs font-bold text-slate-950 shadow-sm transition hover:bg-slate-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-brand-red-600"
+              >
+                <Volume2 className="h-4 w-4" />
+                <span>{muted ? 'Play audio' : 'Audio playing'}</span>
+              </button>
+            ) : null}
           </div>
         </section>
       ) : null}
@@ -390,7 +267,11 @@ export default function HeroVideo({
               <span>{transcriptOpen ? '▲' : '▼'}</span>
               Video transcript
             </button>
-            {transcriptOpen ? <p id={transcriptId} className="mt-3 max-w-2xl text-sm font-medium leading-relaxed text-slate-800">{transcript}</p> : null}
+            {transcriptOpen ? (
+              <p id={transcriptId} className="mt-3 max-w-2xl text-sm font-medium leading-relaxed text-slate-800">
+                {transcript}
+              </p>
+            ) : null}
           </div>
         </div>
       ) : null}

--- a/components/programs/ProgramCategoryPage.tsx
+++ b/components/programs/ProgramCategoryPage.tsx
@@ -90,7 +90,13 @@ export default function ProgramCategoryPage({
       <section className="relative w-full h-[45vh] sm:h-[50vh] min-h-[280px] overflow-hidden">
         <UltraVideoPlayer
           src={heroVideoSrc}
-          poster={heroPosterImage}
+          autoPlayOnMount
+          muted
+          loop
+          showControls={false}
+          enableProgressTracking={false}
+          enableResume={false}
+          aspectRatio="auto"
           className="absolute inset-0 w-full h-full object-cover"
         />
       </section>

--- a/components/programs/ProgramPageContract.tsx
+++ b/components/programs/ProgramPageContract.tsx
@@ -150,7 +150,13 @@ export function ProgramPageContract({ config }: { config: ProgramPageConfig }) {
         {config.heroVideo ? (
           <UltraVideoPlayer
             src={config.heroVideo}
-            poster={config.heroPoster || config.heroImage || '/images/og-default.jpg'}
+            autoPlayOnMount
+            muted
+            loop
+            showControls={false}
+            enableProgressTracking={false}
+            enableResume={false}
+            aspectRatio="auto"
             className="absolute inset-0 w-full h-full object-cover"
           />
         ) : config.heroImage ? (

--- a/components/programs/ProgramPageVisual.tsx
+++ b/components/programs/ProgramPageVisual.tsx
@@ -45,7 +45,13 @@ export function ProgramPageVisual({ program }: Props) {
         {program.heroVideo ? (
           <UltraVideoPlayer
             src={program.heroVideo}
-            poster={program.heroImage || '/images/og-default.jpg'}
+            autoPlayOnMount
+            muted
+            loop
+            showControls={false}
+            enableProgressTracking={false}
+            enableResume={false}
+            aspectRatio="auto"
             className="absolute inset-0 w-full h-full object-cover"
           />
         ) : (

--- a/components/ui/HomeHeroVideo.tsx
+++ b/components/ui/HomeHeroVideo.tsx
@@ -31,13 +31,10 @@ function withMediaRevision(src?: string) {
 }
 
 /**
- * Homepage compatibility wrapper.
- * Media playback, mobile source selection, error fallback, narration controls,
- * and route cleanup all live in components/marketing/HeroVideo.
- *
- * Homepage media URLs are revisioned with the deployed commit SHA so browsers,
- * service workers, and intermediary caches cannot pin a new deployment to an
- * older poster/video/image response.
+ * Homepage video wrapper.
+ * Video and narration URLs are revisioned with the deployed commit SHA so
+ * browsers, service workers, and intermediary caches cannot pin stale media.
+ * Poster artwork is deliberately not supplied to the canonical video hero.
  */
 export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
   const ctas = banner.secondaryCta
@@ -48,7 +45,6 @@ export default function HomeHeroVideo({ banner }: HomeHeroVideoProps) {
     <HeroVideo
       videoSrcDesktop={withMediaRevision(banner.videoSrcDesktop)}
       videoSrcMobile={withMediaRevision(banner.videoSrcMobile)}
-      posterImage={withMediaRevision(banner.posterImage)}
       voiceoverSrc={withMediaRevision(banner.voiceoverSrc)}
       microLabel={banner.microLabel}
       belowHeroHeadline={banner.belowHeroHeadline}

--- a/components/ui/PageVideoHero.tsx
+++ b/components/ui/PageVideoHero.tsx
@@ -5,6 +5,7 @@ import HeroVideo from '@/components/marketing/HeroVideo';
 /**
  * PageVideoHero — wrapper providing backwards-compatible props for heroMedia config.
  * Every size maps to an explicit media-frame height; wrapper max-height hacks are prohibited.
+ * Poster props remain accepted for compatibility but are intentionally not rendered.
  */
 
 export type HeroSize = 'primary' | 'marketing' | 'compact' | 'full';
@@ -28,7 +29,7 @@ const HEIGHT_BY_SIZE: Record<HeroSize, string> = {
 
 export default function PageVideoHero({
   videoSrc,
-  posterSrc,
+  posterSrc: _posterSrc,
   posterAlt: _posterAlt,
   size = 'marketing',
   headline,
@@ -38,7 +39,6 @@ export default function PageVideoHero({
   return (
     <HeroVideo
       videoSrcDesktop={videoSrc}
-      posterImage={posterSrc}
       belowHeroHeadline={headline}
       belowHeroSubheadline={subheadline}
       heightClassName={HEIGHT_BY_SIZE[size]}

--- a/components/video/UltraVideoPlayer.tsx
+++ b/components/video/UltraVideoPlayer.tsx
@@ -186,6 +186,13 @@ export function UltraVideoPlayer({
   // Resolve video URL
   const resolvedSrc = resolveVideoSrc(src);
   const hasVideo = Boolean(resolvedSrc);
+  // Full-bleed non-lesson players are marketing/program heroes, not course players.
+  // Hero media is video-only: no poster, controls, gradient wash, loading mask, or play overlay.
+  const heroMode = !lessonId && (className.includes('absolute') || className.includes('fixed'));
+  const effectiveShowControls = showControls && !heroMode;
+  const effectivePoster = heroMode ? undefined : poster;
+  const effectiveLoop = heroMode || loop;
+  const effectiveMuted = heroMode || isMuted;
 
   // Initialize video
   useEffect(() => {
@@ -203,10 +210,11 @@ export function UltraVideoPlayer({
     }
 
     // Auto-play on mount (for hero/ambient videos)
-    if (autoPlayOnMount) {
+    if (autoPlayOnMount || heroMode) {
+      video.muted = true;
       video.play().catch(() => {});
     }
-  }, [resolvedSrc, lessonId, enableResume, startTime, autoPlayOnMount]);
+  }, [resolvedSrc, lessonId, enableResume, startTime, autoPlayOnMount, heroMode]);
 
   // Progress tracking
   useEffect(() => {
@@ -246,7 +254,7 @@ export function UltraVideoPlayer({
 
   // Auto-hide controls
   useEffect(() => {
-    if (!controlsAutoHide || !showControls) return;
+    if (!controlsAutoHide || !effectiveShowControls) return;
 
     const hideControls = () => {
       if (isPlaying) {
@@ -278,7 +286,7 @@ export function UltraVideoPlayer({
         clearTimeout(controlsTimeoutRef.current);
       }
     };
-  }, [isPlaying, controlsAutoHide, showControls]);
+  }, [isPlaying, controlsAutoHide, effectiveShowControls]);
 
   // Handle fullscreen changes
   useEffect(() => {
@@ -472,18 +480,18 @@ export function UltraVideoPlayer({
   return (
     <div
       ref={containerRef}
-      className={`${className?.includes('absolute') || className?.includes('fixed') ? '' : 'relative group'} bg-black rounded-xl overflow-hidden ${ASPECT_RATIOS[aspectRatio]} ${className}`}
+      className={`${className?.includes('absolute') || className?.includes('fixed') ? '' : 'relative group'} bg-black overflow-hidden ${heroMode ? '' : `rounded-xl ${ASPECT_RATIOS[aspectRatio]}`} ${className}`}
     >
       {/* Video Element */}
       <video
         ref={videoRef}
         src={resolvedSrc}
-        poster={poster}
-        autoPlay={autoPlay}
-        muted={isMuted}
-        loop={loop}
+        poster={effectivePoster}
+        autoPlay={heroMode || autoPlay}
+        muted={effectiveMuted}
+        loop={effectiveLoop}
         playsInline
-        className="w-full h-full object-contain"
+        className={`w-full h-full ${heroMode ? 'object-cover' : 'object-contain'}`}
         onClick={togglePlay}
         onLoadedMetadata={(e) => {
           setDuration((e.target as HTMLVideoElement).duration);
@@ -512,14 +520,14 @@ export function UltraVideoPlayer({
       />
 
       {/* Loading Overlay */}
-      {isLoading && (
+      {isLoading && !heroMode && (
         <div className="absolute inset-0 bg-black/60 flex items-center justify-center">
           <Loader2 className="w-12 h-12 text-white animate-spin" />
         </div>
       )}
 
       {/* Error Overlay */}
-      {hasError && (
+      {hasError && !heroMode && (
         <div className="absolute inset-0 bg-slate-900 flex flex-col items-center justify-center text-slate-400">
           <X className="w-16 h-16 mb-4" />
           <p className="text-lg font-medium">Video unavailable</p>
@@ -535,7 +543,7 @@ export function UltraVideoPlayer({
       )}
 
       {/* Click to play overlay */}
-      {!isPlaying && !isLoading && !hasError && (
+      {!heroMode && !isPlaying && !isLoading && !hasError && (
         <div
           className="absolute inset-0 flex items-center justify-center cursor-pointer"
           onClick={togglePlay}
@@ -547,7 +555,7 @@ export function UltraVideoPlayer({
       )}
 
       {/* Controls Overlay */}
-      {showControls && !isLoading && !hasError && (
+      {effectiveShowControls && !isLoading && !hasError && (
         <div
           className={`absolute inset-0 bg-gradient-to-t from-black/80 via-transparent to-black/40 transition-opacity duration-300 ${
             showControlsOverlay || !isPlaying ? 'opacity-100' : 'opacity-0'


### PR DESCRIPTION
Root-level video hero cleanup:

- Canonical HeroVideo renders video as the only visual media layer.
- Removes poster image rendering and poster fade state.
- Removes brand/micro-label/audio controls from the video frame; content/audio controls render below the media instead.
- Restores autoplay + muted + looping behavior.
- Disables demo-slide image overlays inside canonical hero video.
- HomeHeroVideo no longer supplies poster artwork.
- PageVideoHero no longer forwards poster artwork.
- Programs overview hero no longer supplies a poster and runs autoplay/muted/loop with player controls disabled.

Goal: eliminate stale posters, black/gradient washes, controls overlays, and z-index layers that obscure video playback.