### PR TITLE
Fix stale public catalog and malformed enrollment routes

### DIFF
--- a/apps/marketing/app/enroll/course/page.tsx
+++ b/apps/marketing/app/enroll/course/page.tsx
@@ -1,0 +1,11 @@
+import { permanentRedirect } from 'next/navigation';
+
+/**
+ * Retired malformed generic enrollment URL.
+ * Enrollment requires a real program identifier, so send generic/legacy
+ * traffic to the canonical public program catalog instead of letting the
+ * dynamic /enroll/[programId] route treat "course" as a program slug.
+ */
+export default function RetiredGenericCourseEnrollmentPage() {
+  permanentRedirect('/programs');
+}

--- a/apps/marketing/app/programs/catalog/page.tsx
+++ b/apps/marketing/app/programs/catalog/page.tsx
@@ -1,0 +1,9 @@
+import { permanentRedirect } from 'next/navigation';
+
+/**
+ * Compatibility route for the retired parallel public program catalog.
+ * The canonical public catalog is /programs.
+ */
+export default function ProgramsCatalogCompatibilityPage() {
+  permanentRedirect('/programs');
+}


### PR DESCRIPTION
Canonicalizes two confirmed production route defects without duplicating functionality:

- `/programs/catalog` is now compatibility-only and permanently routes to canonical `/programs`.
- `/enroll/course` no longer falls through to dynamic `/enroll/[programId]` and treat `course` as a program slug; it routes users to `/programs` to choose a real program.

PWA files were audited but intentionally not changed: canonical workers live in root `public/`, `sync-pwa-public.mjs` copies them into service-local public directories during build/start, and the Northflank Admin image copies public assets into runtime.