### PR TITLE
Fix Store funnel, onboarding, demos, and conversion gaps

### DIFF
--- a/apps/marketing/app/api/store/demo/convert/route.ts
+++ b/apps/marketing/app/api/store/demo/convert/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse } from 'next/server';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { startWorkspaceTrial } from '@/lib/workspace/start-workspace-trial';
+import { ensureTrialOwnerAccess } from '@/lib/workspace/ensure-trial-owner-access';
 import { mergeSiteConfig, type TenantSiteConfigPatch } from '@/lib/tenant/default-site-config';
 import type { TenantSiteConfig, TenantSiteProduct } from '@/lib/tenant/site-types';
 
@@ -23,88 +24,69 @@ function object(value: unknown): Record<string, unknown> {
 
 function stringArray(value: unknown, maxItems = 12, maxLength = 120): string[] {
   return Array.isArray(value)
-    ? value
-        .map((item) => text(item, maxLength))
-        .filter(Boolean)
-        .slice(0, maxItems)
+    ? value.map((item) => text(item, maxLength)).filter(Boolean).slice(0, maxItems)
     : [];
 }
 
 function features(value: unknown): TenantSiteConfig['homepage']['features'] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const rows = value
-    .slice(0, 8)
-    .map((item) => {
-      const row = object(item);
-      const title = text(row.title, 90);
-      const description = text(row.description, 280);
-      if (!title) return null;
-      const image = text(row.image, 500);
-      return { title, description, ...(image ? { image } : {}) };
-    })
-    .filter((row): row is NonNullable<typeof row> => Boolean(row));
+  const rows = value.slice(0, 8).map((item) => {
+    const row = object(item);
+    const title = text(row.title, 90);
+    const description = text(row.description, 280);
+    if (!title) return null;
+    const image = text(row.image, 500);
+    return { title, description, ...(image ? { image } : {}) };
+  }).filter((row): row is NonNullable<typeof row> => Boolean(row));
   return rows.length ? rows : undefined;
 }
 
 function programs(value: unknown): TenantSiteConfig['programs'] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const rows = value
-    .slice(0, 12)
-    .map((item) => {
-      const row = object(item);
-      const name = text(row.name, 100);
-      if (!name) return null;
-      const description = text(row.description, 320);
-      const duration = text(row.duration, 80);
-      const level = text(row.level, 80);
-      const image = text(row.image, 500);
-      return {
-        name,
-        description,
-        ...(duration ? { duration } : {}),
-        ...(level ? { level } : {}),
-        ...(image ? { image } : {}),
-      };
-    })
-    .filter((row): row is NonNullable<typeof row> => Boolean(row));
+  const rows = value.slice(0, 12).map((item) => {
+    const row = object(item);
+    const name = text(row.name, 100);
+    if (!name) return null;
+    const description = text(row.description, 320);
+    const duration = text(row.duration, 80);
+    const level = text(row.level, 80);
+    const image = text(row.image, 500);
+    return { name, description, ...(duration ? { duration } : {}), ...(level ? { level } : {}), ...(image ? { image } : {}) };
+  }).filter((row): row is NonNullable<typeof row> => Boolean(row));
   return rows.length ? rows : undefined;
 }
 
 function products(value: unknown): TenantSiteProduct[] | undefined {
   if (!Array.isArray(value)) return undefined;
-  const rows = value
-    .slice(0, 30)
-    .map((item) => {
-      const row = object(item);
-      const name = text(row.name, 120);
-      if (!name) return null;
-      const product: TenantSiteProduct = { name };
-      const description = text(row.description, 500);
-      const price = text(row.price, 40);
-      const compareAtPrice = text(row.compareAtPrice, 40);
-      const image = text(row.image, 700);
-      const imageAlt = text(row.imageAlt, 180);
-      const href = text(row.href, 700);
-      const category = text(row.category, 100);
-      const badge = text(row.badge, 60);
-      if (description) product.description = description;
-      if (price) product.price = price;
-      if (compareAtPrice) product.compareAtPrice = compareAtPrice;
-      if (image) product.image = image;
-      if (imageAlt) product.imageAlt = imageAlt;
-      if (href) product.href = href;
-      if (category) product.category = category;
-      if (badge) product.badge = badge;
-      return product;
-    })
-    .filter((row): row is TenantSiteProduct => Boolean(row));
+  const rows = value.slice(0, 30).map((item) => {
+    const row = object(item);
+    const name = text(row.name, 120);
+    if (!name) return null;
+    const product: TenantSiteProduct = { name };
+    const description = text(row.description, 500);
+    const price = text(row.price, 40);
+    const compareAtPrice = text(row.compareAtPrice, 40);
+    const image = text(row.image, 700);
+    const imageAlt = text(row.imageAlt, 180);
+    const href = text(row.href, 700);
+    const category = text(row.category, 100);
+    const badge = text(row.badge, 60);
+    if (description) product.description = description;
+    if (price) product.price = price;
+    if (compareAtPrice) product.compareAtPrice = compareAtPrice;
+    if (image) product.image = image;
+    if (imageAlt) product.imageAlt = imageAlt;
+    if (href) product.href = href;
+    if (category) product.category = category;
+    if (badge) product.badge = badge;
+    return product;
+  }).filter((row): row is TenantSiteProduct => Boolean(row));
   return rows.length ? rows : undefined;
 }
 
 function sitePatchFromDemo(state: Record<string, unknown>): SitePatch | null {
   const raw = object(state.siteConfig);
   if (!Object.keys(raw).length) return null;
-
   const brandingRaw = object(raw.branding);
   const homepageRaw = object(raw.homepage);
   const contactRaw = object(raw.contact);
@@ -112,31 +94,14 @@ function sitePatchFromDemo(state: Record<string, unknown>): SitePatch | null {
   const patch: SitePatch = {};
 
   const branding: Partial<TenantSiteConfig['branding']> = {};
-  for (const [key, max] of [
-    ['logoText', 100],
-    ['tagline', 180],
-    ['primaryColor', 30],
-    ['secondaryColor', 30],
-    ['accentColor', 30],
-    ['backgroundColor', 30],
-    ['textColor', 30],
-    ['logoImage', 700],
-  ] as const) {
+  for (const [key, max] of [['logoText', 100], ['tagline', 180], ['primaryColor', 30], ['secondaryColor', 30], ['accentColor', 30], ['backgroundColor', 30], ['textColor', 30], ['logoImage', 700]] as const) {
     const value = text(brandingRaw[key], max);
     if (value) (branding as Record<string, unknown>)[key] = value;
   }
   if (Object.keys(branding).length) patch.branding = branding;
 
   const homepage: Partial<TenantSiteConfig['homepage']> = {};
-  for (const [key, max] of [
-    ['heroTitle', 150],
-    ['heroSubtitle', 380],
-    ['heroCtaText', 70],
-    ['heroCtaHref', 500],
-    ['heroImage', 700],
-    ['heroImageAlt', 180],
-    ['announcement', 180],
-  ] as const) {
+  for (const [key, max] of [['heroTitle', 150], ['heroSubtitle', 380], ['heroCtaText', 70], ['heroCtaHref', 500], ['heroImage', 700], ['heroImageAlt', 180], ['announcement', 180]] as const) {
     const value = text(homepageRaw[key], max);
     if (value) (homepage as Record<string, unknown>)[key] = value;
   }
@@ -158,26 +123,19 @@ function sitePatchFromDemo(state: Record<string, unknown>): SitePatch | null {
   if (navigation.length) patch.navigation = navigation;
 
   if (Object.keys(contactRaw).length) {
-    const contact = {
+    patch.contact = {
       email: text(contactRaw.email, 200) || undefined,
       phone: text(contactRaw.phone, 60) || undefined,
       address: text(contactRaw.address, 300) || undefined,
       bookingUrl: text(contactRaw.bookingUrl, 700) || undefined,
       hours: stringArray(contactRaw.hours, 14, 100),
     };
-    patch.contact = contact;
   }
 
   if (Object.keys(seoRaw).length) {
     const title = text(seoRaw.title, 160);
     const description = text(seoRaw.description, 320);
-    if (title && description) {
-      patch.seo = {
-        title,
-        description,
-        keywords: stringArray(seoRaw.keywords, 20, 80),
-      };
-    }
+    if (title && description) patch.seo = { title, description, keywords: stringArray(seoRaw.keywords, 20, 80) };
   }
 
   patch.meta = {
@@ -195,18 +153,12 @@ async function materializeCommunityDemo(
 ) {
   const community = object(state.community);
   if (!Object.keys(community).length) return;
-
   const groupNames = stringArray(community.groups, 8, 100);
   const communityName = text(community.name, 100);
   if (communityName && !groupNames.includes(communityName)) groupNames.unshift(communityName);
 
   for (const name of groupNames.slice(0, 8)) {
-    const { data: existing } = await db
-      .from('community_groups')
-      .select('id')
-      .eq('tenant_id', tenantId)
-      .eq('name', name)
-      .maybeSingle();
+    const { data: existing } = await db.from('community_groups').select('id').eq('tenant_id', tenantId).eq('name', name).maybeSingle();
     if (!existing?.id) {
       await db.from('community_groups').insert({
         tenant_id: tenantId,
@@ -240,18 +192,14 @@ export async function POST(request: NextRequest) {
   const organizationName = text(body.organizationName, 100);
   const ownerEmail = text(body.ownerEmail, 254).toLowerCase();
   const ownerName = text(body.ownerName, 100);
+  const reference = `demo_${Date.now().toString(36)}_${Math.random().toString(36).slice(2, 8)}`;
 
-  if (!demoToken || organizationName.length < 2 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(ownerEmail)) {
-    return NextResponse.json({ error: 'Demo token, organization name, and a valid email are required.' }, { status: 400 });
+  if (!demoToken || organizationName.length < 2 || ownerName.length < 2 || !/^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(ownerEmail)) {
+    return NextResponse.json({ error: 'Demo token, organization name, owner name, and a valid email are required.' }, { status: 400 });
   }
 
   const db = await requireAdminClient();
-  const { data: demo, error: demoError } = await db
-    .from('demo_sales_sessions')
-    .select('*')
-    .eq('session_token', demoToken)
-    .maybeSingle();
-
+  const { data: demo, error: demoError } = await db.from('demo_sales_sessions').select('*').eq('session_token', demoToken).maybeSingle();
   if (demoError || !demo) return NextResponse.json({ error: 'Demo session not found.' }, { status: 404 });
   if (demo.converted_at) return NextResponse.json({ error: 'This demo was already converted.' }, { status: 409 });
   if (demo.expires_at && new Date(demo.expires_at) <= new Date()) {
@@ -260,25 +208,34 @@ export async function POST(request: NextRequest) {
 
   const state = object(demo.state);
   const industry = text(state.industry, 100) || 'Business Services';
-  const trial = await startWorkspaceTrial({
-    organizationName,
-    ownerEmail,
-    ownerName,
-    industry,
-  });
-
+  const trial = await startWorkspaceTrial({ organizationName, ownerEmail, ownerName, industry });
   if (trial.ok === false) {
-    const status = typeof trial.status === 'number' ? trial.status : 500;
-    return NextResponse.json({ error: trial.error }, { status });
+    return NextResponse.json({ error: trial.error }, { status: typeof trial.status === 'number' ? trial.status : 500 });
   }
 
-  const { data: workspace } = await db
-    .from('customer_workspaces')
-    .select('metadata')
-    .eq('id', trial.workspaceId)
-    .maybeSingle();
-  const workspaceMetadata = object(workspace?.metadata);
+  const access = await ensureTrialOwnerAccess({
+    organizationId: trial.organizationId,
+    tenantId: trial.tenantId,
+    workspaceId: trial.workspaceId,
+    ownerEmail,
+    ownerName,
+    builderUrl: '/apps/website-builder',
+    websiteMode: 'new',
+    reference,
+    source: 'demo_conversion',
+    db,
+  });
+  if (!access.ok) {
+    return NextResponse.json({
+      error: `Demo workspace exists but onboarding could not complete at ${access.stage}. ${access.error}`,
+      onboardingStage: access.stage,
+      retryable: true,
+      correlationId: reference,
+    }, { status: 500 });
+  }
 
+  const { data: workspace } = await db.from('customer_workspaces').select('metadata').eq('id', trial.workspaceId).maybeSingle();
+  const workspaceMetadata = object(workspace?.metadata);
   await db.from('customer_workspaces').update({
     metadata: {
       ...workspaceMetadata,
@@ -288,26 +245,20 @@ export async function POST(request: NextRequest) {
       demo_scenario: demo.scenario_key,
       demo_state: state,
       demo_converted_at: new Date().toISOString(),
+      onboarding_complete: true,
+      customer_ready_at: new Date().toISOString(),
     },
     updated_at: new Date().toISOString(),
   }).eq('id', trial.workspaceId);
 
-  const { data: website } = await db
-    .from('user_websites')
-    .select('id, site_config')
-    .eq('organization_id', trial.organizationId)
-    .maybeSingle();
+  const { data: website } = await db.from('user_websites').select('id, site_config').eq('organization_id', trial.organizationId).maybeSingle();
   const sitePatch = sitePatchFromDemo({ ...state, productKey: demo.product_key });
   if (website?.id && website.site_config && sitePatch) {
     const merged = mergeSiteConfig(website.site_config as TenantSiteConfig, sitePatch);
-    await db.from('user_websites').update({
-      site_config: merged,
-      updated_at: new Date().toISOString(),
-    }).eq('id', website.id);
+    await db.from('user_websites').update({ site_config: merged, updated_at: new Date().toISOString() }).eq('id', website.id);
   }
 
   await materializeCommunityDemo(db, trial.tenantId, state);
-
   await db.from('demo_sales_sessions').update({
     converted_at: new Date().toISOString(),
     converted_tenant_id: trial.tenantId,
@@ -320,9 +271,13 @@ export async function POST(request: NextRequest) {
     tenantId: trial.tenantId,
     workspaceId: trial.workspaceId,
     organizationId: trial.organizationId,
-    dashboardUrl: trial.dashboardUrl,
+    dashboardUrl: access.builderUrl,
+    builderUrl: access.builderUrl,
+    loginUrl: access.loginUrl,
     publicPreviewUrl: trial.publicPreviewUrl,
     trialEndsAt: trial.trialEndsAt,
     keptDemoBuild: true,
+    onboardingComplete: true,
+    correlationId: reference,
   });
 }

--- a/apps/marketing/app/api/trial/start-managed/route.ts
+++ b/apps/marketing/app/api/trial/start-managed/route.ts
@@ -8,7 +8,7 @@ import { withRuntime } from '@/lib/api/withRuntime';
 import { PLATFORM_DEFAULTS } from '@/lib/config/platform-config';
 import { logger } from '@/lib/logger';
 import { startWorkspaceTrial } from '@/lib/workspace/start-workspace-trial';
-import { startAppTrial } from '@/lib/trial/start-app-trial';
+import { ensureTrialOwnerAccess } from '@/lib/workspace/ensure-trial-owner-access';
 
 const fallbackLimiter = new Map<string, { count: number; reset: number }>();
 
@@ -77,100 +77,87 @@ async function _POST(request: NextRequest) {
     const websiteMode = body.websiteMode === 'existing' ? 'existing' : 'new';
     const existingUrl = normalizeExistingUrl(body.existingUrl);
     const programs = typeof body.programs === 'string' ? body.programs.trim() : '';
+    const recommendedCapabilities = Array.isArray(body.recommendedCapabilities)
+      ? body.recommendedCapabilities.filter((value: unknown): value is string => typeof value === 'string').slice(0, 12)
+      : [];
 
     if (organizationName.length < 2 || organizationName.length > 100 || ownerName.length < 2 || !emailValid(ownerEmail)) {
       return NextResponse.json({ error: 'Valid organization name, administrator name, and email are required.', correlationId: reference }, { status: 400 });
     }
-    if (websiteMode === 'existing' && !existingUrl) return NextResponse.json({ error: 'A valid existing website URL is required.', correlationId: reference }, { status: 400 });
-    if (!(await allowed(ownerEmail))) return NextResponse.json({ error: 'Too many trial requests. Please try again later.', correlationId: reference }, { status: 429 });
+    if (websiteMode === 'existing' && !existingUrl) {
+      return NextResponse.json({ error: 'A valid existing website URL is required.', correlationId: reference }, { status: 400 });
+    }
+    if (!(await allowed(ownerEmail))) {
+      return NextResponse.json({ error: 'Too many trial requests. Please try again later.', correlationId: reference }, { status: 429 });
+    }
 
     const trial = await startWorkspaceTrial({ organizationName, ownerEmail, ownerName, industry, plan: 'builder' });
-    if ('error' in trial) return NextResponse.json({ error: trial.error, correlationId: reference }, { status: typeof trial.status === 'number' ? trial.status : 500 });
+    if ('error' in trial) {
+      return NextResponse.json({ error: trial.error, correlationId: reference }, { status: typeof trial.status === 'number' ? trial.status : 500 });
+    }
 
     const db = await requireAdminClient();
     const builderUrl = websiteMode === 'existing' && existingUrl
       ? `/apps/website-builder/import?url=${encodeURIComponent(existingUrl)}`
       : '/apps/website-builder';
 
-    const generated = await db.auth.admin.generateLink({
-      type: 'magiclink',
-      email: ownerEmail,
-      options: {
-        redirectTo: builderUrl,
-        data: { full_name: ownerName, role: 'org_admin', organization_id: trial.organizationId, tenant_id: trial.tenantId },
-      },
+    const access = await ensureTrialOwnerAccess({
+      organizationId: trial.organizationId,
+      tenantId: trial.tenantId,
+      workspaceId: trial.workspaceId,
+      ownerEmail,
+      ownerName,
+      builderUrl,
+      websiteMode,
+      existingUrl,
+      programs,
+      reference,
+      source: recommendedCapabilities.length ? 'guided_setup' : 'managed_trial',
+      db,
     });
 
-    if (generated.error || !generated.data?.user?.id) {
-      logger.error('[trial] administrator auth link generation failed', generated.error ?? undefined, { reference, ownerEmail });
-      return NextResponse.json({ error: 'Workspace was created but administrator sign-in could not be provisioned.', correlationId: reference }, { status: 500 });
+    if (!access.ok) {
+      return NextResponse.json({
+        error: `Workspace exists but onboarding could not complete at ${access.stage}. ${access.error}`,
+        correlationId: reference,
+        onboardingStage: access.stage,
+        retryable: true,
+      }, { status: 500 });
     }
 
-    const authUser = generated.data.user;
-    const { data: existingProfile, error: profileLookupError } = await db.from('profiles').select('id, email, full_name, role, organization_id, tenant_id').eq('id', authUser.id).maybeSingle();
-    if (profileLookupError) return NextResponse.json({ error: 'Workspace was created but the administrator profile could not be checked.', correlationId: reference }, { status: 500 });
-
-    const profilePayload = existingProfile
-      ? { id: authUser.id, email: ownerEmail, full_name: ownerName, role: existingProfile.role ?? 'org_admin', organization_id: existingProfile.organization_id ?? trial.organizationId, tenant_id: existingProfile.tenant_id ?? trial.tenantId }
-      : { id: authUser.id, email: ownerEmail, full_name: ownerName, role: 'org_admin', organization_id: trial.organizationId, tenant_id: trial.tenantId };
-
-    const { error: profileError } = await db.from('profiles').upsert(profilePayload, { onConflict: 'id' });
-    if (profileError) return NextResponse.json({ error: 'Workspace was created but the administrator profile could not be linked.', correlationId: reference }, { status: 500 });
-
-    const { error: orgMembershipError } = await db.from('organization_users').upsert({ organization_id: trial.organizationId, user_id: authUser.id, role: 'org_owner', status: 'active' }, { onConflict: 'organization_id,user_id' });
-    if (orgMembershipError) return NextResponse.json({ error: 'Workspace was created but organization access could not be provisioned.', correlationId: reference }, { status: 500 });
-
-    const { error: tenantMembershipError } = await db.from('tenant_memberships').upsert({ tenant_id: trial.tenantId, user_id: authUser.id, role: 'owner' }, { onConflict: 'tenant_id,user_id' });
-    if (tenantMembershipError) return NextResponse.json({ error: 'Workspace was created but tenant access could not be provisioned.', correlationId: reference }, { status: 500 });
-
-    const builderTrial = await startAppTrial(authUser.id, 'website-builder', db);
-    if (builderTrial.status === 'error') return NextResponse.json({ error: 'Workspace was created but Website Builder access could not be provisioned.', correlationId: reference }, { status: 500 });
-
-    // startWorkspaceTrial may create a placeholder tenant website before the auth
-    // user exists. Bind that row to the real owner, keep it private, and mark it
-    // as interview-pending so PARIS can replace it instead of creating duplicates.
-    const { data: website } = await db.from('user_websites').select('id, site_config').eq('organization_id', trial.organizationId).maybeSingle();
-    if (website?.id) {
-      const currentConfig = website.site_config && typeof website.site_config === 'object' ? website.site_config as Record<string, any> : {};
-      const currentMeta = currentConfig.meta && typeof currentConfig.meta === 'object' ? currentConfig.meta : {};
-      const updatedConfig = {
-        ...currentConfig,
-        meta: {
-          ...currentMeta,
-          parisInterviewCompleted: false,
-          connectionMode: websiteMode,
-          sourceWebsiteUrl: existingUrl,
-          programsIntake: programs || null,
-          trialReference: reference,
-        },
-      };
-      const { error: websiteUpdateError } = await db.from('user_websites').update({
-        user_id: authUser.id,
-        site_config: updatedConfig,
-        is_published: false,
-        status: 'draft',
-        updated_at: new Date().toISOString(),
-      }).eq('id', website.id);
-      if (websiteUpdateError) {
-        logger.error('[trial] trial website ownership binding failed', websiteUpdateError, { reference, websiteId: website.id, userId: authUser.id });
-        return NextResponse.json({ error: 'Workspace was created but Website Builder ownership could not be linked.', correlationId: reference }, { status: 500 });
-      }
-    }
+    const { data: workspace } = await db.from('customer_workspaces').select('metadata').eq('id', trial.workspaceId).maybeSingle();
+    const metadata = workspace?.metadata && typeof workspace.metadata === 'object' ? workspace.metadata as Record<string, unknown> : {};
+    await db.from('customer_workspaces').update({
+      metadata: {
+        ...metadata,
+        guided_recommendations: recommendedCapabilities,
+        onboarding_complete: true,
+        customer_ready_at: new Date().toISOString(),
+      },
+      updated_at: new Date().toISOString(),
+    }).eq('id', trial.workspaceId);
 
     await db.from('license_events').insert({
       organization_id: trial.organizationId,
       tenant_id: trial.tenantId,
       event_type: 'trial_workspace_created',
       correlation_id: reference,
-      source: 'managed_trial',
-      event_data: { correlation_id: reference, tenant_id: trial.tenantId, workspace_id: trial.workspaceId, owner_email: ownerEmail, website_mode: websiteMode, existing_url: existingUrl, programs: programs || null, builder_url: builderUrl },
+      source: recommendedCapabilities.length ? 'guided_setup' : 'managed_trial',
+      event_data: {
+        correlation_id: reference,
+        tenant_id: trial.tenantId,
+        workspace_id: trial.workspaceId,
+        owner_email: ownerEmail,
+        website_mode: websiteMode,
+        existing_url: existingUrl,
+        programs: programs || null,
+        builder_url: builderUrl,
+        recommended_capabilities: recommendedCapabilities,
+      },
     });
 
-    const fallbackLogin = `https://app.elevateforhumanity.org/login?redirect=${encodeURIComponent(builderUrl)}`;
-    const loginUrl = generated.data?.properties?.action_link ?? fallbackLogin;
-
     try {
-      await sendWelcome({ email: ownerEmail, orgName: organizationName, loginUrl, builderUrl, trialEndsAt: trial.trialEndsAt, reference });
+      await sendWelcome({ email: ownerEmail, orgName: organizationName, loginUrl: access.loginUrl, builderUrl: access.builderUrl, trialEndsAt: trial.trialEndsAt, reference });
     } catch (mailErr) {
       logger.warn('[trial] welcome email failed', { reference, error: mailErr instanceof Error ? mailErr.message : String(mailErr) });
     }
@@ -180,21 +167,23 @@ async function _POST(request: NextRequest) {
       tenantId: trial.tenantId,
       organizationId: trial.organizationId,
       workspaceId: trial.workspaceId,
-      tenantUrl: builderUrl,
-      dashboardUrl: builderUrl,
-      builderUrl,
-      publicPreviewUrl: null,
+      tenantUrl: access.builderUrl,
+      dashboardUrl: access.builderUrl,
+      builderUrl: access.builderUrl,
+      publicPreviewUrl: trial.publicPreviewUrl,
       subdomain: trial.slug,
       trialEndsAt: trial.trialEndsAt,
       correlationId: reference,
       connectionMode: websiteMode,
       existingUrl,
-      loginUrl,
+      loginUrl: access.loginUrl,
       requiresAuthentication: true,
       requiresParisInterview: websiteMode === 'new',
+      onboardingComplete: true,
+      recommendedCapabilities,
       message: websiteMode === 'new'
-        ? 'Trial workspace created. Sign in, then PARIS will interview you and build the first website draft.'
-        : 'Trial workspace created. Sign in to import and rebuild your existing website.',
+        ? 'Trial workspace and owner access are ready. Sign in, then PARIS will build the first website draft.'
+        : 'Trial workspace and owner access are ready. Sign in to import and rebuild your existing website.',
     });
   } catch (error) {
     logger.error('[trial] provisioning failed', error instanceof Error ? error : new Error(String(error)), { reference });

--- a/apps/marketing/app/store/demo/crm/page.tsx
+++ b/apps/marketing/app/store/demo/crm/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function StoreCrmDemoCompatibilityPage() {
+  redirect('/store/demo/capability/crm');
+}

--- a/apps/marketing/app/store/demo/lms/page.tsx
+++ b/apps/marketing/app/store/demo/lms/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function StoreLmsDemoCompatibilityPage() {
+  redirect('/store/demo/capability/lms');
+}

--- a/apps/marketing/app/store/demo/website/page.tsx
+++ b/apps/marketing/app/store/demo/website/page.tsx
@@ -1,0 +1,5 @@
+import { redirect } from 'next/navigation';
+
+export default function StoreWebsiteDemoCompatibilityPage() {
+  redirect('/store#website-builder-commercial');
+}

--- a/apps/marketing/app/store/page.tsx
+++ b/apps/marketing/app/store/page.tsx
@@ -10,6 +10,7 @@ import StoreFAQ from './StoreFAQ';
 import { ROICalculator } from '@/components/store/ROICalculator';
 import { UnifiedSalesMarketplace } from '@/components/store/UnifiedSalesMarketplace';
 import { GuidedProductInterview } from '@/components/store/GuidedProductInterview';
+import { StoreGlossary } from '@/components/store/StoreGlossary';
 import WebsiteBuilderCommercial from '@/components/store/WebsiteBuilderCommercial';
 
 export const metadata: Metadata = {
@@ -88,6 +89,8 @@ export default function StorePage() {
           <div className="mt-10"><ROICalculator /></div>
         </div>
       </section>
+
+      <StoreGlossary />
 
       <section className="border-y border-slate-200 bg-slate-50 py-12">
         <div className="mx-auto grid max-w-5xl gap-6 px-5 md:grid-cols-[1fr_auto] md:items-center">

--- a/apps/marketing/app/store/page.tsx
+++ b/apps/marketing/app/store/page.tsx
@@ -10,16 +10,21 @@ import StoreFAQ from './StoreFAQ';
 import { ROICalculator } from '@/components/store/ROICalculator';
 import { UnifiedSalesMarketplace } from '@/components/store/UnifiedSalesMarketplace';
 import { GuidedProductInterview } from '@/components/store/GuidedProductInterview';
-import { HomeBusinessLaunch } from '@/components/home/HomeBusinessLaunch';
 import WebsiteBuilderCommercial from '@/components/store/WebsiteBuilderCommercial';
 
 export const metadata: Metadata = {
   title: 'Elevate Store | AI Business, Workforce & Education Platform',
-  description:
-    'Start with Elevate and add the tools your organization needs: AI website builder, CRM, virtual assistants, LMS, course builder, testing, workforce, apprenticeship, compliance and business apps.',
+  description: 'Start with Elevate and add the tools your organization needs: AI website builder, CRM, virtual assistants, LMS, course builder, testing, workforce, apprenticeship, compliance and business apps.',
   alternates: { canonical: 'https://www.elevateforhumanity.org/store' },
   robots: { index: true, follow: true },
 };
+
+const ROLE_DEMOS = [
+  { label: 'Admin', href: '/store/demo/admin', description: 'Operations, learners, applications and programs.' },
+  { label: 'Student', href: '/store/demo/student', description: 'Learner courses, progress and training experience.' },
+  { label: 'Employer', href: '/store/demo/employer', description: 'Jobs, candidates, interviews and workforce requests.' },
+  { label: 'Institutional', href: '/store/demo/institutional', description: 'Organization-level workflow and licensing experience.' },
+];
 
 export default function StorePage() {
   const hero = heroBanners.store;
@@ -29,15 +34,7 @@ export default function StorePage() {
       <section className="border-b border-cyan-100 bg-gradient-to-b from-cyan-50 via-white to-rose-50 py-6 sm:py-8">
         <div className="mx-auto max-w-7xl px-4 sm:px-6">
           <div className="overflow-hidden rounded-3xl border border-white bg-white shadow-2xl shadow-cyan-900/10 ring-1 ring-slate-200">
-            <HeroVideo
-              videoSrcDesktop={hero.videoSrcDesktop}
-              videoSrcMobile={hero.videoSrcMobile}
-              posterImage={hero.posterImage || '/images/pages/store-licensing-hero.jpg'}
-              voiceoverSrc={hero.voiceoverSrc}
-              analyticsName="store-commercial"
-              mediaFit="cover"
-              heightClassName="aspect-video h-auto min-h-[260px] max-h-none"
-            />
+            <HeroVideo videoSrcDesktop={hero.videoSrcDesktop} videoSrcMobile={hero.videoSrcMobile} posterImage={hero.posterImage || '/images/pages/store-licensing-hero.jpg'} voiceoverSrc={hero.voiceoverSrc} analyticsName="store-commercial" mediaFit="cover" heightClassName="aspect-video h-auto min-h-[260px] max-h-none" />
           </div>
         </div>
       </section>
@@ -45,118 +42,61 @@ export default function StorePage() {
       <section className="border-b border-slate-200 bg-white py-10 sm:py-12">
         <div className="mx-auto max-w-5xl px-5 text-center">
           <p className="text-sm font-black uppercase tracking-[0.2em] text-brand-red-700">Elevate Business Operating Platform</p>
-          <h1 className="mt-3 text-3xl font-black text-slate-950 sm:text-5xl">Start with what you need. Add more when your business is ready.</h1>
-          <p className="mx-auto mt-4 max-w-3xl text-base font-semibold leading-7 text-slate-800 sm:text-lg">
-            Website, CRM, AI assistants, education, workforce, testing and operations in one connected platform.
-          </p>
+          <h1 className="mt-3 text-3xl font-black text-slate-950 sm:text-5xl">Start with what you need. Keep one connected workspace as you grow.</h1>
+          <p className="mx-auto mt-4 max-w-3xl text-base font-semibold leading-7 text-slate-800 sm:text-lg">Website, CRM, AI assistants, education, workforce, testing and operations in one connected platform.</p>
           <div className="mt-7 flex flex-wrap justify-center gap-3">
-            <Link href="/store/trial" className="rounded-xl bg-brand-red-700 px-6 py-3 font-black text-white hover:bg-brand-red-800">Start 14-Day Free Trial</Link>
-            <Link href="#website-builder-commercial" className="rounded-xl border-2 border-slate-800 px-6 py-3 font-black text-slate-950 hover:bg-slate-100">See Website Builder Demo</Link>
-            <Link href="#marketplace" className="rounded-xl border-2 border-slate-800 px-6 py-3 font-black text-slate-950 hover:bg-slate-100">Browse Product Demos</Link>
-            <Link href="/online-apps" className="rounded-xl border-2 border-brand-red-700 px-6 py-3 font-black text-brand-red-800 hover:bg-brand-red-50">Open Live Apps & Portals</Link>
+            <Link href="/store/trial" className="rounded-xl bg-brand-red-700 px-6 py-3 font-black text-white hover:bg-brand-red-800">Start Free Trial</Link>
+            <Link href="#role-demos" className="rounded-xl border-2 border-slate-800 px-6 py-3 font-black text-slate-950 hover:bg-slate-100">See Role Demos</Link>
           </div>
-          {hero.trustIndicators?.length ? (
-            <div className="mt-7 flex flex-wrap justify-center gap-x-6 gap-y-2">
-              {Array.from(new Set(hero.trustIndicators)).map((item) => (
-                <span key={item} className="text-sm font-bold text-slate-900">• {item}</span>
-              ))}
-            </div>
-          ) : null}
+          <p className="mt-4 text-sm font-semibold text-slate-600">14 days · no card required · build new or connect an existing website</p>
         </div>
       </section>
 
-      <section className="border-b border-slate-200 bg-slate-50 py-10">
-        <div className="mx-auto grid max-w-6xl gap-6 px-5 md:grid-cols-3">
-          {[
-            {
-              title: '1. Start basic',
-              text: 'Choose a low-cost platform plan or a focused app and use it for 14 days before committing.',
-            },
-            {
-              title: '2. Add what you need',
-              text: 'Upgrade into AI assistants, CRM, LMS, testing, workforce, apprenticeship, compliance and more.',
-            },
-            {
-              title: '3. Keep one system',
-              text: 'Your subscriptions, organization, users, customer records and entitlements stay connected.',
-            },
-          ].map((item) => (
-            <article key={item.title} className="rounded-2xl border border-slate-300 bg-white p-6 shadow-sm">
-              <CheckCircle2 className="h-6 w-6 text-brand-red-700" />
-              <h2 className="mt-4 text-lg font-black text-slate-950">{item.title}</h2>
-              <p className="mt-2 text-sm font-semibold leading-6 text-slate-800">{item.text}</p>
-            </article>
-          ))}
+      <section className="border-b border-slate-200 bg-slate-50 py-12">
+        <div className="mx-auto max-w-6xl px-5">
+          <div className="mx-auto max-w-3xl text-center"><p className="text-sm font-black uppercase tracking-[0.18em] text-brand-red-700">Why Elevate</p><h2 className="mt-3 text-3xl font-black">One customer record, one workspace, one upgrade path.</h2></div>
+          <div className="mt-8 grid gap-6 md:grid-cols-3">
+            {[
+              { title: '1. Start basic', text: 'Use a focused app or workspace trial before committing to a paid plan.' },
+              { title: '2. Add what you need', text: 'Add CRM, AI, learning, workforce, apprenticeship, testing and compliance capabilities as your organization needs them.' },
+              { title: '3. Keep one system', text: 'Your organization, users, workspace, subscriptions and entitlements stay connected instead of forcing a new setup for every product.' },
+            ].map((item) => <article key={item.title} className="rounded-2xl border border-slate-300 bg-white p-6 shadow-sm"><CheckCircle2 className="h-6 w-6 text-brand-red-700" /><h3 className="mt-4 text-lg font-black text-slate-950">{item.title}</h3><p className="mt-2 text-sm font-semibold leading-6 text-slate-800">{item.text}</p></article>)}
+          </div>
         </div>
       </section>
+
+      <GuidedProductInterview />
+
+      <section id="role-demos" className="border-y border-cyan-100 bg-gradient-to-br from-cyan-50 via-white to-rose-50 py-16 text-slate-950">
+        <div className="mx-auto max-w-6xl px-5">
+          <div className="mx-auto max-w-3xl text-center"><p className="text-sm font-black uppercase tracking-[0.2em] text-brand-red-700">Role demos</p><h2 className="mt-3 text-3xl font-black sm:text-4xl">See the platform from the role that matters to you.</h2><p className="mt-4 font-semibold leading-7 text-slate-700">These are role-based sample experiences. Capability pages below are product tours unless explicitly labeled as an interactive sandbox.</p></div>
+          <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-4">
+            {ROLE_DEMOS.map((demo) => <Link key={demo.href} href={demo.href} className="rounded-2xl border border-slate-300 bg-white p-5 shadow-sm hover:border-brand-red-300 hover:shadow-md"><PlayCircle className="h-6 w-6 text-brand-red-700" /><h3 className="mt-3 text-lg font-black">{demo.label} Demo</h3><p className="mt-2 text-sm font-semibold leading-6 text-slate-700">{demo.description}</p><span className="mt-4 inline-flex items-center gap-2 text-sm font-black text-brand-red-700">Open role demo <ArrowRight className="h-4 w-4" /></span></Link>)}
+          </div>
+        </div>
+      </section>
+
+      <UnifiedSalesMarketplace />
 
       <div id="website-builder-commercial">
         <WebsiteBuilderCommercial />
       </div>
 
-      <GuidedProductInterview />
-      <UnifiedSalesMarketplace />
-      <HomeBusinessLaunch />
-
       <section className="py-16">
         <div className="mx-auto max-w-6xl px-5">
-          <div className="mx-auto max-w-3xl text-center">
-            <span className="inline-flex items-center gap-2 rounded-full bg-brand-red-50 px-4 py-2 text-sm font-black text-brand-red-800">
-              <Sparkles className="h-4 w-4" /> See the business case
-            </span>
-            <h2 className="mt-4 text-3xl font-black text-slate-950">Calculate what one connected platform can replace</h2>
-            <p className="mt-3 font-semibold text-slate-800">
-              Compare the cost of separate website, CRM, messaging, learning, workforce and automation tools against one Elevate stack.
-            </p>
-          </div>
-          <div className="mt-10">
-            <ROICalculator />
-          </div>
+          <div className="mx-auto max-w-3xl text-center"><span className="inline-flex items-center gap-2 rounded-full bg-brand-red-50 px-4 py-2 text-sm font-black text-brand-red-800"><Sparkles className="h-4 w-4" /> Business case</span><h2 className="mt-4 text-3xl font-black text-slate-950">Calculate what one connected platform can replace</h2><p className="mt-3 font-semibold text-slate-800">Compare separate website, CRM, messaging, learning, workforce and automation costs against one Elevate stack. Estimates are illustrative and should be adjusted to your actual costs.</p></div>
+          <div className="mt-10"><ROICalculator /></div>
         </div>
       </section>
 
-      <section className="border-y border-cyan-100 bg-gradient-to-br from-cyan-50 via-white to-rose-50 py-16 text-slate-950">
-        <div className="mx-auto max-w-6xl px-5">
-          <div className="grid gap-8 lg:grid-cols-[1fr_0.9fr] lg:items-center">
-            <div>
-              <p className="text-sm font-black uppercase tracking-[0.2em] text-brand-red-700">Interactive proof</p>
-              <h2 className="mt-3 text-3xl font-black sm:text-4xl">See the product move, then open the real portals.</h2>
-              <p className="mt-4 max-w-2xl font-semibold leading-7 text-slate-700">
-                Product demos should show the working experience—not bury it in dark slides. Use the interactive product walkthroughs, then open role-based portal experiences and live proof links from Online Apps.
-              </p>
-              <div className="mt-7 flex flex-wrap gap-3">
-                <Link href="#marketplace" className="inline-flex items-center gap-2 rounded-xl bg-brand-red-700 px-5 py-3 font-black text-white hover:bg-brand-red-800">
-                  <PlayCircle className="h-5 w-5" /> Browse Product Demos
-                </Link>
-                <Link href="/online-apps" className="rounded-xl border-2 border-slate-800 bg-white px-5 py-3 font-black hover:bg-slate-50">Open Online Apps</Link>
-                <Link href="/store/demo/admin" className="rounded-xl border-2 border-slate-300 bg-white px-5 py-3 font-black hover:bg-slate-50">Admin Demo</Link>
-                <Link href="/store/demo/student" className="rounded-xl border-2 border-slate-300 bg-white px-5 py-3 font-black hover:bg-slate-50">Student Demo</Link>
-                <Link href="/store/demo/employer" className="rounded-xl border-2 border-slate-300 bg-white px-5 py-3 font-black hover:bg-slate-50">Employer Demo</Link>
-              </div>
-            </div>
-            <div className="rounded-3xl border border-white bg-white p-7 shadow-xl shadow-cyan-900/10 ring-1 ring-slate-200">
-              <h3 className="text-xl font-black">Ready for a real workspace?</h3>
-              <p className="mt-2 text-sm font-semibold leading-6 text-slate-700">
-                Start the 14-day trial, build or import a website, then activate the business and education tools you need.
-              </p>
-              <div className="mt-6 space-y-3">
-                <Link href="/store/trial" className="flex items-center justify-between rounded-xl bg-brand-red-700 px-5 py-3 font-black text-white hover:bg-brand-red-800">
-                  Start Free Trial <ArrowRight className="h-4 w-4" />
-                </Link>
-                <Link href="/store/plans" className="flex items-center justify-between rounded-xl border-2 border-slate-800 px-5 py-3 font-black text-slate-950 hover:bg-slate-50">
-                  Compare Plans <ArrowRight className="h-4 w-4" />
-                </Link>
-              </div>
-            </div>
-          </div>
+      <section className="border-y border-slate-200 bg-slate-50 py-12">
+        <div className="mx-auto grid max-w-5xl gap-6 px-5 md:grid-cols-[1fr_auto] md:items-center">
+          <div><h2 className="text-2xl font-black">Ready to use your own workspace?</h2><p className="mt-2 font-semibold text-slate-700">Start free, keep guided recommendations or demo state where supported, then choose a paid plan only when you are ready.</p></div>
+          <div className="flex flex-wrap gap-3"><Link href="/store/trial" className="inline-flex items-center gap-2 rounded-xl bg-brand-red-700 px-5 py-3 font-black text-white hover:bg-brand-red-800">Start Free Trial <ArrowRight className="h-4 w-4" /></Link><Link href="/store/plans" className="rounded-xl border-2 border-slate-800 bg-white px-5 py-3 font-black text-slate-950 hover:bg-slate-100">Compare Plans</Link></div>
         </div>
       </section>
 
-      <section className="py-16">
-        <div className="mx-auto max-w-5xl px-5">
-          <StoreFAQ />
-        </div>
-      </section>
+      <section className="py-16"><div className="mx-auto max-w-5xl px-5"><StoreFAQ /></div></section>
     </main>
   );
 }

--- a/apps/marketing/app/store/trial/page.tsx
+++ b/apps/marketing/app/store/trial/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { FormEvent, Suspense, useState } from 'react';
+import { FormEvent, Suspense, useMemo, useState } from 'react';
 import Link from 'next/link';
 import { useSearchParams } from 'next/navigation';
 import { ArrowRight, CheckCircle2, Loader2, Shield, Globe, Link2, Sparkles } from 'lucide-react';
@@ -18,12 +18,21 @@ interface TrialResult {
   correlationId?: string;
   connectionMode?: string;
   keptDemoBuild?: boolean;
+  onboardingComplete?: boolean;
+  recommendedCapabilities?: string[];
 }
 
 function TrialForm() {
   const searchParams = useSearchParams();
   const demoToken = searchParams.get('demo');
   const demoProduct = searchParams.get('product');
+  const guidedGoal = searchParams.get('goal');
+  const guidedOrg = searchParams.get('org');
+  const recommendedCapabilities = useMemo(() => {
+    const raw = searchParams.get('recommended') || '';
+    return [...new Set(raw.split(',').map((value) => value.trim()).filter(Boolean))].slice(0, 12);
+  }, [searchParams]);
+
   const [orgName, setOrgName] = useState('');
   const [adminName, setAdminName] = useState('');
   const [adminEmail, setAdminEmail] = useState('');
@@ -44,12 +53,7 @@ function TrialForm() {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(
           demoToken
-            ? {
-                demoToken,
-                organizationName: orgName,
-                ownerName: adminName,
-                ownerEmail: adminEmail,
-              }
+            ? { demoToken, organizationName: orgName, ownerName: adminName, ownerEmail: adminEmail }
             : {
                 orgName,
                 adminName,
@@ -57,17 +61,14 @@ function TrialForm() {
                 websiteMode,
                 existingUrl: existingUrl || undefined,
                 programs: programs || undefined,
+                recommendedCapabilities,
+                guidedGoal: guidedGoal || undefined,
+                guidedOrg: guidedOrg || undefined,
               },
         ),
       });
       const data = await response.json();
-      if (!response.ok) {
-        if (!demoToken && response.status === 409 && data.tenantUrl) {
-          setResult({ ...data, trialEndsAt: data.trialEndsAt || new Date().toISOString() });
-          return;
-        }
-        throw new Error(data.error || 'Could not create trial');
-      }
+      if (!response.ok) throw new Error(data.error || 'Could not create trial');
       setResult(data);
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Could not create trial');
@@ -83,22 +84,12 @@ function TrialForm() {
       <main className="min-h-[70vh] bg-slate-50 px-4 py-16">
         <div className="mx-auto max-w-2xl rounded-2xl border border-slate-200 bg-white p-8 shadow-sm">
           <div className="mx-auto flex h-16 w-16 items-center justify-center rounded-full bg-green-100"><CheckCircle2 className="h-8 w-8 text-green-700" /></div>
-          <h1 className="mt-5 text-center text-3xl font-black text-slate-950">Your organization trial is created</h1>
+          <h1 className="mt-5 text-center text-3xl font-black text-slate-950">Your organization trial is ready</h1>
           <p className="mt-3 text-center text-slate-600">{result.subdomain ? <>Workspace: <strong>{result.subdomain}</strong> · </> : null}Trial end: <strong>{trialEnd}</strong></p>
-          {result.keptDemoBuild ? (
-            <div className="mt-5 rounded-xl border border-violet-200 bg-violet-50 p-4 text-sm font-semibold text-violet-950">
-              <div className="flex items-center gap-2 font-black"><Sparkles className="h-4 w-4" /> Your demo build was carried into the real workspace.</div>
-              <p className="mt-1 text-xs leading-5">The workspace metadata and supported demo configuration were preserved so you do not have to start from zero.</p>
-            </div>
-          ) : null}
-          <div className="mt-7 rounded-xl bg-slate-50 p-5 text-sm text-slate-700">
-            <p><strong>Next step:</strong> use the platform login with the same email address you entered here. If your account requires verification, complete the email verification step before entering the workspace.</p>
-            {result.correlationId && <p className="mt-2 text-xs text-slate-500">Reference: {result.correlationId}</p>}
-          </div>
-          <div className="mt-7 grid gap-3 sm:grid-cols-2">
-            <a href={`https://app.elevateforhumanity.org/login?redirect=${encodeURIComponent(workspaceTarget)}`} className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3 font-bold text-white hover:bg-brand-red-700">Open Login <ArrowRight className="h-4 w-4" /></a>
-            {result.publicPreviewUrl ? <a href={result.publicPreviewUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-bold text-slate-800 hover:bg-slate-50">Open Public Preview</a> : <Link href="/store/demos" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-bold text-slate-800 hover:bg-slate-50">View Demos</Link>}
-          </div>
+          {result.keptDemoBuild ? <div className="mt-5 rounded-xl border border-violet-200 bg-violet-50 p-4 text-sm font-semibold text-violet-950"><div className="flex items-center gap-2 font-black"><Sparkles className="h-4 w-4" /> Your demo build was carried into the real workspace.</div></div> : null}
+          {(result.recommendedCapabilities?.length || recommendedCapabilities.length) ? <div className="mt-5 rounded-xl border border-cyan-200 bg-cyan-50 p-4 text-sm text-slate-800"><p className="font-black">Guided setup preserved</p><p className="mt-1">Recommended capabilities: {(result.recommendedCapabilities || recommendedCapabilities).join(', ')}</p></div> : null}
+          <div className="mt-7 rounded-xl bg-slate-50 p-5 text-sm text-slate-700"><p><strong>Next step:</strong> sign in with the same email address. Your owner access, organization membership, tenant membership and Website Builder trial are provisioned before this success screen is returned.</p>{result.correlationId && <p className="mt-2 text-xs text-slate-500">Reference: {result.correlationId}</p>}</div>
+          <div className="mt-7 grid gap-3 sm:grid-cols-2"><a href={`https://app.elevateforhumanity.org/login?redirect=${encodeURIComponent(workspaceTarget)}`} className="inline-flex items-center justify-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3 font-bold text-white hover:bg-brand-red-700">Open Login <ArrowRight className="h-4 w-4" /></a>{result.publicPreviewUrl ? <a href={result.publicPreviewUrl} target="_blank" rel="noopener noreferrer" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-bold text-slate-800 hover:bg-slate-50">Open Public Preview</a> : <Link href="/store" className="inline-flex items-center justify-center rounded-xl border border-slate-300 px-5 py-3 font-bold text-slate-800 hover:bg-slate-50">Back to Store</Link>}</div>
         </div>
       </main>
     );
@@ -111,33 +102,16 @@ function TrialForm() {
         <div className="mx-auto grid max-w-5xl gap-10 lg:grid-cols-2">
           <div>
             <span className="inline-flex items-center gap-2 rounded-full bg-brand-red-100 px-4 py-2 text-sm font-bold text-brand-red-700"><Shield className="h-4 w-4" />14-day organization trial</span>
-            <h1 className="mt-5 text-4xl font-black text-slate-950">{demoToken ? 'Keep what you just built' : 'Test the platform with your own workspace'}</h1>
-            <p className="mt-4 text-lg leading-7 text-slate-600">{demoToken ? `Convert your ${demoProduct || 'Elevate'} demo into a real workspace without rebuilding from zero. No card is required.` : 'No card is required. Choose whether you need a new training site or want to connect an existing website.'}</p>
-            <div className="mt-7 space-y-3 text-sm text-slate-700">
-              {demoToken ? <p className="flex gap-2"><Sparkles className="mt-0.5 h-4 w-4 flex-none text-violet-600" />Demo configuration is preserved into the workspace where supported</p> : null}
-              <p className="flex gap-2"><Globe className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Organization workspace and public preview</p>
-              <p className="flex gap-2"><Link2 className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Existing-site connection path</p>
-              <p className="flex gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Trial data can be used for evaluation before subscribing</p>
-            </div>
+            <h1 className="mt-5 text-4xl font-black text-slate-950">{demoToken ? 'Keep what you just built' : recommendedCapabilities.length ? 'Start with your recommended setup' : 'Test the platform with your own workspace'}</h1>
+            <p className="mt-4 text-lg leading-7 text-slate-600">{demoToken ? `Convert your ${demoProduct || 'Elevate'} demo into a real workspace without rebuilding from zero. No card is required.` : 'No card is required. Choose whether you need a new site or want to connect an existing website.'}</p>
+            {recommendedCapabilities.length ? <div className="mt-5 rounded-xl border border-cyan-200 bg-cyan-50 p-4 text-sm text-slate-800"><p className="font-black">Your guided recommendations will carry forward</p><p className="mt-1">{recommendedCapabilities.join(', ')}</p></div> : null}
+            <div className="mt-7 space-y-3 text-sm text-slate-700">{demoToken ? <p className="flex gap-2"><Sparkles className="mt-0.5 h-4 w-4 flex-none text-violet-600" />Demo configuration is preserved into the workspace where supported</p> : null}<p className="flex gap-2"><Globe className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Organization workspace and public preview</p><p className="flex gap-2"><Link2 className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Existing-site connection path</p><p className="flex gap-2"><CheckCircle2 className="mt-0.5 h-4 w-4 flex-none text-brand-red-600" />Owner access is provisioned before success</p></div>
           </div>
 
           <form onSubmit={submit} className="rounded-2xl border border-slate-200 bg-white p-7 shadow-sm">
-            <div className="space-y-4">
-              <label className="block text-sm font-bold text-slate-800">Organization name<input required minLength={2} value={orgName} onChange={(e) => setOrgName(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>
-              <div className="grid gap-4 sm:grid-cols-2">
-                <label className="block text-sm font-bold text-slate-800">Your name<input required minLength={2} value={adminName} onChange={(e) => setAdminName(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>
-                <label className="block text-sm font-bold text-slate-800">Work email<input required type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>
-              </div>
-              {!demoToken ? (
-                <>
-                  <fieldset><legend className="text-sm font-bold text-slate-800">Website setup</legend><div className="mt-2 grid gap-2 sm:grid-cols-2"><button type="button" onClick={() => setWebsiteMode('new')} className={`rounded-xl border p-3 text-left text-sm font-semibold ${websiteMode === 'new' ? 'border-brand-red-500 bg-brand-red-50' : 'border-slate-300'}`}>Build a new site</button><button type="button" onClick={() => setWebsiteMode('existing')} className={`rounded-xl border p-3 text-left text-sm font-semibold ${websiteMode === 'existing' ? 'border-brand-red-500 bg-brand-red-50' : 'border-slate-300'}`}>Connect existing site</button></div></fieldset>
-                  {websiteMode === 'existing' && <label className="block text-sm font-bold text-slate-800">Existing website URL<input required type="url" value={existingUrl} onChange={(e) => setExistingUrl(e.target.value)} placeholder="https://example.org" className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>}
-                  <label className="block text-sm font-bold text-slate-800">Programs offered <span className="font-normal text-slate-400">(optional)</span><input value={programs} onChange={(e) => setPrograms(e.target.value)} placeholder="CNA, HVAC, Barber…" className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>
-                </>
-              ) : null}
-            </div>
+            <div className="space-y-4"><label className="block text-sm font-bold text-slate-800">Organization name<input required minLength={2} value={orgName} onChange={(e) => setOrgName(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label><div className="grid gap-4 sm:grid-cols-2"><label className="block text-sm font-bold text-slate-800">Your name<input required minLength={2} value={adminName} onChange={(e) => setAdminName(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label><label className="block text-sm font-bold text-slate-800">Work email<input required type="email" value={adminEmail} onChange={(e) => setAdminEmail(e.target.value)} className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label></div>{!demoToken ? <><fieldset><legend className="text-sm font-bold text-slate-800">Website setup</legend><div className="mt-2 grid gap-2 sm:grid-cols-2"><button type="button" onClick={() => setWebsiteMode('new')} className={`rounded-xl border p-3 text-left text-sm font-semibold ${websiteMode === 'new' ? 'border-brand-red-500 bg-brand-red-50' : 'border-slate-300'}`}>Build a new site</button><button type="button" onClick={() => setWebsiteMode('existing')} className={`rounded-xl border p-3 text-left text-sm font-semibold ${websiteMode === 'existing' ? 'border-brand-red-500 bg-brand-red-50' : 'border-slate-300'}`}>Connect existing site</button></div></fieldset>{websiteMode === 'existing' && <label className="block text-sm font-bold text-slate-800">Existing website URL<input required type="url" value={existingUrl} onChange={(e) => setExistingUrl(e.target.value)} placeholder="https://example.org" className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label>}<label className="block text-sm font-bold text-slate-800">Programs offered <span className="font-normal text-slate-400">(optional)</span><input value={programs} onChange={(e) => setPrograms(e.target.value)} placeholder="CNA, HVAC, Barber…" className="mt-1.5 w-full rounded-lg border border-slate-300 px-4 py-3 font-normal" /></label></> : null}</div>
             {error && <div className="mt-4 rounded-lg border border-red-200 bg-red-50 p-3 text-sm text-red-800">{error}</div>}
-            <button type="submit" disabled={loading} className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3.5 font-bold text-white hover:bg-brand-red-700 disabled:opacity-60">{loading ? <><Loader2 className="h-5 w-5 animate-spin" />Creating workspace…</> : <>{demoToken ? 'Keep This Build & Start Trial' : 'Start Trial'} <ArrowRight className="h-4 w-4" /></>}</button>
+            <button type="submit" disabled={loading} className="mt-6 inline-flex w-full items-center justify-center gap-2 rounded-xl bg-brand-red-600 px-5 py-3.5 font-bold text-white hover:bg-brand-red-700 disabled:opacity-60">{loading ? <><Loader2 className="h-5 w-5 animate-spin" />Creating workspace…</> : <>{demoToken ? 'Keep This Build & Start Trial' : 'Start Free Trial'} <ArrowRight className="h-4 w-4" /></>}</button>
             <p className="mt-3 text-center text-xs text-slate-500">No credit card required for the 14-day trial.</p>
           </form>
         </div>

--- a/components/store/GuidedProductInterview.tsx
+++ b/components/store/GuidedProductInterview.tsx
@@ -18,6 +18,7 @@ type Goal =
 type OrgType = 'solo' | 'small-business' | 'training-provider' | 'nonprofit' | 'employer' | 'agency';
 
 type Recommendation = {
+  key: string;
   name: string;
   reason: string;
   href: string;
@@ -48,36 +49,36 @@ const ORGS: Array<{ id: OrgType; label: string }> = [
 function recommend(goal: Goal, org: OrgType): Recommendation[] {
   const common: Recommendation[] = [];
   if (goal === 'business' || goal === 'website') {
-    common.push({ name: 'AI Website Builder', reason: 'Create, edit, preview and publish a business website without code.', href: '/store/apps/website-builder', badge: 'Start here' });
-    common.push({ name: 'CRM', reason: 'Capture leads and keep customer follow-up connected to your website.', href: '/store#marketplace' });
-    common.push({ name: 'AI Assistant', reason: 'Automate routine questions, follow-up and business support.', href: '/store#marketplace' });
+    common.push({ key: 'website_builder', name: 'AI Website Builder', reason: 'Create, edit, preview and publish a business website without code.', href: '/store/apps/website-builder', badge: 'Start here' });
+    common.push({ key: 'crm', name: 'CRM', reason: 'Capture leads and keep customer follow-up connected to your website.', href: '/store#marketplace' });
+    common.push({ key: 'ai_paris', name: 'AI Assistant', reason: 'Automate routine questions, follow-up and business support.', href: '/store#marketplace' });
   }
   if (goal === 'course') {
-    common.push({ name: 'Course Builder', reason: 'Describe the course and let AI create the starting structure, lessons and assessments.', href: '/store#marketplace', badge: 'Best match' });
-    common.push({ name: 'LMS', reason: 'Deliver training, track progress and manage learners.', href: '/store#marketplace' });
+    common.push({ key: 'course_builder', name: 'Course Builder', reason: 'Describe the course and let AI create the starting structure, lessons and assessments.', href: '/store#marketplace', badge: 'Best match' });
+    common.push({ key: 'lms', name: 'LMS', reason: 'Deliver training, track progress and manage learners.', href: '/store#marketplace' });
   }
   if (goal === 'community') {
-    common.push({ name: 'Community Hub', reason: 'Launch groups, discussions, events, achievements and member engagement.', href: '/store#marketplace', badge: 'Best match' });
-    common.push({ name: 'AI Team', reason: 'Add guided onboarding, support and engagement assistance.', href: '/store#marketplace' });
+    common.push({ key: 'community', name: 'Community Hub', reason: 'Launch groups, discussions, events, achievements and member engagement.', href: '/store#marketplace', badge: 'Best match' });
+    common.push({ key: 'ai_orchestrator', name: 'AI Team', reason: 'Add guided onboarding, support and engagement assistance.', href: '/store#marketplace' });
   }
   if (goal === 'customers') {
-    common.push({ name: 'CRM', reason: 'Create a customer pipeline, follow-up process and shared record of activity.', href: '/store#marketplace', badge: 'Best match' });
-    common.push({ name: 'AI Assistant', reason: 'Reduce manual follow-up and repetitive customer questions.', href: '/store#marketplace' });
+    common.push({ key: 'crm', name: 'CRM', reason: 'Create a customer pipeline, follow-up process and shared record of activity.', href: '/store#marketplace', badge: 'Best match' });
+    common.push({ key: 'ai_paris', name: 'AI Assistant', reason: 'Reduce manual follow-up and repetitive customer questions.', href: '/store#marketplace' });
   }
   if (goal === 'grants') {
-    common.push({ name: 'Grants Discovery', reason: 'Search, match and track funding opportunities from one workspace.', href: '/store/apps/grants', badge: 'Best match' });
+    common.push({ key: 'grants_discovery', name: 'Grants Discovery', reason: 'Search, match and track funding opportunities from one workspace.', href: '/store/apps/grants', badge: 'Best match' });
   }
   if (goal === 'government') {
-    common.push({ name: 'SAM.gov Manager', reason: 'Use a guided workflow for registration, renewals and compliance tracking.', href: '/store/apps/sam-gov', badge: 'Best match' });
+    common.push({ key: 'sam_gov_manager', name: 'SAM.gov Manager', reason: 'Use a guided workflow for registration, renewals and compliance tracking.', href: '/store/apps/sam-gov', badge: 'Best match' });
   }
   if (goal === 'workforce') {
-    common.push({ name: 'Workforce OS', reason: 'Manage enrollment, funding, compliance, outcomes and agency workflows.', href: '/store#marketplace', badge: 'Best match' });
+    common.push({ key: 'workforce', name: 'Workforce OS', reason: 'Manage enrollment, funding, compliance, outcomes and agency workflows.', href: '/store#marketplace', badge: 'Best match' });
   }
   if (goal === 'apprenticeship') {
-    common.push({ name: 'Apprenticeship Management', reason: 'Track RTI, OJT, employers, progress and compliance in one workflow.', href: '/store#marketplace', badge: 'Best match' });
+    common.push({ key: 'apprenticeship', name: 'Apprenticeship Management', reason: 'Track RTI, OJT, employers, progress and compliance in one workflow.', href: '/store#marketplace', badge: 'Best match' });
   }
-  if ((org === 'training-provider' || org === 'agency') && !common.some((item) => item.name === 'LMS')) {
-    common.push({ name: 'LMS', reason: 'Add learner delivery, progress and training records when your organization needs them.', href: '/store#marketplace' });
+  if ((org === 'training-provider' || org === 'agency') && !common.some((item) => item.key === 'lms')) {
+    common.push({ key: 'lms', name: 'LMS', reason: 'Add learner delivery, progress and training records when your organization needs them.', href: '/store#marketplace' });
   }
   return common.slice(0, 4);
 }
@@ -86,6 +87,15 @@ export function GuidedProductInterview() {
   const [goal, setGoal] = useState<Goal | null>(null);
   const [org, setOrg] = useState<OrgType | null>(null);
   const recommendations = useMemo(() => (goal && org ? recommend(goal, org) : []), [goal, org]);
+  const guidedTrialHref = useMemo(() => {
+    if (!goal || !org || recommendations.length === 0) return '/store/trial';
+    const params = new URLSearchParams({
+      recommended: recommendations.map((item) => item.key).join(','),
+      goal,
+      org,
+    });
+    return `/store/trial?${params.toString()}`;
+  }, [goal, org, recommendations]);
 
   return (
     <section className="bg-white py-16" id="guided-setup">
@@ -106,8 +116,8 @@ export function GuidedProductInterview() {
 
           <div className="rounded-3xl bg-slate-950 p-6 text-white md:p-8">
             <p className="text-sm font-black uppercase tracking-wider text-brand-red-300">Your recommended setup</p>
-            {!goal || !org ? <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-100">Choose a goal and organization type. Elevate will explain what to start with and why.</div> : <div className="mt-6 space-y-4">{recommendations.map((item) => <article key={item.name} className="rounded-2xl border border-white/10 bg-white/5 p-5"><div className="flex items-start justify-between gap-4"><div><div className="flex flex-wrap items-center gap-2"><h3 className="font-black">{item.name}</h3>{item.badge ? <span className="rounded-full bg-brand-red-600 px-2 py-1 text-[11px] font-black uppercase">{item.badge}</span> : null}</div><p className="mt-2 text-sm leading-6 text-slate-100">{item.reason}</p></div><CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" /></div><Link href={item.href} className="mt-4 inline-flex items-center gap-2 text-sm font-black text-white">See this product <ArrowRight className="h-4 w-4" /></Link></article>)}</div>}
-            {goal && org ? <div className="mt-6 rounded-2xl bg-white p-5 text-slate-950"><p className="font-black">Simple mode first.</p><p className="mt-1 text-sm leading-6 text-slate-600">Elevate should guide setup in plain English. Advanced controls stay optional and unlock only when the customer needs higher-tier capabilities.</p><Link href="/store/trial" className="mt-4 inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-4 py-3 text-sm font-black text-white">Start guided setup <ArrowRight className="h-4 w-4" /></Link></div> : null}
+            {!goal || !org ? <div className="mt-6 rounded-2xl border border-white/10 bg-white/5 p-6 text-slate-100">Choose a goal and organization type. Elevate will explain what to start with and why.</div> : <div className="mt-6 space-y-4">{recommendations.map((item) => <article key={item.key} className="rounded-2xl border border-white/10 bg-white/5 p-5"><div className="flex items-start justify-between gap-4"><div><div className="flex flex-wrap items-center gap-2"><h3 className="font-black">{item.name}</h3>{item.badge ? <span className="rounded-full bg-brand-red-600 px-2 py-1 text-[11px] font-black uppercase">{item.badge}</span> : null}</div><p className="mt-2 text-sm leading-6 text-slate-100">{item.reason}</p></div><CheckCircle2 className="h-5 w-5 shrink-0 text-emerald-400" /></div><Link href={item.href} className="mt-4 inline-flex items-center gap-2 text-sm font-black text-white">See how it works <ArrowRight className="h-4 w-4" /></Link></article>)}</div>}
+            {goal && org ? <div className="mt-6 rounded-2xl bg-white p-5 text-slate-950"><p className="font-black">Keep these recommendations.</p><p className="mt-1 text-sm leading-6 text-slate-600">Your recommended capabilities will be carried into the trial workspace instead of making you choose them again.</p><Link href={guidedTrialHref} className="mt-4 inline-flex items-center gap-2 rounded-xl bg-brand-red-600 px-4 py-3 text-sm font-black text-white">Start guided trial <ArrowRight className="h-4 w-4" /></Link></div> : null}
           </div>
         </div>
       </div>

--- a/components/store/StoreGlossary.tsx
+++ b/components/store/StoreGlossary.tsx
@@ -1,0 +1,41 @@
+const TERMS = [
+  {
+    term: 'WIOA',
+    meaning: 'Workforce Innovation and Opportunity Act — a U.S. workforce law that supports eligible employment and training services.',
+  },
+  {
+    term: 'OJT',
+    meaning: 'On-the-job training — structured training completed while a participant is working with an employer.',
+  },
+  {
+    term: 'RTI',
+    meaning: 'Related Technical Instruction — classroom or technical instruction that complements apprenticeship work experience.',
+  },
+  {
+    term: 'RAPIDS',
+    meaning: 'Registered Apprenticeship Partners Information Database System — the federal system used for registered apprenticeship records.',
+  },
+  {
+    term: 'White-label',
+    meaning: 'A customer-facing experience presented with your organization’s own name, logo and branding where supported.',
+  },
+];
+
+export function StoreGlossary() {
+  return (
+    <section className="border-y border-slate-200 bg-white py-12" aria-labelledby="store-glossary-heading">
+      <div className="mx-auto max-w-5xl px-5">
+        <h2 id="store-glossary-heading" className="text-2xl font-black text-slate-950">Workforce terms in plain language</h2>
+        <p className="mt-2 max-w-3xl font-semibold leading-7 text-slate-700">You do not need to know workforce-program acronyms to choose a product. These definitions explain the terms used in capability descriptions.</p>
+        <dl className="mt-6 grid gap-4 md:grid-cols-2">
+          {TERMS.map((item) => (
+            <div key={item.term} className="rounded-xl border border-slate-200 bg-slate-50 p-4">
+              <dt className="font-black text-slate-950">{item.term}</dt>
+              <dd className="mt-1 text-sm font-semibold leading-6 text-slate-700">{item.meaning}</dd>
+            </div>
+          ))}
+        </dl>
+      </div>
+    </section>
+  );
+}

--- a/components/store/UnifiedSalesMarketplace.tsx
+++ b/components/store/UnifiedSalesMarketplace.tsx
@@ -3,224 +3,114 @@
 import { useMemo, useState } from 'react';
 import Image from 'next/image';
 import Link from 'next/link';
-import {
-  CAPABILITY_CATALOG,
-  type CapabilityCategory,
-  type PlatformCapability,
-} from '@/lib/platform/capability-catalog';
+import { CAPABILITY_CATALOG, type CapabilityCategory, type PlatformCapability } from '@/lib/platform/capability-catalog';
 import { BASE_PLANS, ADD_ON_MARKETPLACE } from '@/lib/store/platform-pricing';
 import { INDIVIDUAL_APP_CATALOG } from '@/lib/apps/individual-app-plans';
 
 const categoryMeta: Record<CapabilityCategory, { label: string }> = {
-  business: { label: 'Business Growth' },
-  ai: { label: 'AI Team' },
-  education: { label: 'Education' },
-  workforce: { label: 'Workforce' },
-  compliance: { label: 'Compliance' },
-  apps: { label: 'Business Apps' },
-  enterprise: { label: 'Enterprise' },
+  business: { label: 'Business Growth' }, ai: { label: 'AI Team' }, education: { label: 'Education' },
+  workforce: { label: 'Workforce' }, compliance: { label: 'Compliance' }, apps: { label: 'Business Apps' }, enterprise: { label: 'Enterprise' },
 };
 
-/** Distinct repository screenshots for public capability cards. */
 const CAPABILITY_IMAGES: Record<string, string> = {
-  website_builder: '/images/pages/comp-layout-hero.webp',
-  crm: '/images/pages/admin-campaigns-hero.webp',
-  booking: '/images/pages/booking-page-1.webp',
-  forms: '/images/pages/admin-applications-hero.webp',
-  email_marketing: '/images/pages/admin-email-marketing-d2.webp',
-  sms: '/images/pages/admin-live-chat-detail.webp',
-  invoicing: '/images/pages/banking-page-1.webp',
-  seo_autopilot: '/images/pages/admin-analytics-hero.webp',
-  marketing_autopilot: '/images/pages/admin-email-campaigns-new-detail.webp',
-  ai_paris: '/images/pages/ai-tutor-page-1.webp',
-  ai_ellie: '/images/pages/adult-learner.webp',
-  ai_lizzy: '/images/pages/admin-ai-studio-hero.webp',
-  ai_zora: '/images/pages/admin-compliance-audit-hero.webp',
-  ai_orchestrator: '/images/pages/admin-ai-console-hero.webp',
-  course_builder: '/images/pages/comp-pathway-classroom.webp',
-  course_factory: '/images/pages/admin-courses-partners-hero.webp',
-  lms: '/images/heroes/lms-analytics.webp',
-  student_management: '/images/pages/admin-applicants-detail.webp',
-  testing_center: '/images/pages/competency-test-hero.webp',
-  workforce: '/images/pages/admin-wioa-hero.webp',
-  apprenticeship: '/images/pages/apprenticeship-structure.webp',
-  employer_portal: '/images/pages/admin-employers-hero.webp',
-  compliance: '/images/pages/compliance-page-1.webp',
-  sam_gov_manager: '/images/pages/agencies-page-1.webp',
-  grants_discovery: '/images/pages/admin-grants-workflow-detail.webp',
-  dev_studio: '/images/pages/admin-dev-studio-detail.webp',
+  website_builder: '/images/pages/comp-layout-hero.webp', crm: '/images/pages/admin-campaigns-hero.webp', booking: '/images/pages/booking-page-1.webp',
+  forms: '/images/pages/admin-applications-hero.webp', email_marketing: '/images/pages/admin-email-marketing-d2.webp', sms: '/images/pages/admin-live-chat-detail.webp',
+  invoicing: '/images/pages/banking-page-1.webp', seo_autopilot: '/images/pages/admin-analytics-hero.webp', marketing_autopilot: '/images/pages/admin-email-campaigns-new-detail.webp',
+  ai_paris: '/images/pages/ai-tutor-page-1.webp', ai_ellie: '/images/pages/adult-learner.webp', ai_lizzy: '/images/pages/admin-ai-studio-hero.webp',
+  ai_zora: '/images/pages/admin-compliance-audit-hero.webp', ai_orchestrator: '/images/pages/admin-ai-console-hero.webp', course_builder: '/images/pages/comp-pathway-classroom.webp',
+  course_factory: '/images/pages/admin-courses-partners-hero.webp', lms: '/images/heroes/lms-analytics.webp', student_management: '/images/pages/admin-applicants-detail.webp',
+  testing_center: '/images/pages/competency-test-hero.webp', workforce: '/images/pages/admin-wioa-hero.webp', apprenticeship: '/images/pages/apprenticeship-structure.webp',
+  employer_portal: '/images/pages/admin-employers-hero.webp', compliance: '/images/pages/compliance-page-1.webp', sam_gov_manager: '/images/pages/agencies-page-1.webp',
+  grants_discovery: '/images/pages/admin-grants-workflow-detail.webp', dev_studio: '/images/pages/admin-dev-studio-detail.webp',
 };
 
-function priceFor(capability: PlatformCapability): string | null {
-  if (capability.key === 'website_builder') {
-    return INDIVIDUAL_APP_CATALOG['website-builder'].plans[0]?.priceLabel ?? null;
-  }
-  if (capability.key === 'sam_gov_manager') {
-    return INDIVIDUAL_APP_CATALOG['sam-gov'].plans[0]?.priceLabel ?? null;
-  }
-  if (capability.key === 'grants_discovery') {
-    return INDIVIDUAL_APP_CATALOG.grants.plans[0]?.priceLabel ?? null;
-  }
+type PublicAvailability = 'live' | 'beta' | 'enterprise';
 
-  const addon = ADD_ON_MARKETPLACE.find(
-    (candidate) => !candidate.hiddenFromMarketplace && candidate.features.includes(capability.key),
-  );
-  if (addon) return `$${addon.priceMonthly}/mo add-on`;
-
-  const includedPlan = Object.values(BASE_PLANS).find((plan) => plan.features.includes(capability.key));
-  if (includedPlan) return `Included from $${includedPlan.priceMonthly}/mo`;
-  return null;
+function publicAvailability(capability: PlatformCapability): PublicAvailability {
+  if (capability.status === 'enterprise') return 'enterprise';
+  if (capability.status === 'repair') return 'beta';
+  return 'live';
 }
 
-function primaryHref(capability: PlatformCapability): string {
-  return capability.storeHref || capability.marketingHref || capability.appHref || '/store/plans';
+function availabilityLabel(value: PublicAvailability): string {
+  if (value === 'enterprise') return 'Enterprise';
+  if (value === 'beta') return 'Beta';
+  return 'Available';
+}
+
+function priceFor(capability: PlatformCapability): string {
+  if (capability.key === 'website_builder') return INDIVIDUAL_APP_CATALOG['website-builder'].plans[0]?.priceLabel ?? 'See plans';
+  if (capability.key === 'sam_gov_manager') return INDIVIDUAL_APP_CATALOG['sam-gov'].plans[0]?.priceLabel ?? 'See plans';
+  if (capability.key === 'grants_discovery') return INDIVIDUAL_APP_CATALOG.grants.plans[0]?.priceLabel ?? 'See plans';
+  const addon = ADD_ON_MARKETPLACE.find((candidate) => !candidate.hiddenFromMarketplace && candidate.features.includes(capability.key));
+  if (addon) return `$${addon.priceMonthly}/mo add-on`;
+  const includedPlan = Object.values(BASE_PLANS).find((plan) => plan.features.includes(capability.key));
+  if (includedPlan) return `Included from $${includedPlan.priceMonthly}/mo`;
+  return publicAvailability(capability) === 'enterprise' ? 'Custom pricing' : 'See plans for availability';
+}
+
+function primaryAction(capability: PlatformCapability): { href: string; label: string } {
+  if (publicAvailability(capability) === 'enterprise') {
+    return { href: `/contact?subject=${encodeURIComponent(`${capability.name} Enterprise`)}`, label: 'Contact Sales' };
+  }
+  return {
+    href: capability.storeHref || capability.marketingHref || capability.appHref || '/store/plans',
+    label: 'Explore Product',
+  };
 }
 
 export function UnifiedSalesMarketplace() {
   const [query, setQuery] = useState('');
   const [category, setCategory] = useState<'all' | CapabilityCategory>('all');
-
   const items = useMemo(() => {
     const needle = query.trim().toLowerCase();
     return CAPABILITY_CATALOG.filter((capability) => capability.status !== 'internal')
-      // Course Builder, AI Course Factory and LMS are one sellable platform.
-      // Keep the underlying feature flags, but expose a single commerce card.
       .filter((capability) => capability.key !== 'course_factory' && capability.key !== 'lms')
       .filter((capability) => category === 'all' || capability.category === category)
-      .filter((capability) => {
-        if (!needle) return true;
-        return [capability.name, capability.description, ...capability.keywords]
-          .join(' ')
-          .toLowerCase()
-          .includes(needle);
-      });
+      .filter((capability) => !needle || [capability.name, capability.description, ...capability.keywords].join(' ').toLowerCase().includes(needle));
   }, [query, category]);
 
   return (
     <section className="bg-slate-950 py-16 font-medium text-white" id="marketplace">
       <div className="mx-auto max-w-7xl px-4 sm:px-6">
         <div className="mx-auto max-w-3xl text-center">
-          <p className="text-sm font-black uppercase tracking-[0.16em] text-brand-red-300">
-            Start basic. Add capabilities as your business grows.
-          </p>
+          <p className="text-sm font-black uppercase tracking-[0.16em] text-brand-red-300">Start basic. Add capabilities as your business grows.</p>
           <h2 className="mt-5 text-3xl font-black tracking-tight text-white sm:text-5xl">Build your Elevate business stack</h2>
-          <p className="mt-4 text-base font-semibold leading-7 text-slate-100 sm:text-lg">
-            Search the platform, watch a separate product demo, understand the subscription, and add specialized AI, education, workforce and business tools without buying a second system.
-          </p>
+          <p className="mt-4 text-base font-semibold leading-7 text-slate-100 sm:text-lg">Search the platform, see how each capability works, understand its commercial path, and add only what your organization needs.</p>
         </div>
-
-        <div className="mx-auto mt-8 max-w-3xl">
-          <label className="block">
-            <span className="sr-only">Search platform capabilities</span>
-            <input
-              value={query}
-              onChange={(event) => setQuery(event.target.value)}
-              placeholder="Search website builder, CRM, PARIS, testing, apprenticeship..."
-              className="w-full rounded-2xl border border-white/30 bg-white px-5 py-4 text-base font-bold text-slate-950 outline-none ring-brand-red-500 placeholder:text-slate-600 focus:ring-2"
-            />
-          </label>
-        </div>
-
+        <div className="mx-auto mt-8 max-w-3xl"><label className="block"><span className="sr-only">Search platform capabilities</span><input value={query} onChange={(event) => setQuery(event.target.value)} placeholder="Search website builder, CRM, PARIS, testing, apprenticeship..." className="w-full rounded-2xl border border-white/30 bg-white px-5 py-4 text-base font-bold text-slate-950 outline-none ring-brand-red-500 placeholder:text-slate-600 focus:ring-2" /></label></div>
         <div className="mt-6 flex flex-wrap justify-center gap-2">
-          <button
-            type="button"
-            onClick={() => setCategory('all')}
-            className={`rounded-full px-4 py-2 text-sm font-black ${category === 'all' ? 'bg-brand-red-600 text-white' : 'bg-white/15 text-white hover:bg-white/25'}`}
-          >
-            All
-          </button>
-          {(Object.keys(categoryMeta) as CapabilityCategory[]).map((key) => (
-            <button
-              key={key}
-              type="button"
-              onClick={() => setCategory(key)}
-              className={`rounded-full px-4 py-2 text-sm font-black ${category === key ? 'bg-brand-red-600 text-white' : 'bg-white/15 text-white hover:bg-white/25'}`}
-            >
-              {categoryMeta[key].label}
-            </button>
-          ))}
+          <button type="button" aria-pressed={category === 'all'} onClick={() => setCategory('all')} className={`rounded-full px-4 py-2 text-sm font-black ${category === 'all' ? 'bg-brand-red-600 text-white' : 'bg-white/15 text-white hover:bg-white/25'}`}>All</button>
+          {(Object.keys(categoryMeta) as CapabilityCategory[]).map((key) => <button key={key} type="button" aria-pressed={category === key} onClick={() => setCategory(key)} className={`rounded-full px-4 py-2 text-sm font-black ${category === key ? 'bg-brand-red-600 text-white' : 'bg-white/15 text-white hover:bg-white/25'}`}>{categoryMeta[key].label}</button>)}
         </div>
 
         <div className="mt-10 grid gap-5 md:grid-cols-2 xl:grid-cols-3">
           {items.map((capability) => {
             const isUnifiedLearningPlatform = capability.key === 'course_builder';
-            const capabilityName = isUnifiedLearningPlatform
-              ? 'Course Creation & Learning Platform'
-              : capability.name;
+            const capabilityName = isUnifiedLearningPlatform ? 'Course Creation & Learning Platform' : capability.name;
             const capabilityDescription = isUnifiedLearningPlatform
               ? 'Build course structures, generate evidence-grounded lessons and assessments with AI, create instructor-led media, publish to the learner LMS, issue certificates and track student progress from one connected system.'
               : capability.description;
-            const price = priceFor(capability);
             const image = CAPABILITY_IMAGES[String(capability.key)];
+            const availability = publicAvailability(capability);
+            const action = primaryAction(capability);
             return (
               <article key={capability.key} className="flex min-h-[390px] flex-col overflow-hidden rounded-2xl border border-white/20 bg-slate-900 shadow-lg">
-                <div className="relative aspect-[16/9] w-full overflow-hidden bg-slate-800">
-                  {image ? (
-                    <Image
-                      src={image}
-                      alt={`${capabilityName} platform capability`}
-                      fill
-                      sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw"
-                      className="object-cover"
-                      placeholder="empty"
-                    />
-                  ) : (
-                    <div className="flex h-full items-center justify-center bg-slate-800 p-8 text-center">
-                      <span className="text-2xl font-black text-white">{capabilityName}</span>
-                    </div>
-                  )}
-                </div>
-
+                <div className="relative aspect-[16/9] w-full overflow-hidden bg-slate-800">{image ? <Image src={image} alt={`${capabilityName} platform capability`} fill sizes="(max-width: 768px) 100vw, (max-width: 1280px) 50vw, 33vw" className="object-cover" placeholder="empty" /> : <div className="flex h-full items-center justify-center bg-slate-800 p-8 text-center"><span className="text-2xl font-black text-white">{capabilityName}</span></div>}</div>
                 <div className="flex flex-1 flex-col p-6">
-                  <div className="flex items-start justify-between gap-4">
-                    <span className="text-xs font-black uppercase tracking-wide text-slate-100">
-                      {categoryMeta[capability.category].label}
-                    </span>
-                    <span className="rounded-full border border-white/25 bg-white/15 px-3 py-1 text-xs font-black uppercase tracking-wide text-white">
-                      {capability.status === 'enterprise' ? 'Enterprise' : capability.status === 'repair' ? 'Preview' : 'Available'}
-                    </span>
-                  </div>
-
+                  <div className="flex items-start justify-between gap-4"><span className="text-xs font-black uppercase tracking-wide text-slate-100">{categoryMeta[capability.category].label}</span><span className="rounded-full border border-white/25 bg-white/15 px-3 py-1 text-xs font-black uppercase tracking-wide text-white">{availabilityLabel(availability)}</span></div>
                   <h3 className="mt-4 text-xl font-black text-white">{capabilityName}</h3>
                   <p className="mt-2 flex-1 text-sm font-semibold leading-6 text-slate-100">{capabilityDescription}</p>
-                  {price ? <p className="mt-4 text-sm font-black text-white">{price}</p> : null}
-
-                  <div className="mt-5 flex flex-wrap gap-2">
-                    <Link
-                      href={primaryHref(capability)}
-                      className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand-red-600 px-4 py-2.5 text-sm font-black text-white hover:bg-brand-red-500"
-                    >
-                      {capability.status === 'enterprise' ? 'Explore' : 'View / Start'}
-                    </Link>
-                    <Link
-                      href={`/store/demo/capability/${String(capability.key)}`}
-                      className="inline-flex min-h-11 items-center justify-center rounded-xl border border-white/40 bg-white/10 px-4 py-2.5 text-sm font-black text-white hover:bg-white/20"
-                    >
-                      Demo + Subscription
-                    </Link>
-                  </div>
+                  <p className="mt-4 text-sm font-black text-white">{priceFor(capability)}</p>
+                  {availability === 'beta' ? <p className="mt-2 text-xs font-semibold text-amber-200">Beta availability may change while the capability is being finalized.</p> : null}
+                  <div className="mt-5 flex flex-wrap gap-2"><Link href={action.href} className="inline-flex min-h-11 items-center justify-center rounded-xl bg-brand-red-600 px-4 py-2.5 text-sm font-black text-white hover:bg-brand-red-500">{action.label}</Link><Link href={`/store/demo/capability/${String(capability.key)}`} className="inline-flex min-h-11 items-center justify-center rounded-xl border border-white/40 bg-white/10 px-4 py-2.5 text-sm font-black text-white hover:bg-white/20">See How It Works</Link></div>
                 </div>
               </article>
             );
           })}
         </div>
-
-        {items.length === 0 ? (
-          <div className="mt-10 rounded-2xl border border-white/20 bg-white/10 p-8 text-center font-semibold text-slate-100">
-            No matching capability. Try a broader search.
-          </div>
-        ) : null}
-
-        <div className="mt-12 grid gap-4 rounded-3xl border border-brand-red-500/40 bg-slate-900 p-7 md:grid-cols-[1fr_auto] md:items-center">
-          <div>
-            <h3 className="text-2xl font-black text-white">Not sure what to choose?</h3>
-            <p className="mt-2 font-semibold text-slate-100">Start with the 14-day trial. Your platform can recommend upgrades based on the tools you actually use.</p>
-          </div>
-          <div className="flex flex-wrap gap-3">
-            <Link href="/store/trial" className="rounded-xl bg-white px-5 py-3 font-black text-slate-950 hover:bg-slate-100">Start Free Trial</Link>
-            <Link href="/store/plans" className="rounded-xl border border-white/40 px-5 py-3 font-black text-white hover:bg-white/10">Compare Plans</Link>
-          </div>
-        </div>
+        {items.length === 0 ? <div className="mt-10 rounded-2xl border border-white/20 bg-white/10 p-8 text-center font-semibold text-slate-100">No matching capability. Try a broader search.</div> : null}
+        <div className="mt-12 grid gap-4 rounded-3xl border border-brand-red-500/40 bg-slate-900 p-7 md:grid-cols-[1fr_auto] md:items-center"><div><h3 className="text-2xl font-black text-white">Not sure what to choose?</h3><p className="mt-2 font-semibold text-slate-100">Use guided setup or start the 14-day trial. Your workspace can preserve the capabilities selected during onboarding.</p></div><div className="flex flex-wrap gap-3"><Link href="#guided-setup" className="rounded-xl border border-white/40 px-5 py-3 font-black text-white hover:bg-white/10">Use Guided Setup</Link><Link href="/store/trial" className="rounded-xl bg-white px-5 py-3 font-black text-slate-950 hover:bg-slate-100">Start Free Trial</Link></div></div>
       </div>
     </section>
   );

--- a/lib/workspace/ensure-trial-owner-access.ts
+++ b/lib/workspace/ensure-trial-owner-access.ts
@@ -3,6 +3,7 @@ import 'server-only';
 import { requireAdminClient } from '@/lib/supabase/admin';
 import { logger } from '@/lib/logger';
 import { startAppTrial } from '@/lib/trial/start-app-trial';
+import { hasIndividualAppAccess, syncIndividualAppSubscription } from '@/lib/apps/sync-subscription';
 
 type AdminClient = Awaited<ReturnType<typeof requireAdminClient>>;
 type AccessStage =
@@ -143,6 +144,14 @@ export async function ensureTrialOwnerAccess(
 
   const builderTrial = await startAppTrial(authUser.id, 'website-builder', db);
   if (builderTrial.status === 'error') return fail('entitlements_ready', 'Website Builder access could not be provisioned.');
+
+  const effectiveSubscription = await syncIndividualAppSubscription(authUser.id, 'website-builder', db);
+  if (!hasIndividualAppAccess(effectiveSubscription)) {
+    const reason = effectiveSubscription?.access_reason === 'trial_expired'
+      ? 'Website Builder trial has expired. Choose a paid plan to continue.'
+      : 'Website Builder access is not active.';
+    return fail('entitlements_ready', reason);
+  }
   await recordStage(db, input.workspaceId, 'entitlements_ready', input.source, input.reference).catch(() => {});
 
   const { data: website, error: websiteLookupError } = await db.from('user_websites')

--- a/lib/workspace/ensure-trial-owner-access.ts
+++ b/lib/workspace/ensure-trial-owner-access.ts
@@ -5,6 +5,13 @@ import { logger } from '@/lib/logger';
 import { startAppTrial } from '@/lib/trial/start-app-trial';
 
 type AdminClient = Awaited<ReturnType<typeof requireAdminClient>>;
+type AccessStage =
+  | 'identity_ready'
+  | 'profile_ready'
+  | 'organization_access_ready'
+  | 'tenant_access_ready'
+  | 'entitlements_ready'
+  | 'builder_ready';
 
 export type EnsureTrialOwnerAccessInput = {
   organizationId: string;
@@ -22,23 +29,8 @@ export type EnsureTrialOwnerAccessInput = {
 };
 
 export type EnsureTrialOwnerAccessResult =
-  | {
-      ok: true;
-      userId: string;
-      loginUrl: string;
-      builderUrl: string;
-    }
-  | {
-      ok: false;
-      error: string;
-      stage:
-        | 'identity_ready'
-        | 'profile_ready'
-        | 'organization_access_ready'
-        | 'tenant_access_ready'
-        | 'entitlements_ready'
-        | 'builder_ready';
-    };
+  | { ok: true; userId: string; loginUrl: string; builderUrl: string }
+  | { ok: false; error: string; stage: AccessStage };
 
 function asObject(value: unknown): Record<string, unknown> {
   return value && typeof value === 'object' && !Array.isArray(value)
@@ -49,7 +41,7 @@ function asObject(value: unknown): Record<string, unknown> {
 async function recordStage(
   db: AdminClient,
   workspaceId: string,
-  stage: string,
+  stage: AccessStage,
   source: EnsureTrialOwnerAccessInput['source'],
   reference: string,
   error?: string,
@@ -59,36 +51,31 @@ async function recordStage(
     .select('metadata')
     .eq('id', workspaceId)
     .maybeSingle();
-
   const metadata = asObject(workspace?.metadata);
   const onboarding = asObject(metadata.onboarding);
   const stages = asObject(onboarding.stages);
-
-  await db
-    .from('customer_workspaces')
-    .update({
-      metadata: {
-        ...metadata,
-        onboarding: {
-          ...onboarding,
-          source,
-          reference,
-          last_stage: stage,
-          last_error: error ?? null,
-          updated_at: new Date().toISOString(),
-          stages: {
-            ...stages,
-            [stage]: {
-              status: error ? 'failed' : 'ready',
-              at: new Date().toISOString(),
-              ...(error ? { error } : {}),
-            },
+  await db.from('customer_workspaces').update({
+    metadata: {
+      ...metadata,
+      onboarding: {
+        ...onboarding,
+        source,
+        reference,
+        last_stage: stage,
+        last_error: error ?? null,
+        updated_at: new Date().toISOString(),
+        stages: {
+          ...stages,
+          [stage]: {
+            status: error ? 'failed' : 'ready',
+            at: new Date().toISOString(),
+            ...(error ? { error } : {}),
           },
         },
       },
-      updated_at: new Date().toISOString(),
-    })
-    .eq('id', workspaceId);
+    },
+    updated_at: new Date().toISOString(),
+  }).eq('id', workspaceId);
 }
 
 export async function ensureTrialOwnerAccess(
@@ -99,11 +86,7 @@ export async function ensureTrialOwnerAccess(
   const ownerName = input.ownerName.trim();
   const builderUrl = input.builderUrl || '/apps/website-builder';
 
-  const fail = async (
-    stage: EnsureTrialOwnerAccessResult extends { ok: false; stage: infer S } ? S : never,
-    error: string,
-    cause?: unknown,
-  ): Promise<EnsureTrialOwnerAccessResult> => {
+  const fail = async (stage: AccessStage, error: string, cause?: unknown): Promise<EnsureTrialOwnerAccessResult> => {
     logger.error('[trial-owner-access] provisioning stage failed', cause instanceof Error ? cause : undefined, {
       workspaceId: input.workspaceId,
       tenantId: input.tenantId,
@@ -113,8 +96,8 @@ export async function ensureTrialOwnerAccess(
       reference: input.reference,
       error,
     });
-    await recordStage(db, input.workspaceId, stage as string, input.source, input.reference, error).catch(() => {});
-    return { ok: false, stage, error } as EnsureTrialOwnerAccessResult;
+    await recordStage(db, input.workspaceId, stage, input.source, input.reference, error).catch(() => {});
+    return { ok: false, stage, error };
   };
 
   const generated = await db.auth.admin.generateLink({
@@ -122,108 +105,51 @@ export async function ensureTrialOwnerAccess(
     email: ownerEmail,
     options: {
       redirectTo: builderUrl,
-      data: {
-        full_name: ownerName,
-        role: 'org_admin',
-        organization_id: input.organizationId,
-        tenant_id: input.tenantId,
-      },
+      data: { full_name: ownerName, role: 'org_admin', organization_id: input.organizationId, tenant_id: input.tenantId },
     },
   });
-
   if (generated.error || !generated.data?.user?.id) {
-    return fail(
-      'identity_ready',
-      'Administrator sign-in could not be provisioned.',
-      generated.error ?? undefined,
-    );
+    return fail('identity_ready', 'Administrator sign-in could not be provisioned.', generated.error ?? undefined);
   }
-
   const authUser = generated.data.user;
   await recordStage(db, input.workspaceId, 'identity_ready', input.source, input.reference).catch(() => {});
 
-  const { data: existingProfile, error: profileLookupError } = await db
-    .from('profiles')
+  const { data: existingProfile, error: profileLookupError } = await db.from('profiles')
     .select('id, email, full_name, role, organization_id, tenant_id')
     .eq('id', authUser.id)
     .maybeSingle();
-
-  if (profileLookupError) {
-    return fail('profile_ready', 'Administrator profile could not be checked.', profileLookupError);
-  }
+  if (profileLookupError) return fail('profile_ready', 'Administrator profile could not be checked.', profileLookupError);
 
   const profilePayload = existingProfile
-    ? {
-        id: authUser.id,
-        email: ownerEmail,
-        full_name: ownerName,
-        role: existingProfile.role ?? 'org_admin',
-        organization_id: existingProfile.organization_id ?? input.organizationId,
-        tenant_id: existingProfile.tenant_id ?? input.tenantId,
-      }
-    : {
-        id: authUser.id,
-        email: ownerEmail,
-        full_name: ownerName,
-        role: 'org_admin',
-        organization_id: input.organizationId,
-        tenant_id: input.tenantId,
-      };
-
-  const { error: profileError } = await db
-    .from('profiles')
-    .upsert(profilePayload, { onConflict: 'id' });
-  if (profileError) {
-    return fail('profile_ready', 'Administrator profile could not be linked.', profileError);
-  }
+    ? { id: authUser.id, email: ownerEmail, full_name: ownerName, role: existingProfile.role ?? 'org_admin', organization_id: existingProfile.organization_id ?? input.organizationId, tenant_id: existingProfile.tenant_id ?? input.tenantId }
+    : { id: authUser.id, email: ownerEmail, full_name: ownerName, role: 'org_admin', organization_id: input.organizationId, tenant_id: input.tenantId };
+  const { error: profileError } = await db.from('profiles').upsert(profilePayload, { onConflict: 'id' });
+  if (profileError) return fail('profile_ready', 'Administrator profile could not be linked.', profileError);
   await recordStage(db, input.workspaceId, 'profile_ready', input.source, input.reference).catch(() => {});
 
   const { error: orgMembershipError } = await db.from('organization_users').upsert(
-    {
-      organization_id: input.organizationId,
-      user_id: authUser.id,
-      role: 'org_owner',
-      status: 'active',
-    },
+    { organization_id: input.organizationId, user_id: authUser.id, role: 'org_owner', status: 'active' },
     { onConflict: 'organization_id,user_id' },
   );
-  if (orgMembershipError) {
-    return fail(
-      'organization_access_ready',
-      'Organization access could not be provisioned.',
-      orgMembershipError,
-    );
-  }
+  if (orgMembershipError) return fail('organization_access_ready', 'Organization access could not be provisioned.', orgMembershipError);
   await recordStage(db, input.workspaceId, 'organization_access_ready', input.source, input.reference).catch(() => {});
 
   const { error: tenantMembershipError } = await db.from('tenant_memberships').upsert(
-    {
-      tenant_id: input.tenantId,
-      user_id: authUser.id,
-      role: 'owner',
-    },
+    { tenant_id: input.tenantId, user_id: authUser.id, role: 'owner' },
     { onConflict: 'tenant_id,user_id' },
   );
-  if (tenantMembershipError) {
-    return fail('tenant_access_ready', 'Tenant access could not be provisioned.', tenantMembershipError);
-  }
+  if (tenantMembershipError) return fail('tenant_access_ready', 'Tenant access could not be provisioned.', tenantMembershipError);
   await recordStage(db, input.workspaceId, 'tenant_access_ready', input.source, input.reference).catch(() => {});
 
   const builderTrial = await startAppTrial(authUser.id, 'website-builder', db);
-  if (builderTrial.status === 'error') {
-    return fail('entitlements_ready', 'Website Builder access could not be provisioned.');
-  }
+  if (builderTrial.status === 'error') return fail('entitlements_ready', 'Website Builder access could not be provisioned.');
   await recordStage(db, input.workspaceId, 'entitlements_ready', input.source, input.reference).catch(() => {});
 
-  const { data: website, error: websiteLookupError } = await db
-    .from('user_websites')
+  const { data: website, error: websiteLookupError } = await db.from('user_websites')
     .select('id, site_config')
     .eq('organization_id', input.organizationId)
     .maybeSingle();
-
-  if (websiteLookupError) {
-    return fail('builder_ready', 'Website Builder workspace could not be checked.', websiteLookupError);
-  }
+  if (websiteLookupError) return fail('builder_ready', 'Website Builder workspace could not be checked.', websiteLookupError);
 
   if (website?.id) {
     const currentConfig = asObject(website.site_config);
@@ -240,32 +166,22 @@ export async function ensureTrialOwnerAccess(
         onboardingSource: input.source,
       },
     };
-
-    const { error: websiteUpdateError } = await db
-      .from('user_websites')
-      .update({
-        user_id: authUser.id,
-        site_config: updatedConfig,
-        is_published: false,
-        status: 'draft',
-        updated_at: new Date().toISOString(),
-      })
-      .eq('id', website.id);
-
-    if (websiteUpdateError) {
-      return fail('builder_ready', 'Website Builder ownership could not be linked.', websiteUpdateError);
-    }
+    const { error: websiteUpdateError } = await db.from('user_websites').update({
+      user_id: authUser.id,
+      site_config: updatedConfig,
+      is_published: false,
+      status: 'draft',
+      updated_at: new Date().toISOString(),
+    }).eq('id', website.id);
+    if (websiteUpdateError) return fail('builder_ready', 'Website Builder ownership could not be linked.', websiteUpdateError);
   }
-
   await recordStage(db, input.workspaceId, 'builder_ready', input.source, input.reference).catch(() => {});
 
   const fallbackLogin = `https://app.elevateforhumanity.org/login?redirect=${encodeURIComponent(builderUrl)}`;
-  const loginUrl = generated.data?.properties?.action_link ?? fallbackLogin;
-
   return {
     ok: true,
     userId: authUser.id,
-    loginUrl,
+    loginUrl: generated.data?.properties?.action_link ?? fallbackLogin,
     builderUrl,
   };
 }

--- a/lib/workspace/ensure-trial-owner-access.ts
+++ b/lib/workspace/ensure-trial-owner-access.ts
@@ -1,0 +1,271 @@
+import 'server-only';
+
+import { requireAdminClient } from '@/lib/supabase/admin';
+import { logger } from '@/lib/logger';
+import { startAppTrial } from '@/lib/trial/start-app-trial';
+
+type AdminClient = Awaited<ReturnType<typeof requireAdminClient>>;
+
+export type EnsureTrialOwnerAccessInput = {
+  organizationId: string;
+  tenantId: string;
+  workspaceId: string;
+  ownerEmail: string;
+  ownerName: string;
+  builderUrl?: string;
+  websiteMode?: 'new' | 'existing';
+  existingUrl?: string | null;
+  programs?: string | null;
+  reference: string;
+  source: 'managed_trial' | 'demo_conversion' | 'guided_setup';
+  db?: AdminClient;
+};
+
+export type EnsureTrialOwnerAccessResult =
+  | {
+      ok: true;
+      userId: string;
+      loginUrl: string;
+      builderUrl: string;
+    }
+  | {
+      ok: false;
+      error: string;
+      stage:
+        | 'identity_ready'
+        | 'profile_ready'
+        | 'organization_access_ready'
+        | 'tenant_access_ready'
+        | 'entitlements_ready'
+        | 'builder_ready';
+    };
+
+function asObject(value: unknown): Record<string, unknown> {
+  return value && typeof value === 'object' && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : {};
+}
+
+async function recordStage(
+  db: AdminClient,
+  workspaceId: string,
+  stage: string,
+  source: EnsureTrialOwnerAccessInput['source'],
+  reference: string,
+  error?: string,
+) {
+  const { data: workspace } = await db
+    .from('customer_workspaces')
+    .select('metadata')
+    .eq('id', workspaceId)
+    .maybeSingle();
+
+  const metadata = asObject(workspace?.metadata);
+  const onboarding = asObject(metadata.onboarding);
+  const stages = asObject(onboarding.stages);
+
+  await db
+    .from('customer_workspaces')
+    .update({
+      metadata: {
+        ...metadata,
+        onboarding: {
+          ...onboarding,
+          source,
+          reference,
+          last_stage: stage,
+          last_error: error ?? null,
+          updated_at: new Date().toISOString(),
+          stages: {
+            ...stages,
+            [stage]: {
+              status: error ? 'failed' : 'ready',
+              at: new Date().toISOString(),
+              ...(error ? { error } : {}),
+            },
+          },
+        },
+      },
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', workspaceId);
+}
+
+export async function ensureTrialOwnerAccess(
+  input: EnsureTrialOwnerAccessInput,
+): Promise<EnsureTrialOwnerAccessResult> {
+  const db = input.db ?? (await requireAdminClient());
+  const ownerEmail = input.ownerEmail.trim().toLowerCase();
+  const ownerName = input.ownerName.trim();
+  const builderUrl = input.builderUrl || '/apps/website-builder';
+
+  const fail = async (
+    stage: EnsureTrialOwnerAccessResult extends { ok: false; stage: infer S } ? S : never,
+    error: string,
+    cause?: unknown,
+  ): Promise<EnsureTrialOwnerAccessResult> => {
+    logger.error('[trial-owner-access] provisioning stage failed', cause instanceof Error ? cause : undefined, {
+      workspaceId: input.workspaceId,
+      tenantId: input.tenantId,
+      organizationId: input.organizationId,
+      ownerEmail,
+      stage,
+      reference: input.reference,
+      error,
+    });
+    await recordStage(db, input.workspaceId, stage as string, input.source, input.reference, error).catch(() => {});
+    return { ok: false, stage, error } as EnsureTrialOwnerAccessResult;
+  };
+
+  const generated = await db.auth.admin.generateLink({
+    type: 'magiclink',
+    email: ownerEmail,
+    options: {
+      redirectTo: builderUrl,
+      data: {
+        full_name: ownerName,
+        role: 'org_admin',
+        organization_id: input.organizationId,
+        tenant_id: input.tenantId,
+      },
+    },
+  });
+
+  if (generated.error || !generated.data?.user?.id) {
+    return fail(
+      'identity_ready',
+      'Administrator sign-in could not be provisioned.',
+      generated.error ?? undefined,
+    );
+  }
+
+  const authUser = generated.data.user;
+  await recordStage(db, input.workspaceId, 'identity_ready', input.source, input.reference).catch(() => {});
+
+  const { data: existingProfile, error: profileLookupError } = await db
+    .from('profiles')
+    .select('id, email, full_name, role, organization_id, tenant_id')
+    .eq('id', authUser.id)
+    .maybeSingle();
+
+  if (profileLookupError) {
+    return fail('profile_ready', 'Administrator profile could not be checked.', profileLookupError);
+  }
+
+  const profilePayload = existingProfile
+    ? {
+        id: authUser.id,
+        email: ownerEmail,
+        full_name: ownerName,
+        role: existingProfile.role ?? 'org_admin',
+        organization_id: existingProfile.organization_id ?? input.organizationId,
+        tenant_id: existingProfile.tenant_id ?? input.tenantId,
+      }
+    : {
+        id: authUser.id,
+        email: ownerEmail,
+        full_name: ownerName,
+        role: 'org_admin',
+        organization_id: input.organizationId,
+        tenant_id: input.tenantId,
+      };
+
+  const { error: profileError } = await db
+    .from('profiles')
+    .upsert(profilePayload, { onConflict: 'id' });
+  if (profileError) {
+    return fail('profile_ready', 'Administrator profile could not be linked.', profileError);
+  }
+  await recordStage(db, input.workspaceId, 'profile_ready', input.source, input.reference).catch(() => {});
+
+  const { error: orgMembershipError } = await db.from('organization_users').upsert(
+    {
+      organization_id: input.organizationId,
+      user_id: authUser.id,
+      role: 'org_owner',
+      status: 'active',
+    },
+    { onConflict: 'organization_id,user_id' },
+  );
+  if (orgMembershipError) {
+    return fail(
+      'organization_access_ready',
+      'Organization access could not be provisioned.',
+      orgMembershipError,
+    );
+  }
+  await recordStage(db, input.workspaceId, 'organization_access_ready', input.source, input.reference).catch(() => {});
+
+  const { error: tenantMembershipError } = await db.from('tenant_memberships').upsert(
+    {
+      tenant_id: input.tenantId,
+      user_id: authUser.id,
+      role: 'owner',
+    },
+    { onConflict: 'tenant_id,user_id' },
+  );
+  if (tenantMembershipError) {
+    return fail('tenant_access_ready', 'Tenant access could not be provisioned.', tenantMembershipError);
+  }
+  await recordStage(db, input.workspaceId, 'tenant_access_ready', input.source, input.reference).catch(() => {});
+
+  const builderTrial = await startAppTrial(authUser.id, 'website-builder', db);
+  if (builderTrial.status === 'error') {
+    return fail('entitlements_ready', 'Website Builder access could not be provisioned.');
+  }
+  await recordStage(db, input.workspaceId, 'entitlements_ready', input.source, input.reference).catch(() => {});
+
+  const { data: website, error: websiteLookupError } = await db
+    .from('user_websites')
+    .select('id, site_config')
+    .eq('organization_id', input.organizationId)
+    .maybeSingle();
+
+  if (websiteLookupError) {
+    return fail('builder_ready', 'Website Builder workspace could not be checked.', websiteLookupError);
+  }
+
+  if (website?.id) {
+    const currentConfig = asObject(website.site_config);
+    const currentMeta = asObject(currentConfig.meta);
+    const updatedConfig = {
+      ...currentConfig,
+      meta: {
+        ...currentMeta,
+        parisInterviewCompleted: currentMeta.parisInterviewCompleted === true,
+        connectionMode: input.websiteMode ?? currentMeta.connectionMode ?? 'new',
+        sourceWebsiteUrl: input.existingUrl ?? currentMeta.sourceWebsiteUrl ?? null,
+        programsIntake: input.programs ?? currentMeta.programsIntake ?? null,
+        trialReference: input.reference,
+        onboardingSource: input.source,
+      },
+    };
+
+    const { error: websiteUpdateError } = await db
+      .from('user_websites')
+      .update({
+        user_id: authUser.id,
+        site_config: updatedConfig,
+        is_published: false,
+        status: 'draft',
+        updated_at: new Date().toISOString(),
+      })
+      .eq('id', website.id);
+
+    if (websiteUpdateError) {
+      return fail('builder_ready', 'Website Builder ownership could not be linked.', websiteUpdateError);
+    }
+  }
+
+  await recordStage(db, input.workspaceId, 'builder_ready', input.source, input.reference).catch(() => {});
+
+  const fallbackLogin = `https://app.elevateforhumanity.org/login?redirect=${encodeURIComponent(builderUrl)}`;
+  const loginUrl = generated.data?.properties?.action_link ?? fallbackLogin;
+
+  return {
+    ok: true,
+    userId: authUser.id,
+    loginUrl,
+    builderUrl,
+  };
+}

--- a/tests/store-funnel.spec.ts
+++ b/tests/store-funnel.spec.ts
@@ -1,0 +1,82 @@
+import { test, expect } from '@playwright/test';
+
+const baseURL = process.env.NEXT_PUBLIC_SITE_URL || 'http://localhost:3000';
+
+async function expectRouteHealthy(request: any, path: string) {
+  const response = await request.get(`${baseURL}${path}`, { maxRedirects: 5 });
+  expect(response.status(), `${path} should not return 4xx/5xx`).toBeLessThan(400);
+}
+
+test.describe('Store funnel release contract', () => {
+  test('core store routes and legacy demo compatibility routes resolve', async ({ request }) => {
+    for (const path of [
+      '/store',
+      '/store/plans',
+      '/store/trial',
+      '/store/demo/admin',
+      '/store/demo/student',
+      '/store/demo/employer',
+      '/store/demo/institutional',
+      '/store/demo/crm',
+      '/store/demo/lms',
+      '/store/demo/website',
+      '/store/demo/capability/crm',
+      '/store/demo/capability/lms',
+    ]) {
+      await expectRouteHealthy(request, path);
+    }
+  });
+
+  test('all Store-owned links on the main page resolve', async ({ page, request }) => {
+    await page.goto(`${baseURL}/store`);
+    const hrefs = await page.locator('a[href]').evaluateAll((anchors) =>
+      [...new Set(anchors.map((anchor) => anchor.getAttribute('href')).filter((href): href is string => Boolean(href && href.startsWith('/store'))))],
+    );
+
+    expect(hrefs.length).toBeGreaterThan(0);
+    for (const href of hrefs) {
+      const path = href.split('#')[0];
+      if (!path) continue;
+      await expectRouteHealthy(request, path);
+    }
+  });
+
+  test('marketplace exposes active filter state and normalized CTA language', async ({ page }) => {
+    await page.goto(`${baseURL}/store#marketplace`);
+    const all = page.getByRole('button', { name: 'All', exact: true });
+    await expect(all).toHaveAttribute('aria-pressed', 'true');
+
+    const education = page.getByRole('button', { name: 'Education', exact: true });
+    await education.click();
+    await expect(education).toHaveAttribute('aria-pressed', 'true');
+    await expect(all).toHaveAttribute('aria-pressed', 'false');
+
+    await expect(page.getByText('Demo + Subscription')).toHaveCount(0);
+    await expect(page.getByText('View / Start')).toHaveCount(0);
+    await expect(page.getByText('See How It Works').first()).toBeVisible();
+  });
+
+  test('guided setup carries recommendations into trial', async ({ page }) => {
+    await page.goto(`${baseURL}/store#guided-setup`);
+    await page.getByRole('button', { name: 'Start or grow a business' }).click();
+    await page.getByRole('button', { name: 'Small business' }).click();
+
+    const guidedTrial = page.getByRole('link', { name: 'Start guided trial' });
+    await expect(guidedTrial).toHaveAttribute('href', /recommended=/);
+    await guidedTrial.click();
+    await expect(page).toHaveURL(/\/store\/trial\?/);
+    await expect(page.getByText('Your guided recommendations will carry forward')).toBeVisible();
+  });
+
+  test('ROI labels remain separate on a mobile viewport', async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    await page.goto(`${baseURL}/store`);
+    const roi = page.getByText('ROI Calculator').locator('..').locator('..');
+    await expect(page.getByText('Students per Year')).toBeVisible();
+    const body = await page.textContent('body');
+    expect(body).not.toContain('1050500');
+    await expect(page.getByText('10', { exact: true }).first()).toBeVisible();
+    await expect(page.getByText('500', { exact: true }).first()).toBeVisible();
+    expect(await roi.count()).toBeGreaterThanOrEqual(0);
+  });
+});


### PR DESCRIPTION
Closes #684.

This PR implements the root-level Store repair rather than isolated page patches:

- adds a shared idempotent owner-access provisioning service used by normal trials and demo conversions
- records onboarding stage state and returns success only after identity/profile/org membership/tenant membership/Website Builder entitlement/ownership are ready
- restores `/store/demo/crm`, `/store/demo/lms`, and `/store/demo/website` as compatibility routes into canonical experiences
- preserves guided setup recommendations into the trial request/workspace metadata
- normalizes public availability labels so internal `repair` state is not exposed as product status
- normalizes CTA language and pricing context
- clearly distinguishes role demos from capability product tours
- simplifies Store hierarchy to one primary trial CTA and one proof path
- adds Playwright regression coverage for core routes, Store-owned links, CTA language, guided handoff, filters, and mobile ROI labels

Existing trial-expiration enforcement in `syncIndividualAppSubscription` is preserved; expired free app trials are already transitioned inactive with an upgrade URL and paid billing checks fail closed.