### PR TITLE
Fix portal production QA login readiness

### DIFF
--- a/tests/e2e/portal-responsive-design.spec.ts
+++ b/tests/e2e/portal-responsive-design.spec.ts
@@ -17,20 +17,24 @@ const creds = {
 } as const;
 
 async function login(page: Page, email: string, password: string) {
-  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
+  const response = await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  expect(response?.status() ?? 200, 'Login route returned a server error').toBeLessThan(500);
+
   const emailInput = page.locator('input[type="email"], input[name="email"]').first();
   const passwordInput = page.locator('input[type="password"]').first();
   const submit = page.locator('button[type="submit"]').first();
-  await expect(emailInput).toBeVisible();
-  await expect(passwordInput).toBeVisible();
-  await expect(submit).toBeVisible();
-  await expect(emailInput).toBeEnabled();
-  await expect(passwordInput).toBeEnabled();
-  await expect(submit).toBeEnabled();
+  await expect(emailInput).toBeVisible({ timeout: 15_000 });
+  await expect(passwordInput).toBeVisible({ timeout: 15_000 });
+  await expect(submit).toBeVisible({ timeout: 15_000 });
+  await expect(emailInput).toBeEnabled({ timeout: 20_000 });
+  await expect(passwordInput).toBeEnabled({ timeout: 20_000 });
+  await expect(submit).toBeEnabled({ timeout: 20_000 });
   await emailInput.fill(email);
   await passwordInput.fill(password);
-  await submit.click();
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 25_000 });
+  await Promise.all([
+    page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 }),
+    submit.click(),
+  ]);
 }
 
 async function assertResponsivePage(page: Page, pathOrUrl: string) {
@@ -39,7 +43,7 @@ async function assertResponsivePage(page: Page, pathOrUrl: string) {
   expect(response?.status() ?? 200, `${target} returned server error`).toBeLessThan(500);
   expect(page.url(), `${target} unexpectedly returned to login`).not.toMatch(/\/login(?:\?|$)/);
   expect(page.url(), `${target} redirected to unauthorized`).not.toContain('/unauthorized');
-  await page.waitForLoadState('networkidle').catch(() => {});
+  await page.waitForTimeout(500);
 
   const geometry = await page.evaluate(() => {
     const doc = document.documentElement;

--- a/tests/e2e/registered-apprenticeship-authenticated.spec.ts
+++ b/tests/e2e/registered-apprenticeship-authenticated.spec.ts
@@ -7,18 +7,29 @@ const HOST_EMAIL = process.env.E2E_HOST_SHOP_EMAIL || '';
 const HOST_PASSWORD = process.env.E2E_HOST_SHOP_PASSWORD || '';
 
 async function login(page: Page, email: string, password: string) {
-  await page.goto(`${BASE}/login`, { waitUntil: 'networkidle' });
+  const response = await page.goto(`${BASE}/login`, { waitUntil: 'domcontentloaded', timeout: 30_000 });
+  expect(response?.status() ?? 200, 'Login route returned a server error').toBeLessThan(500);
+
   const emailInput = page.locator('input[type="email"], input[name="email"]').first();
   const passwordInput = page.locator('input[type="password"]').first();
   const submit = page.locator('button[type="submit"]').first();
-  await expect(emailInput).toBeVisible();
-  await expect(passwordInput).toBeVisible();
-  await expect(submit).toBeVisible();
+
+  await expect(emailInput).toBeVisible({ timeout: 15_000 });
+  await expect(passwordInput).toBeVisible({ timeout: 15_000 });
+  await expect(submit).toBeVisible({ timeout: 15_000 });
+  // The production login intentionally keeps controls disabled until React is
+  // hydrated. Enabled controls are the authoritative user-ready signal; a
+  // persistent connection on the page means networkidle is not reliable.
+  await expect(emailInput).toBeEnabled({ timeout: 20_000 });
+  await expect(passwordInput).toBeEnabled({ timeout: 20_000 });
+  await expect(submit).toBeEnabled({ timeout: 20_000 });
+
   await emailInput.fill(email);
   await passwordInput.fill(password);
-  await page.waitForTimeout(250);
-  await submit.click();
-  await page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 20_000 });
+  await Promise.all([
+    page.waitForURL((url) => !url.pathname.includes('/login'), { timeout: 30_000 }),
+    submit.click(),
+  ]);
 }
 
 async function expectPortalRoute(page: Page, path: string, expectedText?: RegExp) {


### PR DESCRIPTION
Fix the proven production QA blocker from run 32595692523. The live login page maintains background network activity, so waiting for Playwright networkidle timed out before credentials were entered. Use DOMContentLoaded plus visible/enabled hydrated controls as the authoritative login-ready signal in both functional and responsive production suites. Current main was re-read at 09a61d96; both target test files are unchanged from the branch base, so concurrent admissions changes are preserved.