### PR TITLE
QA: certify Learner and Program Holder responsive portals

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -12,6 +12,7 @@ on:
       - 'tests/e2e/portal-responsive-design.spec.ts'
       - 'scripts/check-registered-apprenticeship-architecture.mjs'
       - 'scripts/qa/provision-apprenticeship-e2e.mjs'
+      - 'scripts/qa/provision-learner-program-holder-e2e.mjs'
   workflow_run:
     workflows:
       - Deploy LMS
@@ -29,10 +30,10 @@ concurrency:
 jobs:
   production-authenticated-e2e:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    name: Apprentice + Host Shop authenticated persistence and responsive design
+    name: Portal authenticated persistence and responsive design
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 40
+    timeout-minutes: 55
     env:
       PLAYWRIGHT_BASE_URL: https://app.elevateforhumanity.org
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -58,15 +59,11 @@ jobs:
             health_status=$(curl -sS --max-time 10 -o /tmp/lms-health.json -w "%{http_code}" https://app.elevateforhumanity.org/api/health || true)
             if [[ "$ping_status" == "200" && "$health_status" == "200" ]] \
               && grep -q '"ok":true' /tmp/lms-ping.json \
-              && grep -q '"ready":true' /tmp/lms-health.json; then
-              exit 0
-            fi
+              && grep -q '"ready":true' /tmp/lms-health.json; then exit 0; fi
             echo "LMS not ready yet (ping=$ping_status health=$health_status), retry $i/20"
             sleep 15
           done
           echo "::error::Production LMS never reached ready state"
-          cat /tmp/lms-ping.json 2>/dev/null || true
-          cat /tmp/lms-health.json 2>/dev/null || true
           exit 1
       - name: Install dependencies
         run: pnpm install --frozen-lockfile --strict-peer-dependencies=false
@@ -78,6 +75,8 @@ jobs:
           test -n "${SUPABASE_SERVICE_ROLE_KEY:-}" || { echo '::error::SUPABASE_SERVICE_ROLE_KEY is not configured'; exit 1; }
       - name: Provision disposable Host Shop + Apprentice identities
         run: node scripts/qa/provision-apprenticeship-e2e.mjs provision
+      - name: Provision isolated Learner + Program Holder identities
+        run: node scripts/qa/provision-learner-program-holder-e2e.mjs provision
       - name: Install Chromium and WebKit
         run: pnpm exec playwright install chromium webkit --with-deps
       - name: Run registered-apprenticeship architecture gate
@@ -86,6 +85,9 @@ jobs:
         run: pnpm exec playwright test tests/e2e/registered-apprenticeship-authenticated.spec.ts --config playwright.config.ts --project=desktop-chrome
       - name: Run authenticated cross-device responsive design certification
         run: pnpm exec playwright test tests/e2e/portal-responsive-design.spec.ts --config playwright.config.ts --project=desktop-chrome --project=laptop-chrome --project=tablet-chrome --project=iphone-webkit --project=android-chrome
+      - name: Clean isolated Learner + Program Holder identities
+        if: always()
+        run: node scripts/qa/provision-learner-program-holder-e2e.mjs cleanup
       - name: Clean disposable Host Shop + Apprentice identities
         if: always()
         run: node scripts/qa/provision-apprenticeship-e2e.mjs cleanup
@@ -93,7 +95,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: registered-apprenticeship-e2e-results
+          name: portal-responsive-e2e-results
           path: |
             test-results/
             playwright-report/
@@ -110,4 +112,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Host Shop + Apprentice production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixture: disposable CI-created Host Shop and Apprentice; cleanup runs on success or failure.\n- Functional scope: Apprentice dashboard/hours/RTI/competencies/documents/attendance/profile/handbook; Host Shop dashboard/apprentices/pending-hours/documents/competencies/attendance/wages/reports/profile; Host Shop competency write + restore; Apprentice-to-Host-Shop RBAC denial.\n- Responsive design scope: desktop 1440x900, laptop 1280x720, iPad-class tablet, iPhone WebKit, Pixel-class Android Chromium. Checks page overflow, clipped critical controls, zero-size primary content, and undersized mobile form/button controls.\n- Evidence: Playwright traces/screenshots/report artifact retained for 14 days."
+          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Portal production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixtures: isolated disposable Host Shop, Apprentice, Learner and Program Holder identities; no real participant/program-holder data is attached.\n- Functional scope: Apprentice + Host Shop operational workflow and RBAC.\n- Responsive scope: Host Shop, Apprentice, Learner and Program Holder on desktop 1440x900, laptop 1280x720, iPad-class tablet, iPhone WebKit and Pixel-class Android Chromium.\n- Assertions: no 5xx, login/authorization regression, horizontal overflow, clipped critical controls, zero-size primary content or undersized mobile form/button controls.\n- Evidence: Playwright traces/screenshots/report artifact retained for 14 days."

--- a/scripts/qa/provision-learner-program-holder-e2e.mjs
+++ b/scripts/qa/provision-learner-program-holder-e2e.mjs
@@ -1,0 +1,63 @@
+import { createClient } from '@supabase/supabase-js';
+import { randomBytes } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+
+const action = process.argv[2] || 'provision';
+const statePath = process.env.QA_PORTAL_E2E_STATE_PATH || '.qa-learner-program-holder-e2e-state.json';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+if (!supabaseUrl || !serviceRoleKey) {
+  throw new Error('NEXT_PUBLIC_SUPABASE_URL/SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY are required');
+}
+
+const db = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+const runId = String(process.env.GITHUB_RUN_ID || Date.now());
+const marker = `qa-portal-e2e-${runId}`;
+
+function password() { return `Qa!${randomBytes(18).toString('base64url')}9x`; }
+async function must(resultPromise, label) { const result = await resultPromise; if (result.error) throw new Error(`${label}: ${result.error.message}`); return result.data; }
+
+async function createQaUser(kind, role, fullName, tenantId) {
+  const email = `${marker}-${kind}@qa.invalid`;
+  const pass = password();
+  const { data, error } = await db.auth.admin.createUser({ email, password: pass, email_confirm: true, app_metadata: { qa_e2e: true, qa_run_id: runId, role }, user_metadata: { qa_e2e: true, qa_run_id: runId, full_name: fullName } });
+  if (error || !data.user) throw new Error(`create ${kind} auth user: ${error?.message || 'no user returned'}`);
+  await must(db.from('profiles').upsert({ id: data.user.id, email, full_name: fullName, role, tenant_id: tenantId, updated_at: new Date().toISOString() }, { onConflict: 'id' }), `upsert ${kind} profile`);
+  return { id: data.user.id, email, password: pass };
+}
+
+async function provision() {
+  const anchor = await must(db.from('programs').select('organization_id,tenant_id').eq('slug', 'barber-apprenticeship').maybeSingle(), 'load tenant anchor');
+  if (!anchor?.tenant_id) throw new Error('Canonical tenant anchor is missing');
+  let state = { runId, marker, learner: null, programHolder: null, qaProgramId: null, holderId: null, holderProgramId: null };
+  try {
+    const learner = await createQaUser('learner', 'student', '[QA E2E] Learner', anchor.tenant_id); state.learner = learner;
+    const programHolder = await createQaUser('program-holder', 'program_holder', '[QA E2E] Program Holder', anchor.tenant_id); state.programHolder = programHolder;
+    const qaProgram = await must(db.from('programs').insert({ slug: `${marker}-program`, title: '[QA E2E] Isolated Program Holder Program', name: '[QA E2E] Isolated Program Holder Program', category: 'qa', description: 'Disposable isolated program used only for responsive production QA.', is_active: false, published: false, status: 'draft', review_status: 'draft', tenant_id: anchor.tenant_id, organization_id: anchor.organization_id, funding_eligible: false, is_free: true, enrollment_state: 'closed' }).select('id,slug').single(), 'create isolated QA program'); state.qaProgramId = qaProgram.id;
+    const holder = await must(db.from('program_holders').insert({ user_id: programHolder.id, organization_name: '[QA E2E] Isolated Program Holder', name: '[QA E2E] Program Holder', contact_name: '[QA E2E] Program Holder', contact_email: programHolder.email, status: 'approved', approved_at: new Date().toISOString(), mou_signed: true, mou_signed_at: new Date().toISOString(), mou_status: 'signed', is_using_internal_lms: true, payout_status: 'not_started', primary_program_id: qaProgram.id, teaches_multiple: false, features: { qa_e2e: true, qa_run_id: runId, isolated: true } }).select('id').single(), 'create isolated QA program holder'); state.holderId = holder.id;
+    await must(db.from('profiles').update({ program_holder_id: holder.id }).eq('id', programHolder.id), 'link QA profile to program holder');
+    const holderProgram = await must(db.from('program_holder_programs').insert({ program_holder_id: holder.id, program_id: qaProgram.id, program_slug: qaProgram.slug, role_in_program: 'owner', is_primary: true, status: 'active' }).select('id').single(), 'associate isolated QA program'); state.holderProgramId = holderProgram.id;
+    await writeFile(statePath, JSON.stringify(state, null, 2));
+    if (process.env.GITHUB_ENV) {
+      await writeFile(process.env.GITHUB_ENV, [`E2E_LEARNER_EMAIL=${learner.email}`, `E2E_LEARNER_PASSWORD=${learner.password}`, `E2E_PROGRAM_HOLDER_EMAIL=${programHolder.email}`, `E2E_PROGRAM_HOLDER_PASSWORD=${programHolder.password}`].join('\n') + '\n', { flag: 'a' });
+      console.log(`::add-mask::${learner.password}`); console.log(`::add-mask::${programHolder.password}`);
+    }
+    console.log(JSON.stringify({ ok: true, learnerUserId: learner.id, programHolderUserId: programHolder.id, holderId: holder.id, qaProgramId: qaProgram.id }));
+  } catch (error) { await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {}); await cleanup().catch((cleanupError) => console.error('cleanup after provision failure:', cleanupError)); throw error; }
+}
+
+async function cleanup() {
+  let state; try { state = JSON.parse(await readFile(statePath, 'utf8')); } catch { console.log('No Learner/Program Holder QA state file found; nothing to clean up.'); return; }
+  if (state.holderProgramId) await db.from('program_holder_programs').delete().eq('id', state.holderProgramId);
+  if (state.holderId) await db.from('program_holders').delete().eq('id', state.holderId);
+  if (state.qaProgramId) await db.from('programs').delete().eq('id', state.qaProgramId);
+  for (const userId of [state.learner?.id, state.programHolder?.id].filter(Boolean)) {
+    await db.from('profiles').delete().eq('id', userId);
+    const { error } = await db.auth.admin.deleteUser(userId, true);
+    if (error && !/not found/i.test(error.message)) console.error(`soft-delete auth user ${userId}: ${error.message}`);
+  }
+  console.log(JSON.stringify({ ok: true, cleanedRunId: state.runId }));
+}
+
+if (action === 'provision') await provision(); else if (action === 'cleanup') await cleanup(); else throw new Error(`Unknown action: ${action}`);

--- a/tests/e2e/portal-responsive-design.spec.ts
+++ b/tests/e2e/portal-responsive-design.spec.ts
@@ -5,17 +5,22 @@ const APPRENTICE_EMAIL = process.env.E2E_APPRENTICE_EMAIL || '';
 const APPRENTICE_PASSWORD = process.env.E2E_APPRENTICE_PASSWORD || '';
 const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
 const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
+const LEARNER_EMAIL = process.env.E2E_LEARNER_EMAIL || '';
+const LEARNER_PASSWORD = process.env.E2E_LEARNER_PASSWORD || '';
+const PROGRAM_HOLDER_EMAIL = process.env.E2E_PROGRAM_HOLDER_EMAIL || '';
+const PROGRAM_HOLDER_PASSWORD = process.env.E2E_PROGRAM_HOLDER_PASSWORD || '';
 
 async function login(page: Page, email: string, password: string) {
   await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
   const emailInput = page.locator('input[type="email"], input[name="email"]').first();
   const passwordInput = page.locator('input[type="password"]').first();
   const submit = page.locator('button[type="submit"]').first();
-
   await expect(emailInput).toBeVisible();
   await expect(passwordInput).toBeVisible();
   await expect(submit).toBeVisible();
-
+  await expect(emailInput).toBeEnabled();
+  await expect(passwordInput).toBeEnabled();
+  await expect(submit).toBeEnabled();
   await emailInput.fill(email);
   await passwordInput.fill(password);
   await page.waitForTimeout(250);
@@ -28,7 +33,6 @@ async function assertResponsivePage(page: Page, path: string) {
   expect(response?.status() ?? 200, `${path} returned server error`).toBeLessThan(500);
   expect(page.url(), `${path} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
   expect(page.url(), `${path} redirected to unauthorized`).not.toContain('/unauthorized');
-
   await page.waitForLoadState('networkidle').catch(() => {});
 
   const geometry = await page.evaluate(() => {
@@ -39,109 +43,66 @@ async function assertResponsivePage(page: Page, path: string) {
     const scrollWidth = Math.max(doc.scrollWidth, body?.scrollWidth || 0);
     const main = document.querySelector('main') || document.querySelector('[role="main"]') || body;
     const mainRect = main?.getBoundingClientRect();
-
-    const visibleCritical = Array.from(
-      document.querySelectorAll('button, input, select, textarea, a[href]'),
-    ).filter((element) => {
+    const visibleCritical = Array.from(document.querySelectorAll('button, input, select, textarea, a[href]')).filter((element) => {
       const el = element as HTMLElement;
       const style = window.getComputedStyle(el);
       const rect = el.getBoundingClientRect();
       return style.display !== 'none' && style.visibility !== 'hidden' && rect.width > 0 && rect.height > 0;
     });
-
-    const clippedCritical = visibleCritical
-      .filter((element) => {
-        const rect = (element as HTMLElement).getBoundingClientRect();
-        return rect.right > viewportWidth + 2 || rect.left < -2;
-      })
-      .slice(0, 10)
-      .map((element) => ({
-        tag: element.tagName,
-        text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
-        href: element.getAttribute('href'),
-      }));
-
-    return {
-      viewportWidth,
-      viewportHeight,
-      scrollWidth,
-      mainWidth: mainRect?.width || 0,
-      mainHeight: mainRect?.height || 0,
-      clippedCritical,
-    };
+    const clippedCritical = visibleCritical.filter((element) => {
+      const rect = (element as HTMLElement).getBoundingClientRect();
+      return rect.right > viewportWidth + 2 || rect.left < -2;
+    }).slice(0, 10).map((element) => ({
+      tag: element.tagName,
+      text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
+      href: element.getAttribute('href'),
+    }));
+    return { viewportWidth, viewportHeight, scrollWidth, mainWidth: mainRect?.width || 0, mainHeight: mainRect?.height || 0, clippedCritical };
   });
 
-  expect(
-    geometry.scrollWidth,
-    `${path} has page-level horizontal overflow: scrollWidth=${geometry.scrollWidth}, viewport=${geometry.viewportWidth}`,
-  ).toBeLessThanOrEqual(geometry.viewportWidth + 2);
-
+  expect(geometry.scrollWidth, `${path} has page-level horizontal overflow: scrollWidth=${geometry.scrollWidth}, viewport=${geometry.viewportWidth}`).toBeLessThanOrEqual(geometry.viewportWidth + 2);
   expect(geometry.mainWidth, `${path} primary content has zero width`).toBeGreaterThan(0);
   expect(geometry.mainHeight, `${path} primary content has zero height`).toBeGreaterThan(0);
   expect(geometry.clippedCritical, `${path} has clipped critical controls`).toEqual([]);
 
-  const mobile = geometry.viewportWidth < 768;
-  if (mobile) {
-    const tinyCritical = await page.evaluate(() =>
-      Array.from(document.querySelectorAll('button, input, select, textarea'))
-        .filter((element) => {
-          const el = element as HTMLElement;
-          const rect = el.getBoundingClientRect();
-          const style = window.getComputedStyle(el);
-          if (style.display === 'none' || style.visibility === 'hidden' || rect.width === 0 || rect.height === 0) return false;
-          return rect.height < 32 || rect.width < 32;
-        })
-        .slice(0, 10)
-        .map((element) => ({
-          tag: element.tagName,
-          text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
-        })),
-    );
+  if (geometry.viewportWidth < 768) {
+    const tinyCritical = await page.evaluate(() => Array.from(document.querySelectorAll('button, input, select, textarea')).filter((element) => {
+      const el = element as HTMLElement;
+      const rect = el.getBoundingClientRect();
+      const style = window.getComputedStyle(el);
+      if (style.display === 'none' || style.visibility === 'hidden' || rect.width === 0 || rect.height === 0) return false;
+      return rect.height < 32 || rect.width < 32;
+    }).slice(0, 10).map((element) => ({ tag: element.tagName, text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80) })));
     expect(tinyCritical, `${path} has undersized mobile form/button controls`).toEqual([]);
   }
+}
+
+async function certify(page: Page, testInfo: any, role: string, email: string, password: string, paths: string[]) {
+  await login(page, email, password);
+  for (const path of paths) {
+    await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
+  }
+  await page.screenshot({ path: testInfo.outputPath(`${role}-${testInfo.project.name}.png`), fullPage: true });
 }
 
 test.describe('Authenticated portal responsive design certification', () => {
   test.describe('Apprentice', () => {
     test.skip(!APPRENTICE_EMAIL || !APPRENTICE_PASSWORD, 'Disposable Apprentice identity is required');
-
-    test('critical Apprentice surfaces fit the active device viewport', async ({ page }, testInfo) => {
-      await login(page, APPRENTICE_EMAIL, APPRENTICE_PASSWORD);
-      for (const path of [
-        '/apprentice',
-        '/apprentice/hours',
-        '/apprentice/rti',
-        '/apprentice/competencies',
-        '/apprentice/documents',
-        '/apprentice/attendance',
-        '/apprentice/profile',
-        '/apprentice/handbook',
-      ]) {
-        await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
-      }
-      await page.screenshot({ path: testInfo.outputPath(`apprentice-${testInfo.project.name}.png`), fullPage: true });
-    });
+    test('critical Apprentice surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'apprentice', APPRENTICE_EMAIL, APPRENTICE_PASSWORD, ['/apprentice','/apprentice/hours','/apprentice/rti','/apprentice/competencies','/apprentice/documents','/apprentice/attendance','/apprentice/profile','/apprentice/handbook']));
   });
 
   test.describe('Host Shop', () => {
     test.skip(!HOST_EMAIL || !HOST_PASSWORD, 'Disposable Host Shop identity is required');
+    test('critical Host Shop surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'host-shop', HOST_EMAIL, HOST_PASSWORD, ['/host-shop/dashboard','/host-shop/dashboard/apprentices','/host-shop/dashboard/hours/pending','/host-shop/dashboard/documents','/host-shop/dashboard/competencies','/host-shop/dashboard/attendance/record','/host-shop/dashboard/wages','/host-shop/dashboard/reports','/host-shop/dashboard/profile']));
+  });
 
-    test('critical Host Shop surfaces fit the active device viewport', async ({ page }, testInfo) => {
-      await login(page, HOST_EMAIL, HOST_PASSWORD);
-      for (const path of [
-        '/host-shop/dashboard',
-        '/host-shop/dashboard/apprentices',
-        '/host-shop/dashboard/hours/pending',
-        '/host-shop/dashboard/documents',
-        '/host-shop/dashboard/competencies',
-        '/host-shop/dashboard/attendance/record',
-        '/host-shop/dashboard/wages',
-        '/host-shop/dashboard/reports',
-        '/host-shop/dashboard/profile',
-      ]) {
-        await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
-      }
-      await page.screenshot({ path: testInfo.outputPath(`host-shop-${testInfo.project.name}.png`), fullPage: true });
-    });
+  test.describe('Learner', () => {
+    test.skip(!LEARNER_EMAIL || !LEARNER_PASSWORD, 'Disposable Learner identity is required');
+    test('critical Learner surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'learner', LEARNER_EMAIL, LEARNER_PASSWORD, ['/lms/dashboard','/lms/courses','/lms/certificates','/lms/calendar','/lms/messages','/lms/support','/lms/apply/status']));
+  });
+
+  test.describe('Program Holder', () => {
+    test.skip(!PROGRAM_HOLDER_EMAIL || !PROGRAM_HOLDER_PASSWORD, 'Disposable Program Holder identity is required');
+    test('critical Program Holder surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'program-holder', PROGRAM_HOLDER_EMAIL, PROGRAM_HOLDER_PASSWORD, ['/program-holder/dashboard','/program-holder/students','/program-holder/portal/students','/program-holder/portal/reports','/program-holder/rights-responsibilities']));
   });
 });


### PR DESCRIPTION
Extends the production cross-device portal gate from Host Shop/Apprentice to Learner and Program Holder. Creates disposable isolated QA identities; the Learner is not enrolled in real programs, and the Program Holder is linked only to an inactive unpublished QA program with zero real students. Runs the same desktop/laptop/iPad/iPhone/Android responsive assertions and preserves the hydration-aware login helper. Branch is based on current login-hardened main.