### PR TITLE
fix: surface closed-loop exceptions to operator queue

### DIFF
--- a/supabase/migrations/20260823120000_closed_loop_operator_escalations.sql
+++ b/supabase/migrations/20260823120000_closed_loop_operator_escalations.sql
@@ -1,0 +1,91 @@
+-- Surface closed-loop application remediation exceptions in the existing operator_tasks queue.
+-- The follow-up table remains the workflow state authority; operator_tasks is the staff work surface.
+
+create or replace function public.sync_application_remediation_operator_task()
+returns trigger
+language plpgsql
+security definer
+set search_path = public
+as $$
+declare
+  existing_task_id uuid;
+  missing_items text;
+begin
+  if new.workflow_key <> 'application_missing_documents' or new.subject_type <> 'application' then
+    return new;
+  end if;
+
+  if new.state = 'escalated' and new.escalation_status in ('needed', 'created') then
+    select id into existing_task_id
+    from public.operator_tasks
+    where task_type = 'application_remediation_exception'
+      and metadata ->> 'application_id' = new.subject_id::text
+      and status in ('queued', 'processing')
+    order by created_at desc
+    limit 1;
+
+    if existing_task_id is null then
+      missing_items := coalesce(new.detected_condition ->> 'missingDocuments', '[]');
+      insert into public.operator_tasks (
+        workspace_id,
+        task_type,
+        status,
+        prompt,
+        metadata
+      ) values (
+        null,
+        'application_remediation_exception',
+        'queued',
+        format(
+          'Application %s requires staff review. Missing requirements: %s. Attempts: %s/%s. Reason: %s',
+          new.subject_id,
+          missing_items,
+          new.attempt_count,
+          new.max_attempts,
+          coalesce(new.failure_reason, 'closed-loop remediation escalation')
+        ),
+        jsonb_build_object(
+          'application_id', new.subject_id,
+          'workflow_key', new.workflow_key,
+          'followup_id', new.id,
+          'attempt_count', new.attempt_count,
+          'max_attempts', new.max_attempts,
+          'failure_reason', new.failure_reason,
+          'missing_documents', coalesce(new.detected_condition -> 'missingDocuments', '[]'::jsonb),
+          'autopilot', true
+        )
+      ) returning id into existing_task_id;
+    end if;
+
+    if new.escalation_status = 'needed' then
+      new.escalation_status := 'created';
+      new.audit_metadata := coalesce(new.audit_metadata, '{}'::jsonb)
+        || jsonb_build_object('operator_task_id', existing_task_id);
+    end if;
+  elsif new.state = 'resolved' then
+    update public.operator_tasks
+    set status = 'completed',
+        result_summary = coalesce(result_summary, 'Closed automatically after required documents were satisfied.'),
+        completed_at = coalesce(completed_at, now()),
+        updated_at = now()
+    where task_type = 'application_remediation_exception'
+      and metadata ->> 'application_id' = new.subject_id::text
+      and status in ('queued', 'processing');
+
+    if new.escalation_status = 'created' then
+      new.escalation_status := 'closed';
+    end if;
+  end if;
+
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_application_remediation_operator_task on public.automation_followups;
+create trigger trg_application_remediation_operator_task
+before insert or update on public.automation_followups
+for each row
+execute function public.sync_application_remediation_operator_task();
+
+revoke all on function public.sync_application_remediation_operator_task() from public;
+grant execute on function public.sync_application_remediation_operator_task() to service_role;


### PR DESCRIPTION
Completes the closed-loop remediation escalation path by reusing the existing operator_tasks staff work queue. Escalated missing-document follow-ups create one queued staff task idempotently; resolving the follow-up closes any active exception task. No new workflow or notification system is introduced.