### PR TITLE
QA: fix disposable apprenticeship funding state

### DIFF
--- a/scripts/qa/provision-apprenticeship-e2e.mjs
+++ b/scripts/qa/provision-apprenticeship-e2e.mjs
@@ -172,7 +172,7 @@ async function provision() {
         access_granted_at: new Date().toISOString(),
         funding_source: 'SELF_PAY',
         funding_pathway: 'qa_e2e',
-        funding_status: 'self_pay',
+        funding_status: 'unfunded_self_continuing',
         payment_status: 'qa_test',
         funding_verified: false,
         organization_id: program.organization_id,


### PR DESCRIPTION
Fixes the production QA fixture to use the live allowed `program_enrollments.funding_status` value `unfunded_self_continuing` instead of invalid `self_pay`. This is test-fixture-only and does not alter real participant funding records. Concurrent PARIS admissions deployment on main touches different files.