### PR TITLE
Route career-course purchases through the canonical Stripe webhook

### DIFF
--- a/apps/marketing/app/api/webhooks/stripe/route.ts
+++ b/apps/marketing/app/api/webhooks/stripe/route.ts
@@ -40,6 +40,7 @@ import { createEnrollmentCase, submitCaseForSignatures } from '@/lib/workflow/ca
 import { auditLog, AuditAction, AuditEntity } from '@/lib/logging/auditLog';
 import { createOrUpdateEnrollment, linkOrphanedEnrollments } from '@/lib/enrollment-service';
 import { handleCheckoutSessionCompleted } from '@/lib/stripe/handlers/checkout-session-completed';
+import { processCareerCourseStripeEvent } from '@/lib/payments/career-course-webhook';
 import {
   getBillingAuthority,
   getUpdatableFields,
@@ -282,6 +283,22 @@ async function _POST(request: NextRequest) {
     type: event.type,
     livemode: event.livemode,
   });
+
+  // Career-course checkouts use the same canonical Stripe endpoint as every
+  // other marketing payment. This guarantees enrollment without requiring a
+  // second webhook endpoint or a separate signing secret in production.
+  try {
+    const careerCourseResult = await processCareerCourseStripeEvent(event);
+    if (careerCourseResult.handled) {
+      return NextResponse.json(careerCourseResult.response);
+    }
+  } catch (error) {
+    Sentry.captureException(error, {
+      tags: { subsystem: 'career_course_webhook', event_type: event.type },
+    });
+    logger.error('[webhook] Career-course processing failed', error);
+    return NextResponse.json({ error: 'Webhook processing failed' }, { status: 500 });
+  }
 
   // Unified event tracking (secondary to stripe_webhook_events)
   claimWebhookEvent('stripe', event.id, event.type, { livemode: event.livemode }).then(()=>{}, ()=>{});

--- a/lib/payments/career-course-webhook.ts
+++ b/lib/payments/career-course-webhook.ts
@@ -163,6 +163,53 @@ async function recordCompletedCheckout(event: Stripe.Event, session: Stripe.Chec
   return { duplicate: false };
 }
 
+export type CareerCourseWebhookResult = {
+  handled: boolean;
+  response?: Record<string, boolean>;
+};
+
+/**
+ * Process career-course events after the caller has verified the Stripe
+ * signature. The canonical marketing webhook calls this so career-course
+ * purchases do not depend on a second Stripe endpoint or signing secret.
+ */
+export async function processCareerCourseStripeEvent(
+  event: Stripe.Event,
+): Promise<CareerCourseWebhookResult> {
+  switch (event.type) {
+    case 'checkout.session.completed':
+    case 'checkout.session.async_payment_succeeded': {
+      const session = event.data.object as Stripe.Checkout.Session;
+
+      if (session.metadata?.type !== 'career_course') {
+        return { handled: false };
+      }
+
+      if (session.payment_status !== 'paid') {
+        return { handled: true, response: { received: true, pending: true } };
+      }
+
+      const result = await recordCompletedCheckout(event, session);
+      return { handled: true, response: { received: true, ...result } };
+    }
+
+    case 'checkout.session.async_payment_failed': {
+      const session = event.data.object as Stripe.Checkout.Session;
+      if (session.metadata?.type !== 'career_course') {
+        return { handled: false };
+      }
+
+      logger.info('Career-course asynchronous payment failed', {
+        checkoutSessionId: session.id,
+      });
+      return { handled: true, response: { received: true } };
+    }
+
+    default:
+      return { handled: false };
+  }
+}
+
 export async function handleCareerCourseStripeWebhook(req: Request) {
   await hydrateProcessEnv();
 
@@ -199,41 +246,10 @@ export async function handleCareerCourseStripeWebhook(req: Request) {
   }
 
   try {
-    switch (event.type) {
-      case 'checkout.session.completed':
-      case 'checkout.session.async_payment_succeeded': {
-        const session = event.data.object as Stripe.Checkout.Session;
-
-        if (session.metadata?.type !== 'career_course') {
-          return NextResponse.json({ received: true, skipped: true });
-        }
-
-        if (session.payment_status !== 'paid') {
-          return NextResponse.json({ received: true, pending: true });
-        }
-
-        const result = await recordCompletedCheckout(event, session);
-        return NextResponse.json({ received: true, ...result });
-      }
-
-      case 'checkout.session.async_payment_failed': {
-        const session = event.data.object as Stripe.Checkout.Session;
-        if (session.metadata?.type === 'career_course') {
-          logger.info('Career-course asynchronous payment failed', {
-            checkoutSessionId: session.id,
-          });
-        }
-        break;
-      }
-
-      case 'payment_intent.payment_failed': {
-        const paymentIntent = event.data.object as Stripe.PaymentIntent;
-        logger.info('Payment failed', { paymentIntentId: paymentIntent.id });
-        break;
-      }
-    }
-
-    return NextResponse.json({ received: true });
+    const result = await processCareerCourseStripeEvent(event);
+    return NextResponse.json(
+      result.handled ? result.response : { received: true, skipped: true },
+    );
   } catch (error) {
     Sentry.captureException(error, { tags: { subsystem: 'career_course_webhook' } });
     logger.error(


### PR DESCRIPTION
Routes career-course checkout completion and asynchronous BNPL events through the already-registered canonical live Stripe webhook. This removes the unregistered-endpoint gap and preserves idempotent purchase plus LMS enrollment provisioning.

Verified locally:
- Marketing TypeScript
- LMS TypeScript
- Focused ESLint
- Git diff validation