### PR TITLE
Fix LMS production deploy convergence during rapid main updates

### DIFF
--- a/.github/workflows/deploy-lms.yml
+++ b/.github/workflows/deploy-lms.yml
@@ -52,13 +52,13 @@ on:
 permissions:
   contents: read
 
-# Production releases are serialized. Never cancel an in-flight Northflank build
-# because a newer commit landed on main; doing so can strand the public LMS on
-# an old or unhealthy deployment. Each queued run still verifies and deploys
-# its exact triggering SHA before the next run starts.
+# Production must converge on the newest eligible main revision. Superseded
+# workflow runs are safe to cancel because Northflank only receives a deployment
+# after the image build and exact-SHA verification succeed; the existing healthy
+# deployment remains in service under the maxUnavailable=0 rollout contract.
 concurrency:
   group: northflank-lms-deploy
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   deploy-lms:


### PR DESCRIPTION
Production recovery audit found that the LMS runtime network contract is internally consistent (port 3000, 0.0.0.0 bind, /api/ping startup/liveness, /api/health readiness), but the deploy workflow deliberately serializes every historical triggering SHA with cancel-in-progress=false. During rapid writes to main, this can leave an outage-recovery revision queued behind stale builds and can deploy obsolete SHAs before converging.

This change makes the LMS production concurrency group cancel superseded runs so production converges on the newest eligible main revision. The existing workflow still verifies the requested SHA belongs to main, verifies the exact Northflank build SHA before deployment, uses maxUnavailable=0/maxSurge=1 rollout configuration, and performs external /api/ping, /api/health, and /lms/dashboard smoke checks after deployment.

No application routing, DNS, secrets, ports, or health endpoint behavior is changed.