### PR TITLE
Validate restored PR695 release gates

### DIFF
--- a/apps/lms/app/ai/course-factory/page.tsx
+++ b/apps/lms/app/ai/course-factory/page.tsx
@@ -1,3 +1,4 @@
+// Validation-only no-op comment to trigger app-path release gates.
 import { Metadata } from 'next';
 import Link from 'next/link';
 import { Sparkles, FileText, CheckCircle, Clock, Award, Video, FileQuestion, GraduationCap } from 'lucide-react';


### PR DESCRIPTION
Validation-only PR from exact current main. Runtime difference is one inert source comment so normal app-path CI gates execute. This is used to inspect and fix any remaining release failures before declaring the restored #695 fixes green/live.