### PR TITLE
feat: add Elevate intelligence patterns

### DIFF
--- a/apps/admin/app/api/admin/intelligence/knowledge/route.ts
+++ b/apps/admin/app/api/admin/intelligence/knowledge/route.ts
@@ -1,0 +1,47 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { apiRequireAdmin } from '@/lib/admin/guards';
+import { askKnowledge } from '@/lib/ai/knowledge-intelligence';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeInternalError } from '@/lib/api/safe-error';
+
+const sourceSchema = z.object({
+  id: z.string().trim().min(1).max(180),
+  title: z.string().trim().min(1).max(300),
+  content: z.string().trim().min(1).max(25_000),
+  type: z.string().trim().max(80).optional(),
+  updatedAt: z.string().trim().max(80).optional(),
+  location: z.string().trim().max(500).optional(),
+});
+
+const schema = z.object({
+  mode: z.enum(['answer', 'summarize', 'compare', 'actions', 'risks']).default('answer'),
+  question: z.string().trim().min(2).max(4_000),
+  sources: z.array(sourceSchema).min(1).max(20),
+  maxSources: z.number().int().min(1).max(20).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const limited = await applyRateLimit(request, 'api');
+  if (limited) return limited;
+
+  const auth = await apiRequireAdmin(request);
+  if (auth.error) return auth.error;
+
+  const body = await request.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid knowledge request.', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  try {
+    const result = await askKnowledge(parsed.data);
+    return NextResponse.json({ ok: true, result });
+  } catch (error) {
+    return safeInternalError(error, 'Knowledge analysis failed');
+  }
+}

--- a/apps/admin/app/api/admin/intelligence/tabular/route.ts
+++ b/apps/admin/app/api/admin/intelligence/tabular/route.ts
@@ -1,0 +1,72 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { apiRequireAdmin } from '@/lib/admin/guards';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeError } from '@/lib/api/safe-error';
+import {
+  runTabularIntelligenceBatch,
+  type TabularIntelligenceMode,
+  type TabularIntelligenceRequest,
+} from '@/lib/ai/tabular-intelligence';
+
+const MODES = new Set<TabularIntelligenceMode>([
+  'generate',
+  'summarize',
+  'categorize',
+  'sentiment',
+  'extract',
+]);
+
+export async function POST(request: NextRequest) {
+  const rateLimited = await applyRateLimit(request, 'api');
+  if (rateLimited) return rateLimited;
+
+  const auth = await apiRequireAdmin(request);
+  if (auth.error) return auth.error;
+
+  const body = await request.json().catch(() => null);
+  if (!body || !Array.isArray(body.rows) || body.rows.length === 0) {
+    return safeError('rows must be a non-empty array', 400);
+  }
+  if (body.rows.length > 100) {
+    return safeError('A maximum of 100 rows can be analyzed per request', 400);
+  }
+
+  const mode = body.mode as TabularIntelligenceMode;
+  if (!MODES.has(mode)) {
+    return safeError('mode must be generate, summarize, categorize, sentiment, or extract', 400);
+  }
+
+  const instruction = typeof body.instruction === 'string' ? body.instruction.trim() : '';
+  if (!instruction) return safeError('instruction is required', 400);
+
+  const categories = Array.isArray(body.categories)
+    ? body.categories.filter((value: unknown): value is string => typeof value === 'string' && value.trim().length > 0)
+    : undefined;
+
+  if (mode === 'categorize' && categories && categories.length > 50) {
+    return safeError('A maximum of 50 categories is allowed', 400);
+  }
+
+  const requests: TabularIntelligenceRequest[] = body.rows.map((row: unknown) => ({
+    mode,
+    instruction,
+    row: row && typeof row === 'object' && !Array.isArray(row) ? row as Record<string, unknown> : { value: row },
+    categories,
+    outputKey: typeof body.outputKey === 'string' ? body.outputKey.trim() || undefined : undefined,
+  }));
+
+  try {
+    const results = await runTabularIntelligenceBatch(requests, 4);
+    return NextResponse.json({
+      success: true,
+      mode,
+      count: results.length,
+      results,
+    });
+  } catch (error) {
+    return safeError(
+      error instanceof Error ? error.message : 'Tabular intelligence failed',
+      503,
+    );
+  }
+}

--- a/apps/admin/app/api/admin/intelligence/visual/route.ts
+++ b/apps/admin/app/api/admin/intelligence/visual/route.ts
@@ -1,0 +1,50 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { z } from 'zod';
+
+import { apiRequireAdmin } from '@/lib/admin/guards';
+import { composeVisual } from '@/lib/ai/visual-composition';
+import { applyRateLimit } from '@/lib/api/withRateLimit';
+import { safeError, safeInternalError } from '@/lib/api/safe-error';
+
+const schema = z.object({
+  mode: z.enum(['create', 'refine', 'beautify', 'infographic']),
+  instruction: z.string().trim().min(3).max(4_000),
+  target: z.enum(['slide', 'section', 'hero', 'program-card', 'infographic', 'course-visual']).optional(),
+  current: z.record(z.string(), z.unknown()).optional(),
+  sourceContext: z.record(z.string(), z.unknown()).optional(),
+  theme: z.object({
+    brandName: z.string().trim().max(120).optional(),
+    tone: z.string().trim().max(240).optional(),
+    fonts: z.array(z.string().trim().max(80)).max(8).optional(),
+    colors: z.array(z.string().trim().max(40)).max(12).optional(),
+    styleNotes: z.array(z.string().trim().max(240)).max(12).optional(),
+  }).optional(),
+});
+
+export async function POST(request: NextRequest) {
+  const limited = await applyRateLimit(request, 'api');
+  if (limited) return limited;
+
+  const auth = await apiRequireAdmin(request);
+  if (auth.error) return auth.error;
+
+  const body = await request.json().catch(() => null);
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return NextResponse.json(
+      { ok: false, error: 'Invalid visual composition request.', details: parsed.error.flatten() },
+      { status: 400 },
+    );
+  }
+
+  if (parsed.data.mode !== 'create' && !parsed.data.current) {
+    return safeError('current composition is required for refine or beautify operations', 400);
+  }
+
+  try {
+    const spec = await composeVisual(parsed.data);
+    return NextResponse.json({ ok: true, spec });
+  } catch (error) {
+    return safeInternalError(error, 'Visual composition failed');
+  }
+}

--- a/lib/ai/knowledge-intelligence.ts
+++ b/lib/ai/knowledge-intelligence.ts
@@ -1,0 +1,103 @@
+import { aiChat } from './ai-service';
+
+export type KnowledgeMode = 'answer' | 'summarize' | 'compare' | 'actions' | 'risks';
+
+export interface KnowledgeSource {
+  id: string;
+  title: string;
+  content: string;
+  type?: string;
+  updatedAt?: string;
+  location?: string;
+}
+
+export interface KnowledgeRequest {
+  mode: KnowledgeMode;
+  question: string;
+  sources: KnowledgeSource[];
+  maxSources?: number;
+}
+
+export interface KnowledgeCitation {
+  sourceId: string;
+  title: string;
+}
+
+export interface KnowledgeResult {
+  answer: string;
+  citations: KnowledgeCitation[];
+  sourceIds: string[];
+  provider?: string;
+  model?: string;
+}
+
+const MODE_RULES: Record<KnowledgeMode, string> = {
+  answer: 'Answer the question using only the supplied sources.',
+  summarize: 'Summarize the supplied sources and preserve material distinctions between them.',
+  compare: 'Compare the supplied sources, highlighting agreements, conflicts, version differences, and missing evidence.',
+  actions: 'Extract concrete action items, owners, dates, dependencies, and unresolved follow-ups only when explicitly supported by the sources.',
+  risks: 'Identify risks, contradictions, missing evidence, stale information, or policy mismatches supported by the supplied sources.',
+};
+
+function compactSource(source: KnowledgeSource): KnowledgeSource {
+  return {
+    ...source,
+    content: source.content.slice(0, 18_000),
+  };
+}
+
+export async function askKnowledge(
+  request: KnowledgeRequest,
+): Promise<KnowledgeResult> {
+  if (!request.sources.length) throw new Error('At least one knowledge source is required');
+
+  const maxSources = Math.max(1, Math.min(request.maxSources || 12, 20));
+  const sources = request.sources.slice(0, maxSources).map(compactSource);
+  const allowedIds = new Set(sources.map((source) => source.id));
+
+  const result = await aiChat({
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You are Elevate Knowledge Intelligence for workforce, education, apprenticeship, compliance, CRM, operations, and platform records.',
+          MODE_RULES[request.mode],
+          'The supplied sources are the only evidence you may use.',
+          'Do not fill gaps from memory. If the evidence is missing or conflicting, say so clearly.',
+          'Prefer newer source versions when dates are available, but explicitly flag conflicts instead of silently choosing one.',
+          'Never infer regulated eligibility, funding approval, compliance, certification, payment status, or completion unless the authoritative source explicitly states it.',
+          'Return JSON only in this shape: {"answer":"...","sourceIds":["source-id"]}.',
+          'sourceIds must contain only IDs from sources that materially support the answer.',
+        ].join(' '),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          question: request.question,
+          sources,
+        }),
+      },
+    ],
+    temperature: 0.15,
+    maxTokens: 2600,
+  });
+
+  const cleaned = result.content.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+  const parsed = JSON.parse(cleaned) as { answer?: unknown; sourceIds?: unknown };
+  const sourceIds = Array.isArray(parsed.sourceIds)
+    ? parsed.sourceIds.filter((value): value is string => typeof value === 'string' && allowedIds.has(value))
+    : [];
+
+  const citations = sourceIds.map((sourceId) => {
+    const source = sources.find((item) => item.id === sourceId)!;
+    return { sourceId, title: source.title };
+  });
+
+  return {
+    answer: typeof parsed.answer === 'string' ? parsed.answer.trim() : '',
+    citations,
+    sourceIds,
+    provider: result.provider,
+    model: result.model,
+  };
+}

--- a/lib/ai/tabular-intelligence.ts
+++ b/lib/ai/tabular-intelligence.ts
@@ -1,0 +1,103 @@
+import { aiChat } from './ai-service';
+
+export type TabularIntelligenceMode =
+  | 'generate'
+  | 'summarize'
+  | 'categorize'
+  | 'sentiment'
+  | 'extract';
+
+export type TabularRow = Record<string, unknown>;
+
+export interface TabularIntelligenceRequest {
+  mode: TabularIntelligenceMode;
+  instruction: string;
+  row: TabularRow;
+  categories?: string[];
+  outputKey?: string;
+}
+
+export interface TabularIntelligenceResult {
+  value: string;
+  mode: TabularIntelligenceMode;
+  outputKey?: string;
+  provider?: string;
+  model?: string;
+}
+
+const MODE_RULES: Record<TabularIntelligenceMode, string> = {
+  generate: 'Generate concise text from only the supplied row data and instruction.',
+  summarize: 'Summarize the supplied row data. Preserve material facts and do not invent missing information.',
+  categorize: 'Classify the supplied row into exactly one allowed category when categories are provided. If the evidence is insufficient, return "unclassified".',
+  sentiment: 'Classify sentiment as positive, neutral, or negative unless the instruction explicitly requests another fixed label set.',
+  extract: 'Extract only the requested fact or field from the supplied row. If absent, return "unknown".',
+};
+
+function sanitizeRow(row: TabularRow): TabularRow {
+  return Object.fromEntries(
+    Object.entries(row).filter(([, value]) => value !== undefined),
+  );
+}
+
+export async function runTabularIntelligence(
+  request: TabularIntelligenceRequest,
+): Promise<TabularIntelligenceResult> {
+  const row = sanitizeRow(request.row);
+  const categoryRule = request.categories?.length
+    ? `Allowed categories: ${request.categories.join(', ')}.`
+    : '';
+
+  const result = await aiChat({
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You are Elevate Tabular Intelligence, a structured data assistant for workforce, education, apprenticeship, CRM, compliance, and operational records.',
+          MODE_RULES[request.mode],
+          categoryRule,
+          'Treat the supplied row as the only authoritative record context.',
+          'Never approve eligibility, funding, compliance, completion, certification, payment status, or another regulated outcome. You may summarize, flag, classify, or extract evidence for human or deterministic-rule review.',
+          'Return plain text only with no markdown fences.',
+        ]
+          .filter(Boolean)
+          .join(' '),
+      },
+      {
+        role: 'user',
+        content: `Instruction: ${request.instruction}\n\nRow JSON:\n${JSON.stringify(row)}`,
+      },
+    ],
+    temperature: request.mode === 'generate' ? 0.55 : 0.15,
+    maxTokens: request.mode === 'summarize' || request.mode === 'generate' ? 1200 : 400,
+  });
+
+  return {
+    value: result.content.trim(),
+    mode: request.mode,
+    outputKey: request.outputKey,
+    provider: result.provider,
+    model: result.model,
+  };
+}
+
+export async function runTabularIntelligenceBatch(
+  requests: TabularIntelligenceRequest[],
+  concurrency = 4,
+): Promise<TabularIntelligenceResult[]> {
+  const safeConcurrency = Math.max(1, Math.min(concurrency, 8));
+  const results: TabularIntelligenceResult[] = new Array(requests.length);
+  let cursor = 0;
+
+  async function worker(): Promise<void> {
+    while (cursor < requests.length) {
+      const index = cursor++;
+      results[index] = await runTabularIntelligence(requests[index]);
+    }
+  }
+
+  await Promise.all(
+    Array.from({ length: Math.min(safeConcurrency, requests.length) }, () => worker()),
+  );
+
+  return results;
+}

--- a/lib/ai/visual-composition.ts
+++ b/lib/ai/visual-composition.ts
@@ -1,0 +1,86 @@
+import { aiChat } from './ai-service';
+
+export type VisualCompositionMode = 'create' | 'refine' | 'beautify' | 'infographic';
+
+export interface VisualThemeContext {
+  brandName?: string;
+  tone?: string;
+  fonts?: string[];
+  colors?: string[];
+  styleNotes?: string[];
+}
+
+export interface VisualCompositionRequest {
+  mode: VisualCompositionMode;
+  instruction: string;
+  current?: Record<string, unknown>;
+  sourceContext?: Record<string, unknown>;
+  theme?: VisualThemeContext;
+  target?: 'slide' | 'section' | 'hero' | 'program-card' | 'infographic' | 'course-visual';
+}
+
+export interface VisualCompositionSpec {
+  title?: string;
+  subtitle?: string;
+  narrative?: string;
+  layout: string;
+  hierarchy: string[];
+  copy: Array<{ role: string; text: string }>;
+  visualPrompt?: string;
+  dataPoints?: Array<{ label: string; value: string; sourceField?: string }>;
+  refinements?: string[];
+  accessibility?: { altText?: string; readingOrder?: string[] };
+  provider?: string;
+  model?: string;
+}
+
+const MODE_INSTRUCTIONS: Record<VisualCompositionMode, string> = {
+  create: 'Create a new visual composition from the supplied instruction and context.',
+  refine: 'Preserve the current composition intent while applying only the requested changes.',
+  beautify: 'Improve hierarchy, visual storytelling, spacing, copy density, and image direction while preserving factual content and brand identity.',
+  infographic: 'Turn supplied facts into a data-rich visual narrative without inventing statistics or unsupported claims.',
+};
+
+export async function composeVisual(
+  request: VisualCompositionRequest,
+): Promise<VisualCompositionSpec> {
+  const result = await aiChat({
+    messages: [
+      {
+        role: 'system',
+        content: [
+          'You are Elevate Visual Composition Intelligence for the platform’s existing Dev Studio, Website Builder, Course Builder, and Media Studio.',
+          MODE_INSTRUCTIONS[request.mode],
+          'Use the existing theme when provided. Do not replace established brand identity with a generic template.',
+          'Treat supplied sourceContext and current composition as authoritative. Do not invent credentials, prices, outcomes, statistics, approvals, employers, funding, or testimonials.',
+          'Return JSON only with keys: title, subtitle, narrative, layout, hierarchy, copy, visualPrompt, dataPoints, refinements, accessibility.',
+          'copy must be an array of {role,text}. hierarchy and refinements must be string arrays. dataPoints must only contain facts present in sourceContext/current.',
+          'visualPrompt should describe the visual asset needed, not name a specific image provider.',
+          'accessibility should include useful altText and readingOrder when applicable.',
+        ].join(' '),
+      },
+      {
+        role: 'user',
+        content: JSON.stringify({
+          mode: request.mode,
+          target: request.target || 'section',
+          instruction: request.instruction,
+          theme: request.theme || {},
+          current: request.current || {},
+          sourceContext: request.sourceContext || {},
+        }),
+      },
+    ],
+    temperature: request.mode === 'refine' ? 0.25 : 0.5,
+    maxTokens: 2200,
+  });
+
+  const cleaned = result.content.replace(/```json?\n?/g, '').replace(/```/g, '').trim();
+  const parsed = JSON.parse(cleaned) as Omit<VisualCompositionSpec, 'provider' | 'model'>;
+
+  return {
+    ...parsed,
+    provider: result.provider,
+    model: result.model,
+  };
+}

--- a/tests/unit/knowledge-intelligence.test.ts
+++ b/tests/unit/knowledge-intelligence.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const aiChatMock = vi.fn();
+const { aiChatMock } = vi.hoisted(() => ({
+  aiChatMock: vi.fn(),
+}));
 
 vi.mock('../../lib/ai/ai-service', () => ({
   aiChat: aiChatMock,

--- a/tests/unit/knowledge-intelligence.test.ts
+++ b/tests/unit/knowledge-intelligence.test.ts
@@ -1,0 +1,56 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const aiChatMock = vi.fn();
+
+vi.mock('../../lib/ai/ai-service', () => ({
+  aiChat: aiChatMock,
+}));
+
+import { askKnowledge } from '../../lib/ai/knowledge-intelligence';
+
+describe('Elevate knowledge intelligence', () => {
+  beforeEach(() => {
+    aiChatMock.mockReset();
+    aiChatMock.mockResolvedValue({
+      content: JSON.stringify({
+        answer: 'The latest policy requires supervisor approval.',
+        sourceIds: ['policy-v2'],
+      }),
+      provider: 'elevate',
+      model: 'elevate-local',
+    });
+  });
+
+  it('returns source-grounded citations from allowed source ids only', async () => {
+    const result = await askKnowledge({
+      mode: 'answer',
+      question: 'What approval is required?',
+      sources: [
+        { id: 'policy-v1', title: 'Policy v1', content: 'Older policy.', updatedAt: '2026-01-01' },
+        { id: 'policy-v2', title: 'Policy v2', content: 'Supervisor approval is required.', updatedAt: '2026-08-01' },
+      ],
+    });
+
+    expect(result.answer).toContain('supervisor approval');
+    expect(result.citations).toEqual([{ sourceId: 'policy-v2', title: 'Policy v2' }]);
+    const system = aiChatMock.mock.calls[0][0].messages[0].content;
+    expect(system).toContain('only evidence');
+    expect(system).toContain('flag conflicts');
+  });
+
+  it('drops hallucinated citation ids', async () => {
+    aiChatMock.mockResolvedValueOnce({
+      content: JSON.stringify({ answer: 'Supported answer', sourceIds: ['source-1', 'made-up'] }),
+      provider: 'elevate',
+      model: 'local',
+    });
+
+    const result = await askKnowledge({
+      mode: 'summarize',
+      question: 'Summarize this source.',
+      sources: [{ id: 'source-1', title: 'Source 1', content: 'Real content.' }],
+    });
+
+    expect(result.sourceIds).toEqual(['source-1']);
+  });
+});

--- a/tests/unit/tabular-intelligence.test.ts
+++ b/tests/unit/tabular-intelligence.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const aiChatMock = vi.fn();
+const { aiChatMock } = vi.hoisted(() => ({
+  aiChatMock: vi.fn(),
+}));
 
 vi.mock('../../lib/ai/ai-service', () => ({
   aiChat: aiChatMock,

--- a/tests/unit/tabular-intelligence.test.ts
+++ b/tests/unit/tabular-intelligence.test.ts
@@ -1,0 +1,77 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const aiChatMock = vi.fn();
+
+vi.mock('../../lib/ai/ai-service', () => ({
+  aiChat: aiChatMock,
+}));
+
+import {
+  runTabularIntelligence,
+  runTabularIntelligenceBatch,
+} from '../../lib/ai/tabular-intelligence';
+
+describe('Elevate tabular intelligence', () => {
+  beforeEach(() => {
+    aiChatMock.mockReset();
+    aiChatMock.mockResolvedValue({
+      content: 'needs documentation',
+      provider: 'elevate',
+      model: 'elevate-local',
+    });
+  });
+
+  it('uses the existing AI router and preserves provider metadata', async () => {
+    const result = await runTabularIntelligence({
+      mode: 'summarize',
+      instruction: 'Summarize the record and identify missing evidence.',
+      row: {
+        participant: 'Example Learner',
+        attendance: '92%',
+        evidence_received: false,
+      },
+      outputKey: 'review_summary',
+    });
+
+    expect(aiChatMock).toHaveBeenCalledTimes(1);
+    expect(result).toEqual({
+      value: 'needs documentation',
+      mode: 'summarize',
+      outputKey: 'review_summary',
+      provider: 'elevate',
+      model: 'elevate-local',
+    });
+
+    const request = aiChatMock.mock.calls[0][0];
+    expect(request.messages[0].content).toContain('Elevate Tabular Intelligence');
+    expect(request.messages[0].content).toContain('Never approve eligibility');
+    expect(request.messages[1].content).toContain('Example Learner');
+  });
+
+  it('constrains categorization to supplied labels', async () => {
+    await runTabularIntelligence({
+      mode: 'categorize',
+      instruction: 'Classify the follow-up state.',
+      row: { status: 'pending', documents_complete: false },
+      categories: ['ready', 'needs_documents', 'needs_review'],
+    });
+
+    const request = aiChatMock.mock.calls[0][0];
+    expect(request.messages[0].content).toContain(
+      'Allowed categories: ready, needs_documents, needs_review.',
+    );
+  });
+
+  it('processes batches without changing request order', async () => {
+    aiChatMock
+      .mockResolvedValueOnce({ content: 'first', provider: 'elevate', model: 'local' })
+      .mockResolvedValueOnce({ content: 'second', provider: 'elevate', model: 'local' });
+
+    const results = await runTabularIntelligenceBatch([
+      { mode: 'extract', instruction: 'Extract status', row: { status: 'first' } },
+      { mode: 'extract', instruction: 'Extract status', row: { status: 'second' } },
+    ], 2);
+
+    expect(results.map((result) => result.value)).toEqual(['first', 'second']);
+  });
+});

--- a/tests/unit/visual-composition.test.ts
+++ b/tests/unit/visual-composition.test.ts
@@ -1,0 +1,62 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+
+const aiChatMock = vi.fn();
+
+vi.mock('../../lib/ai/ai-service', () => ({
+  aiChat: aiChatMock,
+}));
+
+import { composeVisual } from '../../lib/ai/visual-composition';
+
+describe('Elevate visual composition intelligence', () => {
+  beforeEach(() => {
+    aiChatMock.mockReset();
+    aiChatMock.mockResolvedValue({
+      content: JSON.stringify({
+        title: 'Medical Assistant',
+        subtitle: 'Train for a healthcare career',
+        narrative: 'Career-focused training overview',
+        layout: 'split hero',
+        hierarchy: ['title', 'outcome', 'cta'],
+        copy: [{ role: 'cta', text: 'Apply Now' }],
+        visualPrompt: 'Professional healthcare training environment',
+        dataPoints: [],
+        refinements: ['Increase image prominence'],
+        accessibility: { altText: 'Students training in a clinical classroom', readingOrder: ['title', 'outcome', 'cta'] },
+      }),
+      provider: 'elevate',
+      model: 'elevate-local',
+    });
+  });
+
+  it('preserves theme context and uses the canonical AI router', async () => {
+    const result = await composeVisual({
+      mode: 'beautify',
+      instruction: 'Make this more visual without changing the facts.',
+      target: 'hero',
+      current: { title: 'Medical Assistant', duration: '21 weeks' },
+      sourceContext: { duration: '21 weeks' },
+      theme: { brandName: 'Elevate for Humanity', tone: 'premium workforce institution' },
+    });
+
+    expect(result.provider).toBe('elevate');
+    expect(result.layout).toBe('split hero');
+    const request = aiChatMock.mock.calls[0][0];
+    expect(request.messages[0].content).toContain('Do not replace established brand identity');
+    expect(request.messages[0].content).toContain('Do not invent credentials');
+    expect(request.messages[1].content).toContain('21 weeks');
+  });
+
+  it('asks for data-rich visuals without invented facts', async () => {
+    await composeVisual({
+      mode: 'infographic',
+      instruction: 'Turn these outcomes into an infographic.',
+      target: 'infographic',
+      sourceContext: { completionRate: '84%' },
+    });
+
+    const system = aiChatMock.mock.calls[0][0].messages[0].content;
+    expect(system).toContain('without inventing statistics');
+    expect(system).toContain('dataPoints must only contain facts');
+  });
+});

--- a/tests/unit/visual-composition.test.ts
+++ b/tests/unit/visual-composition.test.ts
@@ -1,6 +1,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 
-const aiChatMock = vi.fn();
+const { aiChatMock } = vi.hoisted(() => ({
+  aiChatMock: vi.fn(),
+}));
 
 vi.mock('../../lib/ai/ai-service', () => ({
   aiChat: aiChatMock,


### PR DESCRIPTION
Implements three provider-neutral pattern layers on top of the existing Elevate AI router, without creating new AI authorities or vendor-branded features:

- Tabular Intelligence: generate, summarize, categorize, sentiment, and extract over row-shaped operational data.
- Visual Composition Intelligence: create, refine, beautify, and infographic composition specs while preserving current theme/content and reusing Media Studio for image generation.
- Knowledge Intelligence: source-scoped Q&A, summarization, comparison, action extraction, and risk analysis with returned source citations.

Safety/architecture constraints:
- Existing aiChat / aiGenerateImage remain canonical AI authorities.
- Supplied records/sources remain authoritative; no regulated approvals are delegated to AI.
- Admin endpoints are authenticated and rate-limited.
- Added unit coverage for each pattern layer.
- No external spreadsheet, presentation, or file-vendor dependency was introduced.

This is intentionally a gap-fill/consolidation change rather than a parallel product stack.