### PR TITLE
QA: fix Apprentice direct RBAC assertion

### DIFF
--- a/tests/e2e/registered-apprenticeship-authenticated.spec.ts
+++ b/tests/e2e/registered-apprenticeship-authenticated.spec.ts
@@ -47,7 +47,10 @@ test.describe('Registered apprenticeship authorization', () => {
     });
     expect([401, 403]).toContain(forbidden.status());
 
-    const hostDashboard = await page.request.get(`${BASE}/host-shop/dashboard`, { failOnStatusCode: false });
+    const hostDashboard = await page.request.get(`${BASE}/host-shop/dashboard`, {
+      failOnStatusCode: false,
+      maxRedirects: 0,
+    });
     expect([302, 303, 307, 308, 401, 403]).toContain(hostDashboard.status());
   });
 });


### PR DESCRIPTION
Stops Playwright from following the Host Shop dashboard redirect during Apprentice RBAC testing, so the gate evaluates the actual denial/redirect response instead of a final 200 login page. No runtime behavior changes.