### PR TITLE
test(studio): enforce architecture convergence in release gate

### DIFF
--- a/scripts/check-studio-architecture.mjs
+++ b/scripts/check-studio-architecture.mjs
@@ -75,8 +75,10 @@ function sourceFiles(current) {
     return /\.(?:[cm]?[jt]sx?|mjs|cjs|sh)$/.test(entry.name) ? [target] : [];
   });
 }
+const checkerPath = path.join(root, 'scripts/check-studio-architecture.mjs');
 for (const sourceRoot of ['apps/admin', 'components', 'lib', 'scripts', 'tests']) {
   for (const file of sourceFiles(path.join(root, sourceRoot))) {
+    if (file === checkerPath) continue;
     if (read(path.relative(root, file)).includes('/api/admin/devstudio')) {
       fail(`legacy /api/admin/devstudio reference exists: ${path.relative(root, file)}`);
     }

--- a/scripts/dev-studio-integration-gate.sh
+++ b/scripts/dev-studio-integration-gate.sh
@@ -16,6 +16,13 @@ LEGACY_APP="$ROOT/apps/app/api/devstudio"
 
 echo "=== Dev Studio Production Integration Gate ==="
 
+echo "\n== Architecture convergence =="
+if node scripts/check-studio-architecture.mjs; then
+  pass "Canonical Studio architecture gate"
+else
+  fail "Canonical Studio architecture gate"
+fi
+
 echo "\n== Canonical API ownership =="
 if [[ -d "$CANONICAL" ]] && find "$CANONICAL" -name route.ts -type f | grep -q .; then
   pass "Admin owns canonical /api/admin/dev-studio"


### PR DESCRIPTION
## What changed
- Runs `scripts/check-studio-architecture.mjs` from the Dev Studio integration gate.
- Makes the production readiness path fail when Studio shell ownership, workspace registry wiring, duplicate API routes, legacy `/api/admin/devstudio`, Course Builder convergence, or other canonical Studio invariants regress.

## Why
`production-readiness-gate.sh` already calls `dev-studio-integration-gate.sh`, but the integration gate did not call the stronger architecture checker. That allowed production readiness to pass even if architecture convergence had regressed.

## Scope
Gate-only hardening. No runtime route moves, no feature deletion, no dependency changes, no schema changes.