### PR TITLE
QA: wait for login hydration before authenticated portal tests

### DIFF
--- a/tests/e2e/portal-responsive-design.spec.ts
+++ b/tests/e2e/portal-responsive-design.spec.ts
@@ -7,7 +7,7 @@ const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
 const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
 
 async function login(page: Page, email: string, password: string) {
-  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
+  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
   const emailInput = page.locator('input[type="email"], input[name="email"]').first();
   const passwordInput = page.locator('input[type="password"]').first();
   const submit = page.locator('button[type="submit"]').first();
@@ -18,6 +18,7 @@ async function login(page: Page, email: string, password: string) {
 
   await emailInput.fill(email);
   await passwordInput.fill(password);
+  await page.waitForTimeout(250);
   await submit.click();
   await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
 }

--- a/tests/e2e/registered-apprenticeship-authenticated.spec.ts
+++ b/tests/e2e/registered-apprenticeship-authenticated.spec.ts
@@ -7,10 +7,17 @@ const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
 const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
 
 async function login(page: Page, email: string, password: string) {
-  await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded' });
-  await page.locator('input[type="email"], input[name="email"]').first().fill(email);
-  await page.locator('input[type="password"]').first().fill(password);
-  await page.locator('button[type="submit"]').first().click();
+  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
+  const emailInput = page.locator('input[type="email"], input[name="email"]').first();
+  const passwordInput = page.locator('input[type="password"]').first();
+  const submit = page.locator('button[type="submit"]').first();
+  await expect(emailInput).toBeVisible();
+  await expect(passwordInput).toBeVisible();
+  await expect(submit).toBeVisible();
+  await emailInput.fill(email);
+  await passwordInput.fill(password);
+  await page.waitForTimeout(250);
+  await submit.click();
   await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
 }
 


### PR DESCRIPTION
Fixes the production E2E login helper to wait for the client login page to finish loading before filling/submitting credentials. The failed run showed a native pre-hydration form GET to `/login?`, so Supabase Auth was never called. This change prevents the harness from misclassifying that race as an authentication failure. Concurrent PARIS admissions changes on main touch different files.