### PR TITLE
Fix current Marketing and LMS production build blockers

### DIFF
--- a/Dockerfile.marketing
+++ b/Dockerfile.marketing
@@ -12,14 +12,17 @@ WORKDIR /workspace
 FROM base AS dependencies
 
 COPY package.json pnpm-lock.yaml pnpm-workspace.yaml ./
+COPY apps/admin/package.json ./apps/admin/package.json
+COPY apps/lms/package.json ./apps/lms/package.json
 COPY apps/marketing/package.json ./apps/marketing/package.json
-COPY packages ./packages
+COPY packages/config/package.json ./packages/config/package.json
+COPY packages/db/package.json ./packages/db/package.json
+COPY packages/shared/package.json ./packages/shared/package.json
+COPY packages/ui/package.json ./packages/ui/package.json
 
-# Marketing never imports ffmpeg-static; runtime video tooling resolves FFmpeg
-# through @ffmpeg-installer/ffmpeg. Do not allow ffmpeg-static's postinstall to
-# download a GitHub-hosted binary during every production image build. That
-# external download has caused ECONNRESET/socket-hang-up failures on Northflank.
-RUN node -e "const fs=require('fs'); const p=JSON.parse(fs.readFileSync('package.json','utf8')); if (p.pnpm?.onlyBuiltDependencies) p.pnpm.onlyBuiltDependencies=p.pnpm.onlyBuiltDependencies.filter((name)=>name!=='ffmpeg-static'); fs.writeFileSync('package.json', JSON.stringify(p,null,2)+'\\n');"
+# Keep the dependency graph identical to source control. Mutating package.json
+# inside the image before a frozen install creates a manifest/lockfile mismatch
+# and makes production builds non-reproducible.
 RUN pnpm install --frozen-lockfile --strict-peer-dependencies=false
 
 FROM base AS builder
@@ -42,11 +45,8 @@ ENV BUILD_TIMESTAMP=$BUILD_TIMESTAMP
 COPY --from=dependencies /workspace/node_modules ./node_modules
 COPY . .
 
-# Capture a real build timestamp even when Northflank does not inject one.
 RUN node -e "const fs=require('fs'); const raw=process.env.BUILD_TIMESTAMP; const ts=raw&&raw!=='unknown'?raw:new Date().toISOString(); fs.writeFileSync('lib/version/generated-build-timestamp.ts', 'export const GENERATED_BUILD_TIMESTAMP = '+JSON.stringify(ts)+';\n'); fs.writeFileSync('/tmp/elevate-build-timestamp', ts); console.log('Marketing build timestamp:', ts)"
 
-# Northflank injects NF_GIT_SHA for Git builds. Use it as the only immutable
-# build identity so deployment does not require a config PATCH per commit.
 RUN EFFECTIVE_SHA="${NF_GIT_SHA}" && \
     EFFECTIVE_BUILT_AT="$(cat /tmp/elevate-build-timestamp)" && \
     test -n "${EFFECTIVE_SHA}" && \
@@ -97,12 +97,6 @@ COPY --from=builder --chown=nextjs:nodejs \
     /workspace/apps/marketing/.next/static \
     ./apps/marketing/.next/static/
 
-# Root public/ is the single canonical Marketing asset tree. Do not overlay the
-# entire apps/marketing/public directory: broad overlays create two competing
-# sources of truth and can silently replace a corrected production asset.
-# The only app-local runtime asset not represented by root public/ is the
-# generated hero-banner data file, so copy that file explicitly after the
-# canonical public tree is installed.
 COPY --from=builder --chown=nextjs:nodejs /workspace/public ./public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/public ./apps/marketing/public/
 COPY --from=builder --chown=nextjs:nodejs /workspace/apps/marketing/public/data/hero-banners.json ./public/data/hero-banners.json

--- a/apps/lms/app/api/videos/generate/route.ts
+++ b/apps/lms/app/api/videos/generate/route.ts
@@ -2,44 +2,17 @@ import { logger } from '@/lib/logger';
 /**
  * POST /api/videos/generate
  *
- * Accepts a lesson_id from the admin course builder, creates a video_jobs row,
- * then fires the render pipeline asynchronously (non-blocking response).
- *
- * The render runs in the background on the container which has
- * ffmpeg, chromium, and Remotion's native binaries available.
- *
- * Flow:
- *   Admin POST lesson_id
- *   → create video_jobs row (status: queued)
- *   → return job_id immediately
- *   → background: render MP4 → upload to Supabase Storage
- *   → markComplete() updates video_jobs + course_lessons
- *
- * Admin polls GET /api/videos/status/:job_id until status = 'complete'.
+ * Video rendering is an Admin-owned production capability. The learner LMS
+ * keeps this legacy endpoint only as a compatibility bridge so old clients do
+ * not pull Remotion/Rspack/TTS native tooling into the learner build graph.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
 import { apiRequireAdmin } from '@/lib/admin/guards';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError } from '@/lib/api/safe-error';
-import { getErrorContext, normalizeError } from '@/lib/errors/normalize-error';
-import { createJob, markRendering, markComplete, markFailed } from '@/lib/video/job-queue';
-
-// Remotion's bundler reaches native @rspack binaries. A static import causes
-// Next/Webpack to trace those ELF binaries during the LMS image build. Keep the
-// entire render pipeline behind the same runtime-only boundary used by Admin.
-type RemotionRender = typeof import('@/lib/video/remotion-render');
-let remotionRender: RemotionRender | null = null;
-async function getRemotionRender(): Promise<RemotionRender> {
-  if (!remotionRender) {
-    remotionRender = await import('@/lib/video/remotion-render');
-  }
-  return remotionRender;
-}
 
 export const runtime = 'nodejs';
-export const maxDuration = 600;
 
 export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
@@ -57,116 +30,26 @@ export async function POST(request: NextRequest) {
     return safeError('Invalid JSON body', 400);
   }
 
-  const supabase = await createClient();
-  const { data: lesson, error: lessonErr } = await supabase
-    .from('course_lessons')
-    .select('id, title, script, bullet_points, duration_seconds, course_id, video_status')
-    .eq('id', lessonId)
-    .maybeSingle();
-
-  if (lessonErr || !lesson) return safeError('Lesson not found', 404);
-  if (lesson.video_status === 'rendering') return safeError('Video is already rendering', 409);
-
-  const { data: course } = await supabase
-    .from('courses')
-    .select('id, title')
-    .eq('id', lesson.course_id)
-    .maybeSingle();
-
-  const job = await createJob({
-    lesson_id: lessonId,
-    course_id: lesson.course_id,
-    lesson_title: lesson.title,
-    script: lesson.script ?? undefined,
-    bullet_points: Array.isArray(lesson.bullet_points) ? lesson.bullet_points : [],
-  });
-
-  runRender({
-    jobId: job.id,
+  const adminBase = (process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.elevateforhumanity.org').replace(/\/$/, '');
+  logger.warn('[VideoGenerate] Legacy LMS generation endpoint redirected to Admin-owned renderer', {
     lessonId,
-    courseId: lesson.course_id,
-    lessonTitle: lesson.title,
-    courseTitle: course?.title ?? 'Elevate LMS',
-    script: lesson.script ?? lesson.title,
-    bulletPoints: Array.isArray(lesson.bullet_points) ? lesson.bullet_points : [],
-    durationSecs: lesson.duration_seconds ?? undefined,
-  }).catch((err) => {
-    logger.error(
-      '[VideoGenerate] Background render threw',
-      normalizeError(err, 'Video generation error'),
-      getErrorContext(err),
-    );
   });
 
   return NextResponse.json(
     {
-      success: true,
-      job_id: job.id,
-      status: 'queued',
-      message: 'Video render queued. Poll /api/videos/status/' + job.id + ' for progress.',
+      success: false,
+      code: 'ADMIN_VIDEO_RENDER_REQUIRED',
+      message: 'Video generation is managed from Admin Dev Studio.',
+      admin_url: `${adminBase}/studio/courses`,
+      lesson_id: lessonId,
     },
-    { status: 202 },
+    {
+      status: 409,
+      headers: {
+        Deprecation: 'true',
+        Sunset: 'Wed, 30 Sep 2026 23:59:59 GMT',
+        Link: `<${adminBase}/studio/courses>; rel="alternate"`,
+      },
+    },
   );
-}
-
-async function runRender(opts: {
-  jobId: string;
-  lessonId: string;
-  courseId: string;
-  lessonTitle: string;
-  courseTitle: string;
-  script: string;
-  bulletPoints: string[];
-  durationSecs?: number;
-}) {
-  const { jobId, lessonId, courseTitle, lessonTitle, script, bulletPoints } = opts;
-
-  await markRendering(jobId);
-
-  try {
-    const { renderLessonVideo, inferDomainKey } = await getRemotionRender();
-    const domainKey = inferDomainKey(courseTitle, lessonTitle);
-    const instructorId = inferInstructorId(courseTitle);
-
-    const result = await renderLessonVideo({
-      lessonId,
-      title: lessonTitle,
-      moduleTitle: courseTitle,
-      objective: lessonTitle,
-      keyPoints: bulletPoints.length
-        ? bulletPoints
-        : script.split(/\.\s+/).filter(Boolean).slice(0, 5),
-      example: script.substring(0, 300),
-      summary: script.substring(0, 150),
-      quizTeaser: 'Complete the knowledge check to continue.',
-      domainKey,
-      instructorId,
-      courseName: courseTitle,
-    });
-
-    if (!result.success || !result.videoUrl) {
-      await markFailed(jobId, result.error ?? 'Render returned no video URL');
-      return;
-    }
-
-    await markComplete(jobId, {
-      video_url: result.videoUrl,
-      audio_url: result.audioUrl ?? undefined,
-      duration_seconds: result.duration,
-      scene_count: undefined,
-    });
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    await markFailed(jobId, msg);
-  }
-}
-
-function inferInstructorId(courseTitle: string): string {
-  const title = courseTitle.toLowerCase();
-  if (/barber|cosmetology|hair/.test(title)) return 'james-williams';
-  if (/business|entrepreneur|esb|marketing/.test(title)) return 'angela-thompson';
-  if (/health|medical|nursing|cna/.test(title)) return 'dr-sarah-chen';
-  if (/technology|cyber|computer|digital/.test(title)) return 'lisa-martinez';
-  if (/cdl|transport|logistics/.test(title)) return 'robert-davis';
-  return 'marcus-johnson';
 }

--- a/apps/lms/app/api/videos/regenerate/route.ts
+++ b/apps/lms/app/api/videos/regenerate/route.ts
@@ -2,41 +2,17 @@ import { logger } from '@/lib/logger';
 /**
  * POST /api/videos/regenerate
  *
- * Re-queues a video render for a lesson that previously failed or
- * whose video needs to be refreshed after script/content changes.
- *
- * Creates a new video_jobs row (preserving history) and fires a fresh render.
- * The old job row is left intact for audit purposes.
- *
- * Input:  { lesson_id: string }
- * Output: { job_id, status: 'queued' }
+ * Video rendering is an Admin-owned production capability. The learner LMS
+ * keeps this legacy endpoint only as a compatibility bridge so old clients do
+ * not pull Remotion/Rspack/TTS native tooling into the learner build graph.
  */
 
 import { NextRequest, NextResponse } from 'next/server';
-import { createClient } from '@/lib/supabase/server';
-import { requireAdminClient } from '@/lib/supabase/admin';
 import { apiRequireAdmin } from '@/lib/admin/guards';
 import { applyRateLimit } from '@/lib/api/withRateLimit';
 import { safeError } from '@/lib/api/safe-error';
-import { resetJob, markRendering, markComplete, markFailed } from '@/lib/video/job-queue';
-import { getErrorContext, normalizeError } from '@/lib/errors/normalize-error';
-import { readFile, unlink } from 'fs/promises';
-import path from 'path';
-
-// Keep Remotion/Rspack native binaries out of the LMS webpack graph. The
-// renderer is loaded only when an authenticated admin actually requests a
-// regeneration, matching the canonical Admin video-generation boundary.
-type RemotionRender = typeof import('@/lib/video/remotion-render');
-let remotionRender: RemotionRender | null = null;
-async function getRemotionRender(): Promise<RemotionRender> {
-  if (!remotionRender) {
-    remotionRender = await import('@/lib/video/remotion-render');
-  }
-  return remotionRender;
-}
 
 export const runtime = 'nodejs';
-export const maxDuration = 600;
 
 export async function POST(request: NextRequest) {
   const rateLimited = await applyRateLimit(request, 'strict');
@@ -54,110 +30,26 @@ export async function POST(request: NextRequest) {
     return safeError('Invalid JSON body', 400);
   }
 
-  const supabase = await createClient();
-  const adminDb = await requireAdminClient();
-
-  const { data: lesson } = await supabase
-    .from('course_lessons')
-    .select('id, title, script, bullet_points, course_id, video_status')
-    .eq('id', lessonId)
-    .maybeSingle();
-
-  if (!lesson) return safeError('Lesson not found', 404);
-  if (lesson.video_status === 'rendering') return safeError('Video is already rendering', 409);
-
-  const { data: course } = await supabase
-    .from('courses')
-    .select('title')
-    .eq('id', lesson.course_id)
-    .maybeSingle();
-
-  const job = await resetJob(lessonId, lesson.course_id);
-
-  runRender({
-    jobId: job.id,
+  const adminBase = (process.env.NEXT_PUBLIC_ADMIN_URL || 'https://admin.elevateforhumanity.org').replace(/\/$/, '');
+  logger.warn('[VideoRegenerate] Legacy LMS regeneration endpoint redirected to Admin-owned renderer', {
     lessonId,
-    courseTitle: course?.title ?? 'Elevate LMS',
-    lessonTitle: lesson.title,
-    script: lesson.script ?? lesson.title,
-    bulletPoints: Array.isArray(lesson.bullet_points) ? lesson.bullet_points : [],
-    adminDb,
-  }).catch((err) => {
-    logger.error('[VideoRegenerate] Background render threw', normalizeError(err, 'Video regeneration error'), getErrorContext(err));
   });
 
   return NextResponse.json(
     {
-      success: true,
-      job_id: job.id,
-      status: 'queued',
-      message: 'Video re-render queued. Poll /api/videos/status/' + job.id,
+      success: false,
+      code: 'ADMIN_VIDEO_RENDER_REQUIRED',
+      message: 'Video regeneration is managed from Admin Dev Studio.',
+      admin_url: `${adminBase}/studio/courses`,
+      lesson_id: lessonId,
     },
-    { status: 202 },
+    {
+      status: 409,
+      headers: {
+        Deprecation: 'true',
+        Sunset: 'Wed, 30 Sep 2026 23:59:59 GMT',
+        Link: `<${adminBase}/studio/courses>; rel="alternate"`,
+      },
+    },
   );
-}
-
-async function runRender(opts: {
-  jobId: string;
-  lessonId: string;
-  courseTitle: string;
-  lessonTitle: string;
-  script: string;
-  bulletPoints: string[];
-  adminDb: NonNullable<Awaited<ReturnType<typeof requireAdminClient>>>;
-}) {
-  const { jobId, lessonId, courseTitle, lessonTitle, script, bulletPoints, adminDb } = opts;
-
-  await markRendering(jobId);
-
-  try {
-    const { renderLessonVideo, inferDomainKey } = await getRemotionRender();
-    const result = await renderLessonVideo({
-      lessonId,
-      title: lessonTitle,
-      moduleTitle: courseTitle,
-      objective: lessonTitle,
-      keyPoints: bulletPoints.length
-        ? bulletPoints
-        : script.split(/\.\s+/).filter(Boolean).slice(0, 5),
-      example: script.substring(0, 300),
-      summary: script.substring(0, 150),
-      quizTeaser: 'Complete the knowledge check to continue.',
-      domainKey: inferDomainKey(courseTitle, lessonTitle),
-      courseName: courseTitle,
-    });
-
-    if (!result.success || !result.videoUrl) {
-      await markFailed(jobId, result.error ?? 'Render returned no video URL');
-      return;
-    }
-
-    const localPath = path.join(process.cwd(), 'public', result.videoUrl);
-    let storageUrl = result.videoUrl;
-
-    try {
-      const buffer = await readFile(localPath);
-      const storagePath = `lessons/${lessonId}/lesson-video.mp4`;
-      const { error: uploadErr } = await adminDb.storage
-        .from('course-videos')
-        .upload(storagePath, buffer, { contentType: 'video/mp4', upsert: true });
-
-      if (!uploadErr) {
-        const { data: urlData } = adminDb.storage.from('course-videos').getPublicUrl(storagePath);
-        storageUrl = urlData.publicUrl;
-        await unlink(localPath).then(() => {}, () => {});
-      }
-    } catch {
-      /* keep local URL */
-    }
-
-    await markComplete(jobId, {
-      video_url: storageUrl,
-      audio_url: result.audioUrl ?? undefined,
-      duration_seconds: result.duration,
-    });
-  } catch (err) {
-    const failMsg = err instanceof Error ? err.message : String(err);
-    await markFailed(jobId, failMsg);
-  }
 }

--- a/apps/lms/next.config.mjs
+++ b/apps/lms/next.config.mjs
@@ -23,8 +23,6 @@ const nextConfig = {
     return { beforeFiles: legacyImageRewrites(), afterFiles: [], fallback: [] };
   },
   async redirects() {
-    // Compatibility redirects live here instead of redirect-only page files.
-    // Internal application code must point directly at the canonical routes.
     return [
       { source: '/reset', destination: '/support/reset-browser', permanent: true },
       { source: '/reset/done', destination: '/support/reset-browser/done', permanent: true },
@@ -41,7 +39,6 @@ const nextConfig = {
       { source: '/store', destination: 'https://www.elevateforhumanity.org/store', permanent: true },
     ];
   },
-  serverExternalPackages: ['@remotion/bundler', '@remotion/renderer', '@remotion/licensing', 'esbuild', 'edge-tts'],
   webpack: (config, { isServer, webpack }) => {
     if (!isServer) {
       config.plugins = config.plugins || [];


### PR DESCRIPTION
Production release repair for the current red Northflank checks.

Changes:
- makes Marketing Docker dependency installation reproducible: no package.json mutation before frozen lockfile install, and all workspace manifests are present
- removes duplicate Admin-owned Remotion/TTS render runtime from the learner LMS build graph while retaining authenticated compatibility responses
- removes Admin-only Remotion/edge-tts external-package declarations from LMS Next config

Current main evidence before this PR:
- Admin Northflank build: success
- LMS wide-cheese-3647: failure
- Marketing aromatic-credit-7786: failure

This branch is based exactly on current main SHA 13db3f6940e9897dc007631b361555d7e7ea019b and does not include unrelated changes.