### PR TITLE
QA: expose production Supabase secrets to authenticated E2E

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -29,6 +29,7 @@ jobs:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
     name: Apprentice + Host Shop authenticated persistence
     runs-on: ubuntu-latest
+    environment: production
     timeout-minutes: 25
     env:
       PLAYWRIGHT_BASE_URL: https://app.elevateforhumanity.org


### PR DESCRIPTION
Runs the apprenticeship production QA job in the existing GitHub `production` environment so it can access the same Supabase URL/service-role secrets already used by the LMS deploy workflow. This is required for short-lived fixture provisioning; no secret values are logged or persisted.