### PR TITLE
Fix Admin route release gate safely

### DIFF
--- a/.github/workflows/one-time-admin-route-canonicalization.yml
+++ b/.github/workflows/one-time-admin-route-canonicalization.yml
@@ -1,0 +1,93 @@
+name: One-time source-aware Admin route canonicalization
+
+on:
+  push:
+    branches:
+      - fix/admin-route-gate-clean
+
+permissions:
+  contents: write
+
+jobs:
+  canonicalize:
+    if: github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: fix/admin-route-gate-clean
+          fetch-depth: 0
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10.28.2
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: pnpm-lock.yaml
+      - name: Canonicalize retired Admin UI routes by owning surface
+        shell: python
+        run: |
+          from pathlib import Path
+          import re
+
+          extensions = {'.ts', '.tsx', '.js', '.jsx', '.mjs'}
+
+          def files(root):
+              p = Path(root)
+              if not p.exists():
+                  return []
+              return [f for f in p.rglob('*') if f.is_file() and f.suffix in extensions]
+
+          def rewrite_admin_owned(text):
+              # Admin service is mounted at admin.elevateforhumanity.org root.
+              # Do not touch /api/admin, which is the valid API namespace.
+              text = re.sub(r'(["\'`])/admin(?=/)', r'\1', text)
+              text = re.sub(r'(["\'`])/admin(["\'`])', r'\1/\2', text)
+              return text
+
+          def rewrite_cross_service(text):
+              # LMS/shared code crossing into Admin must use the Admin host.
+              text = re.sub(r'(["\'`])/admin(?=/)', r'\1https://admin.elevateforhumanity.org', text)
+              text = re.sub(r'(["\'`])/admin(["\'`])', r'\1https://admin.elevateforhumanity.org/\2', text)
+              return text
+
+          changed = []
+          for path in files('apps/admin/app'):
+              before = path.read_text(encoding='utf-8')
+              after = rewrite_admin_owned(before)
+              if after != before:
+                  path.write_text(after, encoding='utf-8')
+                  changed.append(str(path))
+
+          for root in ['apps/lms/app', 'components', 'lib/routes']:
+              for path in files(root):
+                  before = path.read_text(encoding='utf-8')
+                  after = rewrite_cross_service(before)
+                  if after != before:
+                      path.write_text(after, encoding='utf-8')
+                      changed.append(str(path))
+
+          print(f'Canonicalized {len(changed)} files')
+          for path in changed:
+              print(path)
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile --strict-peer-dependencies=false
+      - name: Verify exact release-gate test
+        run: pnpm exec vitest run tests/unit/course-builder-route-consolidation.test.ts
+      - name: Verify Course Factory authority
+        run: node scripts/check-course-factory-authority.mjs
+      - name: Remove one-time workflow and commit verified source
+        shell: bash
+        run: |
+          set -euo pipefail
+          rm .github/workflows/one-time-admin-route-canonicalization.yml
+          git config user.name 'github-actions[bot]'
+          git config user.email '41898282+github-actions[bot]@users.noreply.github.com'
+          git add apps/admin/app apps/lms/app components lib/routes .github/workflows/one-time-admin-route-canonicalization.yml
+          if git diff --cached --quiet; then
+            echo 'No source changes required.'
+            exit 0
+          fi
+          git commit -m 'fix(routes): canonicalize Admin UI navigation by service ownership'
+          git push origin HEAD:fix/admin-route-gate-clean


### PR DESCRIPTION
Replaces retired /admin UI navigation using source ownership: Admin-internal routes become root-relative; LMS/shared callers cross to admin.elevateforhumanity.org. The branch runs the exact route-consolidation unit test and Course Factory authority gate before committing generated source changes.