### PR TITLE
Normalize Admin service role for canonical agentic execution

### DIFF
--- a/apps/admin/app/api/ready/route.ts
+++ b/apps/admin/app/api/ready/route.ts
@@ -7,8 +7,7 @@ export const revalidate = 0;
 
 export async function GET() {
   const readiness = getRuntimeReadiness();
-  const agenticExecutorReady = process.env.ELEVATE_SERVICE !== 'admin'
-    || process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED === 'true';
+  const agenticExecutorReady = process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED === 'true';
   const ready = readiness.ready && agenticExecutorReady;
   const missing = agenticExecutorReady
     ? readiness.missing

--- a/apps/admin/instrumentation.ts
+++ b/apps/admin/instrumentation.ts
@@ -4,7 +4,7 @@
  *
  * IMPORTANT: instrumentation must stay web-runtime safe. Do not import video
  * rendering workers or native media dependencies directly here. The agentic
- * executor owns lazy domain dispatch behind the nodejs/Admin runtime boundary.
+ * executor owns domain dispatch behind the nodejs/Admin runtime boundary.
  */
 export async function register(): Promise<void> {
   if (process.env.NEXT_RUNTIME !== 'nodejs') {
@@ -32,8 +32,13 @@ export async function register(): Promise<void> {
     console.warn('[admin] Environment validation error:', error);
   }
 
-  if (process.env.ELEVATE_SERVICE === 'admin') {
+  const serviceRole = process.env.ELEVATE_SERVICE || process.env.SERVICE_ROLE;
+  if (serviceRole === 'admin') {
     try {
+      // Northflank's canonical service configurator historically exposed
+      // SERVICE_ROLE. Normalize it before entering the shared executor so there
+      // is one runtime authority while older deployments roll forward safely.
+      process.env.ELEVATE_SERVICE = 'admin';
       const { startAgenticExecutor } = await import('../../lib/agentic/executor');
       startAgenticExecutor();
       process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED = 'true';

--- a/scripts/verify-admin-instrumentation-boundary.mjs
+++ b/scripts/verify-admin-instrumentation-boundary.mjs
@@ -36,8 +36,16 @@ if (!instrumentation.includes("process.env.NEXT_RUNTIME !== 'nodejs'")) {
   process.exit(1);
 }
 
-if (!instrumentation.includes("process.env.ELEVATE_SERVICE === 'admin'")) {
-  console.error('[verify-admin-instrumentation-boundary] Missing explicit Admin-service boundary for agentic execution.');
+const roleContracts = [
+  'process.env.ELEVATE_SERVICE || process.env.SERVICE_ROLE',
+  "serviceRole === 'admin'",
+  "process.env.ELEVATE_SERVICE = 'admin'",
+];
+const missingRoleContracts = roleContracts.filter((token) => !instrumentation.includes(token));
+if (missingRoleContracts.length) {
+  console.error(
+    `[verify-admin-instrumentation-boundary] Admin service-role normalization regressed: ${missingRoleContracts.join(', ')}`,
+  );
   process.exit(1);
 }
 
@@ -69,9 +77,9 @@ if (missingExecutorContracts.length) {
 }
 
 const readinessContracts = [
-  'ELEVATE_AGENTIC_EXECUTOR_STARTED',
+  "process.env.ELEVATE_AGENTIC_EXECUTOR_STARTED === 'true'",
   "'AGENTIC_EXECUTOR'",
-  'agenticExecutorReady',
+  'const ready = readiness.ready && agenticExecutorReady',
 ];
 const missingReadinessContracts = readinessContracts.filter((token) => !readiness.includes(token));
 if (missingReadinessContracts.length) {
@@ -81,4 +89,4 @@ if (missingReadinessContracts.length) {
   process.exit(1);
 }
 
-console.info('[verify-admin-instrumentation-boundary] Admin instrumentation is web-build safe, starts canonical course/marketing agentic execution, and gates readiness on executor startup.');
+console.info('[verify-admin-instrumentation-boundary] Admin runtime normalizes service role, starts canonical course/marketing agentic execution, and cannot report ready without executor startup.');


### PR DESCRIPTION
Root production fix for the canonical Admin agentic worker. Northflank currently exposes SERVICE_ROLE=admin while the shared executor requires ELEVATE_SERVICE=admin. Admin instrumentation now recognizes SERVICE_ROLE during rollout, normalizes ELEVATE_SERVICE before entering the shared executor, and Admin readiness unconditionally requires the executor startup marker. The deployment-blocking instrumentation contract enforces this behavior. Concurrent Course Builder acceptance-trigger work does not overlap these files and is preserved.