### PR TITLE
Start canonical agentic executor in Admin runtime

### DIFF
--- a/apps/admin/instrumentation.ts
+++ b/apps/admin/instrumentation.ts
@@ -1,12 +1,10 @@
 /**
- * Admin app entry — validates environment variables at startup.
- * Required because `next build` runs from apps/admin; Next only loads instrumentation.ts
- * from the app project root.
+ * Admin app entry — validates environment variables and starts the canonical
+ * server-side agentic executor when this app is running as the Admin service.
  *
- * IMPORTANT: instrumentation must stay web-runtime safe. Do not import the video
- * rendering worker here. That worker depends on Node filesystem/OS/native Remotion
- * modules and must run from an explicit server-only worker entry, not the Next
- * instrumentation graph.
+ * IMPORTANT: instrumentation must stay web-runtime safe. Do not import video
+ * rendering workers or native media dependencies directly here. The agentic
+ * executor owns lazy domain dispatch behind the nodejs/Admin runtime boundary.
  */
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') {
@@ -32,6 +30,18 @@ export async function register(): Promise<void> {
     }
   } catch (error) {
     console.warn('[admin] Environment validation error:', error);
+  }
+
+  if (process.env.ELEVATE_SERVICE === 'admin') {
+    try {
+      const { startAgenticExecutor } = await import('../../lib/agentic/executor');
+      startAgenticExecutor();
+    } catch (error) {
+      console.error(
+        '[admin] Canonical agentic executor failed to start:',
+        error instanceof Error ? error.message : error,
+      );
+    }
   }
 }
 

--- a/scripts/verify-admin-instrumentation-boundary.mjs
+++ b/scripts/verify-admin-instrumentation-boundary.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 import { readFile } from 'node:fs/promises';
 
-const file = 'apps/admin/instrumentation.ts';
-const source = await readFile(file, 'utf8');
+const instrumentationFile = 'apps/admin/instrumentation.ts';
+const executorFile = 'lib/agentic/executor.ts';
+const instrumentation = await readFile(instrumentationFile, 'utf8');
+const executor = await readFile(executorFile, 'utf8');
 
 const forbidden = [
   'lib/video/background-worker',
@@ -18,18 +20,45 @@ const forbidden = [
   '@rspack/binding',
 ];
 
-const violations = forbidden.filter((token) => source.includes(token));
+const violations = forbidden.filter((token) => instrumentation.includes(token));
 if (violations.length) {
   console.error(
     `[verify-admin-instrumentation-boundary] Admin instrumentation imports Node-only rendering dependencies: ${violations.join(', ')}`,
   );
-  console.error('Run video rendering from a dedicated server worker entry, never from Next instrumentation.');
+  console.error('Keep heavy rendering dependencies behind the canonical agentic executor/domain worker boundary.');
   process.exit(1);
 }
 
-if (!source.includes("process.env.NEXT_RUNTIME !== 'nodejs'")) {
+if (!instrumentation.includes("process.env.NEXT_RUNTIME !== 'nodejs'")) {
   console.error('[verify-admin-instrumentation-boundary] Missing explicit nodejs runtime boundary.');
   process.exit(1);
 }
 
-console.info('[verify-admin-instrumentation-boundary] Admin instrumentation is web-build safe.');
+if (!instrumentation.includes("process.env.ELEVATE_SERVICE === 'admin'")) {
+  console.error('[verify-admin-instrumentation-boundary] Missing explicit Admin-service boundary for agentic execution.');
+  process.exit(1);
+}
+
+if (!instrumentation.includes("import('../../lib/agentic/executor')") || !instrumentation.includes('startAgenticExecutor()')) {
+  console.error('[verify-admin-instrumentation-boundary] Admin runtime does not start the canonical agentic executor.');
+  process.exit(1);
+}
+
+const executorContracts = [
+  "import { processCourseAgenticTask } from './course-executor'",
+  "['marketing_campaign', 'course'].includes(project.target_type)",
+  "project.target_type === 'course'",
+  'processCourseAgenticTask',
+  ".eq('status', 'queued')",
+  'claimTask(task.id)',
+];
+
+const missingExecutorContracts = executorContracts.filter((token) => !executor.includes(token));
+if (missingExecutorContracts.length) {
+  console.error(
+    `[verify-admin-instrumentation-boundary] Canonical agentic course dispatch regressed: ${missingExecutorContracts.join(', ')}`,
+  );
+  process.exit(1);
+}
+
+console.info('[verify-admin-instrumentation-boundary] Admin instrumentation is web-build safe and starts canonical course/marketing agentic execution.');


### PR DESCRIPTION
Runtime completion for the canonical agentic system. The Admin Next app builds from apps/admin, so its own instrumentation must start the shared executor. This change starts the canonical executor only in nodejs + ELEVATE_SERVICE=admin and strengthens the existing deployment-blocking instrumentation contract to require course dispatch. No parallel worker or orchestration authority is created.