### PR TITLE
Enforce Host Shop dashboard role guard

### DIFF
--- a/apps/lms/app/host-shop/dashboard/layout.tsx
+++ b/apps/lms/app/host-shop/dashboard/layout.tsx
@@ -4,15 +4,23 @@ import { requireAdminClient } from '@/lib/supabase/admin';
 import { getMyPartnerContext, getSessionUser } from '@/lib/partner/access';
 import { PlatformShell } from '@/components/platform/PlatformShell';
 import { getHostShopOnboardingPaths, resolveHostShopProgram } from '@/lib/partners/host-shop-onboarding';
+import { requireRole } from '@/lib/auth/require-role';
+import { HOST_SHOP_ROLES } from '@/lib/rbac/role-matrix';
 
 export const dynamic = 'force-dynamic';
 
 /**
  * Single authorization + readiness boundary for every /host-shop/dashboard/* route.
- * A valid Host Shop relationship is required. Operational access remains locked
- * until MOU, onboarding, and required document verification are complete.
+ * A canonical Host Shop role and a valid Host Shop relationship are required.
+ * Operational access remains locked until MOU, onboarding, and required document
+ * verification are complete.
  */
 export default async function HostShopDashboardLayout({ children }: { children: React.ReactNode }) {
+  // Relationship data alone is not permission to enter the Host Shop portal.
+  // Apprentices can legitimately have an active placement at a shop, so enforce
+  // the canonical role taxonomy before resolving partner/shop context.
+  await requireRole(HOST_SHOP_ROLES);
+
   const context = await getMyPartnerContext();
 
   if (!context) {


### PR DESCRIPTION
Production QA found that an apprentice session could load the Host Shop dashboard route with HTTP 200 while the Host Shop API correctly denied access. The shared dashboard layout checks partner context but does not first enforce the canonical Host Shop role list. This change adds the existing canonical role guard before relationship and onboarding checks. Current main was re-read and the target layout is unchanged by concurrent work.