### PR TITLE
fix: recover red Northflank application builds

### DIFF
--- a/apps/lms/app/ai-chat/page.tsx
+++ b/apps/lms/app/ai-chat/page.tsx
@@ -1,15 +1,6 @@
 'use client';
 
-import dynamic from 'next/dynamic';
-
-const AIChat = dynamic(() => import('@/components/studio/AIChat').then(m => m.default || m), {
-  ssr: false,
-  loading: () => (
-    <div className="min-h-screen bg-slate-900 flex items-center justify-center">
-      <div className="text-white">Loading AI Assistant...</div>
-    </div>
-  ),
-});
+import AIChat from '@/components/studio/AIChat';
 
 export default function AIChatPage() {
   return (
@@ -18,4 +9,3 @@ export default function AIChatPage() {
     </div>
   );
 }
-

--- a/components/pwa/MarketingPwaClient.tsx
+++ b/components/pwa/MarketingPwaClient.tsx
@@ -1,12 +1,7 @@
 'use client';
 
-import dynamic from 'next/dynamic';
 import { MarketingPwaRegistration } from './MarketingPwaRegistration';
-
-const PwaInstallBanner = dynamic(
-  () => import('./PwaInstallBanner').then((module) => module.PwaInstallBanner),
-  { ssr: false },
-);
+import { PwaInstallBanner } from './PwaInstallBanner';
 
 export function MarketingPwaClient() {
   return (


### PR DESCRIPTION
Repairs the immediate application build blockers seen in the Multi-Container Build workflow without weakening build gates.

- LMS: removes the failing `next/dynamic` import from `/ai-chat`.
- Marketing: removes the failing `next/dynamic` import from the shared PWA client while preserving the install banner and registration.

Admin remains under separate diagnosis because its webpack minifier failure has a different signature.