### PR TITLE
QA: full authenticated portal responsive certification

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -13,6 +13,7 @@ on:
       - 'scripts/check-registered-apprenticeship-architecture.mjs'
       - 'scripts/qa/provision-apprenticeship-e2e.mjs'
       - 'scripts/qa/provision-learner-program-holder-e2e.mjs'
+      - 'scripts/qa/provision-remaining-portal-e2e.mjs'
   workflow_run:
     workflows:
       - Deploy LMS
@@ -30,10 +31,10 @@ concurrency:
 jobs:
   production-authenticated-e2e:
     if: github.event_name != 'workflow_run' || github.event.workflow_run.conclusion == 'success'
-    name: Portal authenticated persistence and responsive design
+    name: Full portal authenticated persistence and responsive design
     runs-on: ubuntu-latest
     environment: production
-    timeout-minutes: 55
+    timeout-minutes: 70
     env:
       PLAYWRIGHT_BASE_URL: https://app.elevateforhumanity.org
       NEXT_PUBLIC_SUPABASE_URL: ${{ secrets.NEXT_PUBLIC_SUPABASE_URL }}
@@ -57,9 +58,7 @@ jobs:
           for i in $(seq 1 20); do
             ping_status=$(curl -sS --max-time 10 -o /tmp/lms-ping.json -w "%{http_code}" https://app.elevateforhumanity.org/api/ping || true)
             health_status=$(curl -sS --max-time 10 -o /tmp/lms-health.json -w "%{http_code}" https://app.elevateforhumanity.org/api/health || true)
-            if [[ "$ping_status" == "200" && "$health_status" == "200" ]] \
-              && grep -q '"ok":true' /tmp/lms-ping.json \
-              && grep -q '"ready":true' /tmp/lms-health.json; then exit 0; fi
+            if [[ "$ping_status" == "200" && "$health_status" == "200" ]] && grep -q '"ok":true' /tmp/lms-ping.json && grep -q '"ready":true' /tmp/lms-health.json; then exit 0; fi
             echo "LMS not ready yet (ping=$ping_status health=$health_status), retry $i/20"
             sleep 15
           done
@@ -77,6 +76,8 @@ jobs:
         run: node scripts/qa/provision-apprenticeship-e2e.mjs provision
       - name: Provision isolated Learner + Program Holder identities
         run: node scripts/qa/provision-learner-program-holder-e2e.mjs provision
+      - name: Provision Employer + Instructor + Staff + Case Manager + Admin identities
+        run: node scripts/qa/provision-remaining-portal-e2e.mjs provision
       - name: Install Chromium and WebKit
         run: pnpm exec playwright install chromium webkit --with-deps
       - name: Run registered-apprenticeship architecture gate
@@ -85,6 +86,9 @@ jobs:
         run: pnpm exec playwright test tests/e2e/registered-apprenticeship-authenticated.spec.ts --config playwright.config.ts --project=desktop-chrome
       - name: Run authenticated cross-device responsive design certification
         run: pnpm exec playwright test tests/e2e/portal-responsive-design.spec.ts --config playwright.config.ts --project=desktop-chrome --project=laptop-chrome --project=tablet-chrome --project=iphone-webkit --project=android-chrome
+      - name: Clean Employer + Instructor + Staff + Case Manager + Admin identities
+        if: always()
+        run: node scripts/qa/provision-remaining-portal-e2e.mjs cleanup
       - name: Clean isolated Learner + Program Holder identities
         if: always()
         run: node scripts/qa/provision-learner-program-holder-e2e.mjs cleanup
@@ -95,7 +99,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: portal-responsive-e2e-results
+          name: full-portal-responsive-e2e-results
           path: |
             test-results/
             playwright-report/
@@ -112,4 +116,4 @@ jobs:
         shell: bash
         run: |
           set -euo pipefail
-          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Portal production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixtures: isolated disposable Host Shop, Apprentice, Learner and Program Holder identities; no real participant/program-holder data is attached.\n- Functional scope: Apprentice + Host Shop operational workflow and RBAC.\n- Responsive scope: Host Shop, Apprentice, Learner and Program Holder on desktop 1440x900, laptop 1280x720, iPad-class tablet, iPhone WebKit and Pixel-class Android Chromium.\n- Assertions: no 5xx, login/authorization regression, horizontal overflow, clipped critical controls, zero-size primary content or undersized mobile form/button controls.\n- Evidence: Playwright traces/screenshots/report artifact retained for 14 days."
+          gh issue comment 791 --repo "$GITHUB_REPOSITORY" --body "### Full portal production QA: ${QA_STATUS^^}\n\n- SHA: \`${QA_SHA}\`\n- Trigger: \`${QA_EVENT}\`\n- Run: ${QA_RUN_URL}\n- Fixtures: isolated disposable Host Shop, Apprentice, Learner, Program Holder, Employer, Instructor, Staff, Case Manager and Admin identities.\n- Responsive scope: all nine roles on desktop 1440x900, laptop 1280x720, iPad-class tablet, iPhone WebKit and Pixel-class Android Chromium.\n- Assertions: no 5xx, login/authorization regression, horizontal overflow, clipped critical controls, zero-size primary content or undersized mobile controls.\n- Evidence: Playwright traces/screenshots/report artifact retained for 14 days."

--- a/scripts/qa/provision-remaining-portal-e2e.mjs
+++ b/scripts/qa/provision-remaining-portal-e2e.mjs
@@ -1,0 +1,91 @@
+import { createClient } from '@supabase/supabase-js';
+import { randomBytes } from 'node:crypto';
+import { readFile, writeFile } from 'node:fs/promises';
+
+const action = process.argv[2] || 'provision';
+const statePath = process.env.QA_REMAINING_PORTAL_E2E_STATE_PATH || '.qa-remaining-portal-e2e-state.json';
+const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL || process.env.SUPABASE_URL;
+const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY;
+if (!supabaseUrl || !serviceRoleKey) throw new Error('Supabase QA credentials are required');
+
+const db = createClient(supabaseUrl, serviceRoleKey, { auth: { autoRefreshToken: false, persistSession: false } });
+const runId = String(process.env.GITHUB_RUN_ID || Date.now());
+const marker = `qa-portal-e2e-${runId}`;
+const roles = [
+  ['employer', 'employer', 'Employer'],
+  ['instructor', 'instructor', 'Instructor'],
+  ['staff', 'staff', 'Staff'],
+  ['case-manager', 'case_manager', 'Case Manager'],
+  ['admin', 'admin', 'Admin'],
+];
+
+function password() { return `Qa!${randomBytes(18).toString('base64url')}9x`; }
+
+async function provision() {
+  const anchorResult = await db.from('programs').select('tenant_id').eq('slug', 'barber-apprenticeship').maybeSingle();
+  if (anchorResult.error || !anchorResult.data?.tenant_id) throw new Error(`Tenant anchor unavailable: ${anchorResult.error?.message || 'missing tenant'}`);
+  const tenantId = anchorResult.data.tenant_id;
+  const state = { runId, users: [] };
+  try {
+    for (const [kind, role, label] of roles) {
+      const email = `${marker}-${kind}@qa.invalid`;
+      const pass = password();
+      const created = await db.auth.admin.createUser({
+        email,
+        password: pass,
+        email_confirm: true,
+        app_metadata: { qa_e2e: true, qa_run_id: runId, role },
+        user_metadata: { qa_e2e: true, qa_run_id: runId, full_name: `[QA E2E] ${label}` },
+      });
+      if (created.error || !created.data.user) throw new Error(`create ${kind}: ${created.error?.message || 'no user returned'}`);
+      const user = created.data.user;
+      const profile = await db.from('profiles').upsert({
+        id: user.id,
+        email,
+        full_name: `[QA E2E] ${label}`,
+        role,
+        tenant_id: tenantId,
+        onboarding_completed: true,
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'id' });
+      if (profile.error) throw new Error(`profile ${kind}: ${profile.error.message}`);
+      state.users.push({ id: user.id, kind, role, email, password: pass });
+    }
+    await writeFile(statePath, JSON.stringify(state, null, 2));
+    if (process.env.GITHUB_ENV) {
+      const envNames = {
+        employer: 'EMPLOYER', instructor: 'INSTRUCTOR', staff: 'STAFF',
+        'case-manager': 'CASE_MANAGER', admin: 'ADMIN',
+      };
+      const lines = [];
+      for (const user of state.users) {
+        const prefix = envNames[user.kind];
+        lines.push(`E2E_${prefix}_EMAIL=${user.email}`);
+        lines.push(`E2E_${prefix}_PASSWORD=${user.password}`);
+        console.log(`::add-mask::${user.password}`);
+      }
+      await writeFile(process.env.GITHUB_ENV, `${lines.join('\n')}\n`, { flag: 'a' });
+    }
+    console.log(JSON.stringify({ ok: true, roles: state.users.map(({ role }) => role) }));
+  } catch (error) {
+    await writeFile(statePath, JSON.stringify(state, null, 2)).catch(() => {});
+    await cleanup().catch(() => {});
+    throw error;
+  }
+}
+
+async function cleanup() {
+  let state;
+  try { state = JSON.parse(await readFile(statePath, 'utf8')); }
+  catch { console.log('No remaining portal QA state file found; nothing to clean.'); return; }
+  for (const user of state.users || []) {
+    await db.from('profiles').delete().eq('id', user.id);
+    const removed = await db.auth.admin.deleteUser(user.id, true);
+    if (removed.error && !/not found/i.test(removed.error.message)) console.error(`soft-delete ${user.kind}: ${removed.error.message}`);
+  }
+  console.log(JSON.stringify({ ok: true, cleanedRunId: state.runId }));
+}
+
+if (action === 'provision') await provision();
+else if (action === 'cleanup') await cleanup();
+else throw new Error(`Unknown action: ${action}`);

--- a/tests/e2e/portal-responsive-design.spec.ts
+++ b/tests/e2e/portal-responsive-design.spec.ts
@@ -1,14 +1,20 @@
 import { test, expect, type Page } from '@playwright/test';
 
 const BASE = process.env.PLAYWRIGHT_BASE_URL || 'https://app.elevateforhumanity.org';
-const APPRENTICE_EMAIL = process.env.E2E_APPRENTICE_EMAIL || '';
-const APPRENTICE_PASSWORD = process.env.E2E_APPRENTICE_PASSWORD || '';
-const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
-const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
-const LEARNER_EMAIL = process.env.E2E_LEARNER_EMAIL || '';
-const LEARNER_PASSWORD = process.env.E2E_LEARNER_PASSWORD || '';
-const PROGRAM_HOLDER_EMAIL = process.env.E2E_PROGRAM_HOLDER_EMAIL || '';
-const PROGRAM_HOLDER_PASSWORD = process.env.E2E_PROGRAM_HOLDER_PASSWORD || '';
+const ADMIN_BASE = 'https://admin.elevateforhumanity.org';
+const MARKETING_BASE = 'https://www.elevateforhumanity.org';
+
+const creds = {
+  apprentice: [process.env.E2E_APPRENTICE_EMAIL || '', process.env.E2E_APPRENTICE_PASSWORD || ''],
+  hostShop: [process.env.E2E_HOST_SHOP_EMAIL || '', process.env.E2E_HOST_SHOP_PASSWORD || ''],
+  learner: [process.env.E2E_LEARNER_EMAIL || '', process.env.E2E_LEARNER_PASSWORD || ''],
+  programHolder: [process.env.E2E_PROGRAM_HOLDER_EMAIL || '', process.env.E2E_PROGRAM_HOLDER_PASSWORD || ''],
+  employer: [process.env.E2E_EMPLOYER_EMAIL || '', process.env.E2E_EMPLOYER_PASSWORD || ''],
+  instructor: [process.env.E2E_INSTRUCTOR_EMAIL || '', process.env.E2E_INSTRUCTOR_PASSWORD || ''],
+  staff: [process.env.E2E_STAFF_EMAIL || '', process.env.E2E_STAFF_PASSWORD || ''],
+  caseManager: [process.env.E2E_CASE_MANAGER_EMAIL || '', process.env.E2E_CASE_MANAGER_PASSWORD || ''],
+  admin: [process.env.E2E_ADMIN_EMAIL || '', process.env.E2E_ADMIN_PASSWORD || ''],
+} as const;
 
 async function login(page: Page, email: string, password: string) {
   await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
@@ -23,23 +29,22 @@ async function login(page: Page, email: string, password: string) {
   await expect(submit).toBeEnabled();
   await emailInput.fill(email);
   await passwordInput.fill(password);
-  await page.waitForTimeout(250);
   await submit.click();
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
+  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 25_000 });
 }
 
-async function assertResponsivePage(page: Page, path: string) {
-  const response = await page.goto(`${BASE}${path}`, { waitUntil: 'domcontentloaded' });
-  expect(response?.status() ?? 200, `${path} returned server error`).toBeLessThan(500);
-  expect(page.url(), `${path} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
-  expect(page.url(), `${path} redirected to unauthorized`).not.toContain('/unauthorized');
+async function assertResponsivePage(page: Page, pathOrUrl: string) {
+  const target = /^https?:\/\//.test(pathOrUrl) ? pathOrUrl : `${BASE}${pathOrUrl}`;
+  const response = await page.goto(target, { waitUntil: 'domcontentloaded' });
+  expect(response?.status() ?? 200, `${target} returned server error`).toBeLessThan(500);
+  expect(page.url(), `${target} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
+  expect(page.url(), `${target} redirected to unauthorized`).not.toContain('/unauthorized');
   await page.waitForLoadState('networkidle').catch(() => {});
 
   const geometry = await page.evaluate(() => {
     const doc = document.documentElement;
     const body = document.body;
     const viewportWidth = window.innerWidth;
-    const viewportHeight = window.innerHeight;
     const scrollWidth = Math.max(doc.scrollWidth, body?.scrollWidth || 0);
     const main = document.querySelector('main') || document.querySelector('[role="main"]') || body;
     const mainRect = main?.getBoundingClientRect();
@@ -57,13 +62,13 @@ async function assertResponsivePage(page: Page, path: string) {
       text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80),
       href: element.getAttribute('href'),
     }));
-    return { viewportWidth, viewportHeight, scrollWidth, mainWidth: mainRect?.width || 0, mainHeight: mainRect?.height || 0, clippedCritical };
+    return { viewportWidth, scrollWidth, mainWidth: mainRect?.width || 0, mainHeight: mainRect?.height || 0, clippedCritical };
   });
 
-  expect(geometry.scrollWidth, `${path} has page-level horizontal overflow: scrollWidth=${geometry.scrollWidth}, viewport=${geometry.viewportWidth}`).toBeLessThanOrEqual(geometry.viewportWidth + 2);
-  expect(geometry.mainWidth, `${path} primary content has zero width`).toBeGreaterThan(0);
-  expect(geometry.mainHeight, `${path} primary content has zero height`).toBeGreaterThan(0);
-  expect(geometry.clippedCritical, `${path} has clipped critical controls`).toEqual([]);
+  expect(geometry.scrollWidth, `${target} has page-level horizontal overflow`).toBeLessThanOrEqual(geometry.viewportWidth + 2);
+  expect(geometry.mainWidth, `${target} primary content has zero width`).toBeGreaterThan(0);
+  expect(geometry.mainHeight, `${target} primary content has zero height`).toBeGreaterThan(0);
+  expect(geometry.clippedCritical, `${target} has clipped critical controls`).toEqual([]);
 
   if (geometry.viewportWidth < 768) {
     const tinyCritical = await page.evaluate(() => Array.from(document.querySelectorAll('button, input, select, textarea')).filter((element) => {
@@ -73,36 +78,32 @@ async function assertResponsivePage(page: Page, path: string) {
       if (style.display === 'none' || style.visibility === 'hidden' || rect.width === 0 || rect.height === 0) return false;
       return rect.height < 32 || rect.width < 32;
     }).slice(0, 10).map((element) => ({ tag: element.tagName, text: ((element as HTMLElement).innerText || element.getAttribute('aria-label') || '').trim().slice(0, 80) })));
-    expect(tinyCritical, `${path} has undersized mobile form/button controls`).toEqual([]);
+    expect(tinyCritical, `${target} has undersized mobile controls`).toEqual([]);
   }
 }
 
-async function certify(page: Page, testInfo: any, role: string, email: string, password: string, paths: string[]) {
-  await login(page, email, password);
-  for (const path of paths) {
-    await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
-  }
+async function certify(page: Page, testInfo: any, role: string, credentials: readonly string[], paths: string[]) {
+  await login(page, credentials[0], credentials[1]);
+  for (const path of paths) await test.step(`${testInfo.project.name}: ${path}`, async () => assertResponsivePage(page, path));
   await page.screenshot({ path: testInfo.outputPath(`${role}-${testInfo.project.name}.png`), fullPage: true });
 }
 
+function roleSuite(name: string, key: keyof typeof creds, paths: string[]) {
+  test.describe(name, () => {
+    const credentials = creds[key];
+    test.skip(!credentials[0] || !credentials[1], `Disposable ${name} identity is required`);
+    test(`critical ${name} surfaces fit the active device viewport`, async ({ page }, testInfo) => certify(page, testInfo, key, credentials, paths));
+  });
+}
+
 test.describe('Authenticated portal responsive design certification', () => {
-  test.describe('Apprentice', () => {
-    test.skip(!APPRENTICE_EMAIL || !APPRENTICE_PASSWORD, 'Disposable Apprentice identity is required');
-    test('critical Apprentice surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'apprentice', APPRENTICE_EMAIL, APPRENTICE_PASSWORD, ['/apprentice','/apprentice/hours','/apprentice/rti','/apprentice/competencies','/apprentice/documents','/apprentice/attendance','/apprentice/profile','/apprentice/handbook']));
-  });
-
-  test.describe('Host Shop', () => {
-    test.skip(!HOST_EMAIL || !HOST_PASSWORD, 'Disposable Host Shop identity is required');
-    test('critical Host Shop surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'host-shop', HOST_EMAIL, HOST_PASSWORD, ['/host-shop/dashboard','/host-shop/dashboard/apprentices','/host-shop/dashboard/hours/pending','/host-shop/dashboard/documents','/host-shop/dashboard/competencies','/host-shop/dashboard/attendance/record','/host-shop/dashboard/wages','/host-shop/dashboard/reports','/host-shop/dashboard/profile']));
-  });
-
-  test.describe('Learner', () => {
-    test.skip(!LEARNER_EMAIL || !LEARNER_PASSWORD, 'Disposable Learner identity is required');
-    test('critical Learner surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'learner', LEARNER_EMAIL, LEARNER_PASSWORD, ['/lms/dashboard','/lms/courses','/lms/certificates','/lms/calendar','/lms/messages','/lms/support','/lms/apply/status']));
-  });
-
-  test.describe('Program Holder', () => {
-    test.skip(!PROGRAM_HOLDER_EMAIL || !PROGRAM_HOLDER_PASSWORD, 'Disposable Program Holder identity is required');
-    test('critical Program Holder surfaces fit the active device viewport', async ({ page }, testInfo) => certify(page, testInfo, 'program-holder', PROGRAM_HOLDER_EMAIL, PROGRAM_HOLDER_PASSWORD, ['/program-holder/dashboard','/program-holder/students','/program-holder/portal/students','/program-holder/portal/reports','/program-holder/rights-responsibilities']));
-  });
+  roleSuite('Apprentice', 'apprentice', ['/apprentice','/apprentice/hours','/apprentice/rti','/apprentice/competencies','/apprentice/documents','/apprentice/attendance','/apprentice/profile','/apprentice/handbook']);
+  roleSuite('Host Shop', 'hostShop', ['/host-shop/dashboard','/host-shop/dashboard/apprentices','/host-shop/dashboard/hours/pending','/host-shop/dashboard/documents','/host-shop/dashboard/competencies','/host-shop/dashboard/attendance/record','/host-shop/dashboard/wages','/host-shop/dashboard/reports','/host-shop/dashboard/profile']);
+  roleSuite('Learner', 'learner', ['/lms/dashboard','/lms/courses','/lms/certificates','/lms/calendar','/lms/messages','/lms/support','/lms/apply/status']);
+  roleSuite('Program Holder', 'programHolder', ['/program-holder/dashboard','/program-holder/students','/program-holder/portal/students','/program-holder/portal/reports','/program-holder/rights-responsibilities']);
+  roleSuite('Employer', 'employer', ['/employer/dashboard']);
+  roleSuite('Instructor', 'instructor', [`${ADMIN_BASE}/instructor/dashboard`]);
+  roleSuite('Staff', 'staff', [`${ADMIN_BASE}/staff-portal/dashboard`]);
+  roleSuite('Case Manager', 'caseManager', [`${MARKETING_BASE}/case-manager/dashboard`]);
+  roleSuite('Admin', 'admin', [`${ADMIN_BASE}/dashboard`]);
 });


### PR DESCRIPTION
Execution remediation: extend production Playwright certification from four roles to nine primary authenticated portal roles across desktop, laptop, iPad-class tablet, iPhone/WebKit, and Pixel-class Android Chromium. Adds disposable Employer, Instructor, Staff, Case Manager, and Admin identities, preserves isolated Host Shop/Apprentice/Learner/Program Holder fixtures, and cleans all QA identities after the run. Current main was re-read; the newer marketing/PARIS deployment commit does not overlap these QA files.