### PR TITLE
QA: certify portal responsive design across devices

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -7,7 +7,9 @@ on:
       - main
     paths:
       - '.github/workflows/registered-apprenticeship-e2e.yml'
+      - 'playwright.config.ts'
       - 'tests/e2e/registered-apprenticeship-authenticated.spec.ts'
+      - 'tests/e2e/portal-responsive-design.spec.ts'
       - 'scripts/check-registered-apprenticeship-architecture.mjs'
       - 'scripts/qa/provision-apprenticeship-e2e.mjs'
   workflow_run:
@@ -27,10 +29,10 @@ concurrency:
 jobs:
   production-authenticated-e2e:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    name: Apprentice + Host Shop authenticated persistence
+    name: Apprentice + Host Shop authenticated persistence and responsive design
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 25
+    timeout-minutes: 40
     env:
       PLAYWRIGHT_BASE_URL: https://app.elevateforhumanity.org
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -76,17 +78,19 @@ jobs:
           test -n "${SUPABASE_SERVICE_ROLE_KEY:-}" || { echo '::error::SUPABASE_SERVICE_ROLE_KEY is not configured'; exit 1; }
       - name: Provision disposable Host Shop + Apprentice identities
         run: node scripts/qa/provision-apprenticeship-e2e.mjs provision
-      - name: Install Chromium
-        run: pnpm exec playwright install chromium --with-deps
+      - name: Install Chromium and WebKit
+        run: pnpm exec playwright install chromium webkit --with-deps
       - name: Run registered-apprenticeship architecture gate
         run: node scripts/check-registered-apprenticeship-architecture.mjs
-      - name: Run authenticated production E2E
-        run: pnpm exec playwright test tests/e2e/registered-apprenticeship-authenticated.spec.ts --config playwright.config.ts --project=chromium
+      - name: Run authenticated production functional E2E
+        run: pnpm exec playwright test tests/e2e/registered-apprenticeship-authenticated.spec.ts --config playwright.config.ts --project=desktop-chrome
+      - name: Run authenticated cross-device responsive design certification
+        run: pnpm exec playwright test tests/e2e/portal-responsive-design.spec.ts --config playwright.config.ts --project=desktop-chrome --project=laptop-chrome --project=tablet-chrome --project=iphone-webkit --project=android-chrome
       - name: Clean disposable Host Shop + Apprentice identities
         if: always()
         run: node scripts/qa/provision-apprenticeship-e2e.mjs cleanup
-      - name: Upload failure evidence
-        if: failure()
+      - name: Upload QA evidence
+        if: always()
         uses: actions/upload-artifact@v4
         with:
           name: registered-apprenticeship-e2e-results
@@ -94,6 +98,7 @@ jobs:
             test-results/
             playwright-report/
           retention-days: 14
+          if-no-files-found: ignore
       - name: Publish production QA evidence
         if: always()
         env:
@@ -105,4 +110,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Host Shop + Apprentice production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixture: disposable CI-created Host Shop and Apprentice; cleanup runs on success or failure.\n- Scope: authenticated Apprentice dashboard/hours/RTI/competencies/documents/attendance/profile/handbook; authenticated Host Shop dashboard/apprentices/pending-hours/documents/competencies/attendance/wages/reports/profile; Host Shop competency write + restore; Apprentice-to-Host-Shop RBAC denial.\n- Result source: GitHub Actions production Playwright gate."
+          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Host Shop + Apprentice production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixture: disposable CI-created Host Shop and Apprentice; cleanup runs on success or failure.\n- Functional scope: Apprentice dashboard/hours/RTI/competencies/documents/attendance/profile/handbook; Host Shop dashboard/apprentices/pending-hours/documents/competencies/attendance/wages/reports/profile; Host Shop competency write + restore; Apprentice-to-Host-Shop RBAC denial.\n- Responsive design scope: desktop 1440x900, laptop 1280x720, iPad-class tablet, iPhone WebKit, Pixel-class Android Chromium. Checks page overflow, clipped critical controls, zero-size primary content, and undersized mobile form/button controls.\n- Evidence: Playwright traces/screenshots/report artifact retained for 14 days."

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test';
 
+const launchOptions = { args: ['--no-sandbox', '--disable-setuid-sandbox'] };
+
 export default defineConfig({
   globalSetup: './tests/e2e/global-setup.ts',
   testDir: './tests/e2e',
@@ -21,10 +23,42 @@ export default defineConfig({
   },
   projects: [
     {
-      name: 'chromium',
+      name: 'desktop-chrome',
       use: {
         ...devices['Desktop Chrome'],
-        launchOptions: { args: ['--no-sandbox', '--disable-setuid-sandbox'] },
+        viewport: { width: 1440, height: 900 },
+        launchOptions,
+      },
+    },
+    {
+      name: 'laptop-chrome',
+      use: {
+        ...devices['Desktop Chrome'],
+        viewport: { width: 1280, height: 720 },
+        launchOptions,
+      },
+    },
+    {
+      name: 'tablet-chrome',
+      use: {
+        ...devices['iPad Pro 11'],
+        browserName: 'chromium',
+        launchOptions,
+      },
+    },
+    {
+      name: 'iphone-webkit',
+      use: {
+        ...devices['iPhone 13'],
+        browserName: 'webkit',
+      },
+    },
+    {
+      name: 'android-chrome',
+      use: {
+        ...devices['Pixel 7'],
+        browserName: 'chromium',
+        launchOptions,
       },
     },
   ],

--- a/tests/e2e/portal-responsive-design.spec.ts
+++ b/tests/e2e/portal-responsive-design.spec.ts
@@ -1,0 +1,146 @@
+import { test, expect, type Page } from '@playwright/test';
+
+const BASE = process.env.PLAYWRIGHT_BASE_URL || 'https://app.elevateforhumanity.org';
+const APPRENTICE_EMAIL = process.env.E2E_APPRENTICE_EMAIL || '';
+const APPRENTICE_PASSWORD = process.env.E2E_APPRENTICE_PASSWORD || '';
+const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
+const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
+
+async function login(page: Page, email: string, password: string) {
+  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+  const emailInput = page.locator('input[type="email"], input[name="email"]').first();
+  const passwordInput = page.locator('input[type="password"]').first();
+  const submit = page.locator('button[type="submit"]').first();
+
+  await expect(emailInput).toBeVisible();
+  await expect(passwordInput).toBeVisible();
+  await expect(submit).toBeVisible();
+
+  await emailInput.fill(email);
+  await passwordInput.fill(password);
+  await submit.click();
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
+}
+
+async function assertResponsivePage(page: Page, path: string) {
+  const response = await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded' });
+  expect(response?.status() ?? 200, `${path} returned server error`).toBeLessThan(500);
+  expect(page.url(), `${path} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
+  expect(page.url(), `${path} redirected to unauthorized`).not.toContain('/unauthorized');
+
+  await page.waitForLoadState('networkidle').catch(() => {});
+
+  const geometry = await page.evaluate(() => {
+    const doc = document.documentElement;
+    const body = document.body;
+    const viewportWidth = window.innerWidth;
+    const viewportHeight = window.innerHeight;
+    const scrollWidth = Math.max(doc.scrollWidth, body?.scrollWidth || 0);
+    const main = document.querySelector('main') || document.querySelector('[role="main"]') || body;
+    const mainRect = main?.getBoundingClientRect();
+
+    const visibleCritical = Array.from(
+      document.querySelectorAll('button, input, select, textarea, a[href]'),
+    ).filter((element) => {
+      const el = element as HTMLElement;
+      const style = window.getComputedStyle(el);
+      const rect = el.getBoundingClientRect();
+      return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
+    });
+
+    const clippedCritical = visibleCritical
+      .filter((element) => {
+        const rect = (element as HTMLElement).getBoundingClientRect();
+        return rect.right > viewportWidth + 2 || rect.left < -2;
+      })
+      .slice(0, 10)
+      .map((element) => ({
+        tag: element.tagName,
+        text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
+        href: element.getAttribute('href'),
+      }));
+
+    return {
+      viewportWidth,
+      viewportHeight,
+      scrollWidth,
+      mainWidth: mainRect?.width || 0,
+      mainHeight: mainRect?.height || 0,
+      clippedCritical,
+    };
+  });
+
+  expect(
+    geometry.scrollWidth,
+    `${path} has page-level horizontal overflow: scrollWidth=${geometry.scrollWidth}, viewport=${geometry.viewportWidth}`,
+  ).toBeLessThanOrEqual(geometry.viewportWidth + 2);
+
+  expect(geometry.mainWidth, `${path} primary content has zero width`).toBeGreaterThan(0);
+  expect(geometry.mainHeight, `${path} primary content has zero height`).toBeGreaterThan(0);
+  expect(geometry.clippedCritical, `${path} has clipped critical controls`).toEqual([]);
+
+  const mobile = geometry.viewportWidth < 768;
+  if (mobile) {
+    const tinyCritical = await page.evaluate(() =>
+      Array.from(document.querySelectorAll('button, input, select, textarea'))
+        .filter((element) => {
+          const el = element as HTMLElement;
+          const rect = el.getBoundingClientRect();
+          const style = window.getComputedStyle(el);
+          if (style.display === 'none' || style.visibility === 'hidden' || rect.width === 0 || rect.height === 0) return false;
+          return rect.height < 32 || rect.width < 32;
+        })
+        .slice(0, 10)
+        .map((element) => ({
+          tag: element.tagName,
+          text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
+        })),
+    );
+    expect(tinyCritical, `${path} has undersized mobile form/button controls`).toEqual([]);
+  }
+}
+
+test.describe('Authenticated portal responsive design certification', () => {
+  test.describe('Apprentice', () => {
+    test.skip(!APPRENTICE_EMAIL || !APPRENTICE_PASSWORD, 'Disposable Apprentice identity is required');
+
+    test('critical Apprentice surfaces fit the active device viewport', async ({ page }, testInfo) => {
+      await login(page, APPRENTICE_EMAIL, APPRENTICE_PASSWORD);
+      for (const path of [
+        '/apprentice',
+        '/apprentice/hours',
+        '/apprentice/rti',
+        '/apprentice/competencies',
+        '/apprentice/documents',
+        '/apprentice/attendance',
+        '/apprentice/profile',
+        '/apprentice/handbook',
+      ]) {
+        await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
+      }
+      await page.screenshot({ path: testInfo.outputPath(`apprentice-${testInfo.project.name}.png`), fullPage: true });
+    });
+  });
+
+  test.describe('Host Shop', () => {
+    test.skip(!HOST_EMAIL || !HOST_PASSWORD, 'Disposable Host Shop identity is required');
+
+    test('critical Host Shop surfaces fit the active device viewport', async ({ page }, testInfo) => {
+      await login(page, HOST_EMAIL, HOST_PASSWORD);
+      for (const path of [
+        '/host-shop/dashboard',
+        '/host-shop/dashboard/apprentices',
+        '/host-shop/dashboard/hours/pending',
+        '/host-shop/dashboard/documents',
+        '/host-shop/dashboard/competencies',
+        '/host-shop/dashboard/attendance/record',
+        '/host-shop/dashboard/wages',
+        '/host-shop/dashboard/reports',
+        '/host-shop/dashboard/profile',
+      ]) {
+        await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
+      }
+      await page.screenshot({ path: testInfo.outputPath(`host-shop-${testInfo.project.name}.png`), fullPage: true });
+    });
+  });
+});


### PR DESCRIPTION
Adds an authenticated cross-device production design gate for Host Shop and Apprentice portals. Playwright now has explicit desktop (1440x900), laptop (1280x720), iPad-class tablet Chromium, iPhone WebKit, and Pixel-class Android Chromium projects. The responsive test fails on page-level horizontal overflow, clipped critical controls, zero-size primary content, server/login/unauthorized regressions, and undersized mobile form/button controls. The existing disposable production QA identities are reused and always cleaned up. Concurrent admissions changes on main touch different files; no overlap was found.