### PR TITLE
Certify portal runtime only after deployment

### DIFF
--- a/.github/workflows/registered-apprenticeship-e2e.yml
+++ b/.github/workflows/registered-apprenticeship-e2e.yml
@@ -14,19 +14,6 @@ on:
       - 'scripts/qa/provision-apprenticeship-e2e.mjs'
       - 'scripts/qa/provision-learner-program-holder-e2e.mjs'
       - 'scripts/qa/provision-remaining-portal-e2e.mjs'
-      - 'apps/lms/app/host-shop/**'
-      - 'apps/lms/app/apprentice/**'
-      - 'apps/lms/app/lms/**'
-      - 'apps/lms/app/program-holder/**'
-      - 'apps/lms/app/employer/**'
-      - 'apps/admin/app/instructor/**'
-      - 'apps/admin/app/staff-portal/**'
-      - 'apps/admin/app/dashboard/**'
-      - 'apps/marketing/app/case-manager/**'
-      - 'lib/auth/**'
-      - 'lib/rbac/**'
-      - 'lib/partner/**'
-      - 'lib/routing/portal-map.ts'
   workflow_run:
     workflows:
       - Deploy LMS


### PR DESCRIPTION
Corrects the portal QA trigger ordering. Runtime portal/auth changes are deployed by Deploy LMS and the existing workflow_run hook then certifies the exact deployed SHA. Direct push-triggering production QA from runtime files can race the deployment and test the previous healthy container. Direct push triggers remain for the QA workflow/tests/fixtures themselves. Current main was re-read at ca208b3a and this workflow is the only target.