### PR TITLE
Gate Admin readiness on canonical agentic executor

### DIFF
--- a/apps/admin/app/api/ready/route.ts
+++ b/apps/admin/app/api/ready/route.ts
@@ -7,20 +7,27 @@ export const revalidate = 0;
 
 export async function GET() {
   const readiness = getRuntimeReadiness();
+  const agenticExecutorReady = process.env.ELEVATE_SERVICE !== 'admin'
+    || process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED === 'true';
+  const ready = readiness.ready && agenticExecutorReady;
+  const missing = agenticExecutorReady
+    ? readiness.missing
+    : [...readiness.missing, 'AGENTIC_EXECUTOR'];
 
   return NextResponse.json(
     {
       service: 'admin',
-      ready: readiness.ready,
-      status: readiness.ready ? 'ready' : 'not_ready',
+      ready,
+      status: ready ? 'ready' : 'not_ready',
       commit: readiness.commit,
       buildId: readiness.buildId,
       builtAt: readiness.builtAt,
-      missing: readiness.missing,
+      missing,
+      agenticExecutorReady,
       timestamp: new Date().toISOString(),
     },
     {
-      status: readiness.ready ? 200 : 503,
+      status: ready ? 200 : 503,
       headers: { 'Cache-Control': 'no-store' },
     },
   );

--- a/apps/admin/instrumentation.ts
+++ b/apps/admin/instrumentation.ts
@@ -36,7 +36,9 @@ export async function register(): Promise<void> {
     try {
       const { startAgenticExecutor } = await import('../../lib/agentic/executor');
       startAgenticExecutor();
+      process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED = 'true';
     } catch (error) {
+      delete process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED;
       console.error(
         '[admin] Canonical agentic executor failed to start:',
         error instanceof Error ? error.message : error,

--- a/scripts/verify-admin-instrumentation-boundary.mjs
+++ b/scripts/verify-admin-instrumentation-boundary.mjs
@@ -3,8 +3,10 @@ import { readFile } from 'node:fs/promises';
 
 const instrumentationFile = 'apps/admin/instrumentation.ts';
 const executorFile = 'lib/agentic/executor.ts';
+const readinessFile = 'apps/admin/app/api/ready/route.ts';
 const instrumentation = await readFile(instrumentationFile, 'utf8');
 const executor = await readFile(executorFile, 'utf8');
+const readiness = await readFile(readinessFile, 'utf8');
 
 const forbidden = [
   'lib/video/background-worker',
@@ -44,6 +46,11 @@ if (!instrumentation.includes("import('../../lib/agentic/executor')") || !instru
   process.exit(1);
 }
 
+if (!instrumentation.includes("process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED = 'true'")) {
+  console.error('[verify-admin-instrumentation-boundary] Admin runtime does not expose canonical executor startup readiness.');
+  process.exit(1);
+}
+
 const executorContracts = [
   "import { processCourseAgenticTask } from './course-executor'",
   "['marketing_campaign', 'course'].includes(project.target_type)",
@@ -61,4 +68,17 @@ if (missingExecutorContracts.length) {
   process.exit(1);
 }
 
-console.info('[verify-admin-instrumentation-boundary] Admin instrumentation is web-build safe and starts canonical course/marketing agentic execution.');
+const readinessContracts = [
+  'ELEVATE_AGENTIC_EXECUTOR_STARTED',
+  "'AGENTIC_EXECUTOR'",
+  'agenticExecutorReady',
+];
+const missingReadinessContracts = readinessContracts.filter((token) => !readiness.includes(token));
+if (missingReadinessContracts.length) {
+  console.error(
+    `[verify-admin-instrumentation-boundary] Admin readiness can go green without the agentic executor: ${missingReadinessContracts.join(', ')}`,
+  );
+  process.exit(1);
+}
+
+console.info('[verify-admin-instrumentation-boundary] Admin instrumentation is web-build safe, starts canonical course/marketing agentic execution, and gates readiness on executor startup.');


### PR DESCRIPTION
Production-hardening follow-up for the canonical Admin agentic runtime. Marks executor startup only after startAgenticExecutor succeeds, makes /api/ready fail with AGENTIC_EXECUTOR if the worker did not start, and extends the deployment-blocking instrumentation contract so future regressions cannot report Admin ready without course/marketing agentic execution.