### PR TITLE
Fix Employer PWA canonical routes

### DIFF
--- a/public/manifest-employer.json
+++ b/public/manifest-employer.json
@@ -2,8 +2,8 @@
   "name": "Elevate Hire",
   "short_name": "Hire",
   "description": "Employer portal for hiring graduates and workforce solutions",
-  "start_url": "/employer-portal",
-  "scope": "/employer",
+  "start_url": "/employer/dashboard",
+  "scope": "/employer/",
   "display": "standalone",
   "orientation": "any",
   "background_color": "#ffffff",
@@ -41,11 +41,11 @@
   "shortcuts": [
     {
       "name": "Job Postings",
-      "url": "/employer-portal/jobs"
+      "url": "/employer/jobs"
     },
     {
       "name": "Candidates",
-      "url": "/employer-portal/candidates"
+      "url": "/employer/candidates"
     }
   ],
   "id": "org.elevateforhumanity.employer",


### PR DESCRIPTION
Repairs the Employer PWA manifest so installed launches and shortcuts use the actual canonical LMS routes.

- start_url: `/employer/dashboard`
- scope normalized to `/employer/`
- Job Postings shortcut: `/employer/jobs`
- Candidates shortcut: `/employer/candidates`

The prior `/employer-portal*` targets have no matching implementation in the repository. The canonical target pages are existing authenticated employer surfaces.