### PR TITLE
QA: preserve audit history when cleaning disposable users

### DIFF
--- a/scripts/qa/provision-apprenticeship-e2e.mjs
+++ b/scripts/qa/provision-apprenticeship-e2e.mjs
@@ -266,8 +266,10 @@ async function cleanup() {
 
   for (const userId of [apprenticeId, hostId].filter(Boolean)) {
     await db.from('profiles').delete().eq('id', userId);
-    const { error } = await db.auth.admin.deleteUser(userId);
-    if (error && !/not found/i.test(error.message)) console.error(`delete auth user ${userId}: ${error.message}`);
+    // Preserve immutable audit-log foreign keys while disabling the disposable QA identity.
+    // Supabase soft delete prevents future sign-in without erasing compliance history.
+    const { error } = await db.auth.admin.deleteUser(userId, true);
+    if (error && !/not found/i.test(error.message)) console.error(`soft-delete auth user ${userId}: ${error.message}`);
   }
 
   console.log(JSON.stringify({ ok: true, cleanedRunId: state.runId }));


### PR DESCRIPTION
Changes disposable apprenticeship QA cleanup from hard-delete to Supabase soft-delete. The hard delete is blocked because immutable audit_logs retain actor_id references to test users. Soft delete disables future sign-in while preserving compliance/audit history and removes the mutable portal fixture rows normally.