### PR TITLE
QA: expand Host Shop and Apprentice production walkthrough

### DIFF
--- a/tests/e2e/registered-apprenticeship-authenticated.spec.ts
+++ b/tests/e2e/registered-apprenticeship-authenticated.spec.ts
@@ -14,31 +14,75 @@ async function login(page: Page, email: string, password: string) {
   await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
 }
 
+async function expectPortalRoute(page: Page, path: string, expectedText?: RegExp) {
+  const response = await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded' });
+  expect(response?.status() ?? 200, `${path} returned a server error`).toBeLessThan(500);
+  expect(page.url(), `${path} redirected to unauthorized`).not.toContain('/unauthorized');
+  expect(page.url(), `${path} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
+  if (expectedText) await expect(page.locator('body')).toContainText(expectedText);
+}
+
 test.describe('Registered apprenticeship authorization', () => {
   test.skip(!APPRENTICE_EMAIL || !APPRENTICE_PASSWORD, 'Authenticated apprentice credentials are required');
 
-  test('apprentice can reach canonical apprentice and RTI surfaces but cannot use Host Shop verifier API', async ({ page }) => {
+  test('apprentice can use canonical dashboard surfaces but cannot use Host Shop verifier API', async ({ page }) => {
     await login(page, APPRENTICE_EMAIL, APPRENTICE_PASSWORD);
 
-    const dashboard = await page.goto(`${BASE}/apprentice`, { waitUntil: 'domcontentloaded' });
-    expect(dashboard?.status() ?? 200).toBeLessThan(500);
-    expect(page.url()).not.toContain('/unauthorized');
-    await expect(page.locator('body')).toContainText(/apprentice|registered|competenc|RTI/i);
+    await expectPortalRoute(page, '/apprentice', /apprentice|registered|competenc|RTI/i);
 
-    const rti = await page.goto(`${BASE}/apprentice/rti`, { waitUntil: 'domcontentloaded' });
-    expect(rti?.status() ?? 200).toBeLessThan(500);
-    expect(page.url()).not.toContain('/unauthorized');
+    const readOnlySurfaces = [
+      '/apprentice/hours',
+      '/apprentice/rti',
+      '/apprentice/competencies',
+      '/apprentice/documents',
+      '/apprentice/attendance',
+      '/apprentice/profile',
+      '/apprentice/handbook',
+    ];
+    for (const path of readOnlySurfaces) await expectPortalRoute(page, path);
 
     const forbidden = await page.request.patch(`${BASE}/api/host-shop/competencies`, {
       data: { enrollmentId: '00000000-0000-0000-0000-000000000000', competencyId: 'not-authorized', completed: true },
       failOnStatusCode: false,
     });
     expect([401, 403]).toContain(forbidden.status());
+
+    const hostDashboard = await page.request.get(`${BASE}/host-shop/dashboard`, { failOnStatusCode: false });
+    expect([302, 303, 307, 308, 401, 403]).toContain(hostDashboard.status());
   });
 });
 
-test.describe('Host Shop reversible competency persistence', () => {
+test.describe('Host Shop production workspace', () => {
   test.skip(!HOST_EMAIL || !HOST_PASSWORD, 'Authenticated Host Shop credentials are required');
+
+  test('assigned Host Shop can reach scoped operational surfaces', async ({ page }) => {
+    await login(page, HOST_EMAIL, HOST_PASSWORD);
+
+    await expectPortalRoute(page, '/host-shop/dashboard', /host shop/i);
+
+    const operationalSurfaces = [
+      '/host-shop/dashboard/apprentices',
+      '/host-shop/dashboard/hours/pending',
+      '/host-shop/dashboard/documents',
+      '/host-shop/dashboard/competencies',
+      '/host-shop/dashboard/attendance/record',
+      '/host-shop/dashboard/wages',
+      '/host-shop/dashboard/reports',
+      '/host-shop/dashboard/profile',
+    ];
+    for (const path of operationalSurfaces) await expectPortalRoute(page, path);
+
+    const listResponse = await page.request.get(`${BASE}/api/host-shop/competencies`, { failOnStatusCode: false });
+    expect(listResponse.status()).toBe(200);
+    const list = await listResponse.json();
+    expect(Array.isArray(list.apprentices)).toBe(true);
+    expect(list.apprentices.length).toBeGreaterThan(0);
+
+    for (const item of list.apprentices) {
+      expect(item?.enrollmentId).toBeTruthy();
+      expect(item?.standard).toBeTruthy();
+    }
+  });
 
   test('assigned Host Shop verifier can persist a competency change and restore the original state', async ({ page }) => {
     await login(page, HOST_EMAIL, HOST_PASSWORD);


### PR DESCRIPTION
Expands the dedicated authenticated production Playwright gate to cover Apprentice hours, RTI, competencies, documents, attendance, profile and handbook plus Host Shop apprentices, pending hours, documents, competencies, attendance, wages, reports and profile. Retains reversible competency mutation and RBAC denial proof. No real participant fixture changes.