### PR TITLE
QA: execute authenticated apprenticeship gate on main

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -2,6 +2,13 @@ name: Registered Apprenticeship E2E
 
 on:
   workflow_dispatch:
+  push:
+    branches:
+      - main
+    paths:
+      - '.github/workflows/registered-apprenticeship-e2e.yml'
+      - 'tests/e2e/registered-apprenticeship-authenticated.spec.ts'
+      - 'scripts/check-registered-apprenticeship-architecture.mjs'
   workflow_run:
     workflows:
       - Deploy LMS
@@ -14,7 +21,7 @@ concurrency:
 
 jobs:
   production-authenticated-e2e:
-    if: github.event_name == 'workflow_dispatch' || github.event.workflow_run.conclusion == 'success'
+    if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: Apprentice + Host Shop authenticated persistence
     runs-on: ubuntu-latest
     timeout-minutes: 25


### PR DESCRIPTION
Adds an immediate main-push trigger for the existing production-safe Host Shop + Apprentice Playwright gate while retaining the automatic post-Deploy-LMS workflow_run trigger. This lets the current walkthrough execute now and continue protecting future deployments. The concurrent main change did not touch this workflow; the exact main blob was re-read before merge.