### PR TITLE
Run portal QA when portal security surfaces change

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -14,6 +14,19 @@ on:
       - 'scripts/qa/provision-apprenticeship-e2e.mjs'
       - 'scripts/qa/provision-learner-program-holder-e2e.mjs'
       - 'scripts/qa/provision-remaining-portal-e2e.mjs'
+      - 'apps/lms/app/host-shop/**'
+      - 'apps/lms/app/apprentice/**'
+      - 'apps/lms/app/lms/**'
+      - 'apps/lms/app/program-holder/**'
+      - 'apps/lms/app/employer/**'
+      - 'apps/admin/app/instructor/**'
+      - 'apps/admin/app/staff-portal/**'
+      - 'apps/admin/app/dashboard/**'
+      - 'apps/marketing/app/case-manager/**'
+      - 'lib/auth/**'
+      - 'lib/rbac/**'
+      - 'lib/partner/**'
+      - 'lib/routing/portal-map.ts'
   workflow_run:
     workflows:
       - Deploy LMS


### PR DESCRIPTION
Extends the existing production portal QA push filter so changes to portal routes, auth/RBAC, partner access, and canonical portal routing automatically launch the nine-role authenticated responsive gate. This closes the release-gate gap exposed while fixing Host Shop authorization. Current main was re-read at cf6114f9 and the workflow file is unchanged.